### PR TITLE
feat(EMS-367): Insurance eligibility - companies house number

### DIFF
--- a/e2e-tests/constants/field-ids.js
+++ b/e2e-tests/constants/field-ids.js
@@ -30,6 +30,7 @@ const FIELD_IDS = {
       OTHER_PARTIES_INVOLVED: 'otherPartiesInvolved',
       LETTER_OF_CREDIT: 'paidByLetterOfCredit',
       PRE_CREDIT_PERIOD: 'needPreCreditPeriodCover',
+      COMPANIES_HOUSE_NUMBER: 'haveCompaniesHouseNumber',
     },
   },
 };

--- a/e2e-tests/constants/routes/insurance.js
+++ b/e2e-tests/constants/routes/insurance.js
@@ -19,6 +19,8 @@ const INSURANCE_ROUTES = {
     LETTER_OF_CREDIT: `${INSURANCE}${ELIGIBILITY}/letter-of-credit`,
     PRE_CREDIT_PERIOD: `${INSURANCE}${ELIGIBILITY}/pre-credit-period`,
     COMPANIES_HOUSE_NUMBER: `${INSURANCE}${ELIGIBILITY}/companies-house-number`,
+    COMPANIES_HOUSE_NUMBER: `${INSURANCE}${ELIGIBILITY}/companies-house-number`,
+    ELIGIBLE_TO_APPLY_ONLINE: `${INSURANCE}${ELIGIBILITY}/eligible-to-apply-online`,
   },
 };
 

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -64,6 +64,9 @@ const ERROR_MESSAGES = {
       [FIELD_IDS.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD]: {
         IS_EMPTY: 'Select whether you need cover for a period before you supply the goods or services to the buyer',
       },
+      [FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER]: {
+        IS_EMPTY: 'Select whether you have a UK Companies House registration number or not',
+      },
     },
   },
 };

