### PR TITLE
feat(EMS-279): do not render decimal points in 'contract value' and 'max amount owed' summary list rows

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/change-your-answers/change-your-answers-policy-type-and-length.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/change-your-answers/change-your-answers-policy-type-and-length.spec.js
@@ -87,7 +87,7 @@ context('Change your answers after checking answers - Policy type and length', (
     row = checkYourAnswersPage.summaryLists.policy[MAX_AMOUNT_OWED];
 
     row.value().invoke('text').then((text) => {
-      const expected = '£120,000.00';
+      const expected = '£120,000';
 
       expect(text.trim()).equal(expected);
     });
@@ -154,7 +154,7 @@ context('Change your answers after checking answers - Policy type and length', (
       row = checkYourAnswersPage.summaryLists.policy[CONTRACT_VALUE];
 
       row.value().invoke('text').then((text) => {
-        const expected = '£150.00';
+        const expected = '£150';
 
         expect(text.trim()).equal(expected);
       });

--- a/e2e-tests/cypress/e2e/journeys/check-your-answers-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/check-your-answers-multi-policy.spec.js
@@ -172,7 +172,7 @@ context('Check your answers page (multi policy)', () => {
       row.changeLink().should('have.attr', 'href', expectedHref);
     });
 
-    it('renders `Max amount owed` key, value and change link', () => {
+    it('renders `Max amount owed` key, value with no decimal points and change link', () => {
       const row = list[MAX_AMOUNT_OWED];
       const expectedKeyText = FIELDS[MAX_AMOUNT_OWED].SUMMARY.TITLE;
 
@@ -181,7 +181,7 @@ context('Check your answers page (multi policy)', () => {
       });
 
       row.value().invoke('text').then((text) => {
-        const expected = '£150,000.00';
+        const expected = '£150,000';
 
         expect(text.trim()).equal(expected);
       });

--- a/e2e-tests/cypress/e2e/journeys/check-your-answers-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/check-your-answers-single-policy.spec.js
@@ -214,7 +214,7 @@ context('Check your answers page (single policy)', () => {
       row.changeLink().should('have.attr', 'href', expectedHref);
     });
 
-    it('renders `Contract value` key, value and change link', () => {
+    it('renders `Contract value` key, value with no decimal points and change link', () => {
       const row = list[CONTRACT_VALUE];
       const expectedKeyText = FIELDS[CONTRACT_VALUE].SUMMARY.TITLE;
 
@@ -223,7 +223,7 @@ context('Check your answers page (single policy)', () => {
       });
 
       row.value().invoke('text').then((text) => {
-        const expected = '£150,000.00';
+        const expected = '£150,000';
 
         expect(text.trim()).equal(expected);
       });

--- a/e2e-tests/cypress/e2e/journeys/your-quote/your-quote-change-answers-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/your-quote/your-quote-change-answers-multi-policy.spec.js
@@ -73,7 +73,7 @@ context('Your quote page - change policy type and length from multi single', () 
       const row = yourQuotePage.panel.summaryList[MAX_AMOUNT_OWED];
 
       row.value().invoke('text').then((text) => {
-        const expected = '£200.00';
+        const expected = '£200';
 
         expect(text.trim()).equal(expected);
       });

--- a/e2e-tests/cypress/e2e/journeys/your-quote/your-quote-change-answers-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/your-quote/your-quote-change-answers-single-policy.spec.js
@@ -74,7 +74,7 @@ context('Your quote page - change answers (single policy type to multi policy ty
       const row = yourQuotePage.panel.summaryList[CONTRACT_VALUE];
 
       row.value().invoke('text').then((text) => {
-        const expected = '£1,000.00';
+        const expected = '£1,000';
 
         expect(text.trim()).equal(expected);
       });

--- a/e2e-tests/cypress/e2e/journeys/your-quote/your-quote-large-contract-value.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/your-quote/your-quote-large-contract-value.spec.js
@@ -48,7 +48,7 @@ context('Get a quote - large contract value', () => {
     const answersAmount = checkYourAnswersPage.summaryLists.policy[CONTRACT_VALUE].value();
 
     answersAmount.invoke('text').then((text) => {
-      const expected = '£12,345,678.00';
+      const expected = '£12,345,678';
 
       expect(text.trim()).equal(expected);
     });

--- a/e2e-tests/cypress/e2e/journeys/your-quote/your-quote-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/your-quote/your-quote-multi-policy.spec.js
@@ -48,7 +48,7 @@ context('Your quote page - multi policy type', () => {
     context('summary list', () => {
       const { summaryList } = yourQuotePage.panel;
 
-      it('renders `max amount owed` key, value and change link', () => {
+      it('renders `max amount owed` key, value with no decimal points and change link', () => {
         const row = summaryList[MAX_AMOUNT_OWED];
         const expectedKeyText = QUOTE_TITLES[MAX_AMOUNT_OWED];
 
@@ -57,7 +57,7 @@ context('Your quote page - multi policy type', () => {
         });
 
         row.value().invoke('text').then((text) => {
-          const expected = '£150,000.00';
+          const expected = '£150,000';
 
           expect(text.trim()).equal(expected);
         });
@@ -94,7 +94,7 @@ context('Your quote page - multi policy type', () => {
         row.changeLink().should('have.attr', 'href', expectedHref);
       });
 
-      it('renders `insured for` key and value (no change link)', () => {
+      it('renders `insured for` key and value with decimal points (no change link)', () => {
         const row = summaryList[INSURED_FOR];
         const expectedKeyText = QUOTE_TITLES[`${INSURED_FOR}_MULTI_POLICY`];
 

--- a/e2e-tests/cypress/e2e/journeys/your-quote/your-quote-non-gbp-currency.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/your-quote/your-quote-non-gbp-currency.spec.js
@@ -47,7 +47,7 @@ context('Your quote page - non GBP currency', () => {
     context('summary list', () => {
       const { summaryList } = yourQuotePage.panel;
 
-      it('renders `insured for` key and value (no change link)', () => {
+      it('renders `insured for` key and value with decimal points (no change link)', () => {
         const row = summaryList[INSURED_FOR];
         const expectedKeyText = QUOTE_TITLES[`${INSURED_FOR}_SINGLE_POLICY`];
 

--- a/e2e-tests/cypress/e2e/journeys/your-quote/your-quote-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/your-quote/your-quote-single-policy.spec.js
@@ -87,7 +87,7 @@ context('Your quote page (single policy)', () => {
     context('summary list', () => {
       const { summaryList } = yourQuotePage.panel;
 
-      it('renders `contract value` key, value and change link', () => {
+      it('renders `contract value` key, value with no decimal points and change link', () => {
         const row = summaryList[CONTRACT_VALUE];
         const expectedKeyText = QUOTE_TITLES[CONTRACT_VALUE];
 
@@ -96,7 +96,7 @@ context('Your quote page (single policy)', () => {
         });
 
         row.value().invoke('text').then((text) => {
-          const expected = '£150,000.00';
+          const expected = '£150,000';
 
           expect(text.trim()).equal(expected);
         });
@@ -133,7 +133,7 @@ context('Your quote page (single policy)', () => {
         row.changeLink().should('have.attr', 'href', expectedHref);
       });
 
-      it('renders `insured for` key and value (no change link)', () => {
+      it('renders `insured for` key and value with decimal points (no change link)', () => {
         const row = summaryList[INSURED_FOR];
         const expectedKeyText = QUOTE_TITLES[`${INSURED_FOR}_SINGLE_POLICY`];
 

--- a/src/ui/server/helpers/data-content-mappings/map-cost.test.ts
+++ b/src/ui/server/helpers/data-content-mappings/map-cost.test.ts
@@ -20,7 +20,7 @@ describe('server/helpers/data-content-mappings/map-cost', () => {
 
       const expected = {
         [CONTRACT_VALUE]: {
-          text: formatCurrency(mockDataSinglePolicyType[CONTRACT_VALUE], mockDataSinglePolicyType[CURRENCY].isoCode),
+          text: formatCurrency(mockDataSinglePolicyType[CONTRACT_VALUE], mockDataSinglePolicyType[CURRENCY].isoCode, 0),
         },
       };
 
@@ -42,7 +42,7 @@ describe('server/helpers/data-content-mappings/map-cost', () => {
 
       const expected = {
         [MAX_AMOUNT_OWED]: {
-          text: formatCurrency(mockDataMultiPolicyType[MAX_AMOUNT_OWED], mockDataMultiPolicyType[CURRENCY].isoCode),
+          text: formatCurrency(mockDataMultiPolicyType[MAX_AMOUNT_OWED], mockDataMultiPolicyType[CURRENCY].isoCode, 0),
         },
       };
 

--- a/src/ui/server/helpers/data-content-mappings/map-cost.ts
+++ b/src/ui/server/helpers/data-content-mappings/map-cost.ts
@@ -11,7 +11,7 @@ const mapCost = (answers: SubmittedData | Quote) => {
   if (isSinglePolicyType(answers[POLICY_TYPE])) {
     mapped = {
       [CONTRACT_VALUE]: {
-        text: formatCurrency(answers[CONTRACT_VALUE], answers[CURRENCY].isoCode),
+        text: formatCurrency(answers[CONTRACT_VALUE], answers[CURRENCY].isoCode, 0),
       },
     };
   }
@@ -19,7 +19,7 @@ const mapCost = (answers: SubmittedData | Quote) => {
   if (isMultiPolicyType(answers[POLICY_TYPE])) {
     mapped = {
       [MAX_AMOUNT_OWED]: {
-        text: formatCurrency(answers[MAX_AMOUNT_OWED], answers[CURRENCY].isoCode),
+        text: formatCurrency(answers[MAX_AMOUNT_OWED], answers[CURRENCY].isoCode, 0),
       },
     };
   }

--- a/src/ui/server/helpers/data-content-mappings/map-quote-to-content.test.ts
+++ b/src/ui/server/helpers/data-content-mappings/map-quote-to-content.test.ts
@@ -21,13 +21,13 @@ describe('server/helpers/map-quote-to-content', () => {
           text: `${mockQuote[PERCENTAGE_OF_COVER]}%`,
         },
         [INSURED_FOR]: {
-          text: formatCurrency(mockQuote[INSURED_FOR], mockQuote[CURRENCY].isoCode),
+          text: formatCurrency(mockQuote[INSURED_FOR], mockQuote[CURRENCY].isoCode, 2),
         },
         [PREMIUM_RATE_PERCENTAGE]: {
           text: `${mockQuote[PREMIUM_RATE_PERCENTAGE]}%`,
         },
         [ESTIMATED_COST]: {
-          text: formatCurrency(mockQuote[ESTIMATED_COST], mockQuote[CURRENCY].isoCode),
+          text: formatCurrency(mockQuote[ESTIMATED_COST], mockQuote[CURRENCY].isoCode, 2),
         },
         ...mapPolicyLength(mockQuote),
         [BUYER_LOCATION]: {

--- a/src/ui/server/helpers/data-content-mappings/map-quote-to-content.ts
+++ b/src/ui/server/helpers/data-content-mappings/map-quote-to-content.ts
@@ -18,13 +18,13 @@ const mapQuoteToContent = (quote: Quote): QuoteContent => {
       text: `${quote[PERCENTAGE_OF_COVER]}%`,
     },
     insuredFor: {
-      text: formatCurrency(quote[INSURED_FOR], currencyCode),
+      text: formatCurrency(quote[INSURED_FOR], currencyCode, 2),
     },
     premiumRatePercentage: {
       text: `${quote[PREMIUM_RATE_PERCENTAGE]}%`,
     },
     estimatedCost: {
-      text: formatCurrency(quote[ESTIMATED_COST], currencyCode),
+      text: formatCurrency(quote[ESTIMATED_COST], currencyCode, 2),
     },
     ...mapPolicyLength(quote),
     buyerCountry: {

--- a/src/ui/server/helpers/format-currency.test.ts
+++ b/src/ui/server/helpers/format-currency.test.ts
@@ -5,11 +5,13 @@ describe('server/helpers/format-currency', () => {
     const mock = 123456;
     const currencyCode = 'GBP';
 
-    const result = formatCurrency(mock, currencyCode);
+    const result = formatCurrency(mock, currencyCode, 2);
 
     const expected = mock.toLocaleString('en', {
       style: 'currency',
       currency: currencyCode,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
     });
 
     expect(result).toEqual(expected);

--- a/src/ui/server/helpers/format-currency.ts
+++ b/src/ui/server/helpers/format-currency.ts
@@ -1,7 +1,9 @@
-const formatCurrency = (number: number, currencyCode: string): string =>
+const formatCurrency = (number: number, currencyCode: string, decimalPoints: number): string =>
   number.toLocaleString('en', {
     style: 'currency',
     currency: currencyCode,
+    minimumFractionDigits: decimalPoints,
+    maximumFractionDigits: decimalPoints,
   });
 
 export default formatCurrency;


### PR DESCRIPTION
Also includes adding `decimalPoints`param to `format-currency` for  `minimumFractionDigits` and `maximumFractionDigits.