### PR TITLE
feat(EMS-457): UK goods or services - expandable description

### DIFF
--- a/e2e-tests/content-strings/index.js
+++ b/e2e-tests/content-strings/index.js
@@ -8,6 +8,7 @@ const PAGES = require('./pages');
 const PRODUCT = require('./product');
 const QUOTE_TITLES = require('./quote-titles');
 const SUMMARY_ANSWERS = require('./summary-answers');
+const UK_GOODS_AND_SERVICES_DESCRIPTION = require('./uk-goods-and-services-description');
 
 const ORGANISATION = 'UK Export Finance';
 
@@ -23,4 +24,5 @@ module.exports = {
   PRODUCT,
   QUOTE_TITLES,
   SUMMARY_ANSWERS,
+  UK_GOODS_AND_SERVICES_DESCRIPTION,
 };

--- a/e2e-tests/content-strings/pages/quote.js
+++ b/e2e-tests/content-strings/pages/quote.js
@@ -11,62 +11,7 @@ const BUYER_BODY = {
 };
 
 const UK_GOODS_OR_SERVICES = {
-  DETAILS: {
-    INTRO: 'What counts as UK goods and services?',
-    INCLUDES: {
-      INTRO: 'UK goods and services includes:',
-      PRODUCTS: 'products made in the UK',
-      MANUFACTURED: 'goods manufactured outside the UK but processed or modified in the UK, which would then be eligible for a certificate of UK origin',
-      STAFFING_COSTS: {
-        LINK: {
-          TEXT: 'staffing costs',
-          HREF: '#staffing-costs',
-        },
-        TEXT: 'from services provided by UK companies',
-      },
-      NON_PHYSICAL_ASSETS: {
-        LINK: {
-          TEXT: 'non-physical assets',
-          HREF: '#non-physical-assets',
-        },
-        TEXT: 'that are produced in the UK',
-      },
-      CAN_COUNT_AS: 'If any of the above are from the Channel Islands or Isle of Man, you can also count them as UK goods or services.',
-    },
-    DOES_NOT_COUNT: {
-      HEADING: 'What does not count as UK goods and services',
-      TEXT: "Goods or services from outside the UK that you'll send directly to the buyer unprocessed or unaltered in the UK do not count. Instead, they're classed as foreign goods and services.",
-    },
-    STAFFING_COSTS: {
-      HEADING: 'Staffing costs for this export contract',
-      TEXT: 'You can count the following (but only count the actual staffing costs incurred on this specific export contract):',
-      LIST: [
-        {
-          TEXT: 'employees of your UK business',
-        },
-        {
-          TEXT: 'contractors supplied to work for you by a UK sub-contractor',
-        },
-        {
-          TEXT: "staff seconded from abroad to work for you in the UK, on the export contract, and for whom you're financially responsible",
-        },
-      ],
-    },
-    NON_PHYSICAL_ASSETS: {
-      HEADING: 'Non-physical assets',
-      TEXT: "Some assets cannot have a certificate of origin as they're not physical goods, for example, a licence to manufacture goods in another country. But they still count as UK goods or services if they originate from the UK.",
-    },
-    NOT_SURE: {
-      HEADING: "If you're not sure",
-      BODY_1: 'You can speak with',
-      LINK: {
-        TEXT: 'an export finance manager',
-        HREF: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
-      },
-      BODY_2: "if you'd like to check whether you're eligible around this criteria.",
-      BODY_3: "We'll also calculate this thoroughly if you go on to make a full application.",
-    },
-  },
+  WILL_CALCULATE_THOROUGHLY: "We'll also calculate this thoroughly if you go on to make a full application.",
 };
 
 const POLICY_TYPE = {

--- a/e2e-tests/content-strings/uk-goods-and-services-description.js
+++ b/e2e-tests/content-strings/uk-goods-and-services-description.js
@@ -1,0 +1,59 @@
+import LINKS from './links';
+
+const UK_GOODS_AND_SERVICES_DESCRIPTION = {
+  INTRO: 'What counts as UK goods and services?',
+  INCLUDES: {
+    INTRO: 'UK goods and services includes:',
+    PRODUCTS: 'products made in the UK',
+    MANUFACTURED: 'goods manufactured outside the UK but processed or modified in the UK, which would then be eligible for a certificate of UK origin',
+    STAFFING_COSTS: {
+      LINK: {
+        TEXT: 'staffing costs',
+        HREF: '#staffing-costs',
+      },
+      TEXT: 'from services provided by UK companies',
+    },
+    NON_PHYSICAL_ASSETS: {
+      LINK: {
+        TEXT: 'non-physical assets',
+        HREF: '#non-physical-assets',
+      },
+      TEXT: 'that are produced in the UK',
+    },
+    CAN_COUNT_AS: 'If any of the above are from the Channel Islands or Isle of Man, you can also count them as UK goods or services.',
+  },
+  DOES_NOT_COUNT: {
+    HEADING: 'What does not count as UK goods and services',
+    TEXT: "Goods or services from outside the UK that you'll send directly to the buyer unprocessed or unaltered in the UK do not count. Instead, they're classed as foreign goods and services.",
+  },
+  STAFFING_COSTS: {
+    HEADING: 'Staffing costs for this export contract',
+    TEXT: 'You can count the following (but only count the actual staffing costs incurred on this specific export contract):',
+    LIST: [
+      {
+        TEXT: 'employees of your UK business',
+      },
+      {
+        TEXT: 'contractors supplied to work for you by a UK sub-contractor',
+      },
+      {
+        TEXT: "staff seconded from abroad to work for you in the UK, on the export contract, and for whom you're financially responsible",
+      },
+    ],
+  },
+  NON_PHYSICAL_ASSETS: {
+    HEADING: 'Non-physical assets',
+    TEXT: "Some assets cannot have a certificate of origin as they're not physical goods, for example, a licence to manufacture goods in another country. But they still count as UK goods or services if they originate from the UK.",
+  },
+  NOT_SURE: {
+    HEADING: "If you're not sure",
+    BODY_1: 'You can speak with',
+    LINK: {
+      TEXT: 'an export finance manager',
+      HREF: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
+    },
+    BODY_2: "if you'd like to check whether you're eligible around this criteria.",
+  },
+};
+
+export default UK_GOODS_AND_SERVICES_DESCRIPTION;

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -9,6 +9,7 @@ import {
 } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+import { checkSummaryText, checkSummaryClickRevealsContent, checkDescriptionContent } from '../../../../../support/check-uk-goods-and-services-description';
 
 const CONTENT_STRINGS = PAGES.UK_GOODS_OR_SERVICES;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
@@ -110,6 +111,24 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
 
     button.invoke('text').then((text) => {
       expect(text.trim()).equal(BUTTONS.CONTINUE);
+    });
+  });
+
+  describe('expandable details', () => {
+    it('renders summary text', () => {
+      checkSummaryText();
+    });
+
+    it('clicking summary text reveals details', () => {
+      checkSummaryClickRevealsContent();
+    });
+
+    it('renders expanded content', () => {
+      checkDescriptionContent();
+    });
+
+    it('does NOT render `will calculate thoroughly` copy ', () => {
+      partials.ukGoodsOrServicesDescription.calculateThoroughly().should('not.exist');
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -10,6 +10,7 @@ import {
 import CONSTANTS from '../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
 import { completeAndSubmitBuyerBodyForm, completeAndSubmitExporterLocationForm } from '../../../../support/quote/forms';
+import { checkSummaryText, checkSummaryClickRevealsContent, checkDescriptionContent } from '../../../../support/check-uk-goods-and-services-description';
 
 const CONTENT_STRINGS = {
   ...PAGES.UK_GOODS_OR_SERVICES,
@@ -100,148 +101,33 @@ context('UK goods or services page - as an exporter, I want to check if my expor
     });
   });
 
+  describe('expandable details', () => {
+    it('renders summary text', () => {
+      checkSummaryText();
+    });
+
+    it('clicking summary text reveals details', () => {
+      checkSummaryClickRevealsContent();
+    });
+
+    it('renders expanded content', () => {
+      checkDescriptionContent();
+    });
+
+    it('renders `will calculate thoroughly` copy ', () => {
+      partials.ukGoodsOrServicesDescription.calculateThoroughly().invoke('text').then((text) => {
+        const expected = CONTENT_STRINGS.WILL_CALCULATE_THOROUGHLY;
+        expect(text.trim()).equal(expected);
+      });
+    });
+  });
+
   it('renders a submit button', () => {
     const button = ukGoodsOrServicesPage.submitButton();
     button.should('exist');
 
     button.invoke('text').then((text) => {
       expect(text.trim()).equal(BUTTONS.CONTINUE);
-    });
-  });
-
-  describe('expandable details', () => {
-    const { details } = ukGoodsOrServicesPage;
-    const { DETAILS } = CONTENT_STRINGS;
-
-    it('renders a summary', () => {
-      details.summary().should('exist');
-
-      details.summary().invoke('text').then((text) => {
-        expect(text.trim()).equal(CONTENT_STRINGS.DETAILS.INTRO);
-      });
-    });
-
-    it('clicking summary reveals details', () => {
-      details.summary().click();
-
-      details.includes.intro().should('be.visible');
-    });
-
-    describe('`includes` section', () => {
-      it('renders intro', () => {
-        details.includes.intro().invoke('text').then((text) => {
-          expect(text.trim()).equal(DETAILS.INCLUDES.INTRO);
-        });
-      });
-
-      it('renders list items', () => {
-        details.includes.listItem1().invoke('text').then((text) => {
-          expect(text.trim()).equal(DETAILS.INCLUDES.PRODUCTS);
-        });
-
-        details.includes.listItem2().invoke('text').then((text) => {
-          expect(text.trim()).equal(DETAILS.INCLUDES.MANUFACTURED);
-        });
-
-        details.includes.listItem3().invoke('text').then((text) => {
-          const expected = `${DETAILS.INCLUDES.STAFFING_COSTS.LINK.TEXT} ${DETAILS.INCLUDES.STAFFING_COSTS.TEXT}`;
-          expect(text.trim()).equal(expected);
-        });
-
-        details.includes.listItem3Link().should('have.attr', 'href', DETAILS.INCLUDES.STAFFING_COSTS.LINK.HREF);
-
-        details.includes.listItem4().invoke('text').then((text) => {
-          const expected = `${DETAILS.INCLUDES.NON_PHYSICAL_ASSETS.LINK.TEXT} ${DETAILS.INCLUDES.NON_PHYSICAL_ASSETS.TEXT}`;
-          expect(text.trim()).equal(expected);
-        });
-
-        details.includes.listItem4Link().should('have.attr', 'href', DETAILS.INCLUDES.NON_PHYSICAL_ASSETS.LINK.HREF);
-      });
-
-      it('renders `also count as` copy', () => {
-        details.includes.canCountAs().invoke('text').then((text) => {
-          expect(text.trim()).equal(DETAILS.INCLUDES.CAN_COUNT_AS);
-        });
-      });
-    });
-
-    describe('`does not count` section', () => {
-      it('renders a heading', () => {
-        details.doesNotCount.heading().invoke('text').then((text) => {
-          expect(text.trim()).equal(DETAILS.DOES_NOT_COUNT.HEADING);
-        });
-      });
-
-      it('renders copy', () => {
-        details.doesNotCount.copy().invoke('text').then((text) => {
-          expect(text.trim()).equal(DETAILS.DOES_NOT_COUNT.TEXT);
-        });
-      });
-    });
-
-    describe('`staffing costs` section', () => {
-      it('renders a heading', () => {
-        details.staffingCosts.heading().invoke('text').then((text) => {
-          expect(text.trim()).equal(DETAILS.STAFFING_COSTS.HEADING);
-        });
-      });
-
-      it('renders copy', () => {
-        details.staffingCosts.copy().invoke('text').then((text) => {
-          expect(text.trim()).equal(DETAILS.STAFFING_COSTS.TEXT);
-        });
-      });
-
-      it('renders list items', () => {
-        details.staffingCosts.listItem1().invoke('text').then((text) => {
-          expect(text.trim()).equal(DETAILS.STAFFING_COSTS.LIST[0].TEXT);
-        });
-
-        details.staffingCosts.listItem2().invoke('text').then((text) => {
-          expect(text.trim()).equal(DETAILS.STAFFING_COSTS.LIST[1].TEXT);
-        });
-
-        details.staffingCosts.listItem3().invoke('text').then((text) => {
-          expect(text.trim()).equal(DETAILS.STAFFING_COSTS.LIST[2].TEXT);
-        });
-      });
-    });
-
-    describe('`non physical assets` section', () => {
-      it('renders a heading', () => {
-        details.nonPhysicalAssets.heading().invoke('text').then((text) => {
-          expect(text.trim()).equal(DETAILS.NON_PHYSICAL_ASSETS.HEADING);
-        });
-      });
-
-      it('renders copy', () => {
-        details.nonPhysicalAssets.copy().invoke('text').then((text) => {
-          expect(text.trim()).equal(DETAILS.NON_PHYSICAL_ASSETS.TEXT);
-        });
-      });
-    });
-
-    describe('`not sure` section', () => {
-      it('renders a heading', () => {
-        details.notSure.heading().invoke('text').then((text) => {
-          expect(text.trim()).equal(DETAILS.NOT_SURE.HEADING);
-        });
-      });
-
-      it('renders copy', () => {
-        details.notSure.details().invoke('text').then((text) => {
-          const expected = `${DETAILS.NOT_SURE.BODY_1} ${DETAILS.NOT_SURE.LINK.TEXT} ${DETAILS.NOT_SURE.BODY_2}`;
-
-          expect(text.trim()).equal(expected);
-        });
-
-        details.notSure.detailsLast().invoke('text').then((text) => {
-          const expected = DETAILS.NOT_SURE.BODY_3;
-          expect(text.trim()).equal(expected);
-        });
-
-        details.notSure.detailsLink().should('have.attr', 'href', DETAILS.NOT_SURE.LINK.HREF);
-      });
     });
   });
 

--- a/e2e-tests/cypress/e2e/pages/shared/ukGoodsOrServices.js
+++ b/e2e-tests/cypress/e2e/pages/shared/ukGoodsOrServices.js
@@ -8,41 +8,6 @@ const ukGoodsOrServicesPage = {
   noInput: () => cy.get(`[data-cy="${FIELD_IDS.HAS_MINIMUM_UK_GOODS_OR_SERVICES}-no-input"]`),
   errorMessage: () => cy.get(`[data-cy="${FIELD_IDS.HAS_MINIMUM_UK_GOODS_OR_SERVICES}-error-message"]`),
   submitButton: () => cy.get('[data-cy="submit-button"]'),
-  details: {
-    summary: () => cy.get('[data-cy="details"] summary'),
-    includes: {
-      intro: () => cy.get('[data-cy="details-includes-intro"]'),
-      listItem1: () => cy.get('[data-cy="details-includes-item-1"]'),
-      listItem2: () => cy.get('[data-cy="details-includes-item-2"]'),
-      listItem3: () => cy.get('[data-cy="details-includes-item-3"]'),
-      listItem3Link: () => cy.get('[data-cy="details-includes-item-3-link"]'),
-      listItem4: () => cy.get('[data-cy="details-includes-item-4"]'),
-      listItem4Link: () => cy.get('[data-cy="details-includes-item-4-link"]'),
-      canCountAs: () => cy.get('[data-cy="details-includes-can-count-as"]'),
-    },
-    canAlsoCount: () => cy.get('[data-cy="details-can-also-count-copy"]'),
-    doesNotCount: {
-      heading: () => cy.get('[data-cy="details-does-not-count-heading"]'),
-      copy: () => cy.get('[data-cy="details-does-not-count-copy"]'),
-    },
-    staffingCosts: {
-      heading: () => cy.get('[data-cy="details-staffing-costs-heading"]'),
-      copy: () => cy.get('[data-cy="details-staffing-costs-copy"]'),
-      listItem1: () => cy.get('[data-cy="details-staffing-costs-list-item-1"]'),
-      listItem2: () => cy.get('[data-cy="details-staffing-costs-list-item-2"]'),
-      listItem3: () => cy.get('[data-cy="details-staffing-costs-list-item-3"]'),
-    },
-    nonPhysicalAssets: {
-      heading: () => cy.get('[data-cy="details-non-physical-assets-heading"]'),
-      copy: () => cy.get('[data-cy="details-non-physical-assets-copy"]'),
-    },
-    notSure: {
-      heading: () => cy.get('[data-cy="details-not-sure-heading"]'),
-      details: () => cy.get('[data-cy="details-not-sure"]'),
-      detailsLink: () => cy.get('[data-cy="details-not-sure-link"]'),
-      detailsLast: () => cy.get('[data-cy="details-not-sure-last"]'),
-    },
-  },
 };
 
 export default ukGoodsOrServicesPage;

--- a/e2e-tests/cypress/e2e/partials/index.js
+++ b/e2e-tests/cypress/e2e/partials/index.js
@@ -1,6 +1,7 @@
 import cookieBanner from './cookieBanner';
 import footer from './footer';
 import phaseBanner from './phaseBanner';
+import ukGoodsOrServicesDescription from './ukGoodsAndServicesDescription';
 
 const partials = {
   backLink: () => cy.get('[data-cy="back-link"]'),
@@ -8,8 +9,9 @@ const partials = {
   errorSummaryListItems: () => cy.get('.govuk-error-summary li'),
   errorSummaryListItemLinks: () => cy.get('.govuk-error-summary li a'),
   footer,
-  phaseBanner,
   skipLink: () => cy.get('[data-cy="skip-link"]'),
+  phaseBanner,
+  ukGoodsOrServicesDescription,
 };
 
 export default partials;

--- a/e2e-tests/cypress/e2e/partials/ukGoodsAndServicesDescription.js
+++ b/e2e-tests/cypress/e2e/partials/ukGoodsAndServicesDescription.js
@@ -1,0 +1,37 @@
+const ukGoodsOrServicesDescription = {
+  summary: () => cy.get('[data-cy="goods-services"] summary'),
+  includes: {
+    intro: () => cy.get('[data-cy="goods-services-includes-intro"]'),
+    listItem1: () => cy.get('[data-cy="goods-services-includes-item-1"]'),
+    listItem2: () => cy.get('[data-cy="goods-services-includes-item-2"]'),
+    listItem3: () => cy.get('[data-cy="goods-services-includes-item-3"]'),
+    listItem3Link: () => cy.get('[data-cy="goods-services-includes-item-3-link"]'),
+    listItem4: () => cy.get('[data-cy="goods-services-includes-item-4"]'),
+    listItem4Link: () => cy.get('[data-cy="goods-services-includes-item-4-link"]'),
+    canCountAs: () => cy.get('[data-cy="goods-services-includes-can-count-as"]'),
+  },
+  canAlsoCount: () => cy.get('[data-cy="goods-services-can-also-count-copy"]'),
+  doesNotCount: {
+    heading: () => cy.get('[data-cy="goods-services-does-not-count-heading"]'),
+    copy: () => cy.get('[data-cy="goods-services-does-not-count-copy"]'),
+  },
+  staffingCosts: {
+    heading: () => cy.get('[data-cy="goods-services-staffing-costs-heading"]'),
+    copy: () => cy.get('[data-cy="goods-services-staffing-costs-copy"]'),
+    listItem1: () => cy.get('[data-cy="goods-services-staffing-costs-list-item-1"]'),
+    listItem2: () => cy.get('[data-cy="goods-services-staffing-costs-list-item-2"]'),
+    listItem3: () => cy.get('[data-cy="goods-services-staffing-costs-list-item-3"]'),
+  },
+  nonPhysicalAssets: {
+    heading: () => cy.get('[data-cy="goods-services-non-physical-assets-heading"]'),
+    copy: () => cy.get('[data-cy="goods-services-non-physical-assets-copy"]'),
+  },
+  notSure: {
+    heading: () => cy.get('[data-cy="goods-services-not-sure-heading"]'),
+    details: () => cy.get('[data-cy="goods-services-not-sure"]'),
+    detailsLink: () => cy.get('[data-cy="goods-services-not-sure-link"]'),
+  },
+  calculateThoroughly: () => cy.get('[data-cy="goods-services-will-calculate-thoroughly"]'),
+};
+
+export default ukGoodsOrServicesDescription;

--- a/e2e-tests/cypress/support/check-uk-goods-and-services-description.js
+++ b/e2e-tests/cypress/support/check-uk-goods-and-services-description.js
@@ -1,0 +1,116 @@
+import { ukGoodsOrServicesDescription } from '../e2e/partials';
+import { UK_GOODS_AND_SERVICES_DESCRIPTION, PAGES } from '../../content-strings';
+
+const CONTENT_STRINGS  = UK_GOODS_AND_SERVICES_DESCRIPTION;
+
+const checkSummaryText = () => {
+  ukGoodsOrServicesDescription.summary().should('exist');
+
+  ukGoodsOrServicesDescription.summary().invoke('text').then((text) => {
+    expect(text.trim()).equal(CONTENT_STRINGS.INTRO);
+  });
+};
+
+const checkSummaryClickRevealsContent = () => {
+  ukGoodsOrServicesDescription.summary().click();
+
+  ukGoodsOrServicesDescription.includes.intro().should('be.visible');
+};
+
+const checkDescriptionContentSections = {
+  includes: () => {
+    ukGoodsOrServicesDescription.includes.intro().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.INCLUDES.INTRO);
+    });
+
+    ukGoodsOrServicesDescription.includes.listItem1().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.INCLUDES.PRODUCTS);
+    });
+
+    ukGoodsOrServicesDescription.includes.listItem2().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.INCLUDES.MANUFACTURED);
+    });
+
+    ukGoodsOrServicesDescription.includes.listItem3().invoke('text').then((text) => {
+      const expected = `${CONTENT_STRINGS.INCLUDES.STAFFING_COSTS.LINK.TEXT} ${CONTENT_STRINGS.INCLUDES.STAFFING_COSTS.TEXT}`;
+      expect(text.trim()).equal(expected);
+    });
+
+    ukGoodsOrServicesDescription.includes.listItem3Link().should('have.attr', 'href', CONTENT_STRINGS.INCLUDES.STAFFING_COSTS.LINK.HREF);
+
+    ukGoodsOrServicesDescription.includes.listItem4().invoke('text').then((text) => {
+      const expected = `${CONTENT_STRINGS.INCLUDES.NON_PHYSICAL_ASSETS.LINK.TEXT} ${CONTENT_STRINGS.INCLUDES.NON_PHYSICAL_ASSETS.TEXT}`;
+      expect(text.trim()).equal(expected);
+    });
+
+    ukGoodsOrServicesDescription.includes.listItem4Link().should('have.attr', 'href', CONTENT_STRINGS.INCLUDES.NON_PHYSICAL_ASSETS.LINK.HREF);
+
+    ukGoodsOrServicesDescription.includes.canCountAs().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.INCLUDES.CAN_COUNT_AS);
+    });
+  },
+  doesNotCount: () => {
+    ukGoodsOrServicesDescription.doesNotCount.heading().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.DOES_NOT_COUNT.HEADING);
+    });
+
+    ukGoodsOrServicesDescription.doesNotCount.copy().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.DOES_NOT_COUNT.TEXT);
+    });
+  },
+  staffingCosts: () => {
+    ukGoodsOrServicesDescription.staffingCosts.heading().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.STAFFING_COSTS.HEADING);
+    });
+
+    ukGoodsOrServicesDescription.staffingCosts.copy().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.STAFFING_COSTS.TEXT);
+    });
+
+    ukGoodsOrServicesDescription.staffingCosts.listItem1().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.STAFFING_COSTS.LIST[0].TEXT);
+    });
+
+    ukGoodsOrServicesDescription.staffingCosts.listItem2().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.STAFFING_COSTS.LIST[1].TEXT);
+    });
+
+    ukGoodsOrServicesDescription.staffingCosts.listItem3().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.STAFFING_COSTS.LIST[2].TEXT);
+    });
+  },
+  nonPhysicalAssets: () => {
+    ukGoodsOrServicesDescription.nonPhysicalAssets.heading().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.NON_PHYSICAL_ASSETS.HEADING);
+    });
+
+    ukGoodsOrServicesDescription.nonPhysicalAssets.copy().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.NON_PHYSICAL_ASSETS.TEXT);
+    });
+  },
+  notSure: () => {
+    ukGoodsOrServicesDescription.notSure.heading().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.NOT_SURE.HEADING);
+    });
+
+    ukGoodsOrServicesDescription.notSure.details().invoke('text').then((text) => {
+      const expected = `${CONTENT_STRINGS.NOT_SURE.BODY_1} ${CONTENT_STRINGS.NOT_SURE.LINK.TEXT} ${CONTENT_STRINGS.NOT_SURE.BODY_2}`;
+
+      expect(text.trim()).equal(expected);
+    });
+  },
+};
+
+const checkDescriptionContent = () => {
+  checkDescriptionContentSections.includes();
+  checkDescriptionContentSections.doesNotCount();
+  checkDescriptionContentSections.staffingCosts();
+  checkDescriptionContentSections.nonPhysicalAssets();
+  checkDescriptionContentSections.notSure();
+};
+
+module.exports = {
+  checkSummaryText,
+  checkSummaryClickRevealsContent,
+  checkDescriptionContent,
+};

