### PR TITLE
feat(EMS-365): Insurance eligibility - other parties

### DIFF
--- a/e2e-tests/constants/field-ids.js
+++ b/e2e-tests/constants/field-ids.js
@@ -25,7 +25,9 @@ const FIELD_IDS = {
   },
   INSURANCE: {
     ELIGIBILITY: {
-      WANT_COVER_OVER_MAX_AMOUNT: 'wantCoverForMoreThanMaxPeriod',
+      WANT_COVER_OVER_MAX_AMOUNT: 'wantCoverOverMaxAmount',
+      WANT_COVER_OVER_MAX_PERIOD: 'wantCoverOverMaxPeriod',
+      OTHER_PARTIES_INVOLVED: 'otherPartiesInvolved',
     },
   },
 };

--- a/e2e-tests/constants/routes/insurance.js
+++ b/e2e-tests/constants/routes/insurance.js
@@ -13,6 +13,8 @@ const INSURANCE_ROUTES = {
     UK_GOODS_OR_SERVICES: `${INSURANCE}${ELIGIBILITY}/uk-goods-services`,
     INSURED_AMOUNT: `${INSURANCE}${ELIGIBILITY}/insured-amount`,
     INSURED_PERIOD: `${INSURANCE}${ELIGIBILITY}/insured-over-2-years`,
+    OTHER_PARTIES_INVOLVED: `${INSURANCE}${ELIGIBILITY}/other-parties`,
+    LETTER_OF_CREDIT: `${INSURANCE}${ELIGIBILITY}/letter-of-credit`,
   },
 };
 

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -55,6 +55,9 @@ const ERROR_MESSAGES = {
       [FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_PERIOD]: {
         IS_EMPTY: `Select whether you want to be insured for longer than ${PRODUCT.MAX_COVER_PERIOD_YEARS} years`,
       },
+      [FIELD_IDS.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED]: {
+        IS_EMPTY: 'Select whether there are any other parties involved, apart from you and the buyer',
+      },
     },
   },
 };

