### PR TITLE
feat(EMS-485): Insurance eligibility - Insured period page, speak to EFM exit page

### DIFF
--- a/e2e-tests/constants/field-ids.js
+++ b/e2e-tests/constants/field-ids.js
@@ -25,7 +25,7 @@ const FIELD_IDS = {
   },
   INSURANCE: {
     ELIGIBILITY: {
-      WANT_COVER_FOR_MORE_THAN_MAX_PERIOD: 'wantCoverForMoreThanMaxPeriod',
+      WANT_COVER_OVER_MAX_AMOUNT: 'wantCoverForMoreThanMaxPeriod',
     },
   },
 };

--- a/e2e-tests/constants/routes/insurance.js
+++ b/e2e-tests/constants/routes/insurance.js
@@ -8,10 +8,11 @@ const INSURANCE_ROUTES = {
     BUYER_COUNTRY: `${INSURANCE}${ELIGIBILITY}/buyer-location`,
     CANNOT_APPLY: `${INSURANCE}${ELIGIBILITY}/cannot-apply`,
     APPLY_OFFLINE: `${INSURANCE}${ELIGIBILITY}/apply-using-our-form`,
+    SPEAK_TO_UKEF_EFM: `${INSURANCE}${ELIGIBILITY}/speak-to-UKEF-EFM`,
     EXPORTER_LOCATION: `${INSURANCE}${ELIGIBILITY}/exporter-location`,
     UK_GOODS_OR_SERVICES: `${INSURANCE}${ELIGIBILITY}/uk-goods-services`,
     INSURED_AMOUNT: `${INSURANCE}${ELIGIBILITY}/insured-amount`,
-    WANT_INSURANCE_OVER_MAX_PERIOD: `${INSURANCE}${ELIGIBILITY}/insured-over-2-years`,
+    INSURED_PERIOD: `${INSURANCE}${ELIGIBILITY}/insured-over-2-years`,
   },
 };
 

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -49,8 +49,11 @@ const ERROR_MESSAGES = {
   [FIELD_IDS.OPTIONAL_COOKIES]: 'Select whether you want to accept analytics cookies',
   INSURANCE: {
     ELIGIBILITY: {
-      [FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_FOR_MORE_THAN_MAX_PERIOD]: {
+      [FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_AMOUNT]: {
         IS_EMPTY: `Select whether you want to be insured for ${MAX_COVER_AMOUNT} or more`,
+      },
+      [FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_PERIOD]: {
+        IS_EMPTY: `Select whether you want to be insured for longer than ${PRODUCT.MAX_COVER_PERIOD_YEARS} years`,
       },
     },
   },

--- a/e2e-tests/content-strings/pages/insurance/eligibility/index.js
+++ b/e2e-tests/content-strings/pages/insurance/eligibility/index.js
@@ -13,7 +13,7 @@ const APPLY_OFFLINE = {
   HEADING: 'You need to apply using our form',
   REASON: {
     INTRO: 'This is because',
-    WANT_COVER_OVER_MAX_PERIOD: `you want to be insured for more than ${MAX_COVER_AMOUNT} and we need to make extra checks.`,
+    WANT_COVER_OVER_MAX_AMOUNT: `you want to be insured for more than ${MAX_COVER_AMOUNT} and we need to make extra checks.`,
   },
   ACTIONS: {
     DOWNLOAD_FORM: {
@@ -33,6 +33,31 @@ const APPLY_OFFLINE = {
   },
 };
 
+const SPEAK_TO_UKEF_EFM = {
+  PAGE_TITLE: 'You need to speak with a UKEF export finance manager',
+  HEADING: 'You need to speak with a UKEF export finance manager',
+  REASON: {
+    INTRO: 'This is because',
+    WANT_COVER_OVER_MAX_PERIOD: `you want to be insured for longer than ${PRODUCT.MAX_COVER_PERIOD_YEARS} years.`,
+  },
+  ACTIONS: {
+    FIND_EFM: [
+      [
+        {
+          text: 'Find ',
+        },
+        {
+          text: 'your nearest export finance manager',
+          href: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
+        },
+        {
+          text: ' to discuss this.',
+        },
+      ],
+    ],
+  },
+};
+
 const CHECK_IF_ELIGIBLE = {
   PAGE_TITLE: 'Check you can apply for UKEF insurance for your export',
   HEADING: 'Check you can apply for UKEF insurance for your export',
@@ -44,8 +69,15 @@ const INSURED_AMOUNT = {
   HEADING: `Do you want to be insured for ${MAX_COVER_AMOUNT} or more?`,
 };
 
+const INSURED_PERIOD = {
+  PAGE_TITLE: `Do you want to be insured for longer than ${PRODUCT.MAX_COVER_PERIOD_YEARS} years?`,
+  HEADING: `Do you want to be insured for longer than ${PRODUCT.MAX_COVER_PERIOD_YEARS} years?`,
+};
+
 module.exports = {
   APPLY_OFFLINE,
+  SPEAK_TO_UKEF_EFM,
   CHECK_IF_ELIGIBLE,
   INSURED_AMOUNT,
+  INSURED_PERIOD,
 };

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
@@ -15,7 +15,7 @@ const { FIELD_IDS, ROUTES } = CONSTANTS;
 
 const COUNTRY_NAME_UNSUPPORTED = 'France';
 
-context('Cannot apply exit page', () => {
+context('Insurance Eligibility - Cannot apply exit page', () => {
   beforeEach(() => {
     cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
       auth: {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
@@ -6,7 +6,7 @@ import { ROUTES } from '../../../../../constants';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE;
 
-context('Insurance - start page', () => {
+context('Insurance Eligibility - start page', () => {
   before(() => {
     cy.visit(ROUTES.INSURANCE.START, {
       auth: {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount-answer-yes.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Insured amount page - I want to check if I can use online s
   it('renders a specific reason', () => {
     cannotApplyPage.reason().invoke('text').then((text) => {
       console.log('-- CONTENT_STRINGS', CONTENT_STRINGS);
-      const expected = `${CONTENT_STRINGS.REASON.INTRO} ${CONTENT_STRINGS.REASON.WANT_COVER_OVER_MAX_PERIOD}`;
+      const expected = `${CONTENT_STRINGS.REASON.INTRO} ${CONTENT_STRINGS.REASON.WANT_COVER_OVER_MAX_AMOUNT}`;
 
       expect(text.trim()).equal(expected);
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
@@ -122,7 +122,7 @@ context('Insurance - Insured amount page - I want to check if I can use online s
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_FOR_MORE_THAN_MAX_PERIOD].IS_EMPTY;
+        const expectedMessage = ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_AMOUNT].IS_EMPTY;
 
         partials.errorSummaryListItems().first().invoke('text').then((text) => {
           expect(text.trim()).equal(expectedMessage);
@@ -142,11 +142,11 @@ context('Insurance - Insured amount page - I want to check if I can use online s
     });
 
     describe('when submitting the answer as `no`', () => {
-      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.WANT_INSURANCE_OVER_MAX_PERIOD}`, () => {
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD}`, () => {
         noRadio().click();
         submitButton().click();
 
-        const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.WANT_INSURANCE_OVER_MAX_PERIOD}`;
+        const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD}`;
 
         cy.url().should('eq', expected);
       });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/speak-to-ukef-efm.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/speak-to-ukef-efm.spec.js
@@ -1,4 +1,4 @@
-import { heading, yesRadio, noRadio } from '../../../pages/shared';
+import { heading, yesRadio, noRadio, submitButton } from '../../../pages/shared';
 import { insurance } from '../../../pages';
 import partials from '../../../partials';
 import { LINKS, ORGANISATION, PAGES } from '../../../../../content-strings';

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/speak-to-ukef-efm.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/speak-to-ukef-efm.spec.js
@@ -1,17 +1,18 @@
-import { buyerCountryPage, heading, submitButton } from '../../../pages/shared';
+import { heading, yesRadio, noRadio } from '../../../pages/shared';
 import { insurance } from '../../../pages';
 import partials from '../../../partials';
 import { LINKS, ORGANISATION, PAGES } from '../../../../../content-strings';
 import CONSTANTS from '../../../../../constants';
+import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
 
-const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE;
+const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM;
 const { ACTIONS } = CONTENT_STRINGS;
 
-const { FIELD_IDS, ROUTES } = CONSTANTS;
+const { ROUTES } = CONSTANTS;
 
 const COUNTRY_NAME_APPLY_OFFLINE_ONLY = 'Angola';
 
-context('Insurance Eligibility - apply offline exit page', () => {
+context('Insurance Eligibility - speak to UKEF EFM exit page', () => {
   beforeEach(() => {
     cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
       auth: {
@@ -20,16 +21,21 @@ context('Insurance Eligibility - apply offline exit page', () => {
       },
     });
 
-    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY);
+    completeAndSubmitBuyerCountryForm();
 
-    buyerCountryPage.searchInput().type(COUNTRY_NAME_APPLY_OFFLINE_ONLY);
-
-    const results = buyerCountryPage.results();
-    results.first().click();
-
+    yesRadio().click();
     submitButton().click();
 
-    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
+    yesRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
+    yesRadio().click();
+    submitButton().click();
+
+    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM);
   });
 
   it('passes the audits', () => {
@@ -55,11 +61,12 @@ context('Insurance Eligibility - apply offline exit page', () => {
 
   it('renders a back link with correct url', () => {
     partials.backLink().should('exist');
+
     partials.backLink().invoke('text').then((text) => {
       expect(text.trim()).equal(LINKS.BACK);
     });
 
-    const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY}`;
+    const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD}`;
 
     partials.backLink().should('have.attr', 'href', expected);
   });
@@ -73,27 +80,21 @@ context('Insurance Eligibility - apply offline exit page', () => {
     });
   });
 
-  it('renders `download form` copy with link', () => {
-    insurance.eligibility.applyOfflinePage.downloadFormCopy().invoke('text').then((text) => {
-      const expected = `${ACTIONS.DOWNLOAD_FORM.LINK.TEXT} ${ACTIONS.DOWNLOAD_FORM.TEXT}`;
+  it('renders `find your nearest EFM` copy with link', () => {
+    insurance.eligibility.speakToUkefEfmPage.action.text().invoke('text').then((text) => {
+      const expected = `${ACTIONS.FIND_EFM[0][0].text} ${ACTIONS.FIND_EFM[0][1].text}${ACTIONS.FIND_EFM[0][2].text}`;
 
       expect(text.trim()).equal(expected);
     });
 
-    insurance.eligibility.applyOfflinePage.downloadFormLink().invoke('text').then((text) => {
-      expect(text.trim()).equal(ACTIONS.DOWNLOAD_FORM.LINK.TEXT);
-    });
-
-    insurance.eligibility.applyOfflinePage.downloadFormLink().should('have.attr', 'href', ACTIONS.DOWNLOAD_FORM.LINK.HREF);
-  });
-
-  it('renders `contact` copy with link', () => {
-    insurance.eligibility.applyOfflinePage.contactCopy().invoke('text').then((text) => {
-      const expected = `${ACTIONS.CONTACT.TEXT} ${ACTIONS.CONTACT.LINK.TEXT}`;
+    insurance.eligibility.speakToUkefEfmPage.action.link().invoke('text').then((text) => {
+      const expected = `${ACTIONS.FIND_EFM[0][1].text}`;
 
       expect(text.trim()).equal(expected);
     });
 
-    insurance.eligibility.applyOfflinePage.contactLink().should('have.attr', 'href', ACTIONS.CONTACT.LINK.HREF);
+    const expectedHref = ACTIONS.FIND_EFM[0][1].href;
+
+    insurance.eligibility.speakToUkefEfmPage.action.link().should('have.attr', 'href', expectedHref);
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -39,14 +39,14 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  // it('passes the audits', () => {
-  //   cy.lighthouse({
-  //     accessibility: 100,
-  //     performance: 75,
-  //     'best-practices': 100,
-  //     seo: 70,
-  //   });
-  // });
+  it('passes the audits', () => {
+    cy.lighthouse({
+      accessibility: 100,
+      performance: 75,
+      'best-practices': 100,
+      seo: 70,
+    });
+  });
 
   it('renders a back link with correct url', () => {
     partials.backLink().should('exist');

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
@@ -23,14 +23,14 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
     cy.url().should('include', ROUTES.QUOTE.BUYER_BODY);
   });
 
-  // it('passes the audits', () => {
-  //   cy.lighthouse({
-  //     accessibility: 100,
-  //     performance: 75,
-  //     'best-practices': 100,
-  //     seo: 60,
-  //   });
-  // });
+  it('passes the audits', () => {
+    cy.lighthouse({
+      accessibility: 100,
+      performance: 75,
+      'best-practices': 100,
+      seo: 60,
+    });
+  });
 
   it('renders an analytics cookies consent banner that can be accepted', () => {
     cy.checkAnalyticsCookiesConsentAndAccept();

--- a/e2e-tests/cypress/e2e/pages/insurance/eligibility/index.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/eligibility/index.js
@@ -1,7 +1,9 @@
 const checkIfEligiblePage = require('./checkIfEligible');
 const applyOfflinePage = require('./applyOffline');
+const speakToUkefEfmPage = require('./speakToUkefEfm');
 
 module.exports = {
   checkIfEligiblePage,
   applyOfflinePage,
+  speakToUkefEfmPage,
 };

--- a/e2e-tests/cypress/e2e/pages/insurance/eligibility/speakToUkefEfm.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/eligibility/speakToUkefEfm.js
@@ -1,0 +1,10 @@
+const speakToUkefEfmPage = {
+  reason: () => cy.get('[data-cy="reason"]'),
+  description: () => cy.get('[data-cy="description"]'),
+  action: {
+    text: () => cy.get('[data-cy="details-1"]'),
+    link: () => cy.get('[data-cy="details-1"]  a'),
+  },
+};
+
+export default speakToUkefEfmPage;

--- a/src/ui/server/constants/field-ids.ts
+++ b/src/ui/server/constants/field-ids.ts
@@ -25,7 +25,8 @@ export const FIELD_IDS = {
   },
   INSURANCE: {
     ELIGIBILITY: {
-      WANT_COVER_FOR_MORE_THAN_MAX_PERIOD: 'wantCoverForMoreThanMaxPeriod',
+      WANT_COVER_OVER_MAX_AMOUNT: 'wantCoverOverMaxAmount',
+      WANT_COVER_OVER_MAX_PERIOD: 'wantCoverOverMaxPeriod',
     },
   },
 };

--- a/src/ui/server/constants/routes/insurance.ts
+++ b/src/ui/server/constants/routes/insurance.ts
@@ -8,9 +8,10 @@ export const INSURANCE_ROUTES = {
     BUYER_COUNTRY: `${INSURANCE}${ELIGIBILITY}/buyer-location`,
     CANNOT_APPLY: `${INSURANCE}${ELIGIBILITY}/cannot-apply`,
     APPLY_OFFLINE: `${INSURANCE}${ELIGIBILITY}/apply-using-our-form`,
+    SPEAK_TO_UKEF_EFM: `${INSURANCE}${ELIGIBILITY}/speak-to-UKEF-EFM`,
     EXPORTER_LOCATION: `${INSURANCE}${ELIGIBILITY}/exporter-location`,
     UK_GOODS_OR_SERVICES: `${INSURANCE}${ELIGIBILITY}/uk-goods-services`,
     INSURED_AMOUNT: `${INSURANCE}${ELIGIBILITY}/insured-amount`,
-    WANT_INSURANCE_OVER_MAX_PERIOD: `${INSURANCE}${ELIGIBILITY}/insured-over-2-years`,
+    INSURED_PERIOD: `${INSURANCE}${ELIGIBILITY}/insured-over-2-years`,
   },
 };

--- a/src/ui/server/constants/templates/insurance/eligibility/index.ts
+++ b/src/ui/server/constants/templates/insurance/eligibility/index.ts
@@ -1,6 +1,8 @@
 export const ELIGIBILITY_TEMPLATES = {
   CHECK_IF_ELIGIBLE: 'insurance/eligibility/check-if-eligible.njk',
   APPLY_OFFLINE: 'insurance/eligibility/apply-offline.njk',
+  SPEAK_TO_UKEF_EFM: 'insurance/eligibility/speak-to-ukef-efm.njk',
   UK_GOODS_OR_SERVICES: 'insurance/eligibility/uk-goods-or-services.njk',
   INSURED_AMOUNT: 'insurance/eligibility/insured-amount.njk',
+  INSURED_PERIOD: 'insurance/eligibility/insured-period.njk',
 };

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -49,8 +49,11 @@ export const ERROR_MESSAGES = {
   [FIELD_IDS.OPTIONAL_COOKIES]: 'Select whether you want to accept analytics cookies',
   INSURANCE: {
     ELIGIBILITY: {
-      [FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_FOR_MORE_THAN_MAX_PERIOD]: {
+      [FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_AMOUNT]: {
         IS_EMPTY: `Select whether you want to be insured for ${MAX_COVER_AMOUNT} or more`,
+      },
+      [FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_PERIOD]: {
+        IS_EMPTY: `Select whether you want to be insured for longer than ${PRODUCT.MAX_COVER_PERIOD_YEARS} years`,
       },
     },
   },

--- a/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
@@ -9,7 +9,7 @@ const APPLY_OFFLINE = {
   HEADING: 'You need to apply using our form',
   REASON: {
     INTRO: 'This is because',
-    WANT_COVER_OVER_MAX_PERIOD: `you want to be insured for more than ${MAX_COVER_AMOUNT} and we need to make extra checks.`,
+    WANT_COVER_OVER_MAX_AMOUNT: `you want to be insured for more than ${MAX_COVER_AMOUNT} and we need to make extra checks.`,
   },
   ACTIONS: {
     DOWNLOAD_FORM: {
@@ -29,6 +29,31 @@ const APPLY_OFFLINE = {
   },
 };
 
+const SPEAK_TO_UKEF_EFM = {
+  PAGE_TITLE: 'You need to speak with a UKEF export finance manager',
+  HEADING: 'You need to speak with a UKEF export finance manager',
+  REASON: {
+    INTRO: 'This is because',
+    WANT_COVER_OVER_MAX_PERIOD: `you want to be insured for longer than ${PRODUCT.MAX_COVER_PERIOD_YEARS} years.`,
+  },
+  ACTIONS: {
+    FIND_EFM: [
+      [
+        {
+          text: 'Find ',
+        },
+        {
+          text: 'your nearest export finance manager',
+          href: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
+        },
+        {
+          text: ' to discuss this.',
+        },
+      ],
+    ],
+  },
+};
+
 const CHECK_IF_ELIGIBLE = {
   PAGE_TITLE: 'Check you can apply for UKEF insurance for your export',
   HEADING: 'Check you can apply for UKEF insurance for your export',
@@ -40,8 +65,15 @@ const INSURED_AMOUNT = {
   HEADING: `Do you want to be insured for ${MAX_COVER_AMOUNT} or more?`,
 };
 
+const INSURED_PERIOD = {
+  PAGE_TITLE: `Do you want to be insured for longer than ${PRODUCT.MAX_COVER_PERIOD_YEARS} years?`,
+  HEADING: `Do you want to be insured for longer than ${PRODUCT.MAX_COVER_PERIOD_YEARS} years?`,
+};
+
 export default {
   APPLY_OFFLINE,
+  SPEAK_TO_UKEF_EFM,
   CHECK_IF_ELIGIBLE,
   INSURED_AMOUNT,
+  INSURED_PERIOD,
 };

--- a/src/ui/server/controllers/insurance/eligibility/insured-period/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/insured-period/index.test.ts
@@ -6,7 +6,7 @@ import generateValidationErrors from '../../../../shared-validation/yes-no-radio
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes } from '../../../../test-mocks';
 
-describe('controllers/insurance/eligibility/insured-amount', () => {
+describe('controllers/insurance/eligibility/insured-period', () => {
   let req: Request;
   let res: Response;
 
@@ -18,8 +18,8 @@ describe('controllers/insurance/eligibility/insured-amount', () => {
   describe('PAGE_VARIABLES', () => {
     it('should have correct properties', () => {
       const expected = {
-        FIELD_ID: FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_AMOUNT,
-        PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT,
+        FIELD_ID: FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_PERIOD,
+        PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
       };
 
       expect(PAGE_VARIABLES).toEqual(expected);
@@ -31,7 +31,7 @@ describe('controllers/insurance/eligibility/insured-amount', () => {
       get(req, res);
 
       expect(res.render).toHaveBeenCalledWith(
-        TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT,
+        TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
         singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
       );
     });
@@ -42,7 +42,7 @@ describe('controllers/insurance/eligibility/insured-amount', () => {
       it('should render template with validation errors', () => {
         post(req, res);
 
-        expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT, {
+        expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, {
           ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
           validationErrors: generateValidationErrors(req.body, PAGE_VARIABLES.FIELD_ID, ERROR_MESSAGES.INSURANCE.ELIGIBILITY[PAGE_VARIABLES.FIELD_ID].IS_EMPTY),
         });
@@ -52,27 +52,27 @@ describe('controllers/insurance/eligibility/insured-amount', () => {
     describe('when submitted answer is true', () => {
       beforeEach(() => {
         req.body = {
-          [FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_AMOUNT]: 'true',
+          [FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_PERIOD]: 'true',
         };
       });
 
-      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE}`, async () => {
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM}`, async () => {
         await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM);
       });
 
       it('should add exitReason to req.flash', async () => {
         await post(req, res);
 
-        const expectedReason = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE.REASON.WANT_COVER_OVER_MAX_AMOUNT;
+        const expectedReason = PAGES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM.REASON.WANT_COVER_OVER_MAX_PERIOD;
         expect(req.flash).toHaveBeenCalledWith('exitReason', expectedReason);
       });
     });
 
     describe('when there are no validation errors', () => {
       const validBody = {
-        [FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_AMOUNT]: 'false',
+        [FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_PERIOD]: 'false',
       };
 
       beforeEach(() => {

--- a/src/ui/server/controllers/insurance/eligibility/insured-period/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/insured-period/index.ts
@@ -4,21 +4,21 @@ import singleInputPageVariables from '../../../../helpers/single-input-page-vari
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import { Request, Response } from '../../../../../types';
 
-const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_AMOUNT;
+const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_PERIOD;
 
 const PAGE_VARIABLES = {
   FIELD_ID,
-  PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT,
+  PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
 };
 
 const get = (req: Request, res: Response) =>
-  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT, singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }));
+  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }));
 
 const post = (req: Request, res: Response) => {
   const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY);
 
   if (validationErrors) {
-    return res.render(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT, {
+    return res.render(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, {
       ...singleInputPageVariables({
         ...PAGE_VARIABLES,
         BACK_LINK: req.headers.referer,
@@ -31,12 +31,12 @@ const post = (req: Request, res: Response) => {
 
   if (answer === 'true') {
     const { INSURANCE } = PAGES;
-    const { APPLY_OFFLINE } = INSURANCE.ELIGIBILITY;
-    const { REASON } = APPLY_OFFLINE;
+    const { SPEAK_TO_UKEF_EFM } = INSURANCE.ELIGIBILITY;
+    const { REASON } = SPEAK_TO_UKEF_EFM;
 
-    req.flash('exitReason', REASON.WANT_COVER_OVER_MAX_AMOUNT);
+    req.flash('exitReason', REASON.WANT_COVER_OVER_MAX_PERIOD);
 
-    return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
+    return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM);
   }
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD);

--- a/src/ui/server/controllers/insurance/eligibility/speak-to-ukef-efm/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/speak-to-ukef-efm/index.test.ts
@@ -1,0 +1,39 @@
+import get from '.';
+import { PAGES } from '../../../../content-strings';
+import { TEMPLATES } from '../../../../constants';
+import corePageVariables from '../../../../helpers/core-page-variables';
+import { mockReq, mockRes } from '../../../../test-mocks';
+import { Request, Response } from '../../../../../types';
+
+describe('controllers/insurance/eligibility/speak-to-ukef-efm', () => {
+  let req: Request;
+  let res: Response;
+  const mockExitReason = 'mock';
+
+  beforeEach(() => {
+    req = mockReq();
+    req.flash = (property: string) => {
+      const obj = {
+        exitReason: mockExitReason,
+      };
+
+      return obj[property];
+    };
+
+    res = mockRes();
+  });
+
+  it('should render template', () => {
+    get(req, res);
+
+    const expectedVariables = {
+      ...corePageVariables({
+        PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM,
+        BACK_LINK: req.headers.referer,
+      }),
+      EXIT_REASON: mockExitReason,
+    };
+
+    expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM, expectedVariables);
+  });
+});

--- a/src/ui/server/controllers/insurance/eligibility/speak-to-ukef-efm/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/speak-to-ukef-efm/index.ts
@@ -1,0 +1,18 @@
+import { PAGES } from '../../../../content-strings';
+import { TEMPLATES } from '../../../../constants';
+import { Request, Response } from '../../../../../types';
+import corePageVariables from '../../../../helpers/core-page-variables';
+
+const get = (req: Request, res: Response) => {
+  const EXIT_REASON = req.flash('exitReason');
+
+  return res.render(TEMPLATES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM, {
+    ...corePageVariables({
+      PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM,
+      BACK_LINK: req.headers.referer,
+    }),
+    EXIT_REASON,
+  });
+};
+
+export default get;

--- a/src/ui/server/routes/insurance/eligibility/index.test.ts
+++ b/src/ui/server/routes/insurance/eligibility/index.test.ts
@@ -5,6 +5,7 @@ import { get as buyerCountryGet, post as buyerCountryPost } from '../../../contr
 import { get as exporterLocationGet, post as exporterLocationPost } from '../../../controllers/insurance/eligibility/exporter-location';
 import { get as ukGoodsOrServicesGet, post as ukGoodsOrServicesPost } from '../../../controllers/insurance/eligibility/uk-goods-or-services';
 import { get as insuredAmountGet, post as insuredAmountPost } from '../../../controllers/insurance/eligibility/insured-amount';
+import { get as insuredPeriodGet, post as insuredPeriodPost } from '../../../controllers/insurance/eligibility/insured-period';
 import cannotApplyGet from '../../../controllers/insurance/eligibility/cannot-apply';
 import applyOfflineGet from '../../../controllers/insurance/eligibility/apply-offline';
 
@@ -18,8 +19,8 @@ describe('routes/insurance/eligibility', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(7);
-    expect(post).toHaveBeenCalledTimes(5);
+    expect(get).toHaveBeenCalledTimes(9);
+    expect(post).toHaveBeenCalledTimes(6);
 
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE, checkIfEligibleGet);
     expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE, checkIfEligiblePost);
@@ -35,6 +36,9 @@ describe('routes/insurance/eligibility', () => {
 
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT, insuredAmountGet);
     expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT, insuredAmountPost);
+
+    expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, insuredPeriodGet);
+    expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, insuredPeriodPost);
 
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY, cannotApplyGet);
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE, applyOfflineGet);

--- a/src/ui/server/routes/insurance/eligibility/index.ts
+++ b/src/ui/server/routes/insurance/eligibility/index.ts
@@ -5,8 +5,10 @@ import { get as buyerCountryGet, post as buyerCountryPost } from '../../../contr
 import { get as exporterLocationGet, post as exporterLocationPost } from '../../../controllers/insurance/eligibility/exporter-location';
 import { get as ukGoodsOrServicesGet, post as ukGoodsOrServicesPost } from '../../../controllers/insurance/eligibility/uk-goods-or-services';
 import { get as insuredAmountGet, post as insuredAmountPost } from '../../../controllers/insurance/eligibility/insured-amount';
+import { get as insuredPeriodGet, post as insuredPeriodPost } from '../../../controllers/insurance/eligibility/insured-period';
 import cannotApplyGet from '../../../controllers/insurance/eligibility/cannot-apply';
 import applyOfflineGet from '../../../controllers/insurance/eligibility/apply-offline';
+import speakToUkefEfmGet from '../../../controllers/insurance/eligibility/speak-to-ukef-efm';
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
@@ -28,7 +30,11 @@ insuranceEligibilityRouter.post(ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICE
 insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT, insuredAmountGet);
 insuranceEligibilityRouter.post(ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT, insuredAmountPost);
 
+insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, insuredPeriodGet);
+insuranceEligibilityRouter.post(ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, insuredPeriodPost);
+
 insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY, cannotApplyGet);
 insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE, applyOfflineGet);
+insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM, speakToUkefEfmGet);
 
 export default insuranceEligibilityRouter;

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -12,8 +12,8 @@ describe('routes/insurance', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(8);
-    expect(post).toHaveBeenCalledTimes(6);
+    expect(get).toHaveBeenCalledTimes(10);
+    expect(post).toHaveBeenCalledTimes(7);
 
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.START, startGet);
     expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.START, startPost);

--- a/src/ui/server/shared-validation/yes-no-radios-form/index.test.ts
+++ b/src/ui/server/shared-validation/yes-no-radios-form/index.test.ts
@@ -3,7 +3,7 @@ import { FIELD_IDS } from '../../constants';
 import generateValidationErrors from '../../helpers/validation';
 
 describe('shared-validation/yes-no-radios-form', () => {
-  const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_FOR_MORE_THAN_MAX_PERIOD;
+  const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_AMOUNT;
   const mockErrorMessage = 'mock';
 
   describe('when no values are provided in the formBody', () => {

--- a/src/ui/templates/insurance/eligibility/insured-period.njk
+++ b/src/ui/templates/insurance/eligibility/insured-period.njk
@@ -1,0 +1,61 @@
+{% extends 'index.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from 'govuk/components/button/macro.njk' import govukButton %}
+{% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
+{% import '../../components/yes-no-radio-buttons.njk' as yesNoRadioButtons %}
+
+{% block pageTitle %}
+  {{ CONTENT_STRINGS.PAGE_TITLE }}
+{% endblock %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: CONTENT_STRINGS.LINKS.BACK,
+    href: BACK_LINK,
+    attributes: {
+      "data-cy": "back-link"
+    }
+  }) }}
+
+  {% if validationErrors.summary %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: validationErrors.summary
+    }) }}
+  {% endif %}
+
+  {% set class = "govuk-form-group" %}
+
+  {% if validationErrors.errorList[FIELD_ID] %}
+    {% set class = "govuk-form-group govuk-form-group--error" %}
+  {% endif %}
+
+  <form method="POST" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters-from-desktop">
+
+        {{ yesNoRadioButtons.render({
+          fieldId: FIELD_ID,
+          heading: CONTENT_STRINGS.HEADING,
+          submittedAnswer: submittedValues[FIELD_ID],
+          errorMessage: validationErrors.errorList[FIELD_ID]
+        }) }}
+
+      </div>
+    </div>
+
+    {{ govukButton({
+      text: CONTENT_STRINGS.BUTTONS.CONTINUE,
+      attributes: {
+        'data-cy': 'submit-button'
+      }
+    }) }}
+
+  </form>
+
+{% endblock %}

--- a/src/ui/templates/insurance/eligibility/speak-to-ukef-efm.njk
+++ b/src/ui/templates/insurance/eligibility/speak-to-ukef-efm.njk
@@ -1,0 +1,35 @@
+{% extends 'index.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% import "../../components/details-text.njk" as detailsText %}
+
+{% block pageTitle %}
+  {{ CONTENT_STRINGS.PAGE_TITLE }}
+{% endblock %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: CONTENT_STRINGS.LINKS.BACK,
+    href: BACK_LINK,
+    attributes: {
+      "data-cy": "back-link"
+    }
+  }) }}
+
+  <h1 class="govuk-heading-l" data-cy="heading">{{ CONTENT_STRINGS.HEADING }}</h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters-from-desktop">
+
+      {% if EXIT_REASON.length %}
+        <p class="govuk-body" data-cy="reason">{{ CONTENT_STRINGS.REASON.INTRO }} {{ EXIT_REASON }}</p>
+      {% endif %}
+
+      {{ detailsText.render({
+        items: CONTENT_STRINGS.ACTIONS.FIND_EFM
+      }) }}
+
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
This PR adds the “Insured period” page/form to the Insurance Eligibility flow.


## Summary of changes

- Create “Insured period” page.
- Create “Speak to a UKEF EFM” exit page.
- Redirect to new exit page if Insured Period answer is submitted as “Yes” (if Exporter wants cover for over the maximum period available online).

## Other changes/improvements

- Rename `WANT_COVER_FOR_MORE_THAN_MAX_PERIOD` to `WANT_COVER_OVER_MAX_AMOUNT`
- Rename `WANT_INSURANCE_OVER_MAX_PERIOD` constant to `INSURED_PERIOD`
- Rename exit page reason `WANT_COVER_OVER_MAX_PERIOD` to `WANT_COVER_OVER_MAX_AMOUNT`
- Improve some E2E test descriptions.
- Remove some commented out lighthouse checks in E2E tests