### PR TITLE
feat/EMS-302: update pricing grid. Do not use policy length in multi policy calculation

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-multi-policy.spec.js
@@ -120,7 +120,7 @@ context('Get a quote/your quote page (multi policy) - as an exporter, I want to 
         });
 
         row.value().invoke('text').then((text) => {
-          const expected = '3.16%';
+          const expected = '1.15%';
 
           expect(text.trim()).equal(expected);
         });
@@ -137,7 +137,7 @@ context('Get a quote/your quote page (multi policy) - as an exporter, I want to 
         });
 
         row.value().invoke('text').then((text) => {
-          const expected = '£4,740.00';
+          const expected = '£1,725.00';
 
           expect(text.trim()).equal(expected);
         });

--- a/src/ui/server/generate-quote/get-premium-rate/get-premium-rate-multi-policy-high-risk.test.ts
+++ b/src/ui/server/generate-quote/get-premium-rate/get-premium-rate-multi-policy-high-risk.test.ts
@@ -3,12 +3,6 @@ import { API, FIELD_VALUES } from '../../constants';
 
 const highRisk2Months = getAvailableCover('MULTI_POLICY', 'HIGH', 2);
 const highRisk3Months = getAvailableCover('MULTI_POLICY', 'HIGH', 3);
-const highRisk4Months = getAvailableCover('MULTI_POLICY', 'HIGH', 4);
-const highRisk5Months = getAvailableCover('MULTI_POLICY', 'HIGH', 5);
-const highRisk6Months = getAvailableCover('MULTI_POLICY', 'HIGH', 6);
-const highRisk7Months = getAvailableCover('MULTI_POLICY', 'HIGH', 7);
-const highRisk8Months = getAvailableCover('MULTI_POLICY', 'HIGH', 8);
-const highRisk9Months = getAvailableCover('MULTI_POLICY', 'HIGH', 9);
 
 describe('server/generate-quote/get-premium-rate', () => {
   const mockBase = {
@@ -21,16 +15,16 @@ describe('server/generate-quote/get-premium-rate', () => {
     const mock = {
       ...mockBase,
       riskCategory,
-      policyLengthInMonths: 2,
+      creditPeriodInMonths: 1,
     };
 
-    describe('2 months policy length', () => {
+    describe('1 month credit period', () => {
       beforeEach(() => {
-        mock.policyLengthInMonths = 2;
+        mock.creditPeriodInMonths = 1;
       });
 
       it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
+        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.creditPeriodInMonths + 1, mock.insuredFor);
 
         expect(result).toEqual(expected);
 
@@ -40,113 +34,17 @@ describe('server/generate-quote/get-premium-rate', () => {
       });
     });
 
-    describe('3 months policy length', () => {
+    describe('2 months credit period', () => {
       beforeEach(() => {
-        mock.policyLengthInMonths = 3;
+        mock.creditPeriodInMonths = 2;
       });
 
       it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
+        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.creditPeriodInMonths + 1, mock.insuredFor);
 
         expect(result).toEqual(expected);
 
         const manualDataCheck = highRisk3Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('4 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 4;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = highRisk4Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('5 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 5;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = highRisk5Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('6 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 6;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = highRisk6Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('7 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 7;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = highRisk7Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('8 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 8;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = highRisk8Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('9 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 9;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = highRisk9Months.rates[0].premiumRate;
 
         expect(result).toEqual(manualDataCheck);
       });

--- a/src/ui/server/generate-quote/get-premium-rate/get-premium-rate-multi-policy-standard-risk.test.ts
+++ b/src/ui/server/generate-quote/get-premium-rate/get-premium-rate-multi-policy-standard-risk.test.ts
@@ -3,12 +3,6 @@ import { API, FIELD_VALUES } from '../../constants';
 
 const standardRisk2Months = getAvailableCover('MULTI_POLICY', 'STANDARD', 2);
 const standardRisk3Months = getAvailableCover('MULTI_POLICY', 'STANDARD', 3);
-const standardRisk4Months = getAvailableCover('MULTI_POLICY', 'STANDARD', 4);
-const standardRisk5Months = getAvailableCover('MULTI_POLICY', 'STANDARD', 5);
-const standardRisk6Months = getAvailableCover('MULTI_POLICY', 'STANDARD', 6);
-const standardRisk7Months = getAvailableCover('MULTI_POLICY', 'STANDARD', 7);
-const standardRisk8Months = getAvailableCover('MULTI_POLICY', 'STANDARD', 8);
-const standardRisk9Months = getAvailableCover('MULTI_POLICY', 'STANDARD', 9);
 
 describe('server/generate-quote/get-premium-rate', () => {
   const mockBase = {
@@ -21,16 +15,16 @@ describe('server/generate-quote/get-premium-rate', () => {
     const mock = {
       ...mockBase,
       riskCategory,
-      policyLengthInMonths: 2,
+      creditPeriodInMonths: 1,
     };
 
-    describe('2 months policy length', () => {
+    describe('1 month credit period', () => {
       beforeEach(() => {
-        mock.policyLengthInMonths = 2;
+        mock.creditPeriodInMonths = 1;
       });
 
       it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
+        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.creditPeriodInMonths + 1, mock.insuredFor);
 
         expect(result).toEqual(expected);
 
@@ -40,113 +34,17 @@ describe('server/generate-quote/get-premium-rate', () => {
       });
     });
 
-    describe('3 months policy length', () => {
+    describe('2 months credit period', () => {
       beforeEach(() => {
-        mock.policyLengthInMonths = 3;
+        mock.creditPeriodInMonths = 2;
       });
 
       it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
+        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.creditPeriodInMonths + 1, mock.insuredFor);
 
         expect(result).toEqual(expected);
 
         const manualDataCheck = standardRisk3Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('4 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 4;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = standardRisk4Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('5 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 5;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = standardRisk5Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('6 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 6;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = standardRisk6Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('7 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 7;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = standardRisk7Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('8 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 8;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = standardRisk8Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('9 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 9;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = standardRisk9Months.rates[0].premiumRate;
 
         expect(result).toEqual(manualDataCheck);
       });

--- a/src/ui/server/generate-quote/get-premium-rate/get-premium-rate-multi-policy-very-high-risk.test.ts
+++ b/src/ui/server/generate-quote/get-premium-rate/get-premium-rate-multi-policy-very-high-risk.test.ts
@@ -3,12 +3,6 @@ import { API, FIELD_VALUES } from '../../constants';
 
 const veryHighRisk2Months = getAvailableCover('MULTI_POLICY', 'VERY_HIGH', 2);
 const veryHighRisk3Months = getAvailableCover('MULTI_POLICY', 'VERY_HIGH', 3);
-const veryHighRisk4Months = getAvailableCover('MULTI_POLICY', 'VERY_HIGH', 4);
-const veryHighRisk5Months = getAvailableCover('MULTI_POLICY', 'VERY_HIGH', 5);
-const veryHighRisk6Months = getAvailableCover('MULTI_POLICY', 'VERY_HIGH', 6);
-const veryHighRisk7Months = getAvailableCover('MULTI_POLICY', 'VERY_HIGH', 7);
-const veryHighRisk8Months = getAvailableCover('MULTI_POLICY', 'VERY_HIGH', 8);
-const veryHighRisk9Months = getAvailableCover('MULTI_POLICY', 'VERY_HIGH', 9);
 
 describe('server/generate-quote/get-premium-rate', () => {
   const mockBase = {
@@ -21,16 +15,16 @@ describe('server/generate-quote/get-premium-rate', () => {
     const mock = {
       ...mockBase,
       riskCategory,
-      policyLengthInMonths: 2,
+      creditPeriodInMonths: 1,
     };
 
-    describe('2 months policy length', () => {
+    describe('1 month credit period', () => {
       beforeEach(() => {
-        mock.policyLengthInMonths = 2;
+        mock.creditPeriodInMonths = 1;
       });
 
       it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
+        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.creditPeriodInMonths + 1, mock.insuredFor);
 
         expect(result).toEqual(expected);
 
@@ -40,113 +34,17 @@ describe('server/generate-quote/get-premium-rate', () => {
       });
     });
 
-    describe('3 months policy length', () => {
+    describe('2 months credit period', () => {
       beforeEach(() => {
-        mock.policyLengthInMonths = 3;
+        mock.creditPeriodInMonths = 2;
       });
 
       it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
+        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.creditPeriodInMonths + 1, mock.insuredFor);
 
         expect(result).toEqual(expected);
 
         const manualDataCheck = veryHighRisk3Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('4 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 4;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = veryHighRisk4Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('5 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 5;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = veryHighRisk5Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('6 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 6;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = veryHighRisk6Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('7 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 7;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = veryHighRisk7Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('8 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 8;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = veryHighRisk8Months.rates[0].premiumRate;
-
-        expect(result).toEqual(manualDataCheck);
-      });
-    });
-
-    describe('9 months policy length', () => {
-      beforeEach(() => {
-        mock.policyLengthInMonths = 9;
-      });
-
-      it('should return a premium rate from pricing grid', () => {
-        const { result, expected } = getResultAndExpected(mock.policyType, mock.riskCategory, mock.policyLengthInMonths, mock.insuredFor);
-
-        expect(result).toEqual(expected);
-
-        const manualDataCheck = veryHighRisk9Months.rates[0].premiumRate;
 
         expect(result).toEqual(manualDataCheck);
       });

--- a/src/ui/server/generate-quote/get-premium-rate/index.test.ts
+++ b/src/ui/server/generate-quote/get-premium-rate/index.test.ts
@@ -3,13 +3,13 @@ import { API, FIELD_VALUES } from '../../constants';
 import PRICING_GRID from '../pricing-grid.json';
 import { PricingGridMonth, PricingGridRate } from '../../../types';
 
-const expectedPremiumRate = (policyType: string, riskCategory: string, policyLengthInMonths: number, insuredFor: number) => {
+const expectedPremiumRate = (policyType: string, riskCategory: string, totalMonths: number, insuredFor: number) => {
   const mappedPolicyType = PRICING_GRID_MAP.POLICY_TYPE[policyType];
   const mappedRiskCategory = PRICING_GRID_MAP.RISK_CATEGORY[riskCategory];
 
   const risk = PRICING_GRID[mappedPolicyType][mappedRiskCategory];
 
-  const expectedMonth = risk.find((month: PricingGridMonth) => month.months === policyLengthInMonths);
+  const expectedMonth = risk.find((month: PricingGridMonth) => month.months === totalMonths);
 
   const expectedRateObj = expectedMonth.rates.find((rate: PricingGridRate) => rate.insuredFor === insuredFor);
 

--- a/src/ui/server/generate-quote/index.test.ts
+++ b/src/ui/server/generate-quote/index.test.ts
@@ -102,12 +102,12 @@ describe('server/generate-quote/index', () => {
     describe('when policy type is multi', () => {
       it('should return the total of credit period + policy length + business buffer months', () => {
         const mockPolicyType = FIELD_VALUES.POLICY_TYPE.MULTI;
-        const mockPolicyLength = 6;
+        const mockPolicyLength = FIELD_VALUES.POLICY_LENGTH.MULTI;
         const mockCreditPeriod = 2;
 
         const result = getTotalMonths(mockPolicyType, mockPolicyLength, mockCreditPeriod);
 
-        const expected = mockPolicyLength + mockCreditPeriod + 1;
+        const expected = mockCreditPeriod + 1;
 
         expect(result).toEqual(expected);
       });

--- a/src/ui/server/generate-quote/index.ts
+++ b/src/ui/server/generate-quote/index.ts
@@ -50,9 +50,14 @@ const getInsuredFor = (submittedData: SubmittedData): number => {
  * getTotalMonths
  * Business requirement:
  * The premium rate (obtained via the grid) should select a month that is the total of:
- * - policy length
- * - and additional months for business buffer
- * If the policy type is multi, credit period is also included.
+ * - If policy type is single:
+ *   - policy length
+ *   - an additional month for business buffer
+ * - If the policy type is multi:
+ *   - credit period
+ *   - an additional month for business buffer
+ *   - Note: the policy length is not used for a multi policy
+ *     - the multi policy length default is 12 months. The grid only goes up to 3 months.
  * @param {String} Policy type
  * @param {Number} Policy length
  * @param {Number} Credit period
@@ -68,7 +73,7 @@ const getTotalMonths = (policyType: string, policyLength: number, creditPeriod =
   }
 
   if (isMultiPolicyType(policyType)) {
-    const totalMonths = policyLength + creditPeriod + BUSINESS_BUFFER_MONTHS;
+    const totalMonths = creditPeriod + BUSINESS_BUFFER_MONTHS;
 
     return totalMonths;
   }

--- a/src/ui/server/generate-quote/pricing-grid.json
+++ b/src/ui/server/generate-quote/pricing-grid.json
@@ -4,243 +4,639 @@
       {
         "months": 2,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 0.69 },
-          { "insuredFor": 75, "premiumRate": 0.74 },
-          { "insuredFor": 80, "premiumRate": 0.79 },
-          { "insuredFor": 85, "premiumRate": 0.84 },
-          { "insuredFor": 90, "premiumRate": 0.89 },
-          { "insuredFor": 95, "premiumRate": 0.94 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 0.69
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 0.74
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 0.79
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 0.84
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 0.89
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 0.94
+          }
         ]
       },
       {
         "months": 3,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 0.81 },
-          { "insuredFor": 75, "premiumRate": 0.86 },
-          { "insuredFor": 80, "premiumRate": 0.92 },
-          { "insuredFor": 85, "premiumRate": 0.98 },
-          { "insuredFor": 90, "premiumRate": 1.03 },
-          { "insuredFor": 95, "premiumRate": 1.09 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 0.81
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 0.86
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 0.92
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 0.98
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.03
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.09
+          }
         ]
       },
       {
         "months": 4,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 0.92 },
-          { "insuredFor": 75, "premiumRate": 0.98 },
-          { "insuredFor": 80, "premiumRate": 1.05 },
-          { "insuredFor": 85, "premiumRate": 1.12 },
-          { "insuredFor": 90, "premiumRate": 1.18 },
-          { "insuredFor": 95, "premiumRate": 1.25 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 0.92
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 0.98
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.05
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.12
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.18
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.25
+          }
         ]
       },
       {
         "months": 5,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.03 },
-          { "insuredFor": 75, "premiumRate": 1.11 },
-          { "insuredFor": 80, "premiumRate": 1.18 },
-          { "insuredFor": 85, "premiumRate": 1.25 },
-          { "insuredFor": 90, "premiumRate": 1.33 },
-          { "insuredFor": 95, "premiumRate": 1.4 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.03
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.11
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.18
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.25
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.33
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.4
+          }
         ]
       },
       {
         "months": 6,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.15 },
-          { "insuredFor": 75, "premiumRate": 1.23 },
-          { "insuredFor": 80, "premiumRate": 1.31 },
-          { "insuredFor": 85, "premiumRate": 1.39 },
-          { "insuredFor": 90, "premiumRate": 1.47 },
-          { "insuredFor": 95, "premiumRate": 1.56 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.15
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.23
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.31
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.39
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.47
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.56
+          }
         ]
       },
       {
         "months": 7,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.26 },
-          { "insuredFor": 75, "premiumRate": 1.35 },
-          { "insuredFor": 80, "premiumRate": 1.44 },
-          { "insuredFor": 85, "premiumRate": 1.53 },
-          { "insuredFor": 90, "premiumRate": 1.62 },
-          { "insuredFor": 95, "premiumRate": 1.71 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.26
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.35
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.44
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.53
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.62
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.71
+          }
         ]
       },
       {
         "months": 8,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.38 },
-          { "insuredFor": 75, "premiumRate": 1.47 },
-          { "insuredFor": 80, "premiumRate": 1.57 },
-          { "insuredFor": 85, "premiumRate": 1.67 },
-          { "insuredFor": 90, "premiumRate": 1.77 },
-          { "insuredFor": 95, "premiumRate": 1.87 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.38
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.47
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.57
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.67
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.77
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.87
+          }
         ]
       },
       {
         "months": 9,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.49 },
-          { "insuredFor": 75, "premiumRate": 1.6 },
-          { "insuredFor": 80, "premiumRate": 1.7 },
-          { "insuredFor": 85, "premiumRate": 1.81 },
-          { "insuredFor": 90, "premiumRate": 1.92 },
-          { "insuredFor": 95, "premiumRate": 2.02 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.49
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.6
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.7
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.81
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.92
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.02
+          }
         ]
       },
       {
         "months": 10,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.61 },
-          { "insuredFor": 75, "premiumRate": 1.72 },
-          { "insuredFor": 80, "premiumRate": 1.83 },
-          { "insuredFor": 85, "premiumRate": 1.95 },
-          { "insuredFor": 90, "premiumRate": 2.06 },
-          { "insuredFor": 95, "premiumRate": 2.18 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.61
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.72
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.83
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.95
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.06
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.18
+          }
         ]
       },
       {
         "months": 11,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.72 },
-          { "insuredFor": 75, "premiumRate": 1.84 },
-          { "insuredFor": 80, "premiumRate": 1.96 },
-          { "insuredFor": 85, "premiumRate": 2.09 },
-          { "insuredFor": 90, "premiumRate": 2.21 },
-          { "insuredFor": 95, "premiumRate": 2.33 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.72
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.84
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.96
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.09
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.21
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.33
+          }
         ]
       },
       {
         "months": 12,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.83 },
-          { "insuredFor": 75, "premiumRate": 1.96 },
-          { "insuredFor": 80, "premiumRate": 2.1 },
-          { "insuredFor": 85, "premiumRate": 2.23 },
-          { "insuredFor": 90, "premiumRate": 2.36 },
-          { "insuredFor": 95, "premiumRate": 2.49 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.83
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.96
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.1
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.23
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.36
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.49
+          }
         ]
       },
       {
         "months": 13,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.95 },
-          { "insuredFor": 75, "premiumRate": 2.09 },
-          { "insuredFor": 80, "premiumRate": 2.23 },
-          { "insuredFor": 85, "premiumRate": 2.36 },
-          { "insuredFor": 90, "premiumRate": 2.5 },
-          { "insuredFor": 95, "premiumRate": 2.64 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.95
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.09
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.23
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.36
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.5
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.64
+          }
         ]
       },
       {
         "months": 14,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.06 },
-          { "insuredFor": 75, "premiumRate": 2.21 },
-          { "insuredFor": 80, "premiumRate": 2.35 },
-          { "insuredFor": 85, "premiumRate": 2.5 },
-          { "insuredFor": 90, "premiumRate": 2.65 },
-          { "insuredFor": 95, "premiumRate": 2.79 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.06
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.21
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.35
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.5
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.65
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.79
+          }
         ]
       },
       {
         "months": 15,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.17 },
-          { "insuredFor": 75, "premiumRate": 2.32 },
-          { "insuredFor": 80, "premiumRate": 2.48 },
-          { "insuredFor": 85, "premiumRate": 2.63 },
-          { "insuredFor": 90, "premiumRate": 2.79 },
-          { "insuredFor": 95, "premiumRate": 2.94 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.17
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.32
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.48
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.63
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.79
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.94
+          }
         ]
       },
       {
         "months": 16,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.27 },
-          { "insuredFor": 75, "premiumRate": 2.44 },
-          { "insuredFor": 80, "premiumRate": 2.6 },
-          { "insuredFor": 85, "premiumRate": 2.76 },
-          { "insuredFor": 90, "premiumRate": 2.92 },
-          { "insuredFor": 95, "premiumRate": 3.09 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.27
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.44
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.6
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.76
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.92
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.09
+          }
         ]
       },
       {
         "months": 17,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.38 },
-          { "insuredFor": 75, "premiumRate": 2.55 },
-          { "insuredFor": 80, "premiumRate": 2.72 },
-          { "insuredFor": 85, "premiumRate": 2.89 },
-          { "insuredFor": 90, "premiumRate": 3.06 },
-          { "insuredFor": 95, "premiumRate": 3.23 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.38
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.55
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.72
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.89
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.06
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.23
+          }
         ]
       },
       {
         "months": 18,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.48 },
-          { "insuredFor": 75, "premiumRate": 2.66 },
-          { "insuredFor": 80, "premiumRate": 2.84 },
-          { "insuredFor": 85, "premiumRate": 3.01 },
-          { "insuredFor": 90, "premiumRate": 3.19 },
-          { "insuredFor": 95, "premiumRate": 3.37 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.48
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.66
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.84
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.01
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.19
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.37
+          }
         ]
       },
       {
         "months": 19,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.58 },
-          { "insuredFor": 75, "premiumRate": 2.77 },
-          { "insuredFor": 80, "premiumRate": 2.95 },
-          { "insuredFor": 85, "premiumRate": 3.14 },
-          { "insuredFor": 90, "premiumRate": 3.32 },
-          { "insuredFor": 95, "premiumRate": 3.5 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.58
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.77
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.95
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.14
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.32
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.5
+          }
         ]
       },
       {
         "months": 20,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.68 },
-          { "insuredFor": 75, "premiumRate": 2.87 },
-          { "insuredFor": 80, "premiumRate": 3.06 },
-          { "insuredFor": 85, "premiumRate": 3.25 },
-          { "insuredFor": 90, "premiumRate": 3.45 },
-          { "insuredFor": 95, "premiumRate": 3.64 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.68
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.87
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 3.06
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.25
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.45
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.64
+          }
         ]
       },
       {
         "months": 21,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.78 },
