### PR TITLE
feat/EMS-193 - mock unsupported country, improve e2e test coverage

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/buyer-based/buyer-based-unsupported-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/buyer-based/buyer-based-unsupported-country.spec.js
@@ -2,6 +2,7 @@ import {
   buyerBasedPage,
   cannotObtainCoverPage,
 } from '../../pages';
+import partials from '../../partials';
 import { PAGES } from '../../../../content-strings';
 import CONSTANTS from '../../../../constants';
 
@@ -30,6 +31,12 @@ context('Which country is your buyer based page', () => {
 
   it('redirects to exit page', () => {
     cy.url().should('include', ROUTES.CANNOT_OBTAIN_COVER);
+  });
+
+  it('renders a back button with correct link', () => {
+    partials.backLink().should('exist');
+
+    partials.backLink().should('have.attr', 'href', ROUTES.BUYER_BASED);
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/buyer-based/user-testing-scenarios/buyer-based-submit-country-Angola.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/buyer-based/user-testing-scenarios/buyer-based-submit-country-Angola.spec.js
@@ -1,0 +1,43 @@
+import {
+  buyerBasedPage,
+  cannotObtainCoverPage,
+} from '../../../pages';
+import { PAGES } from '../../../../../content-strings';
+import CONSTANTS from '../../../../../constants';
+
+const CONTENT_STRINGS = PAGES.CANNOT_OBTAIN_COVER_PAGE;
+const { ROUTES } = CONSTANTS;
+
+const UNSUPPORTED_COUNTRY_NAME = 'Angola';
+
+context(`Which country is your buyer based page - user testing scenarios - submit ${UNSUPPORTED_COUNTRY_NAME}`, () => {
+  before(() => {
+    cy.visit(ROUTES.BUYER_BASED, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+    cy.url().should('include', ROUTES.BUYER_BASED);
+
+    buyerBasedPage.searchInput().type('Angola');
+
+    const results = buyerBasedPage.results();
+    results.first().click();
+
+    buyerBasedPage.submitButton().click();
+  });
+
+  it('redirects to exit page', () => {
+    cy.url().should('include', ROUTES.CANNOT_OBTAIN_COVER);
+  });
+
+  it('renders a specific reason', () => {
+    cannotObtainCoverPage.reason().invoke('text').then((text) => {
+      const { REASON } = CONTENT_STRINGS;
+      const expected = `${REASON.INTRO} ${REASON.UNSUPPORTED_BUYER_COUNTRY_1} ${UNSUPPORTED_COUNTRY_NAME}, ${REASON.UNSUPPORTED_BUYER_COUNTRY_2}`;
+
+      expect(text.trim()).equal(expected);
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/company-based/company-based-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/company-based/company-based-answer-no.spec.js
@@ -2,6 +2,7 @@ import {
   companyBasedPage,
   cannotObtainCoverPage,
 } from '../../pages';
+import partials from '../../partials';
 import { PAGES } from '../../../../content-strings';
 import CONSTANTS from '../../../../constants';
 
@@ -25,6 +26,12 @@ context('Answering `no` to Company based inside the UK, Channel Islands and Isle
 
   it('redirects to exit page', () => {
     cy.url().should('include', ROUTES.CANNOT_OBTAIN_COVER);
+  });
+
+  it('renders a back button with correct link', () => {
+    partials.backLink().should('exist');
+
+    partials.backLink().should('have.attr', 'href', ROUTES.COMPANY_BASED);
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/tried-to-obtain-cover/tried-to-obtain-cover-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/tried-to-obtain-cover/tried-to-obtain-cover-answer-yes.spec.js
@@ -2,6 +2,7 @@ import {
   triedToObtainCoverPage,
   cannotObtainCoverPage,
 } from '../../pages';
+import partials from '../../partials';
 import { PAGES } from '../../../../content-strings';
 import CONSTANTS from '../../../../constants';
 
@@ -24,6 +25,12 @@ context('Tried to obtain private cover page - answer `yes`', () => {
 
   it('redirects to exit page', () => {
     cy.url().should('include', ROUTES.CANNOT_OBTAIN_COVER);
+  });
+
+  it('renders a back button with correct link', () => {
+    partials.backLink().should('exist');
+
+    partials.backLink().should('have.attr', 'href', ROUTES.TRIED_TO_OBTAIN_COVER);
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/uk-content-percentage/uk-content-percentage-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/uk-content-percentage/uk-content-percentage-answer-no.spec.js
@@ -2,6 +2,7 @@ import {
   ukContentPercentagePage,
   cannotObtainCoverPage,
 } from '../../pages';
+import partials from '../../partials';
 import {
   PAGES,
 } from '../../../../content-strings';
@@ -26,6 +27,12 @@ context('What percentage of your export is UK content page', () => {
 
   it('redirects to exit page', () => {
     cy.url().should('include', ROUTES.CANNOT_OBTAIN_COVER);
+  });
+
+  it('renders a back button with correct link', () => {
+    partials.backLink().should('exist');
+
+    partials.backLink().should('have.attr', 'href', ROUTES.UK_CONTENT_PERCENTAGE);
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/your-quote/user-testing-scenarios/your-quote-buyer-country-Algeria.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/your-quote/user-testing-scenarios/your-quote-buyer-country-Algeria.spec.js
@@ -1,0 +1,64 @@
+import {
+  buyerBasedPage,
+  checkYourAnswersPage,
+  yourQuotePage,
+} from '../../../pages';
+import CONSTANTS from '../../../../../constants';
+
+const { ROUTES, FIELD_IDS } = CONSTANTS;
+
+const {
+  BUYER_COUNTRY,
+  QUOTE,
+} = FIELD_IDS;
+
+const {
+  PREMIUM_RATE_PERCENTAGE,
+  ESTIMATED_COST,
+} = QUOTE;
+
+const COUNTRY_NAME = 'Algeria';
+
+context(`Your quote page - user testing scenarios - ${COUNTRY_NAME} mock quote`, () => {
+  before(() => {
+    cy.login();
+
+    cy.submitAnswersHappyPath();
+
+    // change buyer country
+    checkYourAnswersPage.summaryLists.export[BUYER_COUNTRY].changeLink().click();
+
+    buyerBasedPage.searchInput().type(COUNTRY_NAME);
+    const results = buyerBasedPage.results();
+    results.first().click();
+    buyerBasedPage.submitButton().click();
+
+    checkYourAnswersPage.submitButton().click();
+
+    cy.url().should('include', ROUTES.YOUR_QUOTE);
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+  });
+
+  it('renders expected mock `premium rate` and `estimated cost`', () => {
+    const { summaryList } = yourQuotePage.panel;
+
+    const premiumRateRow = summaryList[PREMIUM_RATE_PERCENTAGE];
+
+    premiumRateRow.value().invoke('text').then((text) => {
+      const expected = '1.88%';
+
+      expect(text.trim()).equal(expected);
+    });
+
+    const estimatedCostRow = summaryList[ESTIMATED_COST];
+
+    estimatedCostRow.value().invoke('text').then((text) => {
+      const expected = '£1,128.00';
+
+      expect(text.trim()).equal(expected);
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/your-quote/user-testing-scenarios/your-quote-buyer-country-Bahrain.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/your-quote/user-testing-scenarios/your-quote-buyer-country-Bahrain.spec.js
@@ -1,0 +1,64 @@
+import {
+  buyerBasedPage,
+  checkYourAnswersPage,
+  yourQuotePage,
+} from '../../../pages';
+import CONSTANTS from '../../../../../constants';
+
+const { ROUTES, FIELD_IDS } = CONSTANTS;
+
+const {
+  BUYER_COUNTRY,
+  QUOTE,
+} = FIELD_IDS;
+
+const {
+  PREMIUM_RATE_PERCENTAGE,
+  ESTIMATED_COST,
+} = QUOTE;
+
+const COUNTRY_NAME = 'Bahrain';
+
+context(`Your quote page - user testing scenarios - ${COUNTRY_NAME} mock quote`, () => {
+  before(() => {
+    cy.login();
+
+    cy.submitAnswersHappyPath();
+
+    // change buyer country
+    checkYourAnswersPage.summaryLists.export[BUYER_COUNTRY].changeLink().click();
+
+    buyerBasedPage.searchInput().type(COUNTRY_NAME);
+    const results = buyerBasedPage.results();
+    results.first().click();
+    buyerBasedPage.submitButton().click();
+
+    checkYourAnswersPage.submitButton().click();
+
+    cy.url().should('include', ROUTES.YOUR_QUOTE);
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+  });
+
+  it('renders expected mock `premium rate` and `estimated cost`', () => {
+    const { summaryList } = yourQuotePage.panel;
+
+    const premiumRateRow = summaryList[PREMIUM_RATE_PERCENTAGE];
+
+    premiumRateRow.value().invoke('text').then((text) => {
+      const expected = '2.38%';
+
+      expect(text.trim()).equal(expected);
+    });
+
+    const estimatedCostRow = summaryList[ESTIMATED_COST];
+
+    estimatedCostRow.value().invoke('text').then((text) => {
+      const expected = '£1,428.00';
+
+      expect(text.trim()).equal(expected);
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/your-quote/your-quote.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/your-quote/your-quote.spec.js
@@ -43,8 +43,6 @@ const submissionData = {
   [CREDIT_PERIOD]: '2',
 };
 
-// TODO: test user testing scenarios
-
 context('Your quote page', () => {
   before(() => {
     cy.login();
@@ -107,7 +105,7 @@ context('Your quote page', () => {
         row.changeLink().should('have.attr', 'href', expectedHref);
       });
 
-      it('renders `percentage` key and value (no change link)', () => {
+      it('renders `premium rate` key and value (no change link)', () => {
         const row = summaryList[PREMIUM_RATE_PERCENTAGE];
         const expectedKeyText = QUOTE_TITLES[PREMIUM_RATE_PERCENTAGE];
 

--- a/ui/server/controllers/company-based/index.js
+++ b/ui/server/controllers/company-based/index.js
@@ -36,7 +36,7 @@ const post = (req, res) => {
   const answer = req.body[FIELD_IDS.VALID_COMPANY_BASE];
 
   if (answer === 'false') {
-    req.flash('previousRoute', ROUTES.VALID_COMPANY_BASE);
+    req.flash('previousRoute', ROUTES.COMPANY_BASED);
 
     const { PAGES } = CONTENT_STRINGS;
     const { CANNOT_OBTAIN_COVER_PAGE } = PAGES;

--- a/ui/server/controllers/company-based/index.test.js
+++ b/ui/server/controllers/company-based/index.test.js
@@ -67,7 +67,7 @@ describe('controllers/company-based', () => {
       it('should add previousRoute and exitReason to req.flash', async () => {
         await controller.post(req, res);
 
-        expect(req.flash).toHaveBeenCalledWith('previousRoute', ROUTES.BUYVALID_COMPANY_BASEER_BASED);
+        expect(req.flash).toHaveBeenCalledWith('previousRoute', ROUTES.COMPANY_BASED);
 
         const expectedReason = CONTENT_STRINGS.PAGES.CANNOT_OBTAIN_COVER_PAGE.REASON.UNSUPPORTED_COMPANY_COUNTRY;
         expect(req.flash).toHaveBeenCalledWith('exitReason', expectedReason);

--- a/ui/server/helpers/is-country-supported.js
+++ b/ui/server/helpers/is-country-supported.js
@@ -1,4 +1,22 @@
+/**
+ * mockUnsupportedCountries
+ * Mock unsupported countries for user testing scenarios
+ */
+const mockUnsupportedCountries = [
+  {
+    isoCode: 'AGO',
+    name: 'Angola',
+  },
+];
+
 const isCountrySupported = (country) => {
+  const isMockUnsupported = mockUnsupportedCountries.find((c) =>
+    c.isoCode === country.isoCode);
+
+  if (isMockUnsupported) {
+    return false;
+  }
+
   if (country.active === true) {
     return true;
   }

--- a/ui/server/helpers/is-country-supported.test.js
+++ b/ui/server/helpers/is-country-supported.test.js
@@ -7,6 +7,20 @@ describe('sever/helpers/is-country-supported', () => {
     active: true,
   };
 
+  describe('mock unsupported countries', () => {
+    describe('when country is `Angola`', () => {
+      it('should return false', () => {
+        const result = isCountrySupported({
+          ...mockCountry,
+          isoCode: 'AGO',
+          name: 'Angola',
+        });
+
+        expect(result).toEqual(false);
+      });
+    });
+  });
+
   describe('when a country has active flag', () => {
     it('should return true', () => {
       const result = isCountrySupported(mockCountry);


### PR DESCRIPTION
- add mock unsupported country
- add e2e tests for mock scenarios used for user testing
- fix issue where 'company based' exit page would have incorrect back link
- add e2e test coverage for back links on all exit page scenarios
