### PR TITLE
feat(EMS-455) - Insurance/application start page

### DIFF
--- a/e2e-tests/constants/routes/index.js
+++ b/e2e-tests/constants/routes/index.js
@@ -1,3 +1,4 @@
+const INSURANCE_ROUTES = require('./insurance');
 const QUOTE_ROUTES = require('./quote');
 
 const ROUTES = {
@@ -5,6 +6,7 @@ const ROUTES = {
   COOKIES: '/cookies',
   PROBLEM_WITH_SERVICE: '/problem-with-service',
   QUOTE: QUOTE_ROUTES,
+  INSURANCE: INSURANCE_ROUTES,
 };
 
 export default ROUTES;

--- a/e2e-tests/constants/routes/insurance.js
+++ b/e2e-tests/constants/routes/insurance.js
@@ -1,0 +1,11 @@
+const INSURANCE = '/insurance';
+const ELIGIBILIY = '/eligibility';
+
+const INSURANCE_ROUTES = {
+  START: `${INSURANCE}/start`,
+  ELIGIBILITY: {
+    CHECK_IF_ELIGIBLE: `${INSURANCE}${ELIGIBILIY}/check-if-eligible`,
+  },
+};
+
+export default INSURANCE_ROUTES;

--- a/e2e-tests/constants/templates/index.js
+++ b/e2e-tests/constants/templates/index.js
@@ -1,9 +1,11 @@
 import QUOTE_TEMPLATES from './quote';
+import INSURANCE_TEMPLATES from './insurance';
 
 const TEMPLATES = {
   COOKIES: 'cookies.njk',
   PROBLEM_WITH_SERVICE: 'problem-with-service.njk',
   QUOTE: QUOTE_TEMPLATES,
+  INSURANCE: INSURANCE_TEMPLATES,
 };
 
 module.exports = TEMPLATES;

--- a/e2e-tests/constants/templates/insurance.js
+++ b/e2e-tests/constants/templates/insurance.js
@@ -1,0 +1,5 @@
+const INSURANCE_TEMPLATES = {
+  START: 'insurance/start.njk',
+};
+
+export default INSURANCE_TEMPLATES;

--- a/e2e-tests/content-strings/buttons.js
+++ b/e2e-tests/content-strings/buttons.js
@@ -2,6 +2,7 @@ const BUTTONS = {
   CONTINUE: 'Continue',
   SUBMIT: 'Submit',
   START_APPLICATION: 'Start an application',
+  START_NOW: 'Start now',
   SAVE_CHANGES: 'Save changes',
 };
 

--- a/e2e-tests/content-strings/pages/index.js
+++ b/e2e-tests/content-strings/pages/index.js
@@ -1,4 +1,5 @@
 const QUOTE_PAGES = require('./quote');
+const INSURANCE_PAGES = require('./insurance');
 
 const COOKIES_PAGE = {
   PAGE_TITLE: 'Cookies',
@@ -68,4 +69,5 @@ module.exports = {
   PAGE_NOT_FOUND_PAGE,
   PROBLEM_WITH_SERVICE_PAGE,
   QUOTE: QUOTE_PAGES,
+  INSURANCE: INSURANCE_PAGES,
 };

--- a/e2e-tests/content-strings/pages/insurance.js
+++ b/e2e-tests/content-strings/pages/insurance.js
@@ -1,0 +1,22 @@
+const START = {
+  PAGE_TITLE: 'Apply for UKEF export insurance',
+  HEADING: 'Apply for UKEF export insurance',
+  INTRO: 'Use this service to make a full application for export insurance from UK Export Finance (UKEF).',
+  LIST: {
+    INTRO: "You'll need your:",
+    ITEMS: [
+      'company details and finances',
+      "buyer's details",
+      "trading history with the buyer, if you've worked together before",
+      'code of conduct, if you have one',
+    ],
+  },
+  BODY_1: "Depending on your export contract, you may also need your buyer's annual report and accounts.",
+  BODY_2: 'You do not need to complete all answers in one session.',
+  BODY_3: "You'll usually get a decision back from UKEF within 2 weeks. This is because underwriters need to carry out checks on risks around the buyer.",
+  BODY_4: 'If you need it more urgently, you can tell us before you submit your application.',
+};
+
+module.exports = {
+  START,
+};

--- a/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
@@ -1,0 +1,110 @@
+import { insurance } from '../../pages';
+import partials from '../../partials';
+import { BUTTONS, LINKS, ORGANISATION, PAGES } from '../../../../content-strings';
+import { ROUTES } from '../../../../constants';
+
+const CONTENT_STRINGS = PAGES.INSURANCE.START;
+
+context('Insurance - start page', () => {
+  beforeEach(() => {
+    cy.visit(ROUTES.INSURANCE.START, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
+  it('passes the audits', () => {
+    cy.lighthouse({
+      accessibility: 100,
+      performance: 70,
+      'best-practices': 100,
+      seo: 70,
+    });
+  });
+
+  it('renders a phase banner', () => {
+    cy.checkPhaseBanner();
+  });
+
+  it('renders a back link with correct url', () => {
+    partials.backLink().should('exist');
+    partials.backLink().invoke('text').then((text) => {
+      expect(text.trim()).equal(LINKS.BACK);
+    });
+
+    partials.backLink().should('have.attr', 'href', '#');
+  });
+
+  it('renders a page title and heading', () => {
+    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
+    cy.title().should('eq', expectedPageTitle);
+
+    insurance.startPage.heading().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.HEADING);
+    });
+  });
+
+  it('renders an intro', () => {
+    insurance.startPage.intro().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.INTRO);
+    });
+  });
+  
+  describe('`you will need` list', () => {
+    it('renders an intro', () => {
+      insurance.startPage.list.intro().invoke('text').then((text) => {
+        expect(text.trim()).equal(CONTENT_STRINGS.LIST.INTRO);
+      });
+    });
+
+    it('renders list items', () => {
+      insurance.startPage.list.item1().invoke('text').then((text) => {
+        expect(text.trim()).equal(CONTENT_STRINGS.LIST.ITEMS[0]);
+      });
+
+      insurance.startPage.list.item2().invoke('text').then((text) => {
+        expect(text.trim()).equal(CONTENT_STRINGS.LIST.ITEMS[1]);
+      });
+
+      insurance.startPage.list.item3().invoke('text').then((text) => {
+        expect(text.trim()).equal(CONTENT_STRINGS.LIST.ITEMS[2]);
+      });
+
+      insurance.startPage.list.item4().invoke('text').then((text) => {
+        expect(text.trim()).equal(CONTENT_STRINGS.LIST.ITEMS[3]);
+      });
+    });
+  });
+
+  it('renders a body text', () => {
+    insurance.startPage.body1().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.BODY_1);
+    });
+
+    insurance.startPage.body2().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.BODY_2);
+    });
+
+    insurance.startPage.body3().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.BODY_3);
+    });
+
+    insurance.startPage.body4().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.BODY_4);
+    });
+  });
+
+  it('renders a start now button', () => {
+    const button = insurance.startPage.submitButton();
+    button.should('exist');
+
+    button.invoke('text').then((text) => {
+      expect(text.trim()).equal(BUTTONS.START_NOW);
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/pages/index.js
+++ b/e2e-tests/cypress/e2e/pages/index.js
@@ -1,9 +1,11 @@
 const cookiesPage = require('./cookies');
+const insurancePages = require('./insurance');
 const pageNotFoundPage = require('./pageNotFound');
 const quotePages = require('./quote');
 
 module.exports = {
   cookiesPage,
+  insurance: insurancePages,
   pageNotFoundPage,
   quote: quotePages,
 };

--- a/e2e-tests/cypress/e2e/pages/insurance/index.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/index.js
@@ -1,0 +1,5 @@
+const startPage = require('./start');
+
+module.exports = {
+  startPage
+};

--- a/e2e-tests/cypress/e2e/pages/insurance/start.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/start.js
@@ -1,0 +1,18 @@
+const startPage = {
+  heading: () => cy.get('[data-cy="heading"]'),  
+  intro: () => cy.get('[data-cy="intro"]'),
+  list: {
+    intro: () => cy.get('[data-cy="list-intro"]'),
+    item1: () => cy.get('[data-cy="list-item-1"]'),
+    item2: () => cy.get('[data-cy="list-item-2"]'),
+    item3: () => cy.get('[data-cy="list-item-3"]'),
+    item4: () => cy.get('[data-cy="list-item-4"]'),
+  },
+  body1: () => cy.get('[data-cy="body-1"]'),
+  body2: () => cy.get('[data-cy="body-2"]'),
+  body3: () => cy.get('[data-cy="body-3"]'),
+  body4: () => cy.get('[data-cy="body-4"]'),
+  submitButton: () => cy.get('[data-cy="submit-button"]'),
+};
+
+export default startPage;

--- a/src/ui/server/constants/routes/index.ts
+++ b/src/ui/server/constants/routes/index.ts
@@ -1,4 +1,5 @@
 import { QUOTE_ROUTES } from './quote';
+import { INSURANCE_ROUTES } from './insurance';
 
 export const ROUTES = {
   ROOT: '/',
@@ -6,4 +7,5 @@ export const ROUTES = {
   COOKIES_CONSENT: '/cookies-consent',
   PROBLEM_WITH_SERVICE: '/problem-with-service',
   QUOTE: QUOTE_ROUTES,
+  INSURANCE: INSURANCE_ROUTES,
 };

--- a/src/ui/server/constants/routes/insurance.ts
+++ b/src/ui/server/constants/routes/insurance.ts
@@ -1,0 +1,9 @@
+const INSURANCE = '/insurance';
+const ELIGIBILIY = '/eligibility';
+
+export const INSURANCE_ROUTES = {
+  START: `${INSURANCE}/start`,
+  ELIGIBILITY: {
+    CHECK_IF_ELIGIBLE: `${INSURANCE}${ELIGIBILIY}/check-if-eligible`,
+  },
+};

--- a/src/ui/server/constants/templates/index.ts
+++ b/src/ui/server/constants/templates/index.ts
@@ -1,7 +1,9 @@
 import { QUOTE_TEMPLATES } from './quote';
+import { INSURANCE_TEMPLATES } from './insurance';
 
 export const TEMPLATES = {
   COOKIES: 'cookies.njk',
   PROBLEM_WITH_SERVICE: 'problem-with-service.njk',
   QUOTE: QUOTE_TEMPLATES,
+  INSURANCE: INSURANCE_TEMPLATES,
 };

--- a/src/ui/server/constants/templates/insurance.ts
+++ b/src/ui/server/constants/templates/insurance.ts
@@ -1,0 +1,3 @@
+export const INSURANCE_TEMPLATES = {
+  START: 'insurance/start.njk',
+};

--- a/src/ui/server/content-strings/buttons.ts
+++ b/src/ui/server/content-strings/buttons.ts
@@ -2,5 +2,6 @@ export const BUTTONS = {
   CONTINUE: 'Continue',
   SUBMIT: 'Submit',
   START_APPLICATION: 'Start an application',
+  START_NOW: 'Start now',
   SAVE_CHANGES: 'Save changes',
 };

--- a/src/ui/server/content-strings/pages/index.ts
+++ b/src/ui/server/content-strings/pages/index.ts
@@ -1,3 +1,4 @@
+import INSURANCE_PAGES from './insurance';
 import QUOTE_PAGES from './quote';
 
 const COOKIES_PAGE = {
@@ -68,4 +69,5 @@ export const PAGES = {
   PAGE_NOT_FOUND_PAGE,
   PROBLEM_WITH_SERVICE_PAGE,
   QUOTE: QUOTE_PAGES,
+  INSURANCE: INSURANCE_PAGES,
 };

--- a/src/ui/server/content-strings/pages/insurance.ts
+++ b/src/ui/server/content-strings/pages/insurance.ts
@@ -1,0 +1,22 @@
+const START = {
+  PAGE_TITLE: 'Apply for UKEF export insurance',
+  HEADING: 'Apply for UKEF export insurance',
+  INTRO: 'Use this service to make a full application for export insurance from UK Export Finance (UKEF).',
+  LIST: {
+    INTRO: "You'll need your:",
+    ITEMS: [
+      'company details and finances',
+      "buyer's details",
+      "trading history with the buyer, if you've worked together before",
+      'code of conduct, if you have one',
+    ],
+  },
+  BODY_1: "Depending on your export contract, you may also need your buyer's annual report and accounts.",
+  BODY_2: 'You do not need to complete all answers in one session.',
+  BODY_3: "You'll usually get a decision back from UKEF within 2 weeks. This is because underwriters need to carry out checks on risks around the buyer.",
+  BODY_4: 'If you need it more urgently, you can tell us before you submit your application.',
+};
+
+export default {
+  START,
+};

--- a/src/ui/server/controllers/insurance/start/index.test.ts
+++ b/src/ui/server/controllers/insurance/start/index.test.ts
@@ -1,0 +1,39 @@
+import { get, post } from '.';
+import { PAGES } from '../../../content-strings';
+import { ROUTES, TEMPLATES } from '../../../constants';
+import corePageVariables from '../../../helpers/core-page-variables';
+import { mockReq, mockRes } from '../../../test-mocks';
+import { Request, Response } from '../../../../types';
+
+describe('controllers/insurance/start', () => {
+  let req: Request;
+  let res: Response;
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+  });
+
+  describe('get', () => {
+    it('should render template', () => {
+      get(req, res);
+
+      const expectedVariables = {
+        ...corePageVariables({
+          PAGE_CONTENT_STRINGS: PAGES.INSURANCE.START,
+          BACK_LINK: req.headers.referer,
+        }),
+      };
+
+      expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.START, expectedVariables);
+    });
+  });
+
+  describe('post', () => {
+    it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE}`, () => {
+      post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/start/index.ts
+++ b/src/ui/server/controllers/insurance/start/index.ts
@@ -1,0 +1,18 @@
+import { PAGES } from '../../../content-strings';
+import { ROUTES, TEMPLATES } from '../../../constants';
+import { Request, Response } from '../../../../types';
+import corePageVariables from '../../../helpers/core-page-variables';
+
+const get = (req: Request, res: Response) =>
+  res.render(TEMPLATES.INSURANCE.START, {
+    ...corePageVariables({
+      PAGE_CONTENT_STRINGS: PAGES.INSURANCE.START,
+      BACK_LINK: req.headers.referer,
+    }),
+  });
+
+const post = (req: Request, res: Response) => {
+  return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE);
+};
+
+export { get, post };

--- a/src/ui/server/helpers/core-page-variables.test.ts
+++ b/src/ui/server/helpers/core-page-variables.test.ts
@@ -1,0 +1,30 @@
+import corePageVariables from './core-page-variables';
+import { BUTTONS, COOKIES_CONSENT, FOOTER, LINKS, PRODUCT } from '../content-strings';
+
+describe('server/helpers/core-page-variables', () => {
+  const mock = {
+    PAGE_CONTENT_STRINGS: {
+      PAGE_TITLE: 'Testing',
+      HEADING: 'Testing',
+    },
+    BACK_LINK: '/mock',
+  };
+
+  it('should return an object with provided data and additional content strings', () => {
+    const result = corePageVariables(mock);
+
+    const expected = {
+      CONTENT_STRINGS: {
+        ...mock.PAGE_CONTENT_STRINGS,
+        BUTTONS,
+        COOKIES_CONSENT,
+        FOOTER,
+        LINKS,
+        PRODUCT,
+      },
+      BACK_LINK: mock.BACK_LINK,
+    };
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/ui/server/helpers/core-page-variables.ts
+++ b/src/ui/server/helpers/core-page-variables.ts
@@ -1,0 +1,16 @@
+import { BUTTONS, COOKIES_CONSENT, FOOTER, LINKS, PRODUCT } from '../content-strings';
+import { CorePageVariablesInput, CorePageVariables } from '../../types';
+
+const corePageVariables = ({ PAGE_CONTENT_STRINGS, BACK_LINK }: CorePageVariablesInput): CorePageVariables => ({
+  CONTENT_STRINGS: {
+    ...PAGE_CONTENT_STRINGS,
+    BUTTONS,
+    COOKIES_CONSENT,
+    FOOTER,
+    LINKS,
+    PRODUCT,
+  },
+  BACK_LINK,
+});
+
+export default corePageVariables;

--- a/src/ui/server/helpers/single-input-page-variables.test.ts
+++ b/src/ui/server/helpers/single-input-page-variables.test.ts
@@ -1,5 +1,6 @@
 import singleInputPageVariables from './single-input-page-variables';
-import { BUTTONS, COOKIES_CONSENT, FIELDS, FOOTER, LINKS, PRODUCT } from '../content-strings';
+import corePageVariables from './core-page-variables';
+import { FIELDS } from '../content-strings';
 import { FIELD_IDS } from '../constants';
 
 describe('server/helpers/single-input-page-variables', () => {
@@ -16,16 +17,8 @@ describe('server/helpers/single-input-page-variables', () => {
     const result = singleInputPageVariables(mock);
 
     const expected = {
-      CONTENT_STRINGS: {
-        ...mock.PAGE_CONTENT_STRINGS,
-        BUTTONS,
-        COOKIES_CONSENT,
-        FOOTER,
-        LINKS,
-        PRODUCT,
-      },
       FIELD_ID: mock.FIELD_ID,
-      BACK_LINK: mock.BACK_LINK,
+      ...corePageVariables(mock),
     };
 
     expect(result).toEqual(expected);

--- a/src/ui/server/helpers/single-input-page-variables.ts
+++ b/src/ui/server/helpers/single-input-page-variables.ts
@@ -1,47 +1,11 @@
-import { BUTTONS, COOKIES_CONSENT, FIELDS, FOOTER, LINKS, PRODUCT } from '../content-strings';
+import corePageVariables from './core-page-variables';
+import { FIELDS } from '../content-strings';
+import { SingleInputPageVariablesInput, SingleInputPageVariables } from '../../types';
 
-interface PageContentStrings {
-  PAGE_TITLE: string;
-  HEADING: string;
-  FIELDS?: object;
-  HINTS?: object;
-  LINKS?: object;
-}
-
-interface SingleInputPageVariables {
-  FIELD_ID: string;
-  PAGE_CONTENT_STRINGS: PageContentStrings;
-  BACK_LINK?: string;
-}
-
-interface PageVariablesContentStrings {
-  BUTTONS: object;
-  COOKIES_CONSENT: object;
-  FOOTER: object;
-  LINKS: object;
-  PRODUCT: object;
-}
-
-interface PageVariables {
-  CONTENT_STRINGS: PageVariablesContentStrings;
-  FIELD_ID: string;
-  FIELD_LABEL?: string;
-  FIELD_HINT?: string | object;
-  BACK_LINK?: string;
-}
-
-const singleInputPageVariables = ({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK }: SingleInputPageVariables) => {
-  const pageVariables: PageVariables = {
-    CONTENT_STRINGS: {
-      ...PAGE_CONTENT_STRINGS,
-      BUTTONS,
-      COOKIES_CONSENT,
-      FOOTER,
-      LINKS,
-      PRODUCT,
-    },
+const singleInputPageVariables = ({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK }: SingleInputPageVariablesInput) => {
+  const pageVariables: SingleInputPageVariables = {
+    ...corePageVariables({ PAGE_CONTENT_STRINGS, BACK_LINK }),
     FIELD_ID,
-    BACK_LINK,
   };
 
   const fieldStrings = FIELDS[FIELD_ID];

--- a/src/ui/server/index.ts
+++ b/src/ui/server/index.ts
@@ -19,7 +19,7 @@ dotenv.config();
 
 import configureNunjucks from './nunjucks-configuration';
 
-import { rootRoute, quoteRoutes, applicationRoutes } from './routes';
+import { rootRoute, quoteRoutes, insuranceRoutes } from './routes';
 import { COOKIES_CONSENT, FOOTER, LINKS, PAGES, PRODUCT } from './content-strings';
 import { requiredDataProvided } from './middleware/required-data-provided';
 
@@ -99,7 +99,7 @@ app.use(requiredDataProvided);
 
 app.use('/', rootRoute);
 app.use('/', quoteRoutes);
-app.use('/', applicationRoutes);
+app.use('/', insuranceRoutes);
 
 app.use(
   '/assets',

--- a/src/ui/server/routes/application/index.ts
+++ b/src/ui/server/routes/application/index.ts
@@ -1,8 +1,0 @@
-import express from 'express';
-
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-ignore
-const applicationRouter = express.Router();
-/* eslint-enable @typescript-eslint/ban-ts-comment */
-
-export default applicationRouter;

--- a/src/ui/server/routes/index.ts
+++ b/src/ui/server/routes/index.ts
@@ -1,7 +1,7 @@
 import root from './root';
 import quote from './quote';
-import application from './application';
+import insurance from './insurance';
 
 export const rootRoute = root;
 export const quoteRoutes = quote;
-export const applicationRoutes = application;
+export const insuranceRoutes = insurance;

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -1,0 +1,21 @@
+import { get, post } from '../../test-mocks/mock-router';
+import { ROUTES } from '../../constants';
+import { get as startGet, post as startPost } from '../../controllers/insurance/start';
+
+describe('routes/insurance', () => {
+  beforeEach(() => {
+    require('.'); // eslint-disable-line global-require
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should setup all routes', () => {
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledTimes(1);
+
+    expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.START, startGet);
+    expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.START, startPost);
+  });
+});

--- a/src/ui/server/routes/insurance/index.ts
+++ b/src/ui/server/routes/insurance/index.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import { ROUTES } from '../../constants';
+import { get as startGet, post as startPost } from '../../controllers/insurance/start';
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-ignore
+const insuranceRouter = express.Router();
+/* eslint-enable @typescript-eslint/ban-ts-comment */
+
+insuranceRouter.get(ROUTES.INSURANCE.START, startGet);
+insuranceRouter.post(ROUTES.INSURANCE.START, startPost);
+
+export default insuranceRouter;

--- a/src/ui/server/routes/quote/index.test.ts
+++ b/src/ui/server/routes/quote/index.test.ts
@@ -12,7 +12,7 @@ import getAQuoteByEmailGet from '../../controllers/quote/get-a-quote-by-email';
 import yourQuoteGet from '../../controllers/quote/your-quote';
 import { get as needToStartAgainGet, post as needToStartAgainPost } from '../../controllers/quote/need-to-start-again';
 
-describe('routes/index', () => {
+describe('routes/quote', () => {
   beforeEach(() => {
     require('.'); // eslint-disable-line global-require
   });

--- a/src/ui/templates/insurance/start.njk
+++ b/src/ui/templates/insurance/start.njk
@@ -1,0 +1,56 @@
+{% extends 'index.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from 'govuk/components/radios/macro.njk' import govukRadios %}
+{% from 'govuk/components/button/macro.njk' import govukButton %}
+
+{% block pageTitle %}
+  {{ CONTENT_STRINGS.PAGE_TITLE }}
+{% endblock %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: CONTENT_STRINGS.LINKS.BACK,
+    href: BACK_LINK,
+    attributes: {
+      "data-cy": "back-link"
+    }
+  }) }}
+
+  <h1 class="govuk-heading-l" data-cy="heading">{{ CONTENT_STRINGS.HEADING }}</h1>
+
+  <p class="govuk-body" data-cy="intro">{{ CONTENT_STRINGS.INTRO }}</p>
+
+  <p class="govuk-body" data-cy="list-intro">{{ CONTENT_STRINGS.LIST.INTRO }}</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    {% for item in CONTENT_STRINGS.LIST.ITEMS %}
+      <li data-cy="list-item-{{ loop.index }}">{{ item }}</li>
+    {% endfor %}
+  </ul> 
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters-from-desktop">
+      <p class="govuk-body" data-cy="body-1">{{ CONTENT_STRINGS.BODY_1 }}</p>
+      <p class="govuk-body" data-cy="body-2">{{ CONTENT_STRINGS.BODY_2 }}</p>
+      <p class="govuk-body" data-cy="body-3">{{ CONTENT_STRINGS.BODY_3 }}</p>
+      <p class="govuk-body" data-cy="body-4">{{ CONTENT_STRINGS.BODY_4 }}</p>
+    </div>
+  </div>
+
+  <form method="POST" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+    {{ govukButton({
+      text: CONTENT_STRINGS.BUTTONS.START_NOW,
+      isStartButton: true,
+      attributes: {
+        'data-cy': 'submit-button'
+      }
+    }) }}
+
+  </form>
+
+{% endblock %}

--- a/src/ui/types/index.d.ts
+++ b/src/ui/types/index.d.ts
@@ -17,14 +17,19 @@ import {
   TellUsAboutPolicyPageVariables,
 } from './pages/tell-us-about-your-policy';
 import { ValidationErrors } from './validation-errors';
+import { CorePageVariablesInput, CorePageVariables, PageContentStrings, PageVariablesContentStrings, SingleInputPageVariablesInput, SingleInputPageVariables } from './page-variables';
 
 export {
   AnswersContent,
   AnswersFieldGroups,
   ApolloResponse,
   CisCountry,
+  CorePageVariablesInput,
+  CorePageVariables,
   Country,
   Currency,
+  PageContentStrings,
+  PageVariablesContentStrings,
   PricingGrid,
   PricingGridMonth,
   PricingGridRate,
@@ -36,6 +41,8 @@ export {
   RequiredDataState,
   Response,
   SelectOption,
+  SingleInputPageVariablesInput,
+  SingleInputPageVariables,
   SubmittedData,
   SummaryListItemData,
   SummaryListItem,

--- a/src/ui/types/index.d.ts
+++ b/src/ui/types/index.d.ts
@@ -17,7 +17,14 @@ import {
   TellUsAboutPolicyPageVariables,
 } from './pages/tell-us-about-your-policy';
 import { ValidationErrors } from './validation-errors';
-import { CorePageVariablesInput, CorePageVariables, PageContentStrings, PageVariablesContentStrings, SingleInputPageVariablesInput, SingleInputPageVariables } from './page-variables';
+import {
+  CorePageVariablesInput,
+  CorePageVariables,
+  PageContentStrings,
+  PageVariablesContentStrings,
+  SingleInputPageVariablesInput,
+  SingleInputPageVariables,
+} from './page-variables';
 
 export {
   AnswersContent,

--- a/src/ui/types/page-variables.d.ts
+++ b/src/ui/types/page-variables.d.ts
@@ -1,0 +1,34 @@
+interface PageContentStrings {
+  PAGE_TITLE: string;
+  HEADING: string;
+}
+
+interface PageVariablesContentStrings {
+  BUTTONS: object;
+  COOKIES_CONSENT: object;
+  FOOTER: object;
+  LINKS: object;
+  PRODUCT: object;
+}
+
+interface CorePageVariablesInput {
+  PAGE_CONTENT_STRINGS: PageContentStrings;
+  BACK_LINK?: string;
+}
+
+interface CorePageVariables {
+  CONTENT_STRINGS: PageVariablesContentStrings;
+  BACK_LINK?: string;
+}
+
+interface SingleInputPageVariablesInput extends CorePageVariablesInput {
+  FIELD_ID: string;
+}
+
+interface SingleInputPageVariables extends CorePageVariables {
+  FIELD_ID: string;
+  FIELD_LABEL?: string;
+  FIELD_HINT?: string | object;
+}
+
+export { CorePageVariablesInput, CorePageVariables, PageContentStrings, PageVariablesContentStrings, SingleInputPageVariablesInput, SingleInputPageVariables };


### PR DESCRIPTION
This PR adds the first Insurance/application page - the start page.

## Summary

- Add start page.
- New routes and directories for `/insurance` routes.
- Create `corePageVariables` for core page variables (e.g heading/cookie strings). Update `singleInputPageVariables` to extend the `corePageVariables` type.
- Remove `/application` routes - insurance is the new name.