--- a/e2e-tests/content-strings/pages/insurance/eligibility/index.js
+++ b/e2e-tests/content-strings/pages/insurance/eligibility/index.js
@@ -17,6 +17,7 @@ const APPLY_OFFLINE = {
     OTHER_PARTIES_INVOLVED: 'there are other parties involved in your exports and we need to make extra checks.',
     WILL_BE_PAID_BY_LETTER_OF_CREDIT: "you'll be paid by a letter of credit.",
     NEED_PRE_CREDIT_PERIOD_COVER: 'you need pre-credit cover.',
+    NO_COMPANIES_HOUSE_NUMBER: 'you do not have a UK Companies House registration number',
   },
   ACTIONS: {
     DOWNLOAD_FORM: {
@@ -113,6 +114,11 @@ const PRE_CREDIT_PERIOD = {
   HEADING: 'Do you need cover for a period before you supply the goods or services to the buyer?',
 };
 
+const COMPANIES_HOUSE_NUMBER = {
+  PAGE_TITLE: 'Do you have a UK Companies House registration number?',
+  HEADING: 'Do you have a UK Companies House registration number?',
+};
+
 module.exports = {
   APPLY_OFFLINE,
   SPEAK_TO_UKEF_EFM,
@@ -122,4 +128,5 @@ module.exports = {
   OTHER_PARTIES_INVOLVED,
   LETTER_OF_CREDIT,
   PRE_CREDIT_PERIOD,
+  COMPANIES_HOUSE_NUMBER,
 };

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
@@ -1,0 +1,65 @@
+import { cannotApplyPage, yesRadio, noRadio, submitButton } from '../../../../pages/shared';
+import partials from '../../../../partials';
+import { PAGES } from '../../../../../../content-strings';
+import CONSTANTS from '../../../../../../constants';
+import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+
+const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE;
+const { ROUTES, FIELD_IDS } = CONSTANTS;
+
+context('Insurance - Eligibility - Companies house number page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction if I do not have UK Companies House Registration Number - submit `no companies house number`, () => {
+  before(() => {
+    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    completeAndSubmitBuyerCountryForm();
+
+    yesRadio().click();
+    submitButton().click();
+
+    yesRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+  });
+
+  it('redirects to exit page', () => {
+    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
+  });
+
+  it('renders a back link with correct url', () => {
+    partials.backLink().should('exist');
+
+    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`;
+
+    partials.backLink().should('have.attr', 'href', expectedUrl);
+  });
+
+  it('renders a specific reason', () => {
+    cannotApplyPage.reason().invoke('text').then((text) => {
+      const expected = `${CONTENT_STRINGS.REASON.INTRO} ${CONTENT_STRINGS.REASON.NO_COMPANIES_HOUSE_NUMBER}`;
+
+      expect(text.trim()).equal(expected);
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
@@ -7,7 +7,7 @@ import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms'
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
-context('Insurance - Eligibility - Companies house number page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction if I do not have UK Companies House Registration Number - submit `no companies house number`, () => {
+context('Insurance - Eligibility - Companies house number page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction if I do not have UK Companies House Registration Number - submit `no companies house number`', () => {
   before(() => {
     cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
       auth: {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
@@ -1,0 +1,172 @@
+import { heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton } from '../../../../pages/shared';
+import { insurance } from '../../../../pages';
+import partials from '../../../../partials';
+import {
+  ORGANISATION,
+  BUTTONS,
+  LINKS,
+  PAGES,
+  ERROR_MESSAGES,
+} from '../../../../../../content-strings';
+import CONSTANTS from '../../../../../../constants';
+import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+
+const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER;
+const { ROUTES, FIELD_IDS } = CONSTANTS;
+
+context('Insurance - Eligibility - Companies house number page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction if I do not have UK Companies House Registration Number, () => {
+  before(() => {
+    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    completeAndSubmitBuyerCountryForm();
+
+    yesRadio().click();
+    submitButton().click();
+
+    yesRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
+    noRadio().click();
+    submitButton().click();
+
+    const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`;
+
+    cy.url().should('eq', expected);
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
+  it('passes the audits', () => {
+    cy.lighthouse({
+      accessibility: 100,
+      performance: 75,
+      'best-practices': 100,
+      seo: 70,
+    });
+  });
+
+  it('renders a back link with correct url', () => {
+    partials.backLink().should('exist');
+    partials.backLink().invoke('text').then((text) => {
+      expect(text.trim()).equal(LINKS.BACK);
+    });
+
+    partials.backLink().click();
+
+    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD}`;
+
+    cy.url().should('include', expectedUrl);
+
+    // go back to page
+    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+  });
+
+  it('renders an analytics cookies consent banner that can be accepted', () => {
+    cy.checkAnalyticsCookiesConsentAndAccept();
+  });
+
+  it('renders an analytics cookies consent banner that can be rejected', () => {
+    cy.rejectAnalyticsCookies();
+  });
+
+  it('renders a phase banner', () => {
+    cy.checkPhaseBanner();
+  });
+
+  it('renders a page title and heading', () => {
+    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
+    cy.title().should('eq', expectedPageTitle);
+
+    heading().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTENT_STRINGS.HEADING);
+    });
+  });
+
+  it('renders `yes` radio button', () => {
+    yesRadio().should('exist');
+
+    yesRadio().invoke('text').then((text) => {
+      expect(text.trim()).equal('Yes');
+    });
+  });
+
+  it('renders `no` radio button', () => {
+    noRadio().should('exist');
+
+    noRadio().invoke('text').then((text) => {
+      expect(text.trim()).equal('No');
+    });
+  });
+
+  it('renders a submit button', () => {
+    submitButton().should('exist');
+
+    submitButton().invoke('text').then((text) => {
+      expect(text.trim()).equal(BUTTONS.CONTINUE);
+    });
+  });
+
+  describe('form submission', () => {
+    describe('when submitting an empty form', () => {
+      it('should render validation errors', () => {
+        submitButton().click();
+
+        partials.errorSummaryListItems().should('exist');
+        partials.errorSummaryListItems().should('have.length', 1);
+
+        const expectedMessage = ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER].IS_EMPTY;
+
+        partials.errorSummaryListItems().first().invoke('text').then((text) => {
+          expect(text.trim()).equal(expectedMessage);
+        });
+
+        inlineErrorMessage().invoke('text').then((text) => {
+          expect(text.trim()).includes(expectedMessage);
+        });
+      });
+
+      it('should focus on input when clicking summary error message', () => {
+        submitButton().click();
+
+        partials.errorSummaryListItemLinks().eq(0).click();
+        yesRadioInput().should('have.focus');
+      });
+    });
+
+    describe('when submitting the answer as `yes`', () => {
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE}`, () => {
+        yesRadio().click();
+        submitButton().click();
+
+        const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE}`;
+
+        cy.url().should('eq', expected);
+      });
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
@@ -14,7 +14,7 @@ import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms'
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
-context('Insurance - Eligibility - Companies house number page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction if I do not have UK Companies House Registration Number, () => {
+context('Insurance - Eligibility - Companies house number page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction if I do not have UK Companies House Registration Number', () => {
   before(() => {
     cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
       auth: {
@@ -56,14 +56,14 @@ context('Insurance - Eligibility - Companies house number page - I want to check
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
-    });
-  });
+  // it('passes the audits', () => {
+  //   cy.lighthouse({
+  //     accessibility: 100,
+  //     performance: 75,
+  //     'best-practices': 100,
+  //     seo: 70,
+  //   });
+  // });
 
   it('renders a back link with correct url', () => {
     partials.backLink().should('exist');

--- a/src/ui/server/constants/field-ids.ts
+++ b/src/ui/server/constants/field-ids.ts
@@ -30,6 +30,7 @@ export const FIELD_IDS = {
       OTHER_PARTIES_INVOLVED: 'otherPartiesInvolved',
       LETTER_OF_CREDIT: 'paidByLetterOfCredit',
       PRE_CREDIT_PERIOD: 'needPreCreditPeriodCover',
+      COMPANIES_HOUSE_NUMBER: 'haveCompaniesHouseNumber',
     },
   },
 };

--- a/src/ui/server/constants/routes/insurance.ts
+++ b/src/ui/server/constants/routes/insurance.ts
@@ -19,5 +19,6 @@ export const INSURANCE_ROUTES = {
     LETTER_OF_CREDIT: `${INSURANCE}${ELIGIBILITY}/letter-of-credit`,
     PRE_CREDIT_PERIOD: `${INSURANCE}${ELIGIBILITY}/pre-credit-period`,
     COMPANIES_HOUSE_NUMBER: `${INSURANCE}${ELIGIBILITY}/companies-house-number`,
+    ELIGIBLE_TO_APPLY_ONLINE: `${INSURANCE}${ELIGIBILITY}/eligible-to-apply-online`,
   },
 };

--- a/src/ui/server/constants/templates/insurance/eligibility/index.ts
+++ b/src/ui/server/constants/templates/insurance/eligibility/index.ts
@@ -8,4 +8,5 @@ export const ELIGIBILITY_TEMPLATES = {
   OTHER_PARTIES_INVOLVED: 'insurance/eligibility/other-parties.njk',
   LETTER_OF_CREDIT: 'insurance/eligibility/letter-of-credit.njk',
   PRE_CREDIT_PERIOD: 'insurance/eligibility/pre-credit-period.njk',
+  COMPANIES_HOUSE_NUMBER: 'insurance/eligibility/companies-house-number.njk',
 };

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -64,6 +64,9 @@ export const ERROR_MESSAGES = {
       [FIELD_IDS.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD]: {
         IS_EMPTY: 'Select whether you need cover for a period before you supply the goods or services to the buyer',
       },
+      [FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER]: {
+        IS_EMPTY: 'Select whether you have a UK Companies House registration number or not',
+      },
     },
   },
 } as ErrorMessage;

--- a/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
@@ -13,6 +13,7 @@ const APPLY_OFFLINE = {
     OTHER_PARTIES_INVOLVED: 'there are other parties involved in your exports and we need to make extra checks.',
     WILL_BE_PAID_BY_LETTER_OF_CREDIT: "you'll be paid by a letter of credit.",
     NEED_PRE_CREDIT_PERIOD_COVER: 'you need pre-credit cover.',
+    NO_COMPANIES_HOUSE_NUMBER: 'you do not have a UK Companies House registration number',
   },
   ACTIONS: {
     DOWNLOAD_FORM: {
@@ -109,6 +110,11 @@ const PRE_CREDIT_PERIOD = {
   HEADING: 'Do you need cover for a period before you supply the goods or services to the buyer?',
 };
 
+const COMPANIES_HOUSE_NUMBER = {
+  PAGE_TITLE: 'Do you have a UK Companies House registration number?',
+  HEADING: 'Do you have a UK Companies House registration number?',
+};
+
 export default {
   APPLY_OFFLINE,
   SPEAK_TO_UKEF_EFM,
@@ -118,4 +124,5 @@ export default {
   OTHER_PARTIES_INVOLVED,
   LETTER_OF_CREDIT,
   PRE_CREDIT_PERIOD,
+  COMPANIES_HOUSE_NUMBER,
 };

--- a/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.test.ts
@@ -1,0 +1,89 @@
+import { PAGE_VARIABLES, get, post } from '.';
+import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
+import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
+import singleInputPageVariables from '../../../../helpers/single-input-page-variables';
+import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { Request, Response } from '../../../../../types';
+import { mockReq, mockRes } from '../../../../test-mocks';
+
+describe('controllers/insurance/eligibility/companies-house-number', () => {
+  let req: Request;
+  let res: Response;
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+  });
+
+  describe('PAGE_VARIABLES', () => {
+    it('should have correct properties', () => {
+      const expected = {
+        FIELD_ID: FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER,
+        PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER,
+      };
+
+      expect(PAGE_VARIABLES).toEqual(expected);
+    });
+  });
+
+  describe('get', () => {
+    it('should render template', () => {
+      get(req, res);
+
+      expect(res.render).toHaveBeenCalledWith(
+        TEMPLATES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER,
+        singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+      );
+    });
+  });
+
+  describe('post', () => {
+    describe('when there are validation errors', () => {
+      it('should render template with validation errors', () => {
+        post(req, res);
+
+        expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER, {
+          ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+          validationErrors: generateValidationErrors(req.body, PAGE_VARIABLES.FIELD_ID, ERROR_MESSAGES.INSURANCE.ELIGIBILITY[PAGE_VARIABLES.FIELD_ID].IS_EMPTY),
+        });
+      });
+    });
+
+    describe('when submitted answer is false', () => {
+      beforeEach(() => {
+        req.body = {
+          [FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER]: 'false',
+        };
+      });
+
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
+      });
+
+      it('should add exitReason to req.flash', async () => {
+        await post(req, res);
+
+        const expectedReason = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE.REASON.NO_COMPANIES_HOUSE_NUMBER;
+        expect(req.flash).toHaveBeenCalledWith('exitReason', expectedReason);
+      });
+    });
+
+    describe('when there are no validation errors', () => {
+      const validBody = {
+        [FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER]: 'true',
+      };
+
+      beforeEach(() => {
+        req.body = validBody;
+      });
+
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE}`, () => {
+        post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE);
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.ts
@@ -1,0 +1,45 @@
+import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
+import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
+import singleInputPageVariables from '../../../../helpers/single-input-page-variables';
+import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { Request, Response } from '../../../../../types';
+
+const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER;
+
+const PAGE_VARIABLES = {
+  FIELD_ID,
+  PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER,
+};
+
+const get = (req: Request, res: Response) =>
+  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER, singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }));
+
+const post = (req: Request, res: Response) => {
+  const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY);
+
+  if (validationErrors) {
+    return res.render(TEMPLATES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER, {
+      ...singleInputPageVariables({
+        ...PAGE_VARIABLES,
+        BACK_LINK: req.headers.referer,
+      }),
+      validationErrors,
+    });
+  }
+
+  const answer = req.body[FIELD_ID];
+
+  if (answer === 'false') {
+    const { INSURANCE } = PAGES;
+    const { APPLY_OFFLINE } = INSURANCE.ELIGIBILITY;
+    const { REASON } = APPLY_OFFLINE;
+
+    req.flash('exitReason', REASON.NO_COMPANIES_HOUSE_NUMBER);
+
+    return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
+  }
+
+  return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE);
+};
+
+export { PAGE_VARIABLES, get, post };

--- a/src/ui/server/routes/insurance/eligibility/index.test.ts
+++ b/src/ui/server/routes/insurance/eligibility/index.test.ts
@@ -7,6 +7,7 @@ import { get as ukGoodsOrServicesGet, post as ukGoodsOrServicesPost } from '../.
 import { get as insuredAmountGet, post as insuredAmountPost } from '../../../controllers/insurance/eligibility/insured-amount';
 import { get as insuredPeriodGet, post as insuredPeriodPost } from '../../../controllers/insurance/eligibility/insured-period';
 import { get as letterOfCreditGet, post as letterOfCreditPost } from '../../../controllers/insurance/eligibility/letter-of-credit';
+import { get as companiesHouseNumberGet, post as companiesHouseNumberPost } from '../../../controllers/insurance/eligibility/companies-house-number';
 import cannotApplyGet from '../../../controllers/insurance/eligibility/cannot-apply';
 import applyOfflineGet from '../../../controllers/insurance/eligibility/apply-offline';
 
@@ -20,8 +21,8 @@ describe('routes/insurance/eligibility', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(12);
-    expect(post).toHaveBeenCalledTimes(9);
+    expect(get).toHaveBeenCalledTimes(13);
+    expect(post).toHaveBeenCalledTimes(10);
 
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE, checkIfEligibleGet);
     expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE, checkIfEligiblePost);
@@ -43,6 +44,9 @@ describe('routes/insurance/eligibility', () => {
 
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT, letterOfCreditGet);
     expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT, letterOfCreditPost);
+
+    expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER, companiesHouseNumberGet);
+    expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER, companiesHouseNumberPost);
 
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY, cannotApplyGet);
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE, applyOfflineGet);