-          { "insuredFor": 75, "premiumRate": 2.98 },
-          { "insuredFor": 80, "premiumRate": 3.17 },
-          { "insuredFor": 85, "premiumRate": 3.37 },
-          { "insuredFor": 90, "premiumRate": 3.57 },
-          { "insuredFor": 95, "premiumRate": 3.77 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.78
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.98
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 3.17
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.37
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.57
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.77
+          }
         ]
       },
       {
         "months": 22,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.87 },
-          { "insuredFor": 75, "premiumRate": 3.08 },
-          { "insuredFor": 80, "premiumRate": 3.28 },
-          { "insuredFor": 85, "premiumRate": 3.49 },
-          { "insuredFor": 90, "premiumRate": 3.69 },
-          { "insuredFor": 95, "premiumRate": 3.9 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.87
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 3.08
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 3.28
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.49
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.69
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.9
+          }
         ]
       },
       {
         "months": 23,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.96 },
-          { "insuredFor": 75, "premiumRate": 3.18 },
-          { "insuredFor": 80, "premiumRate": 3.39 },
-          { "insuredFor": 85, "premiumRate": 3.6 },
-          { "insuredFor": 90, "premiumRate": 3.81 },
-          { "insuredFor": 95, "premiumRate": 4.02 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.96
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 3.18
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 3.39
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.6
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.81
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 4.02
+          }
         ]
       }
     ],
