### PR TITLE
fix(EMS-379): fix issue with buyer country form when JS is disabled

### DIFF
--- a/e2e-tests/content-strings/footer.js
+++ b/e2e-tests/content-strings/footer.js
@@ -17,7 +17,7 @@ const FOOTER = {
   SUPPORT_LINKS_HEADING: 'Support Links',
   PRIVACY: {
     TEXT: 'Privacy',
-    HREF: 'https://www.gov.uk/government/publications/ukef-privacy-notice/ukef-privacy-notice',
+    HREF: 'https://www.gov.uk/government/publications/ukef-privacy-notice',
   },
   COOKIES: {
     TEXT: 'Cookies',

--- a/e2e-tests/content-strings/links.js
+++ b/e2e-tests/content-strings/links.js
@@ -12,7 +12,7 @@ const LINKS = {
   EXTERNAL: {
     GUIDANCE: 'https://www.gov.uk/guidance/export-insurance-policy#eligibility',
     BEFORE_YOU_START: 'https://www.gov.uk/guidance/get-a-quote-for-ukef-export-insurance',
-    PRIVACY: 'https://www.gov.uk/government/publications/ukef-privacy-notice/ukef-privacy-notice',
+    PRIVACY: 'https://www.gov.uk/government/publications/ukef-privacy-notice',
     FEEDBACK: 'https://forms.office.com/r/TacytrRCgJ',
     EXPORT_FINANCE_MANAGERS: 'https://www.gov.uk/government/publications/find-an-export-finance-manager',
     APPROVED_BROKER_LIST: 'https://www.gov.uk/government/publications/uk-export-finance-insurance-list-of-approved-brokers',

--- a/src/ui/server/content-strings/footer.ts
+++ b/src/ui/server/content-strings/footer.ts
@@ -17,7 +17,7 @@ export const FOOTER = {
   SUPPORT_LINKS_HEADING: 'Support Links',
   PRIVACY: {
     TEXT: 'Privacy',
-    HREF: 'https://www.gov.uk/government/publications/ukef-privacy-notice/ukef-privacy-notice',
+    HREF: 'https://www.gov.uk/government/publications/ukef-privacy-notice',
   },
   COOKIES: {
     TEXT: 'Cookies',

--- a/src/ui/server/content-strings/links.ts
+++ b/src/ui/server/content-strings/links.ts
@@ -12,7 +12,7 @@ export const LINKS = {
   EXTERNAL: {
     GUIDANCE: 'https://www.gov.uk/guidance/export-insurance-policy#eligibility',
     BEFORE_YOU_START: 'https://www.gov.uk/guidance/get-a-quote-for-ukef-export-insurance',
-    PRIVACY: 'https://www.gov.uk/government/publications/ukef-privacy-notice/ukef-privacy-notice',
+    PRIVACY: 'https://www.gov.uk/government/publications/ukef-privacy-notice',
     FEEDBACK: 'https://forms.office.com/r/TacytrRCgJ',
     EXPORT_FINANCE_MANAGERS: 'https://www.gov.uk/government/publications/find-an-export-finance-manager',
     APPROVED_BROKER_LIST: 'https://www.gov.uk/government/publications/uk-export-finance-insurance-list-of-approved-brokers',

--- a/src/ui/server/controllers/quote/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.test.ts
@@ -296,5 +296,54 @@ describe('controllers/buyer-country', () => {
         });
       });
     });
+
+    describe(`when the country is supported for an online quote, submitted with ${FIELD_IDS.COUNTRY} (no JS) and there are no validation errors`, () => {
+      const selectedCountryName = mockAnswers[FIELD_IDS.BUYER_COUNTRY];
+      const mappedCountries = mapCountries(mockCountriesResponse);
+
+      const selectedCountry = getCountryByName(mappedCountries, selectedCountryName);
+
+      const validBody = {
+        [FIELD_IDS.BUYER_COUNTRY]: '',
+        [FIELD_IDS.COUNTRY]: selectedCountryName,
+      };
+
+      beforeEach(() => {
+        req.body = validBody;
+      });
+
+      it('should update the session with submitted data, popluated with country object', async () => {
+        await post(req, res);
+
+        const expectedPopulatedData = {
+          ...validBody,
+          [FIELD_IDS.BUYER_COUNTRY]: {
+            name: selectedCountry?.name,
+            isoCode: selectedCountry?.isoCode,
+            riskCategory: selectedCountry?.riskCategory,
+          },
+        };
+
+        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData);
+
+        expect(req.session.submittedData).toEqual(expected);
+      });
+
+      it(`should redirect to ${ROUTES.QUOTE.BUYER_BODY}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.QUOTE.BUYER_BODY);
+      });
+
+      describe("when the url's last substring is `change`", () => {
+        it(`should redirect to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`, async () => {
+          req.originalUrl = 'mock/change';
+
+          await post(req, res);
+
+          expect(res.redirect).toHaveBeenCalledWith(ROUTES.QUOTE.CHECK_YOUR_ANSWERS);
+        });
+      });
+    });
   });
 });

--- a/src/ui/server/controllers/quote/buyer-country/index.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.ts
@@ -91,7 +91,7 @@ export const post = async (req: Request, res: Response) => {
     });
   }
 
-  const submittedCountryName = req.body[FIELD_IDS.BUYER_COUNTRY];
+  const submittedCountryName = req.body[FIELD_IDS.BUYER_COUNTRY] || req.body[FIELD_IDS.COUNTRY];
 
   const country = getCountryByName(mappedCountries, submittedCountryName);
 

--- a/src/ui/templates/partials/footer.njk
+++ b/src/ui/templates/partials/footer.njk
@@ -10,6 +10,7 @@
         </p>
 
         <h2 class="govuk-visually-hidden" data-cy="support-links-heading">{{ CONTENT_STRINGS.FOOTER.SUPPORT_LINKS_HEADING }}</h2>
+
         <ul class="govuk-footer__inline-list">
           <li class="govuk-footer__inline-list-item">
             <a class="govuk-footer__link" href="{{ CONTENT_STRINGS.FOOTER.PRIVACY.HREF }}" data-cy="privacy">


### PR DESCRIPTION
This PR fixes an issue where the buyer country controller would not pick up a submitted country name when JS is disabled.

Also fix a typo where the privacy link HREF had duplicate wording.