### PR TITLE
fix(EMS-458): Fix issue where Policy type page would not render skip content link/text

### DIFF
--- a/src/ui/server/controllers/quote/policy-type/index.test.ts
+++ b/src/ui/server/controllers/quote/policy-type/index.test.ts
@@ -1,5 +1,5 @@
 import { PAGE_VARIABLES, get, post } from '.';
-import { BUTTONS, COOKIES_CONSENT, FIELDS, FOOTER, PAGES, PRODUCT } from '../../../content-strings';
+import { BUTTONS, COOKIES_CONSENT, FIELDS, FOOTER, LINKS, PAGES, PRODUCT } from '../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
 import generateValidationErrors from './validation';
 import { updateSubmittedData } from '../../../helpers/update-submitted-data';
@@ -25,6 +25,7 @@ describe('controllers/quote/policy-type', () => {
         CONTENT_STRINGS: {
           BUTTONS,
           COOKIES_CONSENT,
+          LINKS,
           FOOTER,
           PRODUCT,
           ...PAGES.POLICY_TYPE_PAGE,

--- a/src/ui/server/controllers/quote/policy-type/index.ts
+++ b/src/ui/server/controllers/quote/policy-type/index.ts
@@ -1,4 +1,4 @@
-import { BUTTONS, COOKIES_CONSENT, FIELDS, FOOTER, PAGES, PRODUCT } from '../../../content-strings';
+import { BUTTONS, COOKIES_CONSENT, FIELDS, FOOTER, LINKS, PAGES, PRODUCT } from '../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
 import generateValidationErrors from './validation';
 import { isSinglePolicyType } from '../../../helpers/policy-type';
@@ -11,6 +11,7 @@ const PAGE_VARIABLES = {
   CONTENT_STRINGS: {
     BUTTONS,
     COOKIES_CONSENT,
+    LINKS,
     FOOTER,
     PRODUCT,
     ...PAGES.POLICY_TYPE_PAGE,

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.ts
@@ -16,11 +16,11 @@ const { AMOUNT_CURRENCY, CONTRACT_VALUE, CREDIT_PERIOD, CURRENCY, MAX_AMOUNT_OWE
 const generatePageVariables = (policyType: string) => {
   const pageVariables: TellUsAboutPolicyPageVariables = {
     CONTENT_STRINGS: {
-      PRODUCT,
-      FOOTER,
       BUTTONS,
-      LINKS,
       COOKIES_CONSENT,
+      LINKS,
+      FOOTER,
+      PRODUCT,
       ...PAGES.TELL_US_ABOUT_YOUR_POLICY_PAGE,
     },
     FIELDS: {


### PR DESCRIPTION
This passes "links" content strings to the policy type pgae, so that the "skip to main content" nunjuck partial, has a "skip" link and text.