@@ -248,243 +644,639 @@
       {
         "months": 2,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 0.87 },
-          { "insuredFor": 75, "premiumRate": 0.94 },
-          { "insuredFor": 80, "premiumRate": 1 },
-          { "insuredFor": 85, "premiumRate": 1.06 },
-          { "insuredFor": 90, "premiumRate": 1.12 },
-          { "insuredFor": 95, "premiumRate": 1.18 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 0.87
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 0.94
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.06
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.12
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.18
+          }
         ]
       },
       {
         "months": 3,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.02 },
-          { "insuredFor": 75, "premiumRate": 1.09 },
-          { "insuredFor": 80, "premiumRate": 1.16 },
-          { "insuredFor": 85, "premiumRate": 1.24 },
-          { "insuredFor": 90, "premiumRate": 1.31 },
-          { "insuredFor": 95, "premiumRate": 1.38 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.02
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.09
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.16
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.24
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.31
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.38
+          }
         ]
       },
       {
         "months": 4,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.16 },
-          { "insuredFor": 75, "premiumRate": 1.25 },
-          { "insuredFor": 80, "premiumRate": 1.33 },
-          { "insuredFor": 85, "premiumRate": 1.41 },
-          { "insuredFor": 90, "premiumRate": 1.49 },
-          { "insuredFor": 95, "premiumRate": 1.58 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.16
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.25
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.33
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.41
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.49
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.58
+          }
         ]
       },
       {
         "months": 5,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.31 },
