### PR TITLE
feat(EMS-380): filter out invalid country names from CIS API

### DIFF
--- a/src/ui/server/constants/api.ts
+++ b/src/ui/server/constants/api.ts
@@ -17,6 +17,7 @@ export const API = {
       YES: 'Y',
       NO: 'N',
     },
+    INVALID_COUNTRIES: ['EC Market n/k', 'Non EC Market n/k', 'Non UK', 'Third Country'],
   },
   MAPPINGS: {
     RISK: {

--- a/src/ui/server/constants/invalid-CIS-countries.ts
+++ b/src/ui/server/constants/invalid-CIS-countries.ts
@@ -1,0 +1,1 @@
+export const INVALID_CIS_COUNTRIES = ['EC Market n/k', 'Non EC Market n/k', 'Non UK', 'Third Country'];

--- a/src/ui/server/helpers/mappings/map-countries.test.ts
+++ b/src/ui/server/helpers/mappings/map-countries.test.ts
@@ -1,4 +1,4 @@
-import { mapRiskCategory, mapShortTermCoverAvailable, mapNbiIssueAvailable, mapCountry, mapCountries } from './map-countries';
+import { mapRiskCategory, mapShortTermCoverAvailable, mapNbiIssueAvailable, filterCisCountries, mapCountry, mapCountries } from './map-countries';
 import { API } from '../../constants';
 import sortArrayAlphabetically from '../sort-array-alphabetically';
 import { CisCountry, Country } from '../../../types';
@@ -120,6 +120,36 @@ describe('server/helpers/mappings/map-countries', () => {
     });
   });
 
+  describe('filterCisCountries', () => {
+    it('should return a list of countries without invalid countries defined in INVALID_CIS_COUNTRIES', () => {
+      const mockCountriesWithInvalid = [
+        mockCountries[0],
+        {
+          ...mockCountries[0],
+          marketName: 'EC Market n/k',
+        },
+        {
+          ...mockCountries[0],
+          marketName: 'Non EC Market n/k',
+        },
+        {
+          ...mockCountries[0],
+          marketName: 'Non UK',
+        },
+        {
+          ...mockCountries[0],
+          marketName: 'Third Country',
+        },
+      ];
+
+      const result = filterCisCountries(mockCountriesWithInvalid);
+
+      const expected = [mockCountries[0]];
+
+      expect(result).toEqual(expected);
+    });
+  });
+
   describe('mapCountry', () => {
     it('should return an object', () => {
       const result = mapCountry(mockCountries[0]);
@@ -158,10 +188,12 @@ describe('server/helpers/mappings/map-countries', () => {
   });
 
   describe('mapCountries', () => {
-    it('should returns array of mapped, sorted objects', () => {
+    it('should returns array of filtered, mapped and sorted objects', () => {
       const mockSelectedIsoCode = mockCountries[0].isoCode;
 
-      const result = mapCountries(mockCountries, mockSelectedIsoCode);
+      const filteredCountries = filterCisCountries(mockCountries);
+
+      const result = mapCountries(filteredCountries, mockSelectedIsoCode);
 
       const expected = sortArrayAlphabetically([mapCountry(mockCountries[0], mockSelectedIsoCode), mapCountry(mockCountries[1], mockSelectedIsoCode)], 'name');
 

--- a/src/ui/server/helpers/mappings/map-countries.ts
+++ b/src/ui/server/helpers/mappings/map-countries.ts
@@ -46,6 +46,8 @@ export const mapNbiIssueAvailable = (str: string): boolean => {
   return false;
 };
 
+export const filterCisCountries = (countries: Array<CisCountry>) => countries.filter((country) => !API.CIS.INVALID_COUNTRIES.includes(country.marketName));
+
 export const mapCountry = (country: CisCountry, selectedIsoCode?: string): Country => {
   const mapped = {
     name: country.marketName,
@@ -64,7 +66,9 @@ export const mapCountry = (country: CisCountry, selectedIsoCode?: string): Count
 };
 
 export const mapCountries = (countries: Array<CisCountry>, selectedIsoCode?: string) => {
-  const mapped = countries.map((country) => mapCountry(country, selectedIsoCode));
+  const filteredCountries = filterCisCountries(countries);
+
+  const mapped = filteredCountries.map((country) => mapCountry(country, selectedIsoCode));
 
   const sorted = sortArrayAlphabetically(mapped, 'name');
 


### PR DESCRIPTION
The CIS API returns some invalid countries. This PR filters out these specific invalid countries.