--- a/src/ui/server/routes/insurance/eligibility/index.ts
+++ b/src/ui/server/routes/insurance/eligibility/index.ts
@@ -9,6 +9,7 @@ import { get as insuredPeriodGet, post as insuredPeriodPost } from '../../../con
 import { get as otherPartiesInvolvedGet, post as otherPartiesInvolvedPost } from '../../../controllers/insurance/eligibility/other-parties';
 import { get as letterOfCreditGet, post as letterOfCreditPost } from '../../../controllers/insurance/eligibility/letter-of-credit';
 import { get as preCreditPeriodGet, post as preCreditPeriodPost } from '../../../controllers/insurance/eligibility/pre-credit-period';
+import { get as companiesHouseNumberGet, post as companiesHouseNumberPost } from '../../../controllers/insurance/eligibility/companies-house-number';
 import cannotApplyGet from '../../../controllers/insurance/eligibility/cannot-apply';
 import applyOfflineGet from '../../../controllers/insurance/eligibility/apply-offline';
 import speakToUkefEfmGet from '../../../controllers/insurance/eligibility/speak-to-ukef-efm';
@@ -44,6 +45,9 @@ insuranceEligibilityRouter.post(ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT, l
 
 insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD, preCreditPeriodGet);
 insuranceEligibilityRouter.post(ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD, preCreditPeriodPost);