-          { "insuredFor": 75, "premiumRate": 1.4 },
-          { "insuredFor": 80, "premiumRate": 1.49 },
-          { "insuredFor": 85, "premiumRate": 1.59 },
-          { "insuredFor": 90, "premiumRate": 1.68 },
-          { "insuredFor": 95, "premiumRate": 1.77 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.31
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.4
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.49
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.59
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.68
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.77
+          }
         ]
       },
       {
         "months": 6,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.45 },
-          { "insuredFor": 75, "premiumRate": 1.56 },
-          { "insuredFor": 80, "premiumRate": 1.66 },
-          { "insuredFor": 85, "premiumRate": 1.76 },
-          { "insuredFor": 90, "premiumRate": 1.87 },
-          { "insuredFor": 95, "premiumRate": 1.97 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.45
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.56
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.66
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.76
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.87
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.97
+          }
         ]
       },
       {
         "months": 7,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.6 },
-          { "insuredFor": 75, "premiumRate": 1.71 },
-          { "insuredFor": 80, "premiumRate": 1.83 },
-          { "insuredFor": 85, "premiumRate": 1.94 },
-          { "insuredFor": 90, "premiumRate": 2.05 },
-          { "insuredFor": 95, "premiumRate": 2.17 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.6
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.71
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.83
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.94
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.05
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.17
+          }
         ]
       },
       {
         "months": 8,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.74 },
-          { "insuredFor": 75, "premiumRate": 1.87 },
-          { "insuredFor": 80, "premiumRate": 1.99 },
-          { "insuredFor": 85, "premiumRate": 2.12 },
-          { "insuredFor": 90, "premiumRate": 2.24 },
-          { "insuredFor": 95, "premiumRate": 2.36 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.74
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.87
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.99
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.12
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.24
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.36
+          }
         ]
       },
       {
         "months": 9,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.89 },
-          { "insuredFor": 75, "premiumRate": 2.02 },
-          { "insuredFor": 80, "premiumRate": 2.16 },
-          { "insuredFor": 85, "premiumRate": 2.29 },
-          { "insuredFor": 90, "premiumRate": 2.43 },
-          { "insuredFor": 95, "premiumRate": 2.56 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.89
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.02
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.16
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.29
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.43
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.56
+          }
         ]
       },
       {
         "months": 10,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.03 },
-          { "insuredFor": 75, "premiumRate": 2.18 },
-          { "insuredFor": 80, "premiumRate": 2.32 },
-          { "insuredFor": 85, "premiumRate": 2.47 },
-          { "insuredFor": 90, "premiumRate": 2.61 },
-          { "insuredFor": 95, "premiumRate": 2.76 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.03
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.18
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.32
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.47
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.61
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.76
+          }
         ]
       },
       {
         "months": 11,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.18 },
-          { "insuredFor": 75, "premiumRate": 2.33 },
-          { "insuredFor": 80, "premiumRate": 2.49 },
-          { "insuredFor": 85, "premiumRate": 2.64 },
-          { "insuredFor": 90, "premiumRate": 2.8 },
-          { "insuredFor": 95, "premiumRate": 2.95 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.18
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.33
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.49
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.64
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.8
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.95
+          }
         ]
       },
       {
         "months": 12,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.32 },
-          { "insuredFor": 75, "premiumRate": 2.49 },
-          { "insuredFor": 80, "premiumRate": 2.65 },
-          { "insuredFor": 85, "premiumRate": 2.82 },
-          { "insuredFor": 90, "premiumRate": 2.98 },
-          { "insuredFor": 95, "premiumRate": 3.15 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.32
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.49
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.65
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.82
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.98
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.15
+          }
         ]
       },
       {
         "months": 13,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.47 },
-          { "insuredFor": 75, "premiumRate": 2.64 },
-          { "insuredFor": 80, "premiumRate": 2.82 },
-          { "insuredFor": 85, "premiumRate": 2.99 },
-          { "insuredFor": 90, "premiumRate": 3.17 },
-          { "insuredFor": 95, "premiumRate": 3.34 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.47
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.64
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.82
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.99
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.17
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.34
+          }
         ]
       },
       {
         "months": 14,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.61 },
-          { "insuredFor": 75, "premiumRate": 2.79 },
-          { "insuredFor": 80, "premiumRate": 2.98 },
-          { "insuredFor": 85, "premiumRate": 3.16 },
-          { "insuredFor": 90, "premiumRate": 3.35 },
-          { "insuredFor": 95, "premiumRate": 3.54 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.61
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.79
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.98
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.16
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.35
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.54
+          }
         ]
       },
       {
         "months": 15,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.74 },
-          { "insuredFor": 75, "premiumRate": 2.94 },
-          { "insuredFor": 80, "premiumRate": 3.14 },
-          { "insuredFor": 85, "premiumRate": 3.33 },
-          { "insuredFor": 90, "premiumRate": 3.53 },
-          { "insuredFor": 95, "premiumRate": 3.72 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.74
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.94
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 3.14
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.33
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.53
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.72
+          }
         ]
       },
       {
         "months": 16,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.88 },
-          { "insuredFor": 75, "premiumRate": 3.09 },
-          { "insuredFor": 80, "premiumRate": 3.29 },
-          { "insuredFor": 85, "premiumRate": 3.5 },
-          { "insuredFor": 90, "premiumRate": 3.7 },
-          { "insuredFor": 95, "premiumRate": 3.91 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.88
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 3.09
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 3.29
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.5
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.7
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.91
+          }
         ]
       },
       {
         "months": 17,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 3.01 },
-          { "insuredFor": 75, "premiumRate": 3.23 },
-          { "insuredFor": 80, "premiumRate": 3.44 },
-          { "insuredFor": 85, "premiumRate": 3.66 },
-          { "insuredFor": 90, "premiumRate": 3.87 },
-          { "insuredFor": 95, "premiumRate": 4.09 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 3.01
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 3.23
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 3.44
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.66
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.87
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 4.09
+          }
         ]
       },
       {
         "months": 18,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 3.14 },
-          { "insuredFor": 75, "premiumRate": 3.37 },
-          { "insuredFor": 80, "premiumRate": 3.59 },
-          { "insuredFor": 85, "premiumRate": 3.82 },
-          { "insuredFor": 90, "premiumRate": 4.04 },
-          { "insuredFor": 95, "premiumRate": 4.26 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 3.14
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 3.37
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 3.59
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.82
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 4.04
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 4.26
+          }
         ]
       },
       {
         "months": 19,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 3.27 },