--- a/src/ui/server/content-strings/index.ts
+++ b/src/ui/server/content-strings/index.ts
@@ -9,5 +9,6 @@ export * from './product';
 export * from './quote-titles';
 export * from './summary-answers';
 export * from './tasks';
+export * from './uk-goods-and-services-description';
 
 export const ORGANISATION = 'UK Export Finance';

--- a/src/ui/server/content-strings/pages/quote.ts
+++ b/src/ui/server/content-strings/pages/quote.ts
@@ -11,62 +11,7 @@ const BUYER_BODY = {
 };
 
 const UK_GOODS_OR_SERVICES = {
-  DETAILS: {
-    INTRO: 'What counts as UK goods and services?',
-    INCLUDES: {
-      INTRO: 'UK goods and services includes:',
-      PRODUCTS: 'products made in the UK',
-      MANUFACTURED: 'goods manufactured outside the UK but processed or modified in the UK, which would then be eligible for a certificate of UK origin',
-      STAFFING_COSTS: {
-        LINK: {
-          TEXT: 'staffing costs',
-          HREF: '#staffing-costs',
-        },
-        TEXT: 'from services provided by UK companies',
-      },
-      NON_PHYSICAL_ASSETS: {
-        LINK: {
-          TEXT: 'non-physical assets',
-          HREF: '#non-physical-assets',
-        },
-        TEXT: 'that are produced in the UK',
-      },
-      CAN_COUNT_AS: 'If any of the above are from the Channel Islands or Isle of Man, you can also count them as UK goods or services.',
-    },
-    DOES_NOT_COUNT: {
-      HEADING: 'What does not count as UK goods and services',
-      TEXT: "Goods or services from outside the UK that you'll send directly to the buyer unprocessed or unaltered in the UK do not count. Instead, they're classed as foreign goods and services.",
-    },
-    STAFFING_COSTS: {
-      HEADING: 'Staffing costs for this export contract',
-      TEXT: 'You can count the following (but only count the actual staffing costs incurred on this specific export contract):',
-      LIST: [
-        {
-          TEXT: 'employees of your UK business',
-        },
-        {
-          TEXT: 'contractors supplied to work for you by a UK sub-contractor',
-        },
-        {
-          TEXT: "staff seconded from abroad to work for you in the UK, on the export contract, and for whom you're financially responsible",
-        },
-      ],
-    },
-    NON_PHYSICAL_ASSETS: {
-      HEADING: 'Non-physical assets',
-      TEXT: "Some assets cannot have a certificate of origin as they're not physical goods, for example, a licence to manufacture goods in another country. But they still count as UK goods or services if they originate from the UK.",
-    },
-    NOT_SURE: {
-      HEADING: "If you're not sure",
-      BODY_1: 'You can speak with',
-      LINK: {
-        TEXT: 'an export finance manager',
-        HREF: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
-      },
-      BODY_2: "if you'd like to check whether you're eligible around this criteria.",
-      BODY_3: "We'll also calculate this thoroughly if you go on to make a full application.",
-    },
-  },
+  WILL_CALCULATE_THOROUGHLY: "We'll also calculate this thoroughly if you go on to make a full application.",
 };
 
 const POLICY_TYPE = {

--- a/src/ui/server/content-strings/uk-goods-and-services-description.ts
+++ b/src/ui/server/content-strings/uk-goods-and-services-description.ts
@@ -1,0 +1,57 @@
+import { LINKS } from './links';
+
+export const UK_GOODS_AND_SERVICES_DESCRIPTION = {
+  INTRO: 'What counts as UK goods and services?',
+  INCLUDES: {
+    INTRO: 'UK goods and services includes:',
+    PRODUCTS: 'products made in the UK',
+    MANUFACTURED: 'goods manufactured outside the UK but processed or modified in the UK, which would then be eligible for a certificate of UK origin',
+    STAFFING_COSTS: {
+      LINK: {
+        TEXT: 'staffing costs',
+        HREF: '#staffing-costs',
+      },
+      TEXT: 'from services provided by UK companies',
+    },
+    NON_PHYSICAL_ASSETS: {
+      LINK: {
+        TEXT: 'non-physical assets',
+        HREF: '#non-physical-assets',
+      },
+      TEXT: 'that are produced in the UK',
+    },
+    CAN_COUNT_AS: 'If any of the above are from the Channel Islands or Isle of Man, you can also count them as UK goods or services.',
+  },
+  DOES_NOT_COUNT: {
+    HEADING: 'What does not count as UK goods and services',
+    TEXT: "Goods or services from outside the UK that you'll send directly to the buyer unprocessed or unaltered in the UK do not count. Instead, they're classed as foreign goods and services.",
+  },
+  STAFFING_COSTS: {
+    HEADING: 'Staffing costs for this export contract',
+    TEXT: 'You can count the following (but only count the actual staffing costs incurred on this specific export contract):',
+    LIST: [
+      {
+        TEXT: 'employees of your UK business',
+      },
+      {
+        TEXT: 'contractors supplied to work for you by a UK sub-contractor',
+      },
+      {
+        TEXT: "staff seconded from abroad to work for you in the UK, on the export contract, and for whom you're financially responsible",
+      },
+    ],
+  },
+  NON_PHYSICAL_ASSETS: {
+    HEADING: 'Non-physical assets',
+    TEXT: "Some assets cannot have a certificate of origin as they're not physical goods, for example, a licence to manufacture goods in another country. But they still count as UK goods or services if they originate from the UK.",
+  },
+  NOT_SURE: {
+    HEADING: "If you're not sure",
+    BODY_1: 'You can speak with',
+    LINK: {
+      TEXT: 'an export finance manager',
+      HREF: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
+    },
+    BODY_2: "if you'd like to check whether you're eligible around this criteria.",
+  },
+};

--- a/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.test.ts
@@ -1,5 +1,5 @@
 import { PAGE_VARIABLES, get, post } from '.';
-import { PAGES } from '../../../../content-strings';
+import { PAGES, UK_GOODS_AND_SERVICES_DESCRIPTION } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/single-input-page-variables';
 import generateValidationErrors from '../../../../shared-validation/uk-goods-or-services';
@@ -19,7 +19,10 @@ describe('controllers/insurance/eligibility/uk-goods-or-services', () => {
     it('should have correct properties', () => {
       const expected = {
         FIELD_ID: FIELD_IDS.HAS_MINIMUM_UK_GOODS_OR_SERVICES,
-        PAGE_CONTENT_STRINGS: PAGES.UK_GOODS_OR_SERVICES,
+        PAGE_CONTENT_STRINGS: {
+          ...PAGES.UK_GOODS_OR_SERVICES,
+          UK_GOODS_AND_SERVICES_DESCRIPTION,
+        },
       };
 
       expect(PAGE_VARIABLES).toEqual(expected);

--- a/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.ts
@@ -1,4 +1,4 @@
-import { PAGES } from '../../../../content-strings';
+import { PAGES, UK_GOODS_AND_SERVICES_DESCRIPTION } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/single-input-page-variables';
 import generateValidationErrors from '../../../../shared-validation/uk-goods-or-services';
@@ -6,7 +6,10 @@ import { Request, Response } from '../../../../../types';
 
 const PAGE_VARIABLES = {
   FIELD_ID: FIELD_IDS.HAS_MINIMUM_UK_GOODS_OR_SERVICES,
-  PAGE_CONTENT_STRINGS: PAGES.UK_GOODS_OR_SERVICES,
+  PAGE_CONTENT_STRINGS: {
+    ...PAGES.UK_GOODS_OR_SERVICES,
+    UK_GOODS_AND_SERVICES_DESCRIPTION,
+  },
 };
 
 const get = (req: Request, res: Response) =>

--- a/src/ui/server/controllers/quote/uk-goods-or-services/index.test.ts
+++ b/src/ui/server/controllers/quote/uk-goods-or-services/index.test.ts
@@ -1,5 +1,5 @@
 import { PAGE_VARIABLES, get, post } from '.';
-import { PAGES } from '../../../content-strings';
+import { PAGES, UK_GOODS_AND_SERVICES_DESCRIPTION } from '../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
 import singleInputPageVariables from '../../../helpers/single-input-page-variables';
 import generateValidationErrors from '../../../shared-validation/uk-goods-or-services';
@@ -23,6 +23,7 @@ describe('controllers/quote/uk-goods-or-services', () => {
         PAGE_CONTENT_STRINGS: {
           ...PAGES.UK_GOODS_OR_SERVICES,
           ...PAGES.QUOTE.UK_GOODS_OR_SERVICES,
+          UK_GOODS_AND_SERVICES_DESCRIPTION,
         },
       };
 

--- a/src/ui/server/controllers/quote/uk-goods-or-services/index.ts
+++ b/src/ui/server/controllers/quote/uk-goods-or-services/index.ts
@@ -1,4 +1,4 @@
-import { PAGES } from '../../../content-strings';
+import { PAGES, UK_GOODS_AND_SERVICES_DESCRIPTION } from '../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
 import singleInputPageVariables from '../../../helpers/single-input-page-variables';
 import generateValidationErrors from '../../../shared-validation/uk-goods-or-services';
@@ -11,6 +11,7 @@ const PAGE_VARIABLES = {
   PAGE_CONTENT_STRINGS: {
     ...PAGES.UK_GOODS_OR_SERVICES,
     ...PAGES.QUOTE.UK_GOODS_OR_SERVICES,
+    UK_GOODS_AND_SERVICES_DESCRIPTION,
   },
 };
 

--- a/src/ui/templates/insurance/eligibility/uk-goods-or-services.njk
+++ b/src/ui/templates/insurance/eligibility/uk-goods-or-services.njk
@@ -3,6 +3,7 @@
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from 'govuk/components/radios/macro.njk' import govukRadios %}
 {% from 'govuk/components/button/macro.njk' import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
 
 {% block pageTitle %}
@@ -77,6 +78,24 @@
             attributes: {
               "data-cy": FIELD_ID + "-error-message"
             }
+          }
+        }) }}
+
+      </div>
+    </div>
+
+    {% set detailsHtml %}
+      {% include "partials/uk-goods-and-services-description.njk" %}
+    {% endset %}
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters-from-desktop">
+
+        {{ govukDetails({
+          summaryText: CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.INTRO,
+          html: detailsHtml,
+          attributes: {
+            "data-cy": "goods-services"
           }
         }) }}
 

--- a/src/ui/templates/partials/uk-goods-and-services-description.njk
+++ b/src/ui/templates/partials/uk-goods-and-services-description.njk
@@ -1,0 +1,30 @@
+<p data-cy="goods-services-includes-intro">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.INCLUDES.INTRO }}</p>
+
+<ul class="govuk-!-margin-bottom-7">
+  <li data-cy="goods-services-includes-item-1">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.INCLUDES.PRODUCTS }}</li>
+  <li data-cy="goods-services-includes-item-2">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.INCLUDES.MANUFACTURED }}</li>
+  <li data-cy="goods-services-includes-item-3"><a class="govuk-link" data-cy="goods-services-includes-item-3-link" href="{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.INCLUDES.STAFFING_COSTS.LINK.HREF }}">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.INCLUDES.STAFFING_COSTS.LINK.TEXT }}</a> {{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.INCLUDES.STAFFING_COSTS.TEXT }}</li>
+  <li data-cy="goods-services-includes-item-4"><a class="govuk-link"  data-cy="goods-services-includes-item-4-link" href="{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.INCLUDES.NON_PHYSICAL_ASSETS.LINK.HREF }}">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.INCLUDES.NON_PHYSICAL_ASSETS.LINK.TEXT }}</a> {{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.INCLUDES.NON_PHYSICAL_ASSETS.TEXT }}</li>
+</ul>
+
+<p data-cy="goods-services-includes-can-count-as">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.INCLUDES.CAN_COUNT_AS }}</p>
+
+<h2 class="govuk-heading-s"  data-cy="goods-services-does-not-count-heading">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.DOES_NOT_COUNT.HEADING }}</h2>
+<p data-cy="goods-services-does-not-count-copy">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.DOES_NOT_COUNT.TEXT }}</p>
+
+<h2 class="govuk-heading-s" id="staffing-costs" data-cy="goods-services-staffing-costs-heading">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.STAFFING_COSTS.HEADING }}</h2>
+<p data-cy="goods-services-staffing-costs-copy">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.STAFFING_COSTS.TEXT }}</p>
+
+<ul>
+  {% for item in CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.STAFFING_COSTS.LIST %}
+    <li data-cy="goods-services-staffing-costs-list-item-{{ loop.index }}">{{ item.TEXT }}</li>
+  {% endfor %}
+</ul>
+
+<h2 class="govuk-heading-s" id="non-physical-assets" data-cy="goods-services-non-physical-assets-heading">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.NON_PHYSICAL_ASSETS.HEADING }}</h2>
+<p data-cy="goods-services-non-physical-assets-copy">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.NON_PHYSICAL_ASSETS.TEXT }}</p>
+
+
+<h2 class="govuk-heading-s" data-cy="goods-services-not-sure-heading">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.NOT_SURE.HEADING }}</h2>
+
+<p data-cy="goods-services-not-sure">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.NOT_SURE.BODY_1 }} <a class="govuk-link" data-cy="goods-services-not-sure-link" href="{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.NOT_SURE.LINK.HREF }}">{{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.NOT_SURE.LINK.TEXT }}</a> {{ CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.NOT_SURE.BODY_2 }}</p>