--- a/e2e-tests/content-strings/pages/insurance/eligibility/index.js
+++ b/e2e-tests/content-strings/pages/insurance/eligibility/index.js
@@ -14,6 +14,7 @@ const APPLY_OFFLINE = {
   REASON: {
     INTRO: 'This is because',
     WANT_COVER_OVER_MAX_AMOUNT: `you want to be insured for more than ${MAX_COVER_AMOUNT} and we need to make extra checks.`,
+    OTHER_PARTIES_INVOLVED: 'there are other parties involved in your exports and we need to make extra checks.',
   },
   ACTIONS: {
     DOWNLOAD_FORM: {
@@ -74,10 +75,16 @@ const INSURED_PERIOD = {
   HEADING: `Do you want to be insured for longer than ${PRODUCT.MAX_COVER_PERIOD_YEARS} years?`,
 };
 
+const OTHER_PARTIES_INVOLVED = {
+  PAGE_TITLE: 'Are there any other parties involved, apart from you and the buyer?',
+  HEADING: 'Are there any other parties involved, apart from you and the buyer?',
+};
+
 module.exports = {
   APPLY_OFFLINE,
   SPEAK_TO_UKEF_EFM,
   CHECK_IF_ELIGIBLE,
   INSURED_AMOUNT,
   INSURED_PERIOD,
+  OTHER_PARTIES_INVOLVED,
 };

--- a/e2e-tests/content-strings/pages/insurance/eligibility/index.js
+++ b/e2e-tests/content-strings/pages/insurance/eligibility/index.js
@@ -78,6 +78,27 @@ const INSURED_PERIOD = {
 const OTHER_PARTIES_INVOLVED = {
   PAGE_TITLE: 'Are there any other parties involved, apart from you and the buyer?',
   HEADING: 'Are there any other parties involved, apart from you and the buyer?',
+  OTHER_PARTIES_DESCRIPTION: {
+    INTRO: 'What counts as another party?',
+    LIST_INTRO: 'This includes any:',
+    LIST: [
+      {
+        TEXT: 'agents or third parties',
+      },
+      {
+        TEXT: "companies who'll be jointly insured on the policy",
+      },
+      {
+        TEXT: "'loss payees' who'll be paid in the event of a claim",
+      },
+      {
+        TEXT: "other parties in your buyer's supply chain, who your buyer will depend on for payment before they can pay you - for example, an end-buyer",
+      },
+      {
+        TEXT: "consortium or group you're involved in that has a significant role in these exports",
+      },
+    ]
+  },
 };
 
 module.exports = {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount-answer-yes.spec.js
@@ -1,5 +1,4 @@
-import { cannotApplyPage, exporterLocationPage, ukGoodsOrServicesPage, yesRadio, submitButton } from '../../../../pages/shared';
-import { insurance } from '../../../../pages';
+import { cannotApplyPage, yesRadio, submitButton } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
@@ -1,5 +1,4 @@
-import { exporterLocationPage, ukGoodsOrServicesPage, heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton } from '../../../../pages/shared';
-import { insurance } from '../../../../pages';
+import { heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import {
   ORGANISATION,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties-answer-yes.spec.js
@@ -1,4 +1,4 @@
-import { cannotApplyPage, exporterLocationPage, ukGoodsOrServicesPage, yesRadio, submitButton } from '../../../../pages/shared';
+import { cannotApplyPage, exporterLocationPage, ukGoodsOrServicesPage, yesRadio, noRadio, submitButton } from '../../../../pages/shared';
 import { insurance } from '../../../../pages';
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
@@ -25,6 +25,12 @@ context('Insurance - Insured amount page - I want to check if I can use online s
     yesRadio().click();
     submitButton().click();
 
+    noRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
     yesRadio().click();
     submitButton().click();
   });
@@ -36,14 +42,14 @@ context('Insurance - Insured amount page - I want to check if I can use online s
   it('renders a back link with correct url', () => {
     partials.backLink().should('exist');
 
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT}`;
+    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED}`;
 
     partials.backLink().should('have.attr', 'href', expectedUrl);
   });
 
   it('renders a specific reason', () => {
     cannotApplyPage.reason().invoke('text').then((text) => {
-      const expected = `${CONTENT_STRINGS.REASON.INTRO} ${CONTENT_STRINGS.REASON.WANT_COVER_OVER_MAX_AMOUNT}`;
+      const expected = `${CONTENT_STRINGS.REASON.INTRO} ${CONTENT_STRINGS.REASON.OTHER_PARTIES_INVOLVED}`;
 
       expect(text.trim()).equal(expected);
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
@@ -1,4 +1,4 @@
-import { exporterLocationPage, ukGoodsOrServicesPage, heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton } from '../../../../pages/shared';
+import { heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton } from '../../../../pages/shared';
 import { insurance } from '../../../../pages';
 import partials from '../../../../partials';
 import {
@@ -111,6 +111,48 @@ context('Insurance - Other parties page - I want to check if I can use online se
 
     noRadio().invoke('text').then((text) => {
       expect(text.trim()).equal('No');
+    });
+  });
+
+  describe('expandable details', () => {
+    it('renders summary text', () => {
+      insurance.eligibility.otherPartiesPage.description.summary().should('exist');
+
+      insurance.eligibility.otherPartiesPage.description.summary().invoke('text').then((text) => {
+        expect(text.trim()).equal(CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.INTRO);
+      });
+    });
+
+    it('clicking summary text reveals details', () => {
+      insurance.eligibility.otherPartiesPage.description.summary().click();
+
+      insurance.eligibility.otherPartiesPage.description.list.intro().should('be.visible');
+    });
+
+    it('renders expanded content', () => {
+      insurance.eligibility.otherPartiesPage.description.list.intro().invoke('text').then((text) => {
+        expect(text.trim()).equal(CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST_INTRO);
+      });
+
+      insurance.eligibility.otherPartiesPage.description.list.item1().invoke('text').then((text) => {
+        expect(text.trim()).equal(CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST[0].TEXT);
+      });
+
+      insurance.eligibility.otherPartiesPage.description.list.item2().invoke('text').then((text) => {
+        expect(text.trim()).equal(CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST[1].TEXT);
+      });
+
+      insurance.eligibility.otherPartiesPage.description.list.item3().invoke('text').then((text) => {
+        expect(text.trim()).equal(CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST[2].TEXT);
+      });
+
+      insurance.eligibility.otherPartiesPage.description.list.item4().invoke('text').then((text) => {
+        expect(text.trim()).equal(CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST[3].TEXT);
+      });
+
+      insurance.eligibility.otherPartiesPage.description.list.item5().invoke('text').then((text) => {
+        expect(text.trim()).equal(CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST[4].TEXT);
+      });
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
@@ -1,0 +1,163 @@
+import { exporterLocationPage, ukGoodsOrServicesPage, heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton } from '../../../../pages/shared';
+import { insurance } from '../../../../pages';
+import partials from '../../../../partials';
+import {
+  ORGANISATION,
+  BUTTONS,
+  LINKS,
+  PAGES,
+  ERROR_MESSAGES,
+} from '../../../../../../content-strings';
+import CONSTANTS from '../../../../../../constants';
+import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+
+const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED;
+const { ROUTES, FIELD_IDS } = CONSTANTS;
+
+context('Insurance - Other parties page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction if there are other parties involved in the export', () => {
+  before(() => {
+    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    completeAndSubmitBuyerCountryForm();
+
+    yesRadio().click();
+    submitButton().click();
+
+    yesRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
+    const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED}`;
+
+    cy.url().should('eq', expected);
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
+  // it('passes the audits', () => {
+  //   cy.lighthouse({
+  //     accessibility: 100,
+  //     performance: 75,
+  //     'best-practices': 100,
+  //     seo: 70,
+  //   });
+  // });
+
+  it('renders a back link with correct url', () => {
+    partials.backLink().should('exist');
+    partials.backLink().invoke('text').then((text) => {
+      expect(text.trim()).equal(LINKS.BACK);
+    });
+
+    partials.backLink().click();
+
+    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD}`;
+
+    cy.url().should('include', expectedUrl);
+
+    // go back to page
+    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+  });
+
+  it('renders an analytics cookies consent banner that can be accepted', () => {
+    cy.checkAnalyticsCookiesConsentAndAccept();
+  });
+
+  it('renders an analytics cookies consent banner that can be rejected', () => {
+    cy.rejectAnalyticsCookies();
+  });
+
+  it('renders a phase banner', () => {
+    cy.checkPhaseBanner();
+  });
+
+  it('renders a page title and heading', () => {
+    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
+    cy.title().should('eq', expectedPageTitle);
+
+    heading().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.HEADING);
+    });
+  });
+
+  it('renders `yes` radio button', () => {
+    yesRadio().should('exist');
+
+    yesRadio().invoke('text').then((text) => {
+      expect(text.trim()).equal('Yes');
+    });
+  });
+
+  it('renders `no` radio button', () => {
+    noRadio().should('exist');
+
+    noRadio().invoke('text').then((text) => {
+      expect(text.trim()).equal('No');
+    });
+  });
+
+  it('renders a submit button', () => {
+    submitButton().should('exist');
+
+    submitButton().invoke('text').then((text) => {
+      expect(text.trim()).equal(BUTTONS.CONTINUE);
+    });
+  });
+
+  describe('form submission', () => {
+    describe('when submitting an empty form', () => {
+      it('should render validation errors', () => {
+        submitButton().click();
+
+        partials.errorSummaryListItems().should('exist');
+        partials.errorSummaryListItems().should('have.length', 1);
+
+        const expectedMessage = ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED].IS_EMPTY;
+
+        partials.errorSummaryListItems().first().invoke('text').then((text) => {
+          expect(text.trim()).equal(expectedMessage);
+        });
+
+        inlineErrorMessage().invoke('text').then((text) => {
+          expect(text.trim()).includes(expectedMessage);
+        });
+      });
+
+      it('should focus on input when clicking summary error message', () => {
+        submitButton().click();
+
+        partials.errorSummaryListItemLinks().eq(0).click();
+        yesRadioInput().should('have.focus');
+      });
+    });
+
+    describe('when submitting the answer as `no`', () => {
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`, () => {
+        noRadio().click();
+        submitButton().click();
+
+        const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`;
+
+        cy.url().should('eq', expected);
+      });
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/pages/insurance/eligibility/index.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/eligibility/index.js
@@ -1,9 +1,11 @@
 const checkIfEligiblePage = require('./checkIfEligible');
 const applyOfflinePage = require('./applyOffline');
 const speakToUkefEfmPage = require('./speakToUkefEfm');
+const otherPartiesPage = require('./otherParties');
 
 module.exports = {
   checkIfEligiblePage,
   applyOfflinePage,
   speakToUkefEfmPage,
+  otherPartiesPage,
 };

--- a/e2e-tests/cypress/e2e/pages/insurance/eligibility/otherParties.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/eligibility/otherParties.js
@@ -1,0 +1,15 @@
+const otherPartiesPage = {
+  description: {
+    summary: () => cy.get('[data-cy="other-parties"] summary'),
+    list: {
+      intro: () => cy.get('[data-cy="other-parties-list-intro"]'),
+      item1: () => cy.get('[data-cy="other-parties-list-item-1"]'),
+      item2: () => cy.get('[data-cy="other-parties-list-item-2"]'),
+      item3: () => cy.get('[data-cy="other-parties-list-item-3"]'),
+      item4: () => cy.get('[data-cy="other-parties-list-item-4"]'),
+      item5: () => cy.get('[data-cy="other-parties-list-item-5"]'),
+    },
+  },
+};
+
+export default otherPartiesPage;

--- a/src/ui/server/constants/field-ids.ts
+++ b/src/ui/server/constants/field-ids.ts
@@ -27,6 +27,7 @@ export const FIELD_IDS = {
     ELIGIBILITY: {
       WANT_COVER_OVER_MAX_AMOUNT: 'wantCoverOverMaxAmount',
       WANT_COVER_OVER_MAX_PERIOD: 'wantCoverOverMaxPeriod',
+      OTHER_PARTIES_INVOLVED: 'otherPartiesInvolved',
     },
   },
 };

--- a/src/ui/server/constants/routes/insurance.ts
+++ b/src/ui/server/constants/routes/insurance.ts
@@ -13,5 +13,7 @@ export const INSURANCE_ROUTES = {
     UK_GOODS_OR_SERVICES: `${INSURANCE}${ELIGIBILITY}/uk-goods-services`,
     INSURED_AMOUNT: `${INSURANCE}${ELIGIBILITY}/insured-amount`,
     INSURED_PERIOD: `${INSURANCE}${ELIGIBILITY}/insured-over-2-years`,
+    OTHER_PARTIES_INVOLVED: `${INSURANCE}${ELIGIBILITY}/other-parties`,
+    LETTER_OF_CREDIT: `${INSURANCE}${ELIGIBILITY}/letter-of-credit`,
   },
 };

--- a/src/ui/server/constants/templates/insurance/eligibility/index.ts
+++ b/src/ui/server/constants/templates/insurance/eligibility/index.ts
@@ -5,4 +5,5 @@ export const ELIGIBILITY_TEMPLATES = {
   UK_GOODS_OR_SERVICES: 'insurance/eligibility/uk-goods-or-services.njk',
   INSURED_AMOUNT: 'insurance/eligibility/insured-amount.njk',
   INSURED_PERIOD: 'insurance/eligibility/insured-period.njk',
+  OTHER_PARTIES_INVOLVED: 'insurance/eligibility/other-parties.njk',
 };

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -55,6 +55,9 @@ export const ERROR_MESSAGES = {
       [FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_PERIOD]: {
         IS_EMPTY: `Select whether you want to be insured for longer than ${PRODUCT.MAX_COVER_PERIOD_YEARS} years`,
       },
+      [FIELD_IDS.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED]: {
+        IS_EMPTY: 'Select whether there are any other parties involved, apart from you and the buyer',
+      },
     },
   },
 } as ErrorMessage;

--- a/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
@@ -74,6 +74,27 @@ const INSURED_PERIOD = {
 const OTHER_PARTIES_INVOLVED = {
   PAGE_TITLE: 'Are there any other parties involved, apart from you and the buyer?',
   HEADING: 'Are there any other parties involved, apart from you and the buyer?',
+  OTHER_PARTIES_DESCRIPTION: {
+    INTRO: 'What counts as another party?',
+    LIST_INTRO: 'This includes any:',
+    LIST: [
+      {
+        TEXT: 'agents or third parties',
+      },
+      {
+        TEXT: "companies who'll be jointly insured on the policy",
+      },
+      {
+        TEXT: "'loss payees' who'll be paid in the event of a claim",
+      },
+      {
+        TEXT: "other parties in your buyer's supply chain, who your buyer will depend on for payment before they can pay you - for example, an end-buyer",
+      },
+      {
+        TEXT: "consortium or group you're involved in that has a significant role in these exports",
+      },
+    ],
+  },
 };
 
 export default {

--- a/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
@@ -10,6 +10,7 @@ const APPLY_OFFLINE = {
   REASON: {
     INTRO: 'This is because',
     WANT_COVER_OVER_MAX_AMOUNT: `you want to be insured for more than ${MAX_COVER_AMOUNT} and we need to make extra checks.`,
+    OTHER_PARTIES_INVOLVED: 'there are other parties involved in your exports and we need to make extra checks.',
   },
   ACTIONS: {
     DOWNLOAD_FORM: {
@@ -70,10 +71,16 @@ const INSURED_PERIOD = {
   HEADING: `Do you want to be insured for longer than ${PRODUCT.MAX_COVER_PERIOD_YEARS} years?`,
 };
 
+const OTHER_PARTIES_INVOLVED = {
+  PAGE_TITLE: 'Are there any other parties involved, apart from you and the buyer?',
+  HEADING: 'Are there any other parties involved, apart from you and the buyer?',
+};
+
 export default {
   APPLY_OFFLINE,
   SPEAK_TO_UKEF_EFM,
   CHECK_IF_ELIGIBLE,
   INSURED_AMOUNT,
   INSURED_PERIOD,
+  OTHER_PARTIES_INVOLVED,
 };

--- a/src/ui/server/controllers/insurance/eligibility/other-parties/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/other-parties/index.test.ts
@@ -6,7 +6,7 @@ import generateValidationErrors from '../../../../shared-validation/yes-no-radio
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes } from '../../../../test-mocks';
 
-describe('controllers/insurance/eligibility/insured-period', () => {
+describe('controllers/insurance/eligibility/other-parties', () => {
   let req: Request;
   let res: Response;
 
@@ -18,8 +18,8 @@ describe('controllers/insurance/eligibility/insured-period', () => {
   describe('PAGE_VARIABLES', () => {
     it('should have correct properties', () => {
       const expected = {
-        FIELD_ID: FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_PERIOD,
-        PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
+        FIELD_ID: FIELD_IDS.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED,
+        PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED,
       };
 
       expect(PAGE_VARIABLES).toEqual(expected);
@@ -31,7 +31,7 @@ describe('controllers/insurance/eligibility/insured-period', () => {
       get(req, res);
 
       expect(res.render).toHaveBeenCalledWith(
-        TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
+        TEMPLATES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED,
         singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
       );
     });
@@ -42,7 +42,7 @@ describe('controllers/insurance/eligibility/insured-period', () => {
       it('should render template with validation errors', () => {
         post(req, res);
 
-        expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, {
+        expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED, {
           ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
           validationErrors: generateValidationErrors(req.body, PAGE_VARIABLES.FIELD_ID, ERROR_MESSAGES.INSURANCE.ELIGIBILITY[PAGE_VARIABLES.FIELD_ID].IS_EMPTY),
         });
@@ -52,37 +52,37 @@ describe('controllers/insurance/eligibility/insured-period', () => {
     describe('when submitted answer is true', () => {
       beforeEach(() => {
         req.body = {
-          [FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_PERIOD]: 'true',
+          [FIELD_IDS.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED]: 'true',
         };
       });
 
-      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM}`, async () => {
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE}`, async () => {
         await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM);
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
       });
 
       it('should add exitReason to req.flash', async () => {
         await post(req, res);
 
-        const expectedReason = PAGES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM.REASON.WANT_COVER_OVER_MAX_PERIOD;
+        const expectedReason = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE.REASON.OTHER_PARTIES_INVOLVED;
         expect(req.flash).toHaveBeenCalledWith('exitReason', expectedReason);
       });
     });
 
     describe('when there are no validation errors', () => {
       const validBody = {
-        [FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_PERIOD]: 'false',
+        [FIELD_IDS.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED]: 'false',
       };
 
       beforeEach(() => {
         req.body = validBody;
       });
 
-      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED}`, () => {
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`, () => {
         post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED);
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT);
       });
     });
   });

--- a/src/ui/server/controllers/insurance/eligibility/other-parties/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/other-parties/index.ts
@@ -4,21 +4,21 @@ import singleInputPageVariables from '../../../../helpers/single-input-page-vari
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import { Request, Response } from '../../../../../types';
 
-const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_PERIOD;
+const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED;
 
 const PAGE_VARIABLES = {
   FIELD_ID,
-  PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
+  PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED,
 };
 
 const get = (req: Request, res: Response) =>
-  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }));
+  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED, singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }));
 
 const post = (req: Request, res: Response) => {
   const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY);
 
   if (validationErrors) {
-    return res.render(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, {
+    return res.render(TEMPLATES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED, {
       ...singleInputPageVariables({
         ...PAGE_VARIABLES,
         BACK_LINK: req.headers.referer,
@@ -31,15 +31,15 @@ const post = (req: Request, res: Response) => {
 
   if (answer === 'true') {
     const { INSURANCE } = PAGES;
-    const { SPEAK_TO_UKEF_EFM } = INSURANCE.ELIGIBILITY;
-    const { REASON } = SPEAK_TO_UKEF_EFM;
+    const { APPLY_OFFLINE } = INSURANCE.ELIGIBILITY;
+    const { REASON } = APPLY_OFFLINE;
 
-    req.flash('exitReason', REASON.WANT_COVER_OVER_MAX_PERIOD);
+    req.flash('exitReason', REASON.OTHER_PARTIES_INVOLVED);
 
-    return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM);
+    return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   }
 
-  return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED);
+  return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT);
 };
 
 export { PAGE_VARIABLES, get, post };

--- a/src/ui/server/routes/insurance/eligibility/index.test.ts
+++ b/src/ui/server/routes/insurance/eligibility/index.test.ts
@@ -19,8 +19,8 @@ describe('routes/insurance/eligibility', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(9);
-    expect(post).toHaveBeenCalledTimes(6);
+    expect(get).toHaveBeenCalledTimes(10);
+    expect(post).toHaveBeenCalledTimes(7);
 
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE, checkIfEligibleGet);
     expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE, checkIfEligiblePost);

--- a/src/ui/server/routes/insurance/eligibility/index.ts
+++ b/src/ui/server/routes/insurance/eligibility/index.ts
@@ -6,6 +6,7 @@ import { get as exporterLocationGet, post as exporterLocationPost } from '../../
 import { get as ukGoodsOrServicesGet, post as ukGoodsOrServicesPost } from '../../../controllers/insurance/eligibility/uk-goods-or-services';
 import { get as insuredAmountGet, post as insuredAmountPost } from '../../../controllers/insurance/eligibility/insured-amount';
 import { get as insuredPeriodGet, post as insuredPeriodPost } from '../../../controllers/insurance/eligibility/insured-period';
+import { get as otherPartiesInvolvedGet, post as otherPartiesInvolvedPost } from '../../../controllers/insurance/eligibility/other-parties';
 import cannotApplyGet from '../../../controllers/insurance/eligibility/cannot-apply';
 import applyOfflineGet from '../../../controllers/insurance/eligibility/apply-offline';
 import speakToUkefEfmGet from '../../../controllers/insurance/eligibility/speak-to-ukef-efm';
@@ -32,6 +33,9 @@ insuranceEligibilityRouter.post(ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT, ins
 
 insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, insuredPeriodGet);
 insuranceEligibilityRouter.post(ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, insuredPeriodPost);
+
+insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED, otherPartiesInvolvedGet);
+insuranceEligibilityRouter.post(ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED, otherPartiesInvolvedPost);
 
 insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY, cannotApplyGet);
 insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE, applyOfflineGet);

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -12,8 +12,8 @@ describe('routes/insurance', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(10);
-    expect(post).toHaveBeenCalledTimes(7);
+    expect(get).toHaveBeenCalledTimes(11);
+    expect(post).toHaveBeenCalledTimes(8);
 
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.START, startGet);
     expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.START, startPost);

--- a/src/ui/templates/insurance/eligibility/other-parties.njk
+++ b/src/ui/templates/insurance/eligibility/other-parties.njk
@@ -1,0 +1,61 @@
+{% extends 'index.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from 'govuk/components/button/macro.njk' import govukButton %}
+{% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
+{% import '../../components/yes-no-radio-buttons.njk' as yesNoRadioButtons %}
+
+{% block pageTitle %}
+  {{ CONTENT_STRINGS.PAGE_TITLE }}
+{% endblock %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: CONTENT_STRINGS.LINKS.BACK,
+    href: BACK_LINK,
+    attributes: {
+      "data-cy": "back-link"
+    }
+  }) }}
+
+  {% if validationErrors.summary %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: validationErrors.summary
+    }) }}
+  {% endif %}
+
+  {% set class = "govuk-form-group" %}
+
+  {% if validationErrors.errorList[FIELD_ID] %}
+    {% set class = "govuk-form-group govuk-form-group--error" %}
+  {% endif %}
+
+  <form method="POST" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters-from-desktop">
+
+        {{ yesNoRadioButtons.render({
+          fieldId: FIELD_ID,
+          heading: CONTENT_STRINGS.HEADING,
+          submittedAnswer: submittedValues[FIELD_ID],
+          errorMessage: validationErrors.errorList[FIELD_ID]
+        }) }}
+
+      </div>
+    </div>
+
+    {{ govukButton({
+      text: CONTENT_STRINGS.BUTTONS.CONTINUE,
+      attributes: {
+        'data-cy': 'submit-button'
+      }
+    }) }}
+
+  </form>
+
+{% endblock %}

--- a/src/ui/templates/insurance/eligibility/other-parties.njk
+++ b/src/ui/templates/insurance/eligibility/other-parties.njk
@@ -1,6 +1,7 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from 'govuk/components/button/macro.njk' import govukButton %}
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
 {% import '../../components/yes-no-radio-buttons.njk' as yesNoRadioButtons %}
@@ -44,6 +45,35 @@
           heading: CONTENT_STRINGS.HEADING,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]
+        }) }}
+
+      </div>
+    </div>
+
+
+    {% set detailsHtml %}
+      <p data-cy="other-parties-list-intro">{{ CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST_INTRO }}</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+
+        {% for item in CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST %}
+          <li data-cy="other-parties-list-item-{{ loop.index }}">
+            {{ item.TEXT }}
+          </li>
+        {% endfor %}
+
+      </ul>
+    {% endset %}
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters-from-desktop">
+
+        {{ govukDetails({
+          summaryText: CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.INTRO,
+          html: detailsHtml,
+          attributes: {
+            "data-cy": "other-parties"
+          }
         }) }}
 
       </div>


### PR DESCRIPTION
This PR adds a new page to the Insurance eligibility flow for "other parties

- Add new route, controller and validation for "other parties" page.
- Redirect to "apply offline" exit page if the answer to "are other parties involved" is yes.
- EMS-460: Add "what counts as another party" expandable details to the "other parties" page.