-          { "insuredFor": 75, "premiumRate": 3.5 },
-          { "insuredFor": 80, "premiumRate": 3.74 },
-          { "insuredFor": 85, "premiumRate": 3.97 },
-          { "insuredFor": 90, "premiumRate": 4.2 },
-          { "insuredFor": 95, "premiumRate": 4.44 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 3.27
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 3.5
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 3.74
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.97
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 4.2
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 4.44
+          }
         ]
       },
       {
         "months": 20,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 3.39 },
-          { "insuredFor": 75, "premiumRate": 3.64 },
-          { "insuredFor": 80, "premiumRate": 3.88 },
-          { "insuredFor": 85, "premiumRate": 4.12 },
-          { "insuredFor": 90, "premiumRate": 4.36 },
-          { "insuredFor": 95, "premiumRate": 4.61 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 3.39
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 3.64
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 3.88
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 4.12
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 4.36
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 4.61
+          }
         ]
       },
       {
         "months": 21,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 3.52 },
-          { "insuredFor": 75, "premiumRate": 3.77 },
-          { "insuredFor": 80, "premiumRate": 4.02 },
-          { "insuredFor": 85, "premiumRate": 4.27 },
-          { "insuredFor": 90, "premiumRate": 4.52 },
-          { "insuredFor": 95, "premiumRate": 4.77 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 3.52
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 3.77
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 4.02
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 4.27
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 4.52
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 4.77
+          }
         ]
       },
       {
         "months": 22,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 3.64 },
-          { "insuredFor": 75, "premiumRate": 3.9 },
-          { "insuredFor": 80, "premiumRate": 4.15 },
-          { "insuredFor": 85, "premiumRate": 4.41 },
-          { "insuredFor": 90, "premiumRate": 4.67 },
-          { "insuredFor": 95, "premiumRate": 4.93 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 3.64
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 3.9
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 4.15
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 4.41
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 4.67
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 4.93
+          }
         ]
       },
       {
         "months": 23,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 3.75 },
-          { "insuredFor": 75, "premiumRate": 4.02 },
-          { "insuredFor": 80, "premiumRate": 4.29 },
-          { "insuredFor": 85, "premiumRate": 4.56 },
-          { "insuredFor": 90, "premiumRate": 4.82 },
-          { "insuredFor": 95, "premiumRate": 5.09 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 3.75
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 4.02
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 4.29
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 4.56
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 4.82
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 5.09
+          }
         ]
       }
     ],
@@ -492,243 +1284,639 @@
       {
         "months": 2,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.24 },
-          { "insuredFor": 75, "premiumRate": 1.33 },
-          { "insuredFor": 80, "premiumRate": 1.42 },
-          { "insuredFor": 85, "premiumRate": 1.51 },
-          { "insuredFor": 90, "premiumRate": 1.6 },
-          { "insuredFor": 95, "premiumRate": 1.69 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.24
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.33
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.42
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.51
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.6
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.69
+          }
         ]
       },
       {
         "months": 3,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.45 },
-          { "insuredFor": 75, "premiumRate": 1.55 },
-          { "insuredFor": 80, "premiumRate": 1.66 },
-          { "insuredFor": 85, "premiumRate": 1.76 },
-          { "insuredFor": 90, "premiumRate": 1.86 },
-          { "insuredFor": 95, "premiumRate": 1.97 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.45
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.55
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.66
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.76
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.86
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.97
+          }
         ]
       },
       {
         "months": 4,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.66 },
-          { "insuredFor": 75, "premiumRate": 1.78 },
-          { "insuredFor": 80, "premiumRate": 1.89 },
-          { "insuredFor": 85, "premiumRate": 2.01 },
-          { "insuredFor": 90, "premiumRate": 2.13 },
-          { "insuredFor": 95, "premiumRate": 2.25 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.66
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.78
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.89
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.01
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.13
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.25
+          }
         ]
       },
       {
         "months": 5,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.86 },
-          { "insuredFor": 75, "premiumRate": 2 },
-          { "insuredFor": 80, "premiumRate": 2.13 },
-          { "insuredFor": 85, "premiumRate": 2.26 },
-          { "insuredFor": 90, "premiumRate": 2.4 },
-          { "insuredFor": 95, "premiumRate": 2.53 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.86
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.13
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.26
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.4
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.53
+          }
         ]
       },
       {
         "months": 6,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.07 },
-          { "insuredFor": 75, "premiumRate": 2.22 },
-          { "insuredFor": 80, "premiumRate": 2.37 },
-          { "insuredFor": 85, "premiumRate": 2.51 },
-          { "insuredFor": 90, "premiumRate": 2.66 },
-          { "insuredFor": 95, "premiumRate": 2.81 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.07
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.22
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.37
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.51
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.66
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.81
+          }
         ]
       },
       {
         "months": 7,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.28 },
-          { "insuredFor": 75, "premiumRate": 2.44 },
-          { "insuredFor": 80, "premiumRate": 2.6 },
-          { "insuredFor": 85, "premiumRate": 2.76 },
-          { "insuredFor": 90, "premiumRate": 2.93 },
-          { "insuredFor": 95, "premiumRate": 3.09 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.28
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.44
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.6
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.76
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.93
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.09
+          }
         ]
       },
       {
         "months": 8,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.48 },
-          { "insuredFor": 75, "premiumRate": 2.66 },
-          { "insuredFor": 80, "premiumRate": 2.84 },
-          { "insuredFor": 85, "premiumRate": 3.02 },
-          { "insuredFor": 90, "premiumRate": 3.19 },
-          { "insuredFor": 95, "premiumRate": 3.37 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.48
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.66
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.84
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.02
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.19
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.37
+          }
         ]
       },
       {
         "months": 9,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.69 },
-          { "insuredFor": 75, "premiumRate": 2.88 },
-          { "insuredFor": 80, "premiumRate": 3.07 },
-          { "insuredFor": 85, "premiumRate": 3.27 },
-          { "insuredFor": 90, "premiumRate": 3.46 },
-          { "insuredFor": 95, "premiumRate": 3.65 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.69
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 2.88
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 3.07
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.27
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.46
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.65
+          }
         ]
       },
       {
         "months": 10,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 2.9 },
-          { "insuredFor": 75, "premiumRate": 3.1 },
-          { "insuredFor": 80, "premiumRate": 3.31 },
-          { "insuredFor": 85, "premiumRate": 3.52 },
-          { "insuredFor": 90, "premiumRate": 3.72 },
-          { "insuredFor": 95, "premiumRate": 3.93 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 2.9
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 3.1
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 3.31
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.52
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.72
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 3.93
+          }
         ]
       },
       {
         "months": 11,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 3.1 },
-          { "insuredFor": 75, "premiumRate": 3.33 },
-          { "insuredFor": 80, "premiumRate": 3.55 },
-          { "insuredFor": 85, "premiumRate": 3.77 },
-          { "insuredFor": 90, "premiumRate": 3.99 },
-          { "insuredFor": 95, "premiumRate": 4.21 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 3.1
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 3.33
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 3.55
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 3.77
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 3.99
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 4.21
+          }
         ]
       },
       {
         "months": 12,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 3.31 },
-          { "insuredFor": 75, "premiumRate": 3.55 },
-          { "insuredFor": 80, "premiumRate": 3.78 },
-          { "insuredFor": 85, "premiumRate": 4.02 },
-          { "insuredFor": 90, "premiumRate": 4.26 },
-          { "insuredFor": 95, "premiumRate": 4.49 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 3.31
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 3.55
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 3.78
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 4.02
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 4.26
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 4.49
+          }
         ]
       },
       {
         "months": 13,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 3.52 },
-          { "insuredFor": 75, "premiumRate": 3.77 },
-          { "insuredFor": 80, "premiumRate": 4.02 },
-          { "insuredFor": 85, "premiumRate": 4.27 },
-          { "insuredFor": 90, "premiumRate": 4.52 },
-          { "insuredFor": 95, "premiumRate": 4.77 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 3.52
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 3.77
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 4.02
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 4.27
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 4.52
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 4.77
+          }
         ]
       },
       {
         "months": 14,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 3.72 },
