### PR TITLE
feat(EMS-367): Insurance eligibility - pre-credit period

### DIFF
--- a/e2e-tests/constants/field-ids.js
+++ b/e2e-tests/constants/field-ids.js
@@ -29,6 +29,7 @@ const FIELD_IDS = {
       WANT_COVER_OVER_MAX_PERIOD: 'wantCoverOverMaxPeriod',
       OTHER_PARTIES_INVOLVED: 'otherPartiesInvolved',
       LETTER_OF_CREDIT: 'paidByLetterOfCredit',
+      PRE_CREDIT_PERIOD: 'needPreCreditPeriodCover',
     },
   },
 };

--- a/e2e-tests/constants/routes/insurance.js
+++ b/e2e-tests/constants/routes/insurance.js
@@ -18,6 +18,7 @@ const INSURANCE_ROUTES = {
     OTHER_PARTIES_INVOLVED: `${INSURANCE}${ELIGIBILITY}/other-parties`,
     LETTER_OF_CREDIT: `${INSURANCE}${ELIGIBILITY}/letter-of-credit`,
     PRE_CREDIT_PERIOD: `${INSURANCE}${ELIGIBILITY}/pre-credit-period`,
+    COMPANIES_HOUSE_NUMBER: `${INSURANCE}${ELIGIBILITY}/companies-house-number`,
   },
 };
 

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -61,6 +61,9 @@ const ERROR_MESSAGES = {
       [FIELD_IDS.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT]: {
         IS_EMPTY: "Select whether you'll be paid by a letter of credit or not",
       },
+      [FIELD_IDS.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD]: {
+        IS_EMPTY: 'Select whether you need cover for a period before you supply the goods or services to the buyer',
+      },
     },
   },
 };

--- a/e2e-tests/content-strings/fields.js
+++ b/e2e-tests/content-strings/fields.js
@@ -170,6 +170,13 @@ const FIELDS = {
       },
     },
   },
+  INSURANCE: {
+    ELIGIBILITY: {
+      [FIELD_IDS.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT]: {
+        HINT: 'This is known as the pre-credit period.',
+      }
+    },
+  },
 };
 
 module.exports = FIELDS;