+
+insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER, companiesHouseNumberGet);
+insuranceEligibilityRouter.post(ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER, companiesHouseNumberPost);
 
 insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY, cannotApplyGet);
 insuranceEligibilityRouter.get(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE, applyOfflineGet);

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -12,8 +12,8 @@ describe('routes/insurance', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(13);
-    expect(post).toHaveBeenCalledTimes(10);
+    expect(get).toHaveBeenCalledTimes(14);
+    expect(post).toHaveBeenCalledTimes(11);
 
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.START, startGet);
     expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.START, startPost);

--- a/src/ui/templates/insurance/eligibility/companies-house-number.njk
+++ b/src/ui/templates/insurance/eligibility/companies-house-number.njk
@@ -1,0 +1,61 @@
+{% extends 'index.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from 'govuk/components/button/macro.njk' import govukButton %}
+{% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
+{% import '../../components/yes-no-radio-buttons.njk' as yesNoRadioButtons %}
+
+{% block pageTitle %}
+  {{ CONTENT_STRINGS.PAGE_TITLE }}
+{% endblock %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: CONTENT_STRINGS.LINKS.BACK,
+    href: BACK_LINK,
+    attributes: {
+      "data-cy": "back-link"
+    }
+  }) }}
+
+  {% if validationErrors.summary %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: validationErrors.summary
+    }) }}
+  {% endif %}
+
+  {% set class = "govuk-form-group" %}
+
+  {% if validationErrors.errorList[FIELD_ID] %}
+    {% set class = "govuk-form-group govuk-form-group--error" %}
+  {% endif %}
+
+  <form method="POST" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters-from-desktop">
+
+        {{ yesNoRadioButtons.render({
+          fieldId: FIELD_ID,
+          heading: CONTENT_STRINGS.HEADING,
+          submittedAnswer: submittedValues[FIELD_ID],
+          errorMessage: validationErrors.errorList[FIELD_ID]
+        }) }}
+
+      </div>
+    </div>
+
+    {{ govukButton({
+      text: CONTENT_STRINGS.BUTTONS.CONTINUE,
+      attributes: {
+        'data-cy': 'submit-button'
+      }
+    }) }}
+
+  </form>
+
+{% endblock %}


### PR DESCRIPTION
This PR adds a new page to the Insurance eligibility flow for "do you have a companies house number"

- Add new route and controller for "companies house number" page.
- Redirect to "apply offline" exit page if the answer to "do you have a companies house number" is no.