-          { "insuredFor": 75, "premiumRate": 3.98 },
-          { "insuredFor": 80, "premiumRate": 4.25 },
-          { "insuredFor": 85, "premiumRate": 4.51 },
-          { "insuredFor": 90, "premiumRate": 4.78 },
-          { "insuredFor": 95, "premiumRate": 5.04 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 3.72
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 3.98
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 4.25
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 4.51
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 4.78
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 5.04
+          }
         ]
       },
       {
         "months": 15,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 3.91 },
-          { "insuredFor": 75, "premiumRate": 4.19 },
-          { "insuredFor": 80, "premiumRate": 4.47 },
-          { "insuredFor": 85, "premiumRate": 4.75 },
-          { "insuredFor": 90, "premiumRate": 5.03 },
-          { "insuredFor": 95, "premiumRate": 5.31 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 3.91
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 4.19
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 4.47
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 4.75
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 5.03
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 5.31
+          }
         ]
       },
       {
         "months": 16,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 4.11 },
-          { "insuredFor": 75, "premiumRate": 4.4 },
-          { "insuredFor": 80, "premiumRate": 4.69 },
-          { "insuredFor": 85, "premiumRate": 4.99 },
-          { "insuredFor": 90, "premiumRate": 5.28 },
-          { "insuredFor": 95, "premiumRate": 5.57 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 4.11
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 4.4
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 4.69
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 4.99
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 5.28
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 5.57
+          }
         ]
       },
       {
         "months": 17,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 4.3 },
-          { "insuredFor": 75, "premiumRate": 4.6 },
-          { "insuredFor": 80, "premiumRate": 4.91 },
-          { "insuredFor": 85, "premiumRate": 5.22 },
-          { "insuredFor": 90, "premiumRate": 5.52 },
-          { "insuredFor": 95, "premiumRate": 5.83 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 4.3
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 4.6
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 4.91
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 5.22
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 5.52
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 5.83
+          }
         ]
       },
       {
         "months": 18,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 4.48 },
-          { "insuredFor": 75, "premiumRate": 4.8 },
-          { "insuredFor": 80, "premiumRate": 5.12 },
-          { "insuredFor": 85, "premiumRate": 5.44 },
-          { "insuredFor": 90, "premiumRate": 5.76 },
-          { "insuredFor": 95, "premiumRate": 6.08 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 4.48
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 4.8
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 5.12
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 5.44
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 5.76
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 6.08
+          }
         ]
       },
       {
         "months": 19,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 4.66 },
-          { "insuredFor": 75, "premiumRate": 5 },
-          { "insuredFor": 80, "premiumRate": 5.33 },
-          { "insuredFor": 85, "premiumRate": 5.66 },
-          { "insuredFor": 90, "premiumRate": 5.99 },
-          { "insuredFor": 95, "premiumRate": 6.33 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 4.66
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 5
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 5.33
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 5.66
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 5.99
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 6.33
+          }
         ]
       },
       {
         "months": 20,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 4.84 },
-          { "insuredFor": 75, "premiumRate": 5.19 },
-          { "insuredFor": 80, "premiumRate": 5.53 },
-          { "insuredFor": 85, "premiumRate": 5.88 },
-          { "insuredFor": 90, "premiumRate": 6.22 },
-          { "insuredFor": 95, "premiumRate": 6.57 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 4.84
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 5.19
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 5.53
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 5.88
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 6.22
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 6.57
+          }
         ]
       },
       {
         "months": 21,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 5.02 },
-          { "insuredFor": 75, "premiumRate": 5.37 },
-          { "insuredFor": 80, "premiumRate": 5.73 },
-          { "insuredFor": 85, "premiumRate": 6.09 },
-          { "insuredFor": 90, "premiumRate": 6.45 },
-          { "insuredFor": 95, "premiumRate": 6.8 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 5.02
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 5.37
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 5.73
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 6.09
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 6.45
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 6.8
+          }
         ]
       },
       {
         "months": 22,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 5.19 },
-          { "insuredFor": 75, "premiumRate": 5.56 },
-          { "insuredFor": 80, "premiumRate": 5.93 },
-          { "insuredFor": 85, "premiumRate": 6.3 },
-          { "insuredFor": 90, "premiumRate": 6.67 },
-          { "insuredFor": 95, "premiumRate": 7.04 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 5.19
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 5.56
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 5.93
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 6.3
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 6.67
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 7.04
+          }
         ]
       },
       {
         "months": 23,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 5.35 },
-          { "insuredFor": 75, "premiumRate": 5.73 },
-          { "insuredFor": 80, "premiumRate": 6.12 },
-          { "insuredFor": 85, "premiumRate": 6.5 },
-          { "insuredFor": 90, "premiumRate": 6.88 },
-          { "insuredFor": 95, "premiumRate": 7.26 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 5.35
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 5.73
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 6.12
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 6.5
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 6.88
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 7.26
+          }
         ]
       }
     ]
@@ -738,155 +1926,59 @@
       {
         "months": 2,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 0.9 },
-          { "insuredFor": 75, "premiumRate": 0.96 },
-          { "insuredFor": 80, "premiumRate": 1.02 },
-          { "insuredFor": 85, "premiumRate": 1.09 },
-          { "insuredFor": 90, "premiumRate": 1.15 },
-          { "insuredFor": 95, "premiumRate": 1.21 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 0.9
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 0.96
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.02
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.09
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.15
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.21
+          }
         ]
       },
       {
         "months": 3,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.02 },
