### PR TITLE
Save submitted data to session storage

### DIFF
--- a/e2e-tests/cypress/integration/journeys/before-you-start.spec.js
+++ b/e2e-tests/cypress/integration/journeys/before-you-start.spec.js
@@ -6,7 +6,7 @@ import {
 import CONSTANTS from '../../../constants';
 
 context('Landing page', () => {
-  before(() => {
+  beforeEach(() => {
     beforeYouStartPage.visit();
   });
 
@@ -68,8 +68,6 @@ context('Landing page', () => {
     beforeYouStartPage.submitButton().invoke('text').then((text) => {
       expect(text.trim()).equal(CONTENT_STRINGS.SUBMIT_BUTTON);
     });
-
-    beforeYouStartPage.submitButton().should('have.attr', 'href', CONSTANTS.ROUTES.COMPANY_BASED);
   });
 
   it('renders `before you start` content', () => {

--- a/ui/server/controllers/before-you-start/index.js
+++ b/ui/server/controllers/before-you-start/index.js
@@ -1,14 +1,32 @@
 const CONTENT_STRINGS = require('../../content-strings');
 const { TEMPLATES, ROUTES } = require('../../constants');
 
-const getBeforeYouStart = (req, res) =>
+const PAGE_VARIABLES = {
+  CONTENT_STRINGS: {
+    PRODUCT: CONTENT_STRINGS.PRODUCT,
+    FOOTER: CONTENT_STRINGS.FOOTER,
+    ...CONTENT_STRINGS.LANDING_PAGE,
+  },
+};
+
+const get = (req, res) =>
   res.render(TEMPLATES.BEFORE_YOU_START, {
     CONTENT_STRINGS: {
       PRODUCT: CONTENT_STRINGS.PRODUCT,
       FOOTER: CONTENT_STRINGS.FOOTER,
       ...CONTENT_STRINGS.LANDING_PAGE,
     },
-    SUBMIT_URL: ROUTES.COMPANY_BASED,
   });
 
-module.exports = getBeforeYouStart;
+const post = (req, res) => {
+  // new submitted data session
+  req.session.submittedData = {};
+
+  return res.redirect(ROUTES.COMPANY_BASED);
+};
+
+module.exports = {
+  PAGE_VARIABLES,
+  get,
+  post,
+};

--- a/ui/server/controllers/before-you-start/index.test.js
+++ b/ui/server/controllers/before-you-start/index.test.js
@@ -1,4 +1,8 @@
-const controller = require('.');
+const {
+  PAGE_VARIABLES,
+  get,
+  post,
+} = require('.');
 const { mockReq, mockRes } = require('../../test-mocks');
 const CONTENT_STRINGS = require('../../content-strings');
 const { TEMPLATES, ROUTES } = require('../../constants');
@@ -12,16 +16,45 @@ describe('controllers/index', () => {
     res = mockRes();
   });
 
-  it('should render before-you-start template', () => {
-    controller(req, res);
+  describe('PAGE_VARIABLES', () => {
+    it('should have correct properties', () => {
+      const expected = {
+        CONTENT_STRINGS: {
+          PRODUCT: CONTENT_STRINGS.PRODUCT,
+          FOOTER: CONTENT_STRINGS.FOOTER,
+          ...CONTENT_STRINGS.LANDING_PAGE,
+        },
+      };
 
-    expect(res.render).toHaveBeenCalledWith(TEMPLATES.BEFORE_YOU_START, {
-      CONTENT_STRINGS: {
-        PRODUCT: CONTENT_STRINGS.PRODUCT,
-        FOOTER: CONTENT_STRINGS.FOOTER,
-        ...CONTENT_STRINGS.LANDING_PAGE,
-      },
-      SUBMIT_URL: ROUTES.COMPANY_BASED,
+      expect(PAGE_VARIABLES).toEqual(expected);
+    });
+  });
+
+  describe('get', () => {
+    it('should render template', () => {
+      get(req, res);
+
+      expect(res.render).toHaveBeenCalledWith(TEMPLATES.BEFORE_YOU_START, PAGE_VARIABLES);
+    });
+  });
+
+  describe('post', () => {
+    it('should add an empty submittedData object to the session', () => {
+      req.session = {
+        submittedData: {
+          test: true,
+        },
+      };
+
+      post(req, res);
+
+      expect(req.session.submittedData).toEqual({});
+    });
+
+    it(`should redirect to ${ROUTES.COMPANY_BASED}`, () => {
+      post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(ROUTES.COMPANY_BASED);
     });
   });
 });

--- a/ui/server/controllers/buyer-based/index.js
+++ b/ui/server/controllers/buyer-based/index.js
@@ -2,6 +2,7 @@ const CONTENT_STRINGS = require('../../content-strings');
 const { FIELDS, ROUTES, TEMPLATES } = require('../../constants');
 const singleInputPageVariables = require('../../helpers/single-input-page-variables');
 const generateValidationErrors = require('./validation');
+const updateSubmittedData = require('../../helpers/update-submitted-data');
 
 const PAGE_VARIABLES = {
   FIELD_NAME: FIELDS.VALID_BUYER_BASE,
@@ -21,6 +22,11 @@ const post = (req, res) => {
       validationErrors,
     });
   }
+
+  req.session.submittedData = updateSubmittedData(
+    req.body,
+    req.session.submittedData,
+  );
 
   if (req.body[FIELDS.VALID_BUYER_BASE] === 'false') {
     return res.redirect(ROUTES.BUYER_BASED_UNAVAILABLE);

--- a/ui/server/controllers/buyer-based/index.test.js
+++ b/ui/server/controllers/buyer-based/index.test.js
@@ -3,6 +3,7 @@ const CONTENT_STRINGS = require('../../content-strings');
 const { FIELDS, ROUTES, TEMPLATES } = require('../../constants');
 const singleInputPageVariables = require('../../helpers/single-input-page-variables');
 const generateValidationErrors = require('./validation');
+const updateSubmittedData = require('../../helpers/update-submitted-data');
 const { mockReq, mockRes } = require('../../test-mocks');
 
 describe('controllers/buyer-based', () => {
@@ -59,6 +60,21 @@ describe('controllers/buyer-based', () => {
     });
 
     describe('when there are no validation errors', () => {
+      it('should update the session with submitted data', () => {
+        req.body = {
+          [FIELDS.VALID_BUYER_BASE]: 'true',
+        };
+
+        controller.post(req, res);
+
+        const expected = updateSubmittedData(
+          req.body,
+          req.session.submittedData,
+        );
+
+        expect(req.session.submittedData).toEqual(expected);
+      });
+
       it(`should redirect to ${ROUTES.TRIED_TO_OBTAIN_COVER}`, () => {
         req.body = {
           [FIELDS.VALID_BUYER_BASE]: 'true',

--- a/ui/server/controllers/company-based/index.js
+++ b/ui/server/controllers/company-based/index.js
@@ -2,6 +2,7 @@ const CONTENT_STRINGS = require('../../content-strings');
 const { FIELDS, ROUTES, TEMPLATES } = require('../../constants');
 const singleInputPageVariables = require('../../helpers/single-input-page-variables');
 const generateValidationErrors = require('./validation');
+const updateSubmittedData = require('../../helpers/update-submitted-data');
 
 const PAGE_VARIABLES = {
   FIELD_NAME: FIELDS.VALID_COMPANY_BASE,
@@ -22,9 +23,19 @@ const post = (req, res) => {
     });
   }
 
+  req.session.submittedData = updateSubmittedData(
+    req.body,
+    req.session.submittedData,
+  );
+
   if (req.body[FIELDS.VALID_COMPANY_BASE] === 'false') {
     return res.redirect(ROUTES.COMPANY_BASED_UNAVAILABLE);
   }
+
+  req.session.submittedData = updateSubmittedData(
+    req.body,
+    req.session.submittedData,
+  );
 
   return res.redirect(ROUTES.BUYER_BASED);
 };

--- a/ui/server/controllers/company-based/index.test.js
+++ b/ui/server/controllers/company-based/index.test.js
@@ -3,6 +3,7 @@ const CONTENT_STRINGS = require('../../content-strings');
 const { FIELDS, ROUTES, TEMPLATES } = require('../../constants');
 const singleInputPageVariables = require('../../helpers/single-input-page-variables');
 const generateValidationErrors = require('./validation');
+const updateSubmittedData = require('../../helpers/update-submitted-data');
 const { mockReq, mockRes } = require('../../test-mocks');
 
 describe('controllers/company-based', () => {
@@ -59,6 +60,21 @@ describe('controllers/company-based', () => {
     });
 
     describe('when there are no validation errors', () => {
+      it('should update the session with submitted data', () => {
+        req.body = {
+          [FIELDS.VALID_COMPANY_BASE]: 'true',
+        };
+
+        controller.post(req, res);
+
+        const expected = updateSubmittedData(
+          req.body,
+          req.session.submittedData,
+        );
+
+        expect(req.session.submittedData).toEqual(expected);
+      });
+
       it(`should redirect to ${ROUTES.BUYER_BASED}`, () => {
         req.body = {
           [FIELDS.VALID_COMPANY_BASE]: 'true',

--- a/ui/server/controllers/final-destination/index.js
+++ b/ui/server/controllers/final-destination/index.js
@@ -4,6 +4,7 @@ const singleInputPageVariables = require('../../helpers/single-input-page-variab
 const api = require('../../api');
 const mapCountries = require('../../helpers/map-countries');
 const { validation: generateValidationErrors } = require('./validation');
+const updateSubmittedData = require('../../helpers/update-submitted-data');
 
 const PAGE_VARIABLES = {
   FIELD_NAME: FIELDS.COUNTRY,
@@ -36,6 +37,11 @@ const post = async (req, res) => {
       validationErrors,
     });
   }
+
+  req.session.submittedData = updateSubmittedData(
+    req.body,
+    req.session.submittedData,
+  );
 
   return res.redirect(ROUTES.UK_CONTENT_PERCENTAGE);
 };

--- a/ui/server/controllers/final-destination/index.test.js
+++ b/ui/server/controllers/final-destination/index.test.js
@@ -3,9 +3,10 @@ const CONTENT_STRINGS = require('../../content-strings');
 const { FIELDS, ROUTES, TEMPLATES } = require('../../constants');
 const singleInputPageVariables = require('../../helpers/single-input-page-variables');
 const { validation: generateValidationErrors } = require('./validation');
-const { mockReq, mockRes } = require('../../test-mocks');
 const api = require('../../api');
 const mapCountries = require('../../helpers/map-countries');
+const updateSubmittedData = require('../../helpers/update-submitted-data');
+const { mockReq, mockRes } = require('../../test-mocks');
 
 describe('controllers/final-destination', () => {
   let req;
@@ -85,6 +86,21 @@ describe('controllers/final-destination', () => {
     });
 
     describe('when there are no validation errors', () => {
+      it('should update the session with submitted data', () => {
+        req.body = {
+          [FIELDS.FINAL_DESTINATION]: mapCountries(mockCountriesResponse)[0].value,
+        };
+
+        controller.post(req, res);
+
+        const expected = updateSubmittedData(
+          req.body,
+          req.session.submittedData,
+        );
+
+        expect(req.session.submittedData).toEqual(expected);
+      });
+
       it(`should redirect to ${ROUTES.UK_CONTENT_PERCENTAGE}`, async () => {
         req.body = {
           [FIELDS.FINAL_DESTINATION]: mapCountries(mockCountriesResponse)[0].value,

--- a/ui/server/controllers/tried-to-obtain-cover/index.js
+++ b/ui/server/controllers/tried-to-obtain-cover/index.js
@@ -2,6 +2,7 @@ const CONTENT_STRINGS = require('../../content-strings');
 const { FIELDS, ROUTES, TEMPLATES } = require('../../constants');
 const singleInputPageVariables = require('../../helpers/single-input-page-variables');
 const generateValidationErrors = require('./validation');
+const updateSubmittedData = require('../../helpers/update-submitted-data');
 
 const PAGE_VARIABLES = {
   FIELD_NAME: FIELDS.TRIED_PRIVATE_COVER,
@@ -21,6 +22,11 @@ const post = (req, res) => {
       validationErrors,
     });
   }
+
+  req.session.submittedData = updateSubmittedData(
+    req.body,
+    req.session.submittedData,
+  );
 
   return res.redirect(ROUTES.FINAL_DESTINATION);
 };

--- a/ui/server/controllers/tried-to-obtain-cover/index.test.js
+++ b/ui/server/controllers/tried-to-obtain-cover/index.test.js
@@ -3,6 +3,7 @@ const CONTENT_STRINGS = require('../../content-strings');
 const { FIELDS, ROUTES, TEMPLATES } = require('../../constants');
 const singleInputPageVariables = require('../../helpers/single-input-page-variables');
 const generateValidationErrors = require('./validation');
+const updateSubmittedData = require('../../helpers/update-submitted-data');
 const { mockReq, mockRes } = require('../../test-mocks');
 
 describe('controllers/tried-to-obtain-cover', () => {
@@ -47,6 +48,21 @@ describe('controllers/tried-to-obtain-cover', () => {
     });
 
     describe('when there are no validation errors', () => {
+      it('should update the session with submitted data', () => {
+        req.body = {
+          [FIELDS.TRIED_PRIVATE_COVER]: 'true',
+        };
+
+        controller.post(req, res);
+
+        const expected = updateSubmittedData(
+          req.body,
+          req.session.submittedData,
+        );
+
+        expect(req.session.submittedData).toEqual(expected);
+      });
+
       it(`should redirect to ${ROUTES.FINAL_DESTINATION}`, () => {
         req.body = {
           [FIELDS.TRIED_PRIVATE_COVER]: 'true',

--- a/ui/server/controllers/uk-content-pecentage/index.js
+++ b/ui/server/controllers/uk-content-pecentage/index.js
@@ -2,6 +2,7 @@ const CONTENT_STRINGS = require('../../content-strings');
 const { FIELDS, ROUTES, TEMPLATES } = require('../../constants');
 const singleInputPageVariables = require('../../helpers/single-input-page-variables');
 const { validation: generateValidationErrors } = require('./validation');
+const updateSubmittedData = require('../../helpers/update-submitted-data');
 
 const PAGE_VARIABLES = {
   FIELD_NAME: FIELDS.UK_CONTENT_PERCENTAGE,
@@ -21,6 +22,11 @@ const post = (req, res) => {
       validationErrors,
     });
   }
+
+  req.session.submittedData = updateSubmittedData(
+    req.body,
+    req.session.submittedData,
+  );
 
   return res.redirect(ROUTES.TELL_US_ABOUT_YOUR_DEAL);
 };

--- a/ui/server/controllers/uk-content-pecentage/index.test.js
+++ b/ui/server/controllers/uk-content-pecentage/index.test.js
@@ -3,6 +3,7 @@ const CONTENT_STRINGS = require('../../content-strings');
 const { FIELDS, ROUTES, TEMPLATES } = require('../../constants');
 const singleInputPageVariables = require('../../helpers/single-input-page-variables');
 const { validation: generateValidationErrors } = require('./validation');
+const updateSubmittedData = require('../../helpers/update-submitted-data');
 const { mockReq, mockRes } = require('../../test-mocks');
 
 describe('controllers/uk-content-percentage', () => {
@@ -47,6 +48,21 @@ describe('controllers/uk-content-percentage', () => {
     });
 
     describe('when there are no validation errors', () => {
+      it('should update the session with submitted data', () => {
+        req.body = {
+          [FIELDS.UK_CONTENT_PERCENTAGE]: '50',
+        };
+
+        controller.post(req, res);
+
+        const expected = updateSubmittedData(
+          req.body,
+          req.session.submittedData,
+        );
+
+        expect(req.session.submittedData).toEqual(expected);
+      });
+
       it(`should redirect to ${ROUTES.TELL_US_ABOUT_YOUR_DEAL}`, () => {
         req.body = {
           [FIELDS.UK_CONTENT_PERCENTAGE]: '50',

--- a/ui/server/helpers/sanitise-form-data.js
+++ b/ui/server/helpers/sanitise-form-data.js
@@ -1,0 +1,42 @@
+const shouldChangeStringToNumber = (value) => {
+  if (Number(value) || value === '0') {
+    return true;
+  }
+
+  return false;
+};
+
+const sanitiseValue = (value) => {
+  if (value === 'true') {
+    return true;
+  }
+
+  if (value === 'false') {
+    return false;
+  }
+
+  if (shouldChangeStringToNumber(value)) {
+    return Number(value);
+  }
+
+  return value;
+};
+
+const sanitiseFormData = (formData) => {
+  const sanitised = {};
+  const keys = Object.keys(formData);
+
+  keys.forEach((key) => {
+    const value = formData[key];
+
+    sanitised[key] = sanitiseValue(value);
+  });
+
+  return sanitised;
+};
+
+module.exports = {
+  shouldChangeStringToNumber,
+  sanitiseValue,
+  sanitiseFormData,
+};

--- a/ui/server/helpers/sanitise-form-data.test.js
+++ b/ui/server/helpers/sanitise-form-data.test.js
@@ -1,0 +1,83 @@
+const {
+  shouldChangeStringToNumber,
+  sanitiseValue,
+  sanitiseFormData,
+} = require('./sanitise-form-data');
+
+describe('sever/helpers/sanitise-form-data', () => {
+  describe('shouldChangeStringToNumber', () => {
+    describe('when the value is a string number', () => {
+      it('should return true', () => {
+        const result = shouldChangeStringToNumber('123');
+
+        expect(result).toEqual(true);
+      });
+    });
+
+    describe('when the value is a string number of 0', () => {
+      it('should return true', () => {
+        const result = shouldChangeStringToNumber('0');
+
+        expect(result).toEqual(true);
+      });
+    });
+
+    it('should return false', () => {
+      const result = shouldChangeStringToNumber('mock');
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('sanitiseValue', () => {
+    describe('when value is a string of true', () => {
+      it('should return boolean', () => {
+        const result = sanitiseValue('true');
+
+        expect(result).toEqual(true);
+      });
+    });
+
+    describe('when value is a string of false', () => {
+      it('should return boolean', () => {
+        const result = sanitiseValue('false');
+
+        expect(result).toEqual(false);
+      });
+    });
+
+    describe('when value is a string number', () => {
+      it('should return a number', () => {
+        const result = sanitiseValue('123');
+
+        expect(result).toEqual(123);
+      });
+    });
+
+    describe('when value is a plain string', () => {
+      it('should return value', () => {
+        const result = sanitiseValue('mock');
+
+        expect(result).toEqual('mock');
+      });
+    });
+  });
+
+  describe('sanitiseFormData', () => {
+    const mockFormData = {
+      a: 'mock',
+      b: 'true',
+      c: '100',
+    };
+
+    const result = sanitiseFormData(mockFormData);
+
+    const expected = {
+      a: mockFormData.a,
+      b: true,
+      c: 100,
+    };
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/ui/server/helpers/update-submitted-data.js
+++ b/ui/server/helpers/update-submitted-data.js
@@ -1,0 +1,22 @@
+const { sanitiseFormData } = require('./sanitise-form-data');
+
+const updateSubmittedData = (formData, existingData) => {
+  const { _csrf, ...submittedFormData } = formData;
+
+  let modifiedData;
+
+  if (existingData) {
+    modifiedData = {
+      ...existingData,
+      ...sanitiseFormData(submittedFormData),
+    };
+
+    return modifiedData;
+  }
+
+  modifiedData = sanitiseFormData(submittedFormData);
+
+  return modifiedData;
+};
+
+module.exports = updateSubmittedData;

--- a/ui/server/helpers/update-submitted-data.test.js
+++ b/ui/server/helpers/update-submitted-data.test.js
@@ -1,0 +1,79 @@
+const updateSubmittedData = require('./update-submitted-data');
+const { sanitiseFormData } = require('./sanitise-form-data');
+
+describe('sever/helpers/update-submitted-data', () => {
+  describe('when there is existing data', () => {
+    it('should return an object with existing and new, sanitised form data', () => {
+      const mockFormData = {
+        a: true,
+      };
+
+      const mockExistingData = {
+        mock: true,
+      };
+
+      const result = updateSubmittedData(
+        mockFormData,
+        mockExistingData,
+      );
+
+      const expected = {
+        ...mockExistingData,
+        ...sanitiseFormData(mockFormData),
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when there is no existing data', () => {
+    it('should return an object with new, sanitised form data', () => {
+      const mockFormData = {
+        a: true,
+      };
+
+      const mockExistingData = {};
+
+      const result = updateSubmittedData(
+        mockFormData,
+        mockExistingData,
+      );
+
+      const expected = sanitiseFormData(mockFormData);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  it('should not return _csrf from provided form data', () => {
+    const mockFormData = {
+      _csrf: '123',
+      a: true,
+    };
+
+    const mockExistingData = {};
+
+    const result = updateSubmittedData(
+      mockFormData,
+      mockExistingData,
+    );
+
+    const expected = sanitiseFormData({
+      a: mockFormData.a,
+    });
+
+    expect(result).toEqual(expected);
+  });
+
+  describe('when there is no existing or provided data', () => {
+    it('should return empty object', () => {
+      const mockFormData = {
+        _csrf: '123',
+      };
+
+      const result = updateSubmittedData(mockFormData);
+
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/ui/server/routes/index.js
+++ b/ui/server/routes/index.js
@@ -12,7 +12,8 @@ const problemWithServiceController = require('../controllers/problem-with-servic
 
 const router = express.Router();
 
-router.get(ROUTES.BEFORE_YOU_START, beforeYouStartController);
+router.get(ROUTES.BEFORE_YOU_START, beforeYouStartController.get);
+router.post(ROUTES.BEFORE_YOU_START, beforeYouStartController.post);
 
 router.get(ROUTES.COMPANY_BASED, companyBasedController.get);
 router.post(ROUTES.COMPANY_BASED, companyBasedController.post);

--- a/ui/server/routes/index.test.js
+++ b/ui/server/routes/index.test.js
@@ -24,9 +24,10 @@ describe('routes/index', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(9);
-    expect(post).toHaveBeenCalledTimes(5);
+    expect(post).toHaveBeenCalledTimes(6);
 
-    expect(get).toHaveBeenCalledWith(ROUTES.BEFORE_YOU_START, beforeYouStartController);
+    expect(get).toHaveBeenCalledWith(ROUTES.BEFORE_YOU_START, beforeYouStartController.get);
+    expect(post).toHaveBeenCalledWith(ROUTES.BEFORE_YOU_START, beforeYouStartController.post);
 
     expect(get).toHaveBeenCalledWith(ROUTES.COMPANY_BASED, companyBasedController.get);
     expect(post).toHaveBeenCalledWith(ROUTES.COMPANY_BASED, companyBasedController.post);

--- a/ui/templates/before-you-start.njk
+++ b/ui/templates/before-you-start.njk
@@ -27,15 +27,21 @@
 
   <p class="govuk-body" data-cy="completion-time">{{ CONTENT_STRINGS.COMPLETION_TIME }}</p>
 
-  {{ govukButton({
-    text: CONTENT_STRINGS.SUBMIT_BUTTON,
-    attributes: {
-      'data-cy': 'submit-button'
-    },
-    isStartButton: true,
-    href: SUBMIT_URL,
-    classes: 'govuk-!-margin-bottom-9'
-  }) }}
+  <form method="POST">
+
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+    {{ govukButton({
+      text: CONTENT_STRINGS.SUBMIT_BUTTON,
+      attributes: {
+        'data-cy': 'submit-button'
+      },
+      isStartButton: true,
+      href: SUBMIT_URL,
+      classes: 'govuk-!-margin-bottom-9'
+    }) }}
+  
+  </form>
 
   <h2 class="govuk-heading-l" data-cy="before-you-start-heading">{{ CONTENT_STRINGS.BEFORE_YOU_START.HEADING }}</h2>
 


### PR DESCRIPTION
- Create `sanitise-form-data` function
- Create `update-submitted-data` function
- Update session/submitted data on every form POST
- Before you start page using POST redirect instead of a link
- Before you start page creating a new empty session on submit