--- a/src/ui/templates/quote/uk-goods-or-services.njk
+++ b/src/ui/templates/quote/uk-goods-or-services.njk
@@ -91,53 +91,20 @@
       }
     }) }}
 
-
     {% set detailsHtml %}
-      <p data-cy="details-includes-intro">{{ CONTENT_STRINGS.DETAILS.INCLUDES.INTRO }}</p>
+      {% include "partials/uk-goods-and-services-description.njk" %}
 
-      <ul class="govuk-!-margin-bottom-7">
-        <li data-cy="details-includes-item-1">{{ CONTENT_STRINGS.DETAILS.INCLUDES.PRODUCTS }}</li>
-        <li data-cy="details-includes-item-2">{{ CONTENT_STRINGS.DETAILS.INCLUDES.MANUFACTURED }}</li>
-        <li data-cy="details-includes-item-3"><a class="govuk-link" data-cy="details-includes-item-3-link" href="{{ CONTENT_STRINGS.DETAILS.INCLUDES.STAFFING_COSTS.LINK.HREF }}">{{ CONTENT_STRINGS.DETAILS.INCLUDES.STAFFING_COSTS.LINK.TEXT }}</a> {{ CONTENT_STRINGS.DETAILS.INCLUDES.STAFFING_COSTS.TEXT }}</li>
-        <li data-cy="details-includes-item-4"><a class="govuk-link"  data-cy="details-includes-item-4-link" href="{{ CONTENT_STRINGS.DETAILS.INCLUDES.NON_PHYSICAL_ASSETS.LINK.HREF }}">{{ CONTENT_STRINGS.DETAILS.INCLUDES.NON_PHYSICAL_ASSETS.LINK.TEXT }}</a> {{ CONTENT_STRINGS.DETAILS.INCLUDES.NON_PHYSICAL_ASSETS.TEXT }}</li>
-      </ul>
-
-      <p data-cy="details-includes-can-count-as">{{ CONTENT_STRINGS.DETAILS.INCLUDES.CAN_COUNT_AS }}</p>
-
-      <h2 class="govuk-heading-s"  data-cy="details-does-not-count-heading">{{ CONTENT_STRINGS.DETAILS.DOES_NOT_COUNT.HEADING }}</h2>
-      <p data-cy="details-does-not-count-copy">{{ CONTENT_STRINGS.DETAILS.DOES_NOT_COUNT.TEXT }}</p>
-
-      <h2 class="govuk-heading-s" id="staffing-costs" data-cy="details-staffing-costs-heading">{{ CONTENT_STRINGS.DETAILS.STAFFING_COSTS.HEADING }}</h2>
-      <p data-cy="details-staffing-costs-copy">{{ CONTENT_STRINGS.DETAILS.STAFFING_COSTS.TEXT }}</p>
-
-      <ul>
-        {% for item in CONTENT_STRINGS.DETAILS.STAFFING_COSTS.LIST %}
-          <li data-cy="details-staffing-costs-list-item-{{ loop.index }}">{{ item.TEXT }}</li>
-        {% endfor %}
-      </ul>
-
-      <h2 class="govuk-heading-s" id="non-physical-assets" data-cy="details-non-physical-assets-heading">{{ CONTENT_STRINGS.DETAILS.NON_PHYSICAL_ASSETS.HEADING }}</h2>
-      <p data-cy="details-non-physical-assets-copy">{{ CONTENT_STRINGS.DETAILS.NON_PHYSICAL_ASSETS.TEXT }}</p>
-
-
-      <h2 class="govuk-heading-s" data-cy="details-not-sure-heading">{{ CONTENT_STRINGS.DETAILS.NOT_SURE.HEADING }}</h2>
-
-      <div>
-        <p data-cy="details-not-sure">{{ CONTENT_STRINGS.DETAILS.NOT_SURE.BODY_1 }} <a class="govuk-link" data-cy="details-not-sure-link" href="{{ CONTENT_STRINGS.DETAILS.NOT_SURE.LINK.HREF }}">{{ CONTENT_STRINGS.DETAILS.NOT_SURE.LINK.TEXT }}</a> {{ CONTENT_STRINGS.DETAILS.NOT_SURE.BODY_2 }}</p>
-
-        <p data-cy="details-not-sure-last">{{ CONTENT_STRINGS.DETAILS.NOT_SURE.BODY_3 }}</p>
-
-      </div>
+      <p data-cy="goods-services-will-calculate-thoroughly">{{ CONTENT_STRINGS.WILL_CALCULATE_THOROUGHLY }}</p>
     {% endset %}
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters-from-desktop">
 
         {{ govukDetails({
-          summaryText: CONTENT_STRINGS.DETAILS.INTRO,
+          summaryText: CONTENT_STRINGS.UK_GOODS_AND_SERVICES_DESCRIPTION.INTRO,
           html: detailsHtml,
           attributes: {
-            "data-cy": "details"
+            "data-cy": "goods-services"
           }
         }) }}
 


### PR DESCRIPTION
This PR adds an expandable details section of "What counts as UK Goods and services", to the "UK goods and services" page of the Insurance Eligibility section.

## Summary

- Extract the existing "What counts as UK Goods and services" part of the UK page in the Quote flow into it's own component/partial.
- Consume this component in both UK goods and services pages in the Quote flow and Insurance Eligibility flow, but with the Quote version rendering and additional line of text.
- Extract relevant content strings and e2e assertions into their own files, to be consumed in multiple places.