-          { "insuredFor": 75, "premiumRate": 1.09 },
-          { "insuredFor": 80, "premiumRate": 1.17 },
-          { "insuredFor": 85, "premiumRate": 1.24 },
-          { "insuredFor": 90, "premiumRate": 1.31 },
-          { "insuredFor": 95, "premiumRate": 1.38 }
-        ]
-      },
-      {
-        "months": 4,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 1.15 },
-          { "insuredFor": 75, "premiumRate": 1.23 },
-          { "insuredFor": 80, "premiumRate": 1.31 },
-          { "insuredFor": 85, "premiumRate": 1.39 },
-          { "insuredFor": 90, "premiumRate": 1.47 },
-          { "insuredFor": 95, "premiumRate": 1.55 }
-        ]
-      },
-      {
-        "months": 5,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 1.27 },
-          { "insuredFor": 75, "premiumRate": 1.36 },
-          { "insuredFor": 80, "premiumRate": 1.45 },
-          { "insuredFor": 85, "premiumRate": 1.54 },
-          { "insuredFor": 90, "premiumRate": 1.63 },
-          { "insuredFor": 95, "premiumRate": 1.72 }
-        ]
-      },
-      {
-        "months": 6,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 1.4 },
-          { "insuredFor": 75, "premiumRate": 1.5 },
-          { "insuredFor": 80, "premiumRate": 1.59 },
-          { "insuredFor": 85, "premiumRate": 1.69 },
-          { "insuredFor": 90, "premiumRate": 1.79 },
-          { "insuredFor": 95, "premiumRate": 1.89 }
-        ]
-      },
-      {
-        "months": 7,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 1.52 },
-          { "insuredFor": 75, "premiumRate": 1.63 },
-          { "insuredFor": 80, "premiumRate": 1.74 },
-          { "insuredFor": 85, "premiumRate": 1.85 },
-          { "insuredFor": 90, "premiumRate": 1.95 },
-          { "insuredFor": 95, "premiumRate": 2.06 }
-        ]
-      },
-      {
-        "months": 8,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 1.64 },
-          { "insuredFor": 75, "premiumRate": 1.76 },
-          { "insuredFor": 80, "premiumRate": 1.88 },
-          { "insuredFor": 85, "premiumRate": 2 },
-          { "insuredFor": 90, "premiumRate": 2.11 },
-          { "insuredFor": 95, "premiumRate": 2.23 }
-        ]
-      },
-      {
-        "months": 9,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 1.77 },
-          { "insuredFor": 75, "premiumRate": 1.89 },
-          { "insuredFor": 80, "premiumRate": 2.02 },
-          { "insuredFor": 85, "premiumRate": 2.15 },
-          { "insuredFor": 90, "premiumRate": 2.27 },
-          { "insuredFor": 95, "premiumRate": 2.4 }
-        ]
-      },
-      {
-        "months": 10,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 1.89 },
-          { "insuredFor": 75, "premiumRate": 2.03 },
-          { "insuredFor": 80, "premiumRate": 2.16 },
-          { "insuredFor": 85, "premiumRate": 2.3 },
-          { "insuredFor": 90, "premiumRate": 2.43 },
-          { "insuredFor": 95, "premiumRate": 2.57 }
-        ]
-      },
-      {
-        "months": 11,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.02 },
-          { "insuredFor": 75, "premiumRate": 2.16 },
-          { "insuredFor": 80, "premiumRate": 2.3 },
-          { "insuredFor": 85, "premiumRate": 2.45 },
-          { "insuredFor": 90, "premiumRate": 2.59 },
-          { "insuredFor": 95, "premiumRate": 2.73 }
-        ]
-      },
-      {
-        "months": 12,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.14 },
-          { "insuredFor": 75, "premiumRate": 2.29 },
-          { "insuredFor": 80, "premiumRate": 2.44 },
-          { "insuredFor": 85, "premiumRate": 2.6 },
-          { "insuredFor": 90, "premiumRate": 2.75 },
-          { "insuredFor": 95, "premiumRate": 2.9 }
-        ]
-      },
-      {
-        "months": 13,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.3 },
-          { "insuredFor": 75, "premiumRate": 2.46 },
-          { "insuredFor": 80, "premiumRate": 2.63 },
-          { "insuredFor": 85, "premiumRate": 2.79 },
-          { "insuredFor": 90, "premiumRate": 2.96 },
-          { "insuredFor": 95, "premiumRate": 3.12 }
-        ]
-      },
-      {
-        "months": 14,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.46 },
-          { "insuredFor": 75, "premiumRate": 2.64 },
-          { "insuredFor": 80, "premiumRate": 2.81 },
-          { "insuredFor": 85, "premiumRate": 2.99 },
-          { "insuredFor": 90, "premiumRate": 3.16 },
-          { "insuredFor": 95, "premiumRate": 3.34 }
-        ]
-      },
-      {
-        "months": 15,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.62 },
-          { "insuredFor": 75, "premiumRate": 2.81 },
-          { "insuredFor": 80, "premiumRate": 3 },
-          { "insuredFor": 85, "premiumRate": 3.18 },
-          { "insuredFor": 90, "premiumRate": 3.37 },
-          { "insuredFor": 95, "premiumRate": 3.56 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.02
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.09
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.17
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.24
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.31
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.38
+          }
         ]
       }
     ],
@@ -894,155 +1986,59 @@
       {
         "months": 2,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.13 },
-          { "insuredFor": 75, "premiumRate": 1.21 },
-          { "insuredFor": 80, "premiumRate": 1.3 },
-          { "insuredFor": 85, "premiumRate": 1.38 },
-          { "insuredFor": 90, "premiumRate": 1.46 },
-          { "insuredFor": 95, "premiumRate": 1.54 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.13
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.21
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.3
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.38
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.46
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.54
+          }
         ]
       },
       {
         "months": 3,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.29 },
-          { "insuredFor": 75, "premiumRate": 1.38 },
-          { "insuredFor": 80, "premiumRate": 1.48 },
-          { "insuredFor": 85, "premiumRate": 1.57 },
-          { "insuredFor": 90, "premiumRate": 1.66 },
-          { "insuredFor": 95, "premiumRate": 1.75 }
-        ]
-      },
-      {
-        "months": 4,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 1.45 },
-          { "insuredFor": 75, "premiumRate": 1.55 },
-          { "insuredFor": 80, "premiumRate": 1.66 },
-          { "insuredFor": 85, "premiumRate": 1.76 },
-          { "insuredFor": 90, "premiumRate": 1.86 },
-          { "insuredFor": 95, "premiumRate": 1.97 }
-        ]
-      },
-      {
-        "months": 5,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 1.61 },
-          { "insuredFor": 75, "premiumRate": 1.72 },
-          { "insuredFor": 80, "premiumRate": 1.84 },
-          { "insuredFor": 85, "premiumRate": 1.95 },
-          { "insuredFor": 90, "premiumRate": 2.07 },
-          { "insuredFor": 95, "premiumRate": 2.18 }
-        ]
-      },
-      {
-        "months": 6,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 1.77 },
-          { "insuredFor": 75, "premiumRate": 1.89 },
-          { "insuredFor": 80, "premiumRate": 2.02 },
-          { "insuredFor": 85, "premiumRate": 2.14 },
-          { "insuredFor": 90, "premiumRate": 2.27 },
-          { "insuredFor": 95, "premiumRate": 2.4 }
-        ]
-      },
-      {
-        "months": 7,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 1.92 },
-          { "insuredFor": 75, "premiumRate": 2.06 },
-          { "insuredFor": 80, "premiumRate": 2.2 },
-          { "insuredFor": 85, "premiumRate": 2.34 },
-          { "insuredFor": 90, "premiumRate": 2.47 },
-          { "insuredFor": 95, "premiumRate": 2.61 }
-        ]
-      },
-      {
-        "months": 8,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.08 },
-          { "insuredFor": 75, "premiumRate": 2.23 },
-          { "insuredFor": 80, "premiumRate": 2.38 },
-          { "insuredFor": 85, "premiumRate": 2.53 },
-          { "insuredFor": 90, "premiumRate": 2.68 },
-          { "insuredFor": 95, "premiumRate": 2.82 }
-        ]
-      },
-      {
-        "months": 9,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.24 },
-          { "insuredFor": 75, "premiumRate": 2.4 },
-          { "insuredFor": 80, "premiumRate": 2.56 },
-          { "insuredFor": 85, "premiumRate": 2.72 },
-          { "insuredFor": 90, "premiumRate": 2.88 },
-          { "insuredFor": 95, "premiumRate": 3.04 }
-        ]
-      },
-      {
-        "months": 10,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.4 },
-          { "insuredFor": 75, "premiumRate": 2.57 },
-          { "insuredFor": 80, "premiumRate": 2.74 },
-          { "insuredFor": 85, "premiumRate": 2.91 },
-          { "insuredFor": 90, "premiumRate": 3.08 },
-          { "insuredFor": 95, "premiumRate": 3.25 }
-        ]
-      },
-      {
-        "months": 11,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.55 },
-          { "insuredFor": 75, "premiumRate": 2.73 },
-          { "insuredFor": 80, "premiumRate": 2.92 },
-          { "insuredFor": 85, "premiumRate": 3.1 },
-          { "insuredFor": 90, "premiumRate": 3.28 },
-          { "insuredFor": 95, "premiumRate": 3.46 }
-        ]
-      },
-      {
-        "months": 12,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.71 },
-          { "insuredFor": 75, "premiumRate": 2.9 },
-          { "insuredFor": 80, "premiumRate": 3.09 },
-          { "insuredFor": 85, "premiumRate": 3.29 },
-          { "insuredFor": 90, "premiumRate": 3.48 },
-          { "insuredFor": 95, "premiumRate": 3.67 }
-        ]
-      },
-      {
-        "months": 13,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.91 },
-          { "insuredFor": 75, "premiumRate": 3.12 },
-          { "insuredFor": 80, "premiumRate": 3.33 },
-          { "insuredFor": 85, "premiumRate": 3.54 },
-          { "insuredFor": 90, "premiumRate": 3.74 },
-          { "insuredFor": 95, "premiumRate": 3.95 }
-        ]
-      },
-      {
-        "months": 14,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 3.12 },
-          { "insuredFor": 75, "premiumRate": 3.34 },
-          { "insuredFor": 80, "premiumRate": 3.56 },
-          { "insuredFor": 85, "premiumRate": 3.78 },
-          { "insuredFor": 90, "premiumRate": 4.01 },
-          { "insuredFor": 95, "premiumRate": 4.23 }
-        ]
-      },
-      {
-        "months": 15,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 3.32 },
-          { "insuredFor": 75, "premiumRate": 3.56 },
-          { "insuredFor": 80, "premiumRate": 3.79 },
-          { "insuredFor": 85, "premiumRate": 4.03 },
-          { "insuredFor": 90, "premiumRate": 4.27 },
-          { "insuredFor": 95, "premiumRate": 4.5 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.29
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.38
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.48
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.57
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 1.66
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 1.75
+          }
         ]
       }
     ],
