### PR TITLE
fix(EMS-465): Redirect to problem with service page if no currencies are returned from API

### DIFF
--- a/src/ui/server/controllers/quote/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.test.ts
@@ -161,7 +161,7 @@ describe('controllers/quote/buyer-country', () => {
       });
     });
 
-    describe('when the CIS API has no data', () => {
+    describe('when the CIS (country information system) API has no data', () => {
       beforeEach(() => {
         // @ts-ignore
         getCountriesSpy = jest.fn(() => Promise.resolve());
@@ -174,7 +174,7 @@ describe('controllers/quote/buyer-country', () => {
       });
     });
 
-    describe('when the CIS API does not return an array', () => {
+    describe('when the CIS (country information system) API does not return an array', () => {
       beforeEach(() => {
         // @ts-ignore
         getCountriesSpy = jest.fn(() => Promise.resolve({}));
@@ -187,7 +187,7 @@ describe('controllers/quote/buyer-country', () => {
       });
     });
 
-    describe('when the CIS API does not return a populated array', () => {
+    describe('when the CIS (country information system) API does not return a populated array', () => {
       beforeEach(() => {
         getCountriesSpy = jest.fn(() => Promise.resolve([]));
         api.getCountries = getCountriesSpy;
@@ -384,7 +384,7 @@ describe('controllers/quote/buyer-country', () => {
       });
     });
 
-    describe('when the CIS API has no data', () => {
+    describe('when the CIS (country information system) API has no data', () => {
       beforeEach(() => {
         // @ts-ignore
         getCountriesSpy = jest.fn(() => Promise.resolve());
@@ -397,7 +397,7 @@ describe('controllers/quote/buyer-country', () => {
       });
     });
 
-    describe('when the CIS API does not return an array', () => {
+    describe('when the CIS (country information system) API does not return an array', () => {
       beforeEach(() => {
         // @ts-ignore
         getCountriesSpy = jest.fn(() => Promise.resolve({}));
@@ -410,7 +410,7 @@ describe('controllers/quote/buyer-country', () => {
       });
     });
 
-    describe('when the CIS API does not return a populated array', () => {
+    describe('when the CIS (country information system) API does not return a populated array', () => {
       beforeEach(() => {
         getCountriesSpy = jest.fn(() => Promise.resolve([]));
         api.getCountries = getCountriesSpy;

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
@@ -196,7 +196,7 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
   });
 
   describe('get', () => {
-    const getCurrenciesSpy = jest.fn(() => Promise.resolve(mockCurrenciesResponse));
+    let getCurrenciesSpy = jest.fn(() => Promise.resolve(mockCurrenciesResponse));
 
     beforeEach(() => {
       req.session.submittedData = {
@@ -309,10 +309,48 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
         });
       });
     });
+
+    describe('when the currencies API has no data', () => {
+      beforeEach(() => {
+        // @ts-ignore
+        getCurrenciesSpy = jest.fn(() => Promise.resolve());
+        api.getCurrencies = getCurrenciesSpy;
+      });
+
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+        await get(req, res);
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+      });
+    });
+
+    describe('when the currencies API does not return an array', () => {
+      beforeEach(() => {
+        // @ts-ignore
+        getCurrenciesSpy = jest.fn(() => Promise.resolve({}));
+        api.getCurrencies = getCurrenciesSpy;
+      });
+
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+        await get(req, res);
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+      });
+    });
+
+    describe('when the currencies API does not return a populated array', () => {
+      beforeEach(() => {
+        getCurrenciesSpy = jest.fn(() => Promise.resolve([]));
+        api.getCurrencies = getCurrenciesSpy;
+      });
+
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+        await get(req, res);
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+      });
+    });
   });
 
   describe('post', () => {
-    const getCurrenciesSpy = jest.fn(() => Promise.resolve(mockCurrenciesResponse));
+    let getCurrenciesSpy = jest.fn(() => Promise.resolve(mockCurrenciesResponse));
 
     beforeEach(() => {
       api.getCurrencies = getCurrenciesSpy;
@@ -473,6 +511,44 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
 
           expect(res.redirect).toHaveBeenCalledWith(ROUTES.QUOTE.CHECK_YOUR_ANSWERS);
         });
+      });
+    });
+
+    describe('when the currencies API has no data', () => {
+      beforeEach(() => {
+        // @ts-ignore
+        getCurrenciesSpy = jest.fn(() => Promise.resolve());
+        api.getCurrencies = getCurrenciesSpy;
+      });
+
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+      });
+    });
+
+    describe('when the currencies API does not return an array', () => {
+      beforeEach(() => {
+        // @ts-ignore
+        getCurrenciesSpy = jest.fn(() => Promise.resolve({}));
+        api.getCurrencies = getCurrenciesSpy;
+      });
+
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+      });
+    });
+
+    describe('when the currencies API does not return a populated array', () => {
+      beforeEach(() => {
+        getCurrenciesSpy = jest.fn(() => Promise.resolve([]));
+        api.getCurrencies = getCurrenciesSpy;
+      });
+
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
       });
     });
   });

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.ts
@@ -91,6 +91,10 @@ const get = async (req: Request, res: Response) => {
   const { submittedData } = req.session;
   const currencies = await api.getCurrencies();
 
+  if (!currencies || !currencies.length) {
+    return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+  }
+
   let mappedCurrencies;
   if (submittedData && submittedData[FIELD_IDS.CURRENCY]) {
     mappedCurrencies = mapCurrencies(currencies, submittedData[FIELD_IDS.CURRENCY].isoCode);
@@ -138,6 +142,10 @@ const post = async (req: Request, res: Response) => {
   });
 
   const currencies = await api.getCurrencies();
+
+  if (!currencies || !currencies.length) {
+    return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+  }
 
   const submittedCurrencyCode = req.body[FIELD_IDS.CURRENCY];
 


### PR DESCRIPTION
This PR fixes an issue where if the currencies API is down when we call it in the "Tell us about your policy" page, the server would crash. Now we redirect to problem-with-service page.