--- a/e2e-tests/content-strings/pages/insurance/eligibility/index.js
+++ b/e2e-tests/content-strings/pages/insurance/eligibility/index.js
@@ -16,6 +16,7 @@ const APPLY_OFFLINE = {
     WANT_COVER_OVER_MAX_AMOUNT: `you want to be insured for more than ${MAX_COVER_AMOUNT} and we need to make extra checks.`,
     OTHER_PARTIES_INVOLVED: 'there are other parties involved in your exports and we need to make extra checks.',
     WILL_BE_PAID_BY_LETTER_OF_CREDIT: "you'll be paid by a letter of credit.",
+    NEED_PRE_CREDIT_PERIOD_COVER: 'you need pre-credit cover.',
   },
   ACTIONS: {
     DOWNLOAD_FORM: {
@@ -107,6 +108,11 @@ const LETTER_OF_CREDIT = {
   HEADING: 'Will you be paid by a letter of credit?',
 };
 
+const PRE_CREDIT_PERIOD = {
+  PAGE_TITLE: 'Do you need cover for a period before you supply the goods or services to the buyer?',
+  HEADING: 'Do you need cover for a period before you supply the goods or services to the buyer?',
+};
+
 module.exports = {
   APPLY_OFFLINE,
   SPEAK_TO_UKEF_EFM,
@@ -115,4 +121,5 @@ module.exports = {
   INSURED_PERIOD,
   OTHER_PARTIES_INVOLVED,
   LETTER_OF_CREDIT,
+  PRE_CREDIT_PERIOD,
 };

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period-answer-yes.spec.js
@@ -8,7 +8,7 @@ import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms'
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
-context('Insurance - Insured amount page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction that is less than the maxium amount of cover available online - submit `cover over max amount`', () => {
+context('Insurance - Eligibility - Pre-credit period page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction that is paid via letter of credit - submit `need pre-credit period cover`', () => {
   before(() => {
     cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
       auth: {
@@ -31,6 +31,12 @@ context('Insurance - Insured amount page - I want to check if I can use online s
     noRadio().click();
     submitButton().click();
 
+    noRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
     yesRadio().click();
     submitButton().click();
   });
@@ -42,14 +48,14 @@ context('Insurance - Insured amount page - I want to check if I can use online s
   it('renders a back link with correct url', () => {
     partials.backLink().should('exist');
 
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED}`;
+    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD}`;
 
     partials.backLink().should('have.attr', 'href', expectedUrl);
   });
 
   it('renders a specific reason', () => {
     cannotApplyPage.reason().invoke('text').then((text) => {
-      const expected = `${CONTENT_STRINGS.REASON.INTRO} ${CONTENT_STRINGS.REASON.OTHER_PARTIES_INVOLVED}`;
+      const expected = `${CONTENT_STRINGS.REASON.INTRO} ${CONTENT_STRINGS.REASON.NEED_PRE_CREDIT_PERIOD_COVER}`;
 
       expect(text.trim()).equal(expected);
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -11,10 +11,10 @@ import {
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
 
-const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED;
+const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
-context('Insurance - Other parties page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction if there are other parties involved in the export', () => {
+context('Insurance - Eligibility - Pre-credit period page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction that is paid via letter of credit', () => {
   before(() => {
     cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
       auth: {
@@ -37,7 +37,13 @@ context('Insurance - Other parties page - I want to check if I can use online se
     noRadio().click();
     submitButton().click();
 
-    const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED}`;
+    noRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
+    const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD}`;
 
     cy.url().should('eq', expected);
   });
@@ -47,14 +53,14 @@ context('Insurance - Other parties page - I want to check if I can use online se
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
-    });
-  });
+  // it('passes the audits', () => {
+  //   cy.lighthouse({
+  //     accessibility: 100,
+  //     performance: 75,
+  //     'best-practices': 100,
+  //     seo: 70,
+  //   });
+  // });
 
   it('renders a back link with correct url', () => {
     partials.backLink().should('exist');
@@ -64,12 +70,12 @@ context('Insurance - Other parties page - I want to check if I can use online se
 
     partials.backLink().click();
 
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD}`;
+    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`;
 
     cy.url().should('include', expectedUrl);
 
     // go back to page
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED, {
+    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
@@ -114,48 +120,6 @@ context('Insurance - Other parties page - I want to check if I can use online se
     });
   });
 
-  describe('expandable details', () => {
-    it('renders summary text', () => {
-      insurance.eligibility.otherPartiesPage.description.summary().should('exist');
-
-      insurance.eligibility.otherPartiesPage.description.summary().invoke('text').then((text) => {
-        expect(text.trim()).equal(CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.INTRO);
-      });
-    });
-
-    it('clicking summary text reveals details', () => {
-      insurance.eligibility.otherPartiesPage.description.summary().click();
-
-      insurance.eligibility.otherPartiesPage.description.list.intro().should('be.visible');
-    });
-
-    it('renders expanded content', () => {
-      insurance.eligibility.otherPartiesPage.description.list.intro().invoke('text').then((text) => {
-        expect(text.trim()).equal(CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST_INTRO);
-      });
-
-      insurance.eligibility.otherPartiesPage.description.list.item1().invoke('text').then((text) => {
-        expect(text.trim()).equal(CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST[0].TEXT);
-      });
-
-      insurance.eligibility.otherPartiesPage.description.list.item2().invoke('text').then((text) => {
-        expect(text.trim()).equal(CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST[1].TEXT);
-      });
-
-      insurance.eligibility.otherPartiesPage.description.list.item3().invoke('text').then((text) => {
-        expect(text.trim()).equal(CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST[2].TEXT);
-      });
-
-      insurance.eligibility.otherPartiesPage.description.list.item4().invoke('text').then((text) => {
-        expect(text.trim()).equal(CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST[3].TEXT);
-      });
-
-      insurance.eligibility.otherPartiesPage.description.list.item5().invoke('text').then((text) => {
-        expect(text.trim()).equal(CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST[4].TEXT);
-      });
-    });
-  });
-
   it('renders a submit button', () => {
     submitButton().should('exist');
 
@@ -172,7 +136,7 @@ context('Insurance - Other parties page - I want to check if I can use online se
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED].IS_EMPTY;
+        const expectedMessage = ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD].IS_EMPTY;
 
         partials.errorSummaryListItems().first().invoke('text').then((text) => {
           expect(text.trim()).equal(expectedMessage);
@@ -192,11 +156,11 @@ context('Insurance - Other parties page - I want to check if I can use online se
     });
 
     describe('when submitting the answer as `no`', () => {
-      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`, () => {
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`, () => {
         noRadio().click();
         submitButton().click();
 
-        const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`;
+        const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`;
 
         cy.url().should('eq', expected);
       });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -53,14 +53,14 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  // it('passes the audits', () => {
-  //   cy.lighthouse({
-  //     accessibility: 100,
-  //     performance: 75,
-  //     'best-practices': 100,
-  //     seo: 70,
-  //   });
-  // });
+  it('passes the audits', () => {
+    cy.lighthouse({
+      accessibility: 100,
+      performance: 75,
+      'best-practices': 100,
+      seo: 70,
+    });
+  });
 
   it('renders a back link with correct url', () => {
     partials.backLink().should('exist');

--- a/e2e-tests/cypress/support/analytics/check-analytics-cookie-properties.js
+++ b/e2e-tests/cypress/support/analytics/check-analytics-cookie-properties.js
@@ -10,9 +10,12 @@ const checkAnalyticsCookieProperties = () => {
     const month = new Date(date).getMonth();
     const year = new Date(date).getFullYear();
 
-    const expectedDay = new Date().getDate() + 1;
-    const expectedMonth = new Date().getMonth();
-    const expectedYear = new Date().getFullYear();
+    const today = new Date();
+    const tomorrow = today.setDate(today.getDate() + 1)
+
+    const expectedDay = new Date(tomorrow).getDate();
+    const expectedMonth = new Date(tomorrow).getMonth();
+    const expectedYear = new Date(tomorrow).getFullYear();
 
     expect(day).to.equal(expectedDay);
     expect(month).to.equal(expectedMonth);

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -1,4 +1,3 @@
 # Export Insurance Policies UI
 
 UI to check if a UK based exporter can apply for export insurance and get a premium quote.
-

--- a/src/ui/server/constants/field-ids.ts
+++ b/src/ui/server/constants/field-ids.ts
@@ -29,6 +29,7 @@ export const FIELD_IDS = {
       WANT_COVER_OVER_MAX_PERIOD: 'wantCoverOverMaxPeriod',
       OTHER_PARTIES_INVOLVED: 'otherPartiesInvolved',
       LETTER_OF_CREDIT: 'paidByLetterOfCredit',
+      PRE_CREDIT_PERIOD: 'needPreCreditPeriodCover',
     },
   },
 };

--- a/src/ui/server/constants/routes/insurance.ts
+++ b/src/ui/server/constants/routes/insurance.ts
@@ -18,5 +18,6 @@ export const INSURANCE_ROUTES = {
     OTHER_PARTIES_INVOLVED: `${INSURANCE}${ELIGIBILITY}/other-parties`,
     LETTER_OF_CREDIT: `${INSURANCE}${ELIGIBILITY}/letter-of-credit`,
     PRE_CREDIT_PERIOD: `${INSURANCE}${ELIGIBILITY}/pre-credit-period`,
+    COMPANIES_HOUSE_NUMBER: `${INSURANCE}${ELIGIBILITY}/companies-house-number`,
   },
 };

--- a/src/ui/server/constants/templates/insurance/eligibility/index.ts
+++ b/src/ui/server/constants/templates/insurance/eligibility/index.ts
@@ -7,4 +7,5 @@ export const ELIGIBILITY_TEMPLATES = {
   INSURED_PERIOD: 'insurance/eligibility/insured-period.njk',
   OTHER_PARTIES_INVOLVED: 'insurance/eligibility/other-parties.njk',
   LETTER_OF_CREDIT: 'insurance/eligibility/letter-of-credit.njk',
+  PRE_CREDIT_PERIOD: 'insurance/eligibility/pre-credit-period.njk',
 };

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -61,6 +61,9 @@ export const ERROR_MESSAGES = {
       [FIELD_IDS.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT]: {
         IS_EMPTY: "Select whether you'll be paid by a letter of credit or not",
       },
+      [FIELD_IDS.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD]: {
+        IS_EMPTY: 'Select whether you need cover for a period before you supply the goods or services to the buyer',
+      },
     },
   },
 } as ErrorMessage;

--- a/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
@@ -12,6 +12,7 @@ const APPLY_OFFLINE = {
     WANT_COVER_OVER_MAX_AMOUNT: `you want to be insured for more than ${MAX_COVER_AMOUNT} and we need to make extra checks.`,
     OTHER_PARTIES_INVOLVED: 'there are other parties involved in your exports and we need to make extra checks.',
     WILL_BE_PAID_BY_LETTER_OF_CREDIT: "you'll be paid by a letter of credit.",
+    NEED_PRE_CREDIT_PERIOD_COVER: 'you need pre-credit cover.',
   },
   ACTIONS: {
     DOWNLOAD_FORM: {
@@ -103,6 +104,11 @@ const LETTER_OF_CREDIT = {
   HEADING: 'Will you be paid by a letter of credit?',
 };
 
+const PRE_CREDIT_PERIOD = {
+  PAGE_TITLE: 'Do you need cover for a period before you supply the goods or services to the buyer?',
+  HEADING: 'Do you need cover for a period before you supply the goods or services to the buyer?',
+};
+
 export default {
   APPLY_OFFLINE,
   SPEAK_TO_UKEF_EFM,
@@ -111,4 +117,5 @@ export default {
   INSURED_PERIOD,
   OTHER_PARTIES_INVOLVED,
   LETTER_OF_CREDIT,
+  PRE_CREDIT_PERIOD,
 };

--- a/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.test.ts
@@ -1,0 +1,89 @@
+import { PAGE_VARIABLES, get, post } from '.';
+import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
+import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
+import singleInputPageVariables from '../../../../helpers/single-input-page-variables';
+import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { Request, Response } from '../../../../../types';
+import { mockReq, mockRes } from '../../../../test-mocks';
+
+describe('controllers/insurance/eligibility/pre-credit-period', () => {
+  let req: Request;
+  let res: Response;
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+  });
+
+  describe('PAGE_VARIABLES', () => {
+    it('should have correct properties', () => {
+      const expected = {
+        FIELD_ID: FIELD_IDS.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD,
+        PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD,
+      };
+
+      expect(PAGE_VARIABLES).toEqual(expected);
+    });
+  });
+
+  describe('get', () => {
+    it('should render template', () => {
+      get(req, res);
+
+      expect(res.render).toHaveBeenCalledWith(
+        TEMPLATES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD,
+        singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+      );
+    });
+  });
+
+  describe('post', () => {
+    describe('when there are validation errors', () => {
+      it('should render template with validation errors', () => {
+        post(req, res);
+
+        expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD, {
+          ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+          validationErrors: generateValidationErrors(req.body, PAGE_VARIABLES.FIELD_ID, ERROR_MESSAGES.INSURANCE.ELIGIBILITY[PAGE_VARIABLES.FIELD_ID].IS_EMPTY),
+        });
+      });
+    });
+
+    describe('when submitted answer is true', () => {
+      beforeEach(() => {
+        req.body = {
+          [FIELD_IDS.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD]: 'true',
+        };
+      });
+
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
+      });
+
+      it('should add exitReason to req.flash', async () => {
+        await post(req, res);
+
+        const expectedReason = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE.REASON.NEED_PRE_CREDIT_PERIOD_COVER;
+        expect(req.flash).toHaveBeenCalledWith('exitReason', expectedReason);
+      });
+    });
+
+    describe('when there are no validation errors', () => {
+      const validBody = {
+        [FIELD_IDS.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD]: 'false',
+      };
+
+      beforeEach(() => {
+        req.body = validBody;
+      });
+
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`, () => {
+        post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER);
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.ts
@@ -1,0 +1,45 @@
+import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
+import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
+import singleInputPageVariables from '../../../../helpers/single-input-page-variables';
+import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { Request, Response } from '../../../../../types';
+
+const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD;
+
+const PAGE_VARIABLES = {
+  FIELD_ID,
+  PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD,
+};
+
+const get = (req: Request, res: Response) =>
+  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD, singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }));
+
+const post = (req: Request, res: Response) => {
+  const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY);
+
+  if (validationErrors) {
+    return res.render(TEMPLATES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD, {
+      ...singleInputPageVariables({
+        ...PAGE_VARIABLES,
+        BACK_LINK: req.headers.referer,
+      }),
+      validationErrors,
+    });
+  }
+
+  const answer = req.body[FIELD_ID];
+
+  if (answer === 'true') {
+    const { INSURANCE } = PAGES;
+    const { APPLY_OFFLINE } = INSURANCE.ELIGIBILITY;
+    const { REASON } = APPLY_OFFLINE;
+
+    req.flash('exitReason', REASON.NEED_PRE_CREDIT_PERIOD_COVER);
+
+    return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
+  }
+
+  return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER);
+};
+
+export { PAGE_VARIABLES, get, post };

--- a/src/ui/server/routes/insurance/eligibility/index.test.ts
+++ b/src/ui/server/routes/insurance/eligibility/index.test.ts
@@ -20,8 +20,8 @@ describe('routes/insurance/eligibility', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(11);
-    expect(post).toHaveBeenCalledTimes(8);
+    expect(get).toHaveBeenCalledTimes(12);
+    expect(post).toHaveBeenCalledTimes(9);
 
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE, checkIfEligibleGet);
     expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE, checkIfEligiblePost);

--- a/src/ui/server/routes/insurance/eligibility/index.ts
+++ b/src/ui/server/routes/insurance/eligibility/index.ts
@@ -8,6 +8,7 @@ import { get as insuredAmountGet, post as insuredAmountPost } from '../../../con
 import { get as insuredPeriodGet, post as insuredPeriodPost } from '../../../controllers/insurance/eligibility/insured-period';
 import { get as otherPartiesInvolvedGet, post as otherPartiesInvolvedPost } from '../../../controllers/insurance/eligibility/other-parties';
 import { get as letterOfCreditGet, post as letterOfCreditPost } from '../../../controllers/insurance/eligibility/letter-of-credit';
+import { get as preCreditPeriodGet, post as preCreditPeriodPost } from '../../../controllers/insurance/eligibility/pre-credit-period';
 import cannotApplyGet from '../../../controllers/insurance/eligibility/cannot-apply';
 import applyOfflineGet from '../../../controllers/insurance/eligibility/apply-offline';
 import speakToUkefEfmGet from '../../../controllers/insurance/eligibility/speak-to-ukef-efm';
@@ -40,6 +41,9 @@ insuranceEligibilityRouter.post(ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOL
 
 insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT, letterOfCreditGet);
 insuranceEligibilityRouter.post(ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT, letterOfCreditPost);
+
+insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD, preCreditPeriodGet);
+insuranceEligibilityRouter.post(ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD, preCreditPeriodPost);
 
 insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY, cannotApplyGet);
 insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE, applyOfflineGet);

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -12,8 +12,8 @@ describe('routes/insurance', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(12);
-    expect(post).toHaveBeenCalledTimes(9);
+    expect(get).toHaveBeenCalledTimes(13);
+    expect(post).toHaveBeenCalledTimes(10);
 
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.START, startGet);
     expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.START, startPost);

--- a/src/ui/templates/insurance/eligibility/pre-credit-period.njk
+++ b/src/ui/templates/insurance/eligibility/pre-credit-period.njk
@@ -1,0 +1,61 @@
+{% extends 'index.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from 'govuk/components/button/macro.njk' import govukButton %}
+{% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
+{% import '../../components/yes-no-radio-buttons.njk' as yesNoRadioButtons %}
+
+{% block pageTitle %}
+  {{ CONTENT_STRINGS.PAGE_TITLE }}
+{% endblock %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: CONTENT_STRINGS.LINKS.BACK,
+    href: BACK_LINK,
+    attributes: {
+      "data-cy": "back-link"
+    }
+  }) }}
+
+  {% if validationErrors.summary %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: validationErrors.summary
+    }) }}
+  {% endif %}
+
+  {% set class = "govuk-form-group" %}
+
+  {% if validationErrors.errorList[FIELD_ID] %}
+    {% set class = "govuk-form-group govuk-form-group--error" %}
+  {% endif %}
+
+  <form method="POST" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters-from-desktop">
+
+        {{ yesNoRadioButtons.render({
+          fieldId: FIELD_ID,
+          heading: CONTENT_STRINGS.HEADING,
+          submittedAnswer: submittedValues[FIELD_ID],
+          errorMessage: validationErrors.errorList[FIELD_ID]
+        }) }}
+
+      </div>
+    </div>
+
+    {{ govukButton({
+      text: CONTENT_STRINGS.BUTTONS.CONTINUE,
+      attributes: {
+        'data-cy': 'submit-button'
+      }
+    }) }}
+
+  </form>
+
+{% endblock %}


### PR DESCRIPTION
This PR adds a new page to the Insurance eligibility flow for "pre-credit period"

- Add new route, controller and validation for "pre-credit period" page.
- Redirect to "apply offline" exit page if the answer to "need cover for pre-credit period" is yes.