@@ -1050,155 +2046,59 @@
       {
         "months": 2,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.62 },
-          { "insuredFor": 75, "premiumRate": 1.73 },
-          { "insuredFor": 80, "premiumRate": 1.85 },
-          { "insuredFor": 85, "premiumRate": 1.96 },
-          { "insuredFor": 90, "premiumRate": 2.08 },
-          { "insuredFor": 95, "premiumRate": 2.19 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.62
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.73
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 1.85
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 1.96
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.08
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.19
+          }
         ]
       },
       {
         "months": 3,
         "rates": [
-          { "insuredFor": 70, "premiumRate": 1.84 },
-          { "insuredFor": 75, "premiumRate": 1.97 },
-          { "insuredFor": 80, "premiumRate": 2.1 },
-          { "insuredFor": 85, "premiumRate": 2.24 },
-          { "insuredFor": 90, "premiumRate": 2.37 },
-          { "insuredFor": 95, "premiumRate": 2.5 }
-        ]
-      },
-      {
-        "months": 4,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.07 },
-          { "insuredFor": 75, "premiumRate": 2.22 },
-          { "insuredFor": 80, "premiumRate": 2.36 },
-          { "insuredFor": 85, "premiumRate": 2.51 },
-          { "insuredFor": 90, "premiumRate": 2.66 },
-          { "insuredFor": 95, "premiumRate": 2.8 }
-        ]
-      },
-      {
-        "months": 5,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.29 },
-          { "insuredFor": 75, "premiumRate": 2.46 },
-          { "insuredFor": 80, "premiumRate": 2.62 },
-          { "insuredFor": 85, "premiumRate": 2.78 },
-          { "insuredFor": 90, "premiumRate": 2.95 },
-          { "insuredFor": 95, "premiumRate": 3.11 }
-        ]
-      },
-      {
-        "months": 6,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.52 },
-          { "insuredFor": 75, "premiumRate": 2.7 },
-          { "insuredFor": 80, "premiumRate": 2.88 },
-          { "insuredFor": 85, "premiumRate": 3.06 },
-          { "insuredFor": 90, "premiumRate": 3.24 },
-          { "insuredFor": 95, "premiumRate": 3.42 }
-        ]
-      },
-      {
-        "months": 7,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.74 },
-          { "insuredFor": 75, "premiumRate": 2.94 },
-          { "insuredFor": 80, "premiumRate": 3.13 },
-          { "insuredFor": 85, "premiumRate": 3.33 },
-          { "insuredFor": 90, "premiumRate": 3.53 },
-          { "insuredFor": 95, "premiumRate": 3.72 }
-        ]
-      },
-      {
-        "months": 8,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 2.97 },
-          { "insuredFor": 75, "premiumRate": 3.18 },
-          { "insuredFor": 80, "premiumRate": 3.39 },
-          { "insuredFor": 85, "premiumRate": 3.6 },
-          { "insuredFor": 90, "premiumRate": 3.81 },
-          { "insuredFor": 95, "premiumRate": 4.03 }
-        ]
-      },
-      {
-        "months": 9,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 3.19 },
-          { "insuredFor": 75, "premiumRate": 3.42 },
-          { "insuredFor": 80, "premiumRate": 3.65 },
-          { "insuredFor": 85, "premiumRate": 3.87 },
-          { "insuredFor": 90, "premiumRate": 4.1 },
-          { "insuredFor": 95, "premiumRate": 4.33 }
-        ]
-      },
-      {
-        "months": 10,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 3.42 },
-          { "insuredFor": 75, "premiumRate": 3.66 },
-          { "insuredFor": 80, "premiumRate": 3.9 },
-          { "insuredFor": 85, "premiumRate": 4.15 },
-          { "insuredFor": 90, "premiumRate": 4.39 },
-          { "insuredFor": 95, "premiumRate": 4.63 }
-        ]
-      },
-      {
-        "months": 11,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 3.64 },
-          { "insuredFor": 75, "premiumRate": 3.9 },
-          { "insuredFor": 80, "premiumRate": 4.16 },
-          { "insuredFor": 85, "premiumRate": 4.42 },
-          { "insuredFor": 90, "premiumRate": 4.68 },
-          { "insuredFor": 95, "premiumRate": 4.94 }
-        ]
-      },
-      {
-        "months": 12,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 3.86 },
-          { "insuredFor": 75, "premiumRate": 4.14 },
-          { "insuredFor": 80, "premiumRate": 4.41 },
-          { "insuredFor": 85, "premiumRate": 4.69 },
-          { "insuredFor": 90, "premiumRate": 4.96 },
-          { "insuredFor": 95, "premiumRate": 5.24 }
-        ]
-      },
-      {
-        "months": 13,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 4.15 },
-          { "insuredFor": 75, "premiumRate": 4.45 },
-          { "insuredFor": 80, "premiumRate": 4.75 },
-          { "insuredFor": 85, "premiumRate": 5.04 },
-          { "insuredFor": 90, "premiumRate": 5.34 },
-          { "insuredFor": 95, "premiumRate": 5.63 }
-        ]
-      },
-      {
-        "months": 14,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 4.44 },
-          { "insuredFor": 75, "premiumRate": 4.76 },
-          { "insuredFor": 80, "premiumRate": 5.08 },
-          { "insuredFor": 85, "premiumRate": 5.4 },
-          { "insuredFor": 90, "premiumRate": 5.71 },
-          { "insuredFor": 95, "premiumRate": 6.03 }
-        ]
-      },
-      {
-        "months": 15,
-        "rates": [
-          { "insuredFor": 70, "premiumRate": 4.73 },
-          { "insuredFor": 75, "premiumRate": 5.07 },
-          { "insuredFor": 80, "premiumRate": 5.41 },
-          { "insuredFor": 85, "premiumRate": 5.75 },
-          { "insuredFor": 90, "premiumRate": 6.09 },
-          { "insuredFor": 95, "premiumRate": 6.42 }
+          {
+            "insuredFor": 70,
+            "premiumRate": 1.84
+          },
+          {
+            "insuredFor": 75,
+            "premiumRate": 1.97
+          },
+          {
+            "insuredFor": 80,
+            "premiumRate": 2.1
+          },
+          {
+            "insuredFor": 85,
+            "premiumRate": 2.24
+          },
+          {
+            "insuredFor": 90,
+            "premiumRate": 2.37
+          },
+          {
+            "insuredFor": 95,
+            "premiumRate": 2.5
+          }
         ]
       }
     ]


### PR DESCRIPTION
- Update pricing grid.
- Update quote calculation logic to _not_ use policy length for a multi poicy.
- Update e2e tests to use new multi policy calculation results.
- Remove now outdated unit tests for multi policy calculations for over 3 months (maximum in the pricing grid is 3 months).
- Rename some variables/tidy some comments.