### PR TITLE
feat(EMS-511): split up submittedData for quote eligibility and insurance eligibility

### DIFF
--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
@@ -46,7 +46,7 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
     let getCountriesSpy = jest.fn(() => Promise.resolve(mockCountriesResponse));
 
     beforeEach(() => {
-      delete req.session.submittedData[FIELD_IDS.BUYER_COUNTRY];
+      delete req.session.submittedData.quoteEligibility[FIELD_IDS.BUYER_COUNTRY];
       api.getCountries = getCountriesSpy;
     });
 
@@ -75,7 +75,7 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
 
         await get(req, res);
 
-        const expectedCountries = mapCountries(mockCountriesResponse, req.session.submittedData[FIELD_IDS.BUYER_COUNTRY].isoCode);
+        const expectedCountries = mapCountries(mockCountriesResponse, req.session.submittedData.quoteEligibility[FIELD_IDS.BUYER_COUNTRY].isoCode);
 
         const expectedVariables = {
           ...singleInputPageVariables(PAGE_VARIABLES),

--- a/src/ui/server/controllers/quote/buyer-body/index.test.ts
+++ b/src/ui/server/controllers/quote/buyer-body/index.test.ts
@@ -86,7 +86,7 @@ describe('controllers/quote/buyer-body', () => {
       const expectedVariables = {
         ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
         submittedValues: {
-          ...req.session.submittedData,
+          ...req.session.submittedData.quoteEligibility,
           [PAGE_VARIABLES.FIELD_ID]: mapSubmittedAnswer(req.session.submittedData[FIELD_IDS.VALID_BUYER_BODY]),
         },
       };

--- a/src/ui/server/controllers/quote/buyer-body/index.test.ts
+++ b/src/ui/server/controllers/quote/buyer-body/index.test.ts
@@ -1,6 +1,6 @@
 import { PAGE_VARIABLES, mapAnswer, mapSubmittedAnswer, get, post } from '.';
 import { ERROR_MESSAGES, PAGES } from '../../../content-strings';
-import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
+import { ROUTES, TEMPLATES } from '../../../constants';
 import singleInputPageVariables from '../../../helpers/single-input-page-variables';
 import generateValidationErrors from '../../../shared-validation/yes-no-radios-form';
 import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
@@ -27,7 +27,7 @@ describe('controllers/quote/buyer-body', () => {
   describe('PAGE_VARIABLES', () => {
     it('should have correct properties', () => {
       const expected = {
-        FIELD_ID: FIELD_IDS.VALID_BUYER_BODY,
+        FIELD_ID: PAGE_VARIABLES.FIELD_ID,
         PAGE_CONTENT_STRINGS: PAGES.QUOTE.BUYER_BODY,
       };
 
@@ -87,7 +87,7 @@ describe('controllers/quote/buyer-body', () => {
         ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
         submittedValues: {
           ...req.session.submittedData.quoteEligibility,
-          [PAGE_VARIABLES.FIELD_ID]: mapSubmittedAnswer(req.session.submittedData[FIELD_IDS.VALID_BUYER_BODY]),
+          [PAGE_VARIABLES.FIELD_ID]: mapSubmittedAnswer(req.session.submittedData.quoteEligibility[PAGE_VARIABLES.FIELD_ID]),
         },
       };
 
@@ -109,7 +109,7 @@ describe('controllers/quote/buyer-body', () => {
 
     describe('when the submitted answer is `yes`', () => {
       beforeEach(() => {
-        req.body[FIELD_IDS.VALID_BUYER_BODY] = 'true';
+        req.body[PAGE_VARIABLES.FIELD_ID] = 'true';
       });
 
       it('should add previousRoute, exitReason and exitDescription to req.flash', async () => {
@@ -135,7 +135,7 @@ describe('controllers/quote/buyer-body', () => {
 
     describe('when there are no validation errors', () => {
       const validBody = {
-        [FIELD_IDS.VALID_BUYER_BODY]: 'false',
+        [PAGE_VARIABLES.FIELD_ID]: 'false',
       };
 
       beforeEach(() => {
@@ -145,9 +145,9 @@ describe('controllers/quote/buyer-body', () => {
       it('should update the session with submitted data, popluated with mapped buyer body answer', async () => {
         await post(req, res);
 
-        const expectedMappedAnswer = mapAnswer(req.body[FIELD_IDS.VALID_BUYER_BODY]);
+        const expectedMappedAnswer = mapAnswer(req.body[PAGE_VARIABLES.FIELD_ID]);
 
-        const expected = updateSubmittedData({ [FIELD_IDS.VALID_BUYER_BODY]: expectedMappedAnswer }, req.session.submittedData.quoteEligibility);
+        const expected = updateSubmittedData({ [PAGE_VARIABLES.FIELD_ID]: expectedMappedAnswer }, req.session.submittedData.quoteEligibility);
 
         expect(req.session.submittedData.quoteEligibility).toEqual(expected);
       });

--- a/src/ui/server/controllers/quote/buyer-body/index.test.ts
+++ b/src/ui/server/controllers/quote/buyer-body/index.test.ts
@@ -3,7 +3,7 @@ import { ERROR_MESSAGES, PAGES } from '../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
 import singleInputPageVariables from '../../../helpers/single-input-page-variables';
 import generateValidationErrors from '../../../shared-validation/yes-no-radios-form';
-import { updateSubmittedData } from '../../../helpers/update-submitted-data';
+import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
 import { mockReq, mockRes } from '../../../test-mocks';
 import { Request, Response } from '../../../../types';
 
@@ -147,9 +147,9 @@ describe('controllers/quote/buyer-body', () => {
 
         const expectedMappedAnswer = mapAnswer(req.body[FIELD_IDS.VALID_BUYER_BODY]);
 
-        const expected = updateSubmittedData({ [FIELD_IDS.VALID_BUYER_BODY]: expectedMappedAnswer }, req.session.submittedData);
+        const expected = updateSubmittedData({ [FIELD_IDS.VALID_BUYER_BODY]: expectedMappedAnswer }, req.session.submittedData.quoteEligibility);
 
-        expect(req.session.submittedData).toEqual(expected);
+        expect(req.session.submittedData.quoteEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.QUOTE.EXPORTER_LOCATION}`, async () => {

--- a/src/ui/server/controllers/quote/buyer-body/index.ts
+++ b/src/ui/server/controllers/quote/buyer-body/index.ts
@@ -49,7 +49,7 @@ const mapSubmittedAnswer = (answer?: boolean) => {
 };
 
 const get = (req: Request, res: Response) => {
-  const mappedAnswer = mapSubmittedAnswer(req.session.submittedData[FIELD_IDS.VALID_BUYER_BODY]);
+  const mappedAnswer = mapSubmittedAnswer(req.session.submittedData.quoteEligibility[FIELD_ID]);
 
   return res.render(TEMPLATES.QUOTE.BUYER_BODY, {
     ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
@@ -70,11 +70,11 @@ const post = (req: Request, res: Response) => {
     });
   }
 
-  const answer = req.body[FIELD_IDS.VALID_BUYER_BODY];
+  const answer = req.body[FIELD_ID];
 
-  const mappedAnswer = mapAnswer(req.body[FIELD_IDS.VALID_BUYER_BODY]);
+  const mappedAnswer = mapAnswer(req.body[FIELD_ID]);
 
-  req.session.submittedData.quoteEligibility = updateSubmittedData({ [FIELD_IDS.VALID_BUYER_BODY]: mappedAnswer }, req.session.submittedData.quoteEligibility);
+  req.session.submittedData.quoteEligibility = updateSubmittedData({ [FIELD_ID]: mappedAnswer }, req.session.submittedData.quoteEligibility);
 
   if (answer === 'true') {
     req.flash('previousRoute', ROUTES.QUOTE.BUYER_BODY);

--- a/src/ui/server/controllers/quote/buyer-body/index.ts
+++ b/src/ui/server/controllers/quote/buyer-body/index.ts
@@ -54,7 +54,7 @@ const get = (req: Request, res: Response) => {
   return res.render(TEMPLATES.QUOTE.BUYER_BODY, {
     ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
     submittedValues: {
-      ...req.session.submittedData,
+      ...req.session.submittedData.quoteEligibility,
       [FIELD_ID]: mappedAnswer,
     },
   });

--- a/src/ui/server/controllers/quote/buyer-body/index.ts
+++ b/src/ui/server/controllers/quote/buyer-body/index.ts
@@ -2,7 +2,7 @@ import { ERROR_MESSAGES, PAGES } from '../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
 import singleInputPageVariables from '../../../helpers/single-input-page-variables';
 import generateValidationErrors from '../../../shared-validation/yes-no-radios-form';
-import { updateSubmittedData } from '../../../helpers/update-submitted-data';
+import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
 import { Request, Response } from '../../../../types';
 
 const FIELD_ID = FIELD_IDS.VALID_BUYER_BODY;
@@ -74,7 +74,7 @@ const post = (req: Request, res: Response) => {
 
   const mappedAnswer = mapAnswer(req.body[FIELD_IDS.VALID_BUYER_BODY]);
 
-  req.session.submittedData = updateSubmittedData({ [FIELD_IDS.VALID_BUYER_BODY]: mappedAnswer }, req.session.submittedData);
+  req.session.submittedData.quoteEligibility = updateSubmittedData({ [FIELD_IDS.VALID_BUYER_BODY]: mappedAnswer }, req.session.submittedData.quoteEligibility);
 
   if (answer === 'true') {
     req.flash('previousRoute', ROUTES.QUOTE.BUYER_BODY);

--- a/src/ui/server/controllers/quote/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.test.ts
@@ -7,7 +7,7 @@ import isChangeRoute from '../../../helpers/is-change-route';
 import getCountryByName from '../../../helpers/get-country-by-name';
 import api from '../../../api';
 import { mapCountries } from '../../../helpers/mappings/map-countries';
-import { updateSubmittedData } from '../../../helpers/update-submitted-data';
+import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
 import { mockReq, mockRes, mockAnswers, mockSession, mockCisCountries } from '../../../test-mocks';
 import { Request, Response } from '../../../../types';
 
@@ -93,7 +93,7 @@ describe('controllers/quote/buyer-country', () => {
     let getCountriesSpy = jest.fn(() => Promise.resolve(mockCountriesResponse));
 
     beforeEach(() => {
-      delete req.session.submittedData[FIELD_IDS.BUYER_COUNTRY];
+      delete req.session.submittedData.quoteEligibility[FIELD_IDS.BUYER_COUNTRY];
       api.getCountries = getCountriesSpy;
     });
 
@@ -110,7 +110,7 @@ describe('controllers/quote/buyer-country', () => {
         ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: getBackLink(req.headers.referer) }),
         HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
         countries: mapCountries(mockCountriesResponse),
-        submittedValues: req.session.submittedData,
+        submittedValues: req.session.submittedData.quoteEligibility,
         isChangeRoute: isChangeRoute(req.originalUrl),
       };
 
@@ -123,13 +123,13 @@ describe('controllers/quote/buyer-country', () => {
 
         await get(req, res);
 
-        const expectedCountries = mapCountries(mockCountriesResponse, req.session.submittedData[FIELD_IDS.BUYER_COUNTRY].isoCode);
+        const expectedCountries = mapCountries(mockCountriesResponse, req.session.submittedData.quoteEligibility[FIELD_IDS.BUYER_COUNTRY].isoCode);
 
         const expectedVariables = {
           ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: getBackLink(req.headers.referer) }),
           HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
           countries: expectedCountries,
-          submittedValues: req.session.submittedData,
+          submittedValues: req.session.submittedData.quoteEligibility,
           isChangeRoute: isChangeRoute(req.originalUrl),
         };
 
@@ -288,9 +288,9 @@ describe('controllers/quote/buyer-country', () => {
           },
         };
 
-        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData);
+        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.quoteEligibility);
 
-        expect(req.session.submittedData).toEqual(expected);
+        expect(req.session.submittedData.quoteEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.QUOTE.BUYER_BODY}`, async () => {
@@ -337,9 +337,9 @@ describe('controllers/quote/buyer-country', () => {
           },
         };
 
-        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData);
+        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.quoteEligibility);
 
-        expect(req.session.submittedData).toEqual(expected);
+        expect(req.session.submittedData.quoteEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.QUOTE.BUYER_BODY}`, async () => {

--- a/src/ui/server/controllers/quote/buyer-country/index.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.ts
@@ -72,7 +72,7 @@ export const get = async (req: Request, res: Response) => {
     ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: getBackLink(req.headers.referer) }),
     HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
     countries: mappedCountries,
-    submittedValues: req.session.submittedData.quoteEligibility,
+    submittedValues: req.session.submittedData?.quoteEligibility,
     isChangeRoute: isChangeRoute(req.originalUrl),
   });
 };

--- a/src/ui/server/controllers/quote/buyer-country/index.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.ts
@@ -7,7 +7,7 @@ import { validation as generateValidationErrors } from '../../../shared-validati
 import isChangeRoute from '../../../helpers/is-change-route';
 import getCountryByName from '../../../helpers/get-country-by-name';
 import { canGetAQuoteOnline, canGetAQuoteByEmail, cannotGetAQuote } from '../../../helpers/country-support';
-import { updateSubmittedData } from '../../../helpers/update-submitted-data';
+import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
 import { Request, Response } from '../../../../types';
 
 export const PAGE_VARIABLES = {
@@ -56,8 +56,8 @@ export const get = async (req: Request, res: Response) => {
 
   let countryValue;
 
-  if (submittedData && submittedData[FIELD_IDS.BUYER_COUNTRY]) {
-    countryValue = submittedData[FIELD_IDS.BUYER_COUNTRY];
+  if (submittedData && submittedData.quoteEligibility[FIELD_IDS.BUYER_COUNTRY]) {
+    countryValue = submittedData.quoteEligibility[FIELD_IDS.BUYER_COUNTRY];
   }
 
   let mappedCountries;
@@ -72,7 +72,7 @@ export const get = async (req: Request, res: Response) => {
     ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: getBackLink(req.headers.referer) }),
     HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
     countries: mappedCountries,
-    submittedValues: req.session.submittedData,
+    submittedValues: req.session.submittedData.quoteEligibility,
     isChangeRoute: isChangeRoute(req.originalUrl),
   });
 };
@@ -116,7 +116,7 @@ export const post = async (req: Request, res: Response) => {
       },
     };
 
-    req.session.submittedData = updateSubmittedData(populatedData, req.session.submittedData);
+    req.session.submittedData.quoteEligibility = updateSubmittedData(populatedData, req.session.submittedData.quoteEligibility);
 
     if (isChangeRoute(req.originalUrl)) {
       return res.redirect(ROUTES.QUOTE.CHECK_YOUR_ANSWERS);

--- a/src/ui/server/controllers/quote/check-your-answers/index.test.ts
+++ b/src/ui/server/controllers/quote/check-your-answers/index.test.ts
@@ -14,19 +14,22 @@ describe('controllers/quote/check-your-answers', () => {
   let res: Response;
 
   const mockSessionData = {
-    [BUYER_COUNTRY]: {
-      name: mockAnswers[BUYER_COUNTRY],
-      isoCode: 'FRA',
+    quoteEligibility: {
+      [BUYER_COUNTRY]: {
+        name: mockAnswers[BUYER_COUNTRY],
+        isoCode: 'FRA',
+      },
+      [CREDIT_PERIOD]: 2,
+      [CURRENCY]: {
+        name: 'UK Sterling',
+        isoCode: 'GBP',
+      },
+      [MAX_AMOUNT_OWED]: 1234,
+      [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.MULTI,
+      [HAS_MINIMUM_UK_GOODS_OR_SERVICES]: true,
+      [VALID_EXPORTER_LOCATION]: true,
     },
-    [CREDIT_PERIOD]: 2,
-    [CURRENCY]: {
-      name: 'UK Sterling',
-      isoCode: 'GBP',
-    },
-    [MAX_AMOUNT_OWED]: 1234,
-    [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.MULTI,
-    [HAS_MINIMUM_UK_GOODS_OR_SERVICES]: true,
-    [VALID_EXPORTER_LOCATION]: true,
+    insuranceEligibility: {},
   };
 
   beforeEach(() => {
@@ -42,7 +45,7 @@ describe('controllers/quote/check-your-answers', () => {
     it('should render template', () => {
       get(req, res);
 
-      const answers = mapAnswersToContent(mockSessionData);
+      const answers = mapAnswersToContent(mockSessionData.quoteEligibility);
 
       const expectedSummaryList = answersSummaryList(answers);
 

--- a/src/ui/server/controllers/quote/check-your-answers/index.ts
+++ b/src/ui/server/controllers/quote/check-your-answers/index.ts
@@ -6,7 +6,7 @@ import corePageVariables from '../../../helpers/core-page-variables';
 import { Request, Response } from '../../../../types';
 
 const get = async (req: Request, res: Response) => {
-  const answers = mapAnswersToContent(req.session.submittedData);
+  const answers = mapAnswersToContent(req.session.submittedData.quoteEligibility);
 
   const summaryList = answersSummaryList(answers);
 

--- a/src/ui/server/controllers/quote/exporter-location/index.test.ts
+++ b/src/ui/server/controllers/quote/exporter-location/index.test.ts
@@ -3,7 +3,7 @@ import { ERROR_MESSAGES, PAGES } from '../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
 import singleInputPageVariables from '../../../helpers/single-input-page-variables';
 import generateValidationErrors from '../../../shared-validation/yes-no-radios-form';
-import { updateSubmittedData } from '../../../helpers/update-submitted-data';
+import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
 import { mockReq, mockRes } from '../../../test-mocks';
 import { Request, Response } from '../../../../types';
 
@@ -87,9 +87,9 @@ describe('controllers/quote/exporter-location', () => {
       it('should update the session with submitted data', () => {
         post(req, res);
 
-        const expected = updateSubmittedData(req.body, req.session.submittedData);
+        const expected = updateSubmittedData(req.body, req.session.submittedData.quoteEligibility);
 
-        expect(req.session.submittedData).toEqual(expected);
+        expect(req.session.submittedData.quoteEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.QUOTE.UK_GOODS_OR_SERVICES}`, () => {

--- a/src/ui/server/controllers/quote/exporter-location/index.test.ts
+++ b/src/ui/server/controllers/quote/exporter-location/index.test.ts
@@ -34,7 +34,7 @@ describe('controllers/quote/exporter-location', () => {
       expect(res.render).toHaveBeenCalledWith(TEMPLATES.SHARED_PAGES.EXPORTER_LOCATION, {
         ...singleInputPageVariables(PAGE_VARIABLES),
         BACK_LINK: req.headers.referer,
-        submittedValues: req.session.submittedData,
+        submittedValues: req.session.submittedData.quoteEligibility,
       });
     });
   });

--- a/src/ui/server/controllers/quote/exporter-location/index.ts
+++ b/src/ui/server/controllers/quote/exporter-location/index.ts
@@ -2,7 +2,7 @@ import { ERROR_MESSAGES, PAGES } from '../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
 import singleInputPageVariables from '../../../helpers/single-input-page-variables';
 import generateValidationErrors from '../../../shared-validation/yes-no-radios-form';
-import { updateSubmittedData } from '../../../helpers/update-submitted-data';
+import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
 import isChangeRoute from '../../../helpers/is-change-route';
 import { Request, Response } from '../../../../types';
 
@@ -35,7 +35,10 @@ const post = (req: Request, res: Response) => {
     });
   }
 
-  req.session.submittedData = updateSubmittedData(req.body, req.session.submittedData);
+  req.session.submittedData = {
+    quoteEligibility: updateSubmittedData(req.body, req.session.submittedData.quoteEligibility),
+    insuranceEligibility: {},
+  };
 
   const answer = req.body[FIELD_IDS.VALID_EXPORTER_LOCATION];
 

--- a/src/ui/server/controllers/quote/exporter-location/index.ts
+++ b/src/ui/server/controllers/quote/exporter-location/index.ts
@@ -19,7 +19,7 @@ const get = (req: Request, res: Response) =>
       ...PAGE_VARIABLES,
       BACK_LINK: req.headers.referer,
     }),
-    submittedValues: req.session.submittedData,
+    submittedValues: req.session.submittedData.quoteEligibility,
   });
 
 const post = (req: Request, res: Response) => {

--- a/src/ui/server/controllers/quote/policy-type/index.test.ts
+++ b/src/ui/server/controllers/quote/policy-type/index.test.ts
@@ -58,7 +58,7 @@ describe('controllers/quote/policy-type', () => {
       expect(res.render).toHaveBeenCalledWith(TEMPLATES.QUOTE.POLICY_TYPE, {
         ...corePageVariables({ PAGE_CONTENT_STRINGS: PAGES.QUOTE.POLICY_TYPE, BACK_LINK: req.headers.referer }),
         ...PAGE_VARIABLES,
-        submittedValues: req.session.submittedData,
+        submittedValues: req.session.submittedData.quoteEligibility,
       });
     });
   });

--- a/src/ui/server/controllers/quote/policy-type/index.test.ts
+++ b/src/ui/server/controllers/quote/policy-type/index.test.ts
@@ -3,7 +3,7 @@ import { FIELDS, PAGES } from '../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
 import corePageVariables from '../../../helpers/core-page-variables';
 import generateValidationErrors from './validation';
-import { updateSubmittedData } from '../../../helpers/update-submitted-data';
+import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
 import { mockReq, mockRes, mockAnswers } from '../../../test-mocks';
 import { Request, Response } from '../../../../types';
 
@@ -104,9 +104,9 @@ describe('controllers/quote/policy-type', () => {
       it('should update the session with submitted data', () => {
         post(req, res);
 
-        const expected = updateSubmittedData(req.body, req.session.submittedData);
+        const expected = updateSubmittedData(req.body, req.session.submittedData.quoteEligibility);
 
-        expect(req.session.submittedData).toEqual(expected);
+        expect(req.session.submittedData.quoteEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY}`, () => {

--- a/src/ui/server/controllers/quote/policy-type/index.ts
+++ b/src/ui/server/controllers/quote/policy-type/index.ts
@@ -37,7 +37,7 @@ const get = (req: Request, res: Response) =>
   res.render(TEMPLATES.QUOTE.POLICY_TYPE, {
     ...corePageVariables({ PAGE_CONTENT_STRINGS: PAGES.QUOTE.POLICY_TYPE, BACK_LINK: req.headers.referer }),
     ...PAGE_VARIABLES,
-    submittedValues: req.session.submittedData,
+    submittedValues: req.session.submittedData.quoteEligibility,
   });
 
 const post = (req: Request, res: Response) => {

--- a/src/ui/server/controllers/quote/policy-type/index.ts
+++ b/src/ui/server/controllers/quote/policy-type/index.ts
@@ -3,7 +3,7 @@ import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
 import corePageVariables from '../../../helpers/core-page-variables';
 import generateValidationErrors from './validation';
 import { isSinglePolicyType } from '../../../helpers/policy-type';
-import { updateSubmittedData } from '../../../helpers/update-submitted-data';
+import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
 import { Request, Response } from '../../../../types';
 
 const { MULTI_POLICY_TYPE, POLICY_LENGTH, POLICY_TYPE, SINGLE_POLICY_LENGTH, SINGLE_POLICY_TYPE } = FIELD_IDS;
@@ -61,7 +61,7 @@ const post = (req: Request, res: Response) => {
     };
   }
 
-  req.session.submittedData = updateSubmittedData(populatedData, req.session.submittedData);
+  req.session.submittedData.quoteEligibility = updateSubmittedData(populatedData, req.session.submittedData.quoteEligibility);
 
   return res.redirect(ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY);
 };

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
@@ -7,7 +7,7 @@ import generateValidationErrors from './validation';
 import getCurrencyByCode from '../../../helpers/get-currency-by-code';
 import mapPercentageOfCover from '../../../helpers/mappings/map-percentage-of-cover';
 import mapCreditPeriod from '../../../helpers/mappings/map-credit-period';
-import { updateSubmittedData } from '../../../helpers/update-submitted-data';
+import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
 import { isSinglePolicyType, isMultiPolicyType } from '../../../helpers/policy-type';
 import { mockReq, mockRes, mockAnswers, mockSession } from '../../../test-mocks';
 import { Request, Response, SelectOption, TellUsAboutPolicyPageVariables } from '../../../../types';
@@ -38,10 +38,10 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
   let mappedCreditPeriod: Array<SelectOption>;
 
   const previousFlowSubmittedData = {
-    [BUYER_COUNTRY]: mockSession.submittedData[BUYER_COUNTRY],
-    [CONTRACT_VALUE]: mockSession.submittedData[CONTRACT_VALUE],
-    [POLICY_TYPE]: mockSession.submittedData[POLICY_TYPE],
-    [POLICY_LENGTH]: mockSession.submittedData[POLICY_LENGTH],
+    [BUYER_COUNTRY]: mockSession.submittedData.quoteEligibility[BUYER_COUNTRY],
+    [CONTRACT_VALUE]: mockSession.submittedData.quoteEligibility[CONTRACT_VALUE],
+    [POLICY_TYPE]: mockSession.submittedData.quoteEligibility[POLICY_TYPE],
+    [POLICY_LENGTH]: mockSession.submittedData.quoteEligibility[POLICY_LENGTH],
   };
 
   beforeEach(() => {
@@ -198,8 +198,11 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
 
     beforeEach(() => {
       req.session.submittedData = {
-        [POLICY_TYPE]: mockSession.submittedData[POLICY_TYPE],
-        [BUYER_COUNTRY]: mockSession.submittedData[BUYER_COUNTRY],
+        quoteEligibility: {
+          [POLICY_TYPE]: mockSession.submittedData.quoteEligibility[POLICY_TYPE],
+          [BUYER_COUNTRY]: mockSession.submittedData.quoteEligibility[BUYER_COUNTRY],
+        },
+        insuranceEligibility: {},
       };
 
       api.getCurrencies = getCurrenciesSpy;
@@ -217,10 +220,10 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
       const expectedCurrencies = mapCurrencies(mockCurrenciesResponse);
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATES.QUOTE.TELL_US_ABOUT_YOUR_POLICY, {
-        ...generatePageVariables(req.session.submittedData[POLICY_TYPE]),
+        ...generatePageVariables(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
         BACK_LINK: req.headers.referer,
-        isSinglePolicyType: isSinglePolicyType(req.session.submittedData[POLICY_TYPE]),
-        isMultiPolicyType: isMultiPolicyType(req.session.submittedData[POLICY_TYPE]),
+        isSinglePolicyType: isSinglePolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
+        isMultiPolicyType: isMultiPolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
         currencies: expectedCurrencies,
         percentageOfCover: mappedPercentageOfCover,
         creditPeriod: mappedCreditPeriod,
@@ -231,20 +234,20 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
     describe('when a currency has been submitted', () => {
       beforeEach(() => {
         req.session.submittedData = mockSession.submittedData;
-        delete req.session.submittedData[PERCENTAGE_OF_COVER];
-        delete req.session.submittedData[CREDIT_PERIOD];
+        delete req.session.submittedData.quoteEligibility[PERCENTAGE_OF_COVER];
+        delete req.session.submittedData.quoteEligibility[CREDIT_PERIOD];
       });
 
       it('should render template with currencies mapped to submitted currency and submittedValues', async () => {
         await get(req, res);
 
-        const expectedCurrencies = mapCurrencies(mockCurrenciesResponse, req.session.submittedData[CURRENCY].isoCode);
+        const expectedCurrencies = mapCurrencies(mockCurrenciesResponse, req.session.submittedData.quoteEligibility[CURRENCY].isoCode);
 
         expect(res.render).toHaveBeenCalledWith(TEMPLATES.QUOTE.TELL_US_ABOUT_YOUR_POLICY, {
-          ...generatePageVariables(req.session.submittedData[POLICY_TYPE]),
+          ...generatePageVariables(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
           BACK_LINK: req.headers.referer,
-          isSinglePolicyType: isSinglePolicyType(req.session.submittedData[POLICY_TYPE]),
-          isMultiPolicyType: isMultiPolicyType(req.session.submittedData[POLICY_TYPE]),
+          isSinglePolicyType: isSinglePolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
+          isMultiPolicyType: isMultiPolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
           currencies: expectedCurrencies,
           percentageOfCover: mappedPercentageOfCover,
           creditPeriod: mappedCreditPeriod,
@@ -256,22 +259,22 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
     describe('when a percentage of cover has been submitted', () => {
       beforeEach(() => {
         req.session.submittedData = mockSession.submittedData;
-        req.session.submittedData[PERCENTAGE_OF_COVER] = mockAnswers[PERCENTAGE_OF_COVER];
-        delete req.session.submittedData[CREDIT_PERIOD];
+        req.session.submittedData.quoteEligibility[PERCENTAGE_OF_COVER] = mockAnswers[PERCENTAGE_OF_COVER];
+        delete req.session.submittedData.quoteEligibility[CREDIT_PERIOD];
       });
 
       it('should render template with percentage of cover mapped to submitted percentage and submittedValues', async () => {
         await get(req, res);
 
-        const expectedCurrencies = mapCurrencies(mockCurrenciesResponse, req.session.submittedData[CURRENCY].isoCode);
+        const expectedCurrencies = mapCurrencies(mockCurrenciesResponse, req.session.submittedData.quoteEligibility[CURRENCY].isoCode);
 
-        const mappedPercentageOfCoverWithSelected = mapPercentageOfCover(PERCENTAGES_OF_COVER, req.session.submittedData[PERCENTAGE_OF_COVER]);
+        const mappedPercentageOfCoverWithSelected = mapPercentageOfCover(PERCENTAGES_OF_COVER, req.session.submittedData.quoteEligibility[PERCENTAGE_OF_COVER]);
 
         expect(res.render).toHaveBeenCalledWith(TEMPLATES.QUOTE.TELL_US_ABOUT_YOUR_POLICY, {
-          ...generatePageVariables(req.session.submittedData[POLICY_TYPE]),
+          ...generatePageVariables(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
           BACK_LINK: req.headers.referer,
-          isSinglePolicyType: isSinglePolicyType(req.session.submittedData[POLICY_TYPE]),
-          isMultiPolicyType: isMultiPolicyType(req.session.submittedData[POLICY_TYPE]),
+          isSinglePolicyType: isSinglePolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
+          isMultiPolicyType: isMultiPolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
           currencies: expectedCurrencies,
           percentageOfCover: mappedPercentageOfCoverWithSelected,
           creditPeriod: mappedCreditPeriod,
@@ -283,23 +286,24 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
     describe('when a credit period has been submitted', () => {
       beforeEach(() => {
         req.session.submittedData = mockSession.submittedData;
-        req.session.submittedData[CREDIT_PERIOD] = 2;
+        // @ts-ignore
+        req.session.submittedData.quoteEligibility[CREDIT_PERIOD] = 2;
       });
 
       it('should render template with credit period mapped to submitted credit period and submittedValues', async () => {
         await get(req, res);
 
-        const expectedCurrencies = mapCurrencies(mockCurrenciesResponse, req.session.submittedData[CURRENCY].isoCode);
+        const expectedCurrencies = mapCurrencies(mockCurrenciesResponse, req.session.submittedData.quoteEligibility[CURRENCY].isoCode);
 
-        const mappedPercentageOfCoverWithSelected = mapPercentageOfCover(PERCENTAGES_OF_COVER, req.session.submittedData[PERCENTAGE_OF_COVER]);
+        const mappedPercentageOfCoverWithSelected = mapPercentageOfCover(PERCENTAGES_OF_COVER, req.session.submittedData.quoteEligibility[PERCENTAGE_OF_COVER]);
 
-        const mappedCreditPeriodWithSelected = mapCreditPeriod(creditPeriodOptions, String(req.session.submittedData[CREDIT_PERIOD]));
+        const mappedCreditPeriodWithSelected = mapCreditPeriod(creditPeriodOptions, String(req.session.submittedData.quoteEligibility[CREDIT_PERIOD]));
 
         expect(res.render).toHaveBeenCalledWith(TEMPLATES.QUOTE.TELL_US_ABOUT_YOUR_POLICY, {
-          ...generatePageVariables(req.session.submittedData[POLICY_TYPE]),
+          ...generatePageVariables(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
           BACK_LINK: req.headers.referer,
-          isSinglePolicyType: isSinglePolicyType(req.session.submittedData[POLICY_TYPE]),
-          isMultiPolicyType: isMultiPolicyType(req.session.submittedData[POLICY_TYPE]),
+          isSinglePolicyType: isSinglePolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
+          isMultiPolicyType: isMultiPolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
           currencies: expectedCurrencies,
           percentageOfCover: mappedPercentageOfCoverWithSelected,
           creditPeriod: mappedCreditPeriodWithSelected,
@@ -353,7 +357,10 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
     beforeEach(() => {
       api.getCurrencies = getCurrenciesSpy;
       req.body = mockAnswers;
-      req.session.submittedData = previousFlowSubmittedData;
+      req.session.submittedData = {
+        quoteEligibility: previousFlowSubmittedData,
+        insuranceEligibility: {},
+      };
     });
 
     describe('when a currency code has been submitted', () => {
@@ -373,13 +380,13 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
         await post(req, res);
 
         expect(res.render).toHaveBeenCalledWith(TEMPLATES.QUOTE.TELL_US_ABOUT_YOUR_POLICY, {
-          ...generatePageVariables(req.session.submittedData[POLICY_TYPE]),
+          ...generatePageVariables(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
           BACK_LINK: req.headers.referer,
-          isSinglePolicyType: isSinglePolicyType(req.session.submittedData[POLICY_TYPE]),
-          isMultiPolicyType: isMultiPolicyType(req.session.submittedData[POLICY_TYPE]),
+          isSinglePolicyType: isSinglePolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
+          isMultiPolicyType: isMultiPolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
           currencies: mapCurrencies(mockCurrenciesResponse),
           validationErrors: generateValidationErrors({
-            ...req.session.submittedData,
+            ...req.session.submittedData.quoteEligibility,
             ...req.body,
           }),
           percentageOfCover: mappedPercentageOfCover,
@@ -390,7 +397,10 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
 
       describe('when a currency code has been submitted', () => {
         beforeEach(() => {
-          req.session.submittedData = previousFlowSubmittedData;
+          req.session.submittedData = {
+            quoteEligibility: previousFlowSubmittedData,
+            insuranceEligibility: {},
+          };
           req.body[CURRENCY] = mockAnswers[CURRENCY];
         });
 
@@ -398,13 +408,13 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
           await post(req, res);
 
           expect(res.render).toHaveBeenCalledWith(TEMPLATES.QUOTE.TELL_US_ABOUT_YOUR_POLICY, {
-            ...generatePageVariables(req.session.submittedData[POLICY_TYPE]),
+            ...generatePageVariables(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
             BACK_LINK: req.headers.referer,
-            isSinglePolicyType: isSinglePolicyType(req.session.submittedData[POLICY_TYPE]),
-            isMultiPolicyType: isMultiPolicyType(req.session.submittedData[POLICY_TYPE]),
+            isSinglePolicyType: isSinglePolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
+            isMultiPolicyType: isMultiPolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
             currencies: mapCurrencies(mockCurrenciesResponse, req.body[CURRENCY]),
             validationErrors: generateValidationErrors({
-              ...req.session.submittedData,
+              ...req.session.submittedData.quoteEligibility,
               ...req.body,
             }),
             percentageOfCover: mappedPercentageOfCover,
@@ -425,13 +435,13 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
           const mappedPercentageOfCoverWithSelected = mapPercentageOfCover(PERCENTAGES_OF_COVER, req.body[PERCENTAGE_OF_COVER]);
 
           expect(res.render).toHaveBeenCalledWith(TEMPLATES.QUOTE.TELL_US_ABOUT_YOUR_POLICY, {
-            ...generatePageVariables(req.session.submittedData[POLICY_TYPE]),
+            ...generatePageVariables(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
             BACK_LINK: req.headers.referer,
-            isSinglePolicyType: isSinglePolicyType(req.session.submittedData[POLICY_TYPE]),
-            isMultiPolicyType: isMultiPolicyType(req.session.submittedData[POLICY_TYPE]),
+            isSinglePolicyType: isSinglePolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
+            isMultiPolicyType: isMultiPolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
             currencies: mapCurrencies(mockCurrenciesResponse, req.body[CURRENCY]),
             validationErrors: generateValidationErrors({
-              ...req.session.submittedData,
+              ...req.session.submittedData.quoteEligibility,
               ...req.body,
             }),
             percentageOfCover: mappedPercentageOfCoverWithSelected,
@@ -449,16 +459,16 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
         it('should render template with mapped submitted credit period', async () => {
           await post(req, res);
 
-          const mappedCreditPeriodWithSelected = mapCreditPeriod(creditPeriodOptions, String(req.session.submittedData[CREDIT_PERIOD]));
+          const mappedCreditPeriodWithSelected = mapCreditPeriod(creditPeriodOptions, String(req.session.submittedData.quoteEligibility[CREDIT_PERIOD]));
 
           expect(res.render).toHaveBeenCalledWith(TEMPLATES.QUOTE.TELL_US_ABOUT_YOUR_POLICY, {
-            ...generatePageVariables(req.session.submittedData[POLICY_TYPE]),
+            ...generatePageVariables(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
             BACK_LINK: req.headers.referer,
-            isSinglePolicyType: isSinglePolicyType(req.session.submittedData[POLICY_TYPE]),
-            isMultiPolicyType: isMultiPolicyType(req.session.submittedData[POLICY_TYPE]),
+            isSinglePolicyType: isSinglePolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
+            isMultiPolicyType: isMultiPolicyType(req.session.submittedData.quoteEligibility[POLICY_TYPE]),
             currencies: mapCurrencies(mockCurrenciesResponse, req.body[CURRENCY]),
             validationErrors: generateValidationErrors({
-              ...req.session.submittedData,
+              ...req.session.submittedData.quoteEligibility,
               ...req.body,
             }),
             percentageOfCover: mappedPercentageOfCover,
@@ -490,9 +500,9 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
           [PERCENTAGE_OF_COVER]: validBody[PERCENTAGE_OF_COVER],
         };
 
-        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData);
+        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.quoteEligibility);
 
-        expect(req.session.submittedData).toEqual(expected);
+        expect(req.session.submittedData.quoteEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`, async () => {

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
@@ -227,7 +227,7 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
         currencies: expectedCurrencies,
         percentageOfCover: mappedPercentageOfCover,
         creditPeriod: mappedCreditPeriod,
-        submittedValues: req.session.submittedData,
+        submittedValues: req.session.submittedData.quoteEligibility,
       });
     });
 
@@ -251,7 +251,7 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
           currencies: expectedCurrencies,
           percentageOfCover: mappedPercentageOfCover,
           creditPeriod: mappedCreditPeriod,
-          submittedValues: req.session.submittedData,
+          submittedValues: req.session.submittedData.quoteEligibility,
         });
       });
     });
@@ -278,7 +278,7 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
           currencies: expectedCurrencies,
           percentageOfCover: mappedPercentageOfCoverWithSelected,
           creditPeriod: mappedCreditPeriod,
-          submittedValues: req.session.submittedData,
+          submittedValues: req.session.submittedData.quoteEligibility,
         });
       });
     });
@@ -307,7 +307,7 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
           currencies: expectedCurrencies,
           percentageOfCover: mappedPercentageOfCoverWithSelected,
           creditPeriod: mappedCreditPeriodWithSelected,
-          submittedValues: req.session.submittedData,
+          submittedValues: req.session.submittedData.quoteEligibility,
         });
       });
     });

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.ts
@@ -127,7 +127,7 @@ const get = async (req: Request, res: Response) => {
     currencies: mappedCurrencies,
     percentageOfCover: mappedPercentageOfCover,
     creditPeriod: mappedCreditPeriod,
-    submittedValues: submittedData,
+    submittedValues: submittedData.quoteEligibility,
   });
 };
 

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.ts
@@ -6,7 +6,7 @@ import generateValidationErrors from './validation';
 import getCurrencyByCode from '../../../helpers/get-currency-by-code';
 import mapPercentageOfCover from '../../../helpers/mappings/map-percentage-of-cover';
 import mapCreditPeriod from '../../../helpers/mappings/map-credit-period';
-import { updateSubmittedData } from '../../../helpers/update-submitted-data';
+import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
 import isChangeRoute from '../../../helpers/is-change-route';
 import { isSinglePolicyType, isMultiPolicyType } from '../../../helpers/policy-type';
 import { Request, Response, SelectOption, TellUsAboutPolicyPageVariables } from '../../../../types';
@@ -94,16 +94,16 @@ const get = async (req: Request, res: Response) => {
   }
 
   let mappedCurrencies;
-  if (submittedData && submittedData[FIELD_IDS.CURRENCY]) {
-    mappedCurrencies = mapCurrencies(currencies, submittedData[FIELD_IDS.CURRENCY].isoCode);
+  if (submittedData && submittedData.quoteEligibility && submittedData.quoteEligibility[FIELD_IDS.CURRENCY]) {
+    mappedCurrencies = mapCurrencies(currencies, submittedData.quoteEligibility[FIELD_IDS.CURRENCY].isoCode);
   } else {
     mappedCurrencies = mapCurrencies(currencies);
   }
 
   let mappedPercentageOfCover;
 
-  if (submittedData && submittedData[PERCENTAGE_OF_COVER]) {
-    mappedPercentageOfCover = mapPercentageOfCover(PERCENTAGES_OF_COVER, Number(submittedData[PERCENTAGE_OF_COVER]));
+  if (submittedData && submittedData.quoteEligibility && submittedData.quoteEligibility[PERCENTAGE_OF_COVER]) {
+    mappedPercentageOfCover = mapPercentageOfCover(PERCENTAGES_OF_COVER, Number(submittedData.quoteEligibility[PERCENTAGE_OF_COVER]));
   } else {
     mappedPercentageOfCover = mapPercentageOfCover(PERCENTAGES_OF_COVER);
   }
@@ -111,19 +111,19 @@ const get = async (req: Request, res: Response) => {
   const creditPeriodOptions = FIELDS[FIELD_IDS.CREDIT_PERIOD].OPTIONS as Array<SelectOption>;
   let mappedCreditPeriod;
 
-  if (submittedData && submittedData[CREDIT_PERIOD]) {
-    mappedCreditPeriod = mapCreditPeriod(creditPeriodOptions, String(submittedData[CREDIT_PERIOD]));
+  if (submittedData && submittedData.quoteEligibility && submittedData.quoteEligibility[CREDIT_PERIOD]) {
+    mappedCreditPeriod = mapCreditPeriod(creditPeriodOptions, String(submittedData.quoteEligibility[CREDIT_PERIOD]));
   } else {
     mappedCreditPeriod = mapCreditPeriod(creditPeriodOptions);
   }
 
-  const PAGE_VARIABLES = generatePageVariables(submittedData[POLICY_TYPE]);
+  const PAGE_VARIABLES = generatePageVariables(submittedData.quoteEligibility[POLICY_TYPE]);
 
   return res.render(TEMPLATES.QUOTE.TELL_US_ABOUT_YOUR_POLICY, {
     ...PAGE_VARIABLES,
     BACK_LINK: req.headers.referer,
-    isSinglePolicyType: isSinglePolicyType(submittedData[POLICY_TYPE]),
-    isMultiPolicyType: isMultiPolicyType(submittedData[POLICY_TYPE]),
+    isSinglePolicyType: isSinglePolicyType(submittedData.quoteEligibility[POLICY_TYPE]),
+    isMultiPolicyType: isMultiPolicyType(submittedData.quoteEligibility[POLICY_TYPE]),
     currencies: mappedCurrencies,
     percentageOfCover: mappedPercentageOfCover,
     creditPeriod: mappedCreditPeriod,
@@ -135,7 +135,7 @@ const post = async (req: Request, res: Response) => {
   const { submittedData } = req.session;
 
   const validationErrors = generateValidationErrors({
-    ...submittedData,
+    ...submittedData.quoteEligibility,
     ...req.body,
   });
 
@@ -179,13 +179,13 @@ const post = async (req: Request, res: Response) => {
       mappedCreditPeriod = mapCreditPeriod(creditPeriodOptions);
     }
 
-    const PAGE_VARIABLES = generatePageVariables(submittedData[POLICY_TYPE]);
+    const PAGE_VARIABLES = generatePageVariables(submittedData.quoteEligibility[POLICY_TYPE]);
 
     return res.render(TEMPLATES.QUOTE.TELL_US_ABOUT_YOUR_POLICY, {
       ...PAGE_VARIABLES,
       BACK_LINK: req.headers.referer,
-      isSinglePolicyType: isSinglePolicyType(submittedData[POLICY_TYPE]),
-      isMultiPolicyType: isMultiPolicyType(submittedData[POLICY_TYPE]),
+      isSinglePolicyType: isSinglePolicyType(submittedData.quoteEligibility[POLICY_TYPE]),
+      isMultiPolicyType: isMultiPolicyType(submittedData.quoteEligibility[POLICY_TYPE]),
       currencies: mappedCurrencies,
       validationErrors,
       percentageOfCover: mappedPercentageOfCover,
@@ -199,7 +199,7 @@ const post = async (req: Request, res: Response) => {
     [FIELD_IDS.CURRENCY]: getCurrencyByCode(currencies, submittedCurrencyCode),
   };
 
-  req.session.submittedData = updateSubmittedData(populatedData, req.session.submittedData);
+  req.session.submittedData.quoteEligibility = updateSubmittedData(populatedData, req.session.submittedData.quoteEligibility);
 
   if (isChangeRoute(req.originalUrl)) {
     return res.redirect(ROUTES.QUOTE.CHECK_YOUR_ANSWERS);

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/validation/index.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/validation/index.ts
@@ -1,7 +1,7 @@
 import validationRules from './rules';
-import { SubmittedData } from '../../../../../types';
+import { SubmittedDataQuoteEligibility } from '../../../../../types';
 
-const validation = (submittedData: SubmittedData) => {
+const validation = (submittedData: SubmittedDataQuoteEligibility) => {
   let errors!: object;
 
   for (let i = 0; i < validationRules.length; i += 1) {

--- a/src/ui/server/controllers/quote/uk-goods-or-services/index.test.ts
+++ b/src/ui/server/controllers/quote/uk-goods-or-services/index.test.ts
@@ -3,7 +3,7 @@ import { ERROR_MESSAGES, PAGES, UK_GOODS_AND_SERVICES_DESCRIPTION } from '../../
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
 import singleInputPageVariables from '../../../helpers/single-input-page-variables';
 import generateValidationErrors from '../../../shared-validation/yes-no-radios-form';
-import { updateSubmittedData } from '../../../helpers/update-submitted-data';
+import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
 import { mockReq, mockRes } from '../../../test-mocks';
 import { Request, Response } from '../../../../types';
 
@@ -89,9 +89,9 @@ describe('controllers/quote/uk-goods-or-services', () => {
       it('should update the session with submitted data', () => {
         post(req, res);
 
-        const expected = updateSubmittedData(req.body, req.session.submittedData);
+        const expected = updateSubmittedData(req.body, req.session.submittedData.quoteEligibility);
 
-        expect(req.session.submittedData).toEqual(expected);
+        expect(req.session.submittedData.quoteEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.QUOTE.POLICY_TYPE}`, () => {

--- a/src/ui/server/controllers/quote/uk-goods-or-services/index.test.ts
+++ b/src/ui/server/controllers/quote/uk-goods-or-services/index.test.ts
@@ -38,7 +38,7 @@ describe('controllers/quote/uk-goods-or-services', () => {
       expect(res.render).toHaveBeenCalledWith(TEMPLATES.QUOTE.UK_GOODS_OR_SERVICES, {
         ...singleInputPageVariables(PAGE_VARIABLES),
         BACK_LINK: req.headers.referer,
-        submittedValues: req.session.submittedData,
+        submittedValues: req.session.submittedData.quoteEligibility,
       });
     });
   });

--- a/src/ui/server/controllers/quote/uk-goods-or-services/index.ts
+++ b/src/ui/server/controllers/quote/uk-goods-or-services/index.ts
@@ -21,7 +21,7 @@ const get = (req: Request, res: Response) =>
   res.render(TEMPLATES.QUOTE.UK_GOODS_OR_SERVICES, {
     ...singleInputPageVariables(PAGE_VARIABLES),
     BACK_LINK: req.headers.referer,
-    submittedValues: req.session.submittedData,
+    submittedValues: req.session.submittedData.quoteEligibility,
   });
 
 const post = (req: Request, res: Response) => {

--- a/src/ui/server/controllers/quote/uk-goods-or-services/index.ts
+++ b/src/ui/server/controllers/quote/uk-goods-or-services/index.ts
@@ -2,7 +2,7 @@ import { PAGES, UK_GOODS_AND_SERVICES_DESCRIPTION, ERROR_MESSAGES } from '../../
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
 import singleInputPageVariables from '../../../helpers/single-input-page-variables';
 import generateValidationErrors from '../../../shared-validation/yes-no-radios-form';
-import { updateSubmittedData } from '../../../helpers/update-submitted-data';
+import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
 import isChangeRoute from '../../../helpers/is-change-route';
 import { Request, Response } from '../../../../types';
 
@@ -50,7 +50,7 @@ const post = (req: Request, res: Response) => {
     return res.redirect(ROUTES.QUOTE.CANNOT_APPLY);
   }
 
-  req.session.submittedData = updateSubmittedData(req.body, req.session.submittedData);
+  req.session.submittedData.quoteEligibility = updateSubmittedData(req.body, req.session.submittedData.quoteEligibility);
 
   if (isChangeRoute(req.originalUrl)) {
     return res.redirect(ROUTES.QUOTE.CHECK_YOUR_ANSWERS);

--- a/src/ui/server/controllers/root/index.test.ts
+++ b/src/ui/server/controllers/root/index.test.ts
@@ -16,13 +16,19 @@ describe('controllers/root', () => {
     it('should add an empty submittedData object to the session', () => {
       req.session = {
         submittedData: {
-          [FIELD_IDS.CREDIT_PERIOD]: 1,
+          quoteEligibility: {
+            [FIELD_IDS.CREDIT_PERIOD]: 1,
+          },
+          insuranceEligibility: {},
         },
       };
 
       get(req, res);
 
-      expect(req.session.submittedData).toEqual({});
+      expect(req.session.submittedData).toEqual({
+        quoteEligibility: {},
+        insuranceEligibility: {},
+      });
     });
 
     it(`should redirect to ${ROUTES.QUOTE.BUYER_COUNTRY}`, () => {

--- a/src/ui/server/controllers/root/index.ts
+++ b/src/ui/server/controllers/root/index.ts
@@ -3,7 +3,10 @@ import { Request, Response } from '../../../types';
 
 const get = (req: Request, res: Response) => {
   // new submitted data session
-  req.session.submittedData = {};
+  req.session.submittedData = {
+    quoteEligibility: {},
+    insuranceEligibility: {},
+  };
 
   return res.redirect(ROUTES.QUOTE.BUYER_COUNTRY);
 };

--- a/src/ui/server/generate-quote/index.test.ts
+++ b/src/ui/server/generate-quote/index.test.ts
@@ -51,12 +51,14 @@ describe('server/generate-quote/index', () => {
     describe('when policy type is single', () => {
       it('should return pecentage of contract value', () => {
         const mockSubmittedData = {
-          [CONTRACT_VALUE]: 1234,
-          [PERCENTAGE_OF_COVER]: 80,
-          [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.SINGLE,
+          quoteEligibility: {
+            [CONTRACT_VALUE]: 1234,
+            [PERCENTAGE_OF_COVER]: 80,
+            [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.SINGLE,
+          },
         };
 
-        const result = getInsuredFor(mockSubmittedData);
+        const result = getInsuredFor(mockSubmittedData.quoteEligibility);
         const expected = Number(getPercentageOfNumber(80, 1234));
 
         expect(result).toEqual(expected);
@@ -66,12 +68,14 @@ describe('server/generate-quote/index', () => {
     describe('when policy type is multi', () => {
       it('should return pecentage of max amount owed', () => {
         const mockSubmittedData = {
-          [MAX_AMOUNT_OWED]: 5678,
-          [PERCENTAGE_OF_COVER]: 80,
-          [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.MULTI,
+          quoteEligibility: {
+            [MAX_AMOUNT_OWED]: 5678,
+            [PERCENTAGE_OF_COVER]: 80,
+            [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.MULTI,
+          },
         };
 
-        const result = getInsuredFor(mockSubmittedData);
+        const result = getInsuredFor(mockSubmittedData.quoteEligibility);
         const expected = Number(getPercentageOfNumber(80, 5678));
 
         expect(result).toEqual(expected);
@@ -147,29 +151,30 @@ describe('server/generate-quote/index', () => {
 
       const mockPercentageOfCover = 90;
 
-      const expectedTotalMonths = getTotalMonths(mockSubmittedData[POLICY_TYPE], mockSubmittedData[POLICY_LENGTH], mockSubmittedData[CREDIT_PERIOD]);
+      const { quoteEligibility } = mockSubmittedData;
+      const expectedTotalMonths = getTotalMonths(quoteEligibility[POLICY_TYPE], quoteEligibility[POLICY_LENGTH], quoteEligibility[CREDIT_PERIOD]);
 
       const expectedPremiumRate = getPremiumRate(
-        mockSubmittedData[POLICY_TYPE],
-        mockSubmittedData[BUYER_COUNTRY].riskCategory,
+        mockSubmittedData.quoteEligibility[POLICY_TYPE],
+        mockSubmittedData.quoteEligibility[BUYER_COUNTRY].riskCategory,
         expectedTotalMonths,
         mockPercentageOfCover,
       );
 
       const expected = {
-        ...getContractValue(mockSubmittedData),
-        [PERCENTAGE_OF_COVER]: mockSubmittedData[PERCENTAGE_OF_COVER],
-        [QUOTE.INSURED_FOR]: getInsuredFor(mockSubmittedData),
-        [QUOTE.BUYER_LOCATION]: mockSubmittedData[BUYER_COUNTRY],
-        [CURRENCY]: mockSubmittedData[CURRENCY],
-        [CREDIT_PERIOD]: mockSubmittedData[CREDIT_PERIOD],
-        [POLICY_TYPE]: mockSubmittedData[POLICY_TYPE],
-        [POLICY_LENGTH]: mockSubmittedData[POLICY_LENGTH],
+        ...getContractValue(mockSubmittedData.quoteEligibility),
+        [PERCENTAGE_OF_COVER]: mockSubmittedData.quoteEligibility[PERCENTAGE_OF_COVER],
+        [QUOTE.INSURED_FOR]: getInsuredFor(mockSubmittedData.quoteEligibility),
+        [QUOTE.BUYER_LOCATION]: mockSubmittedData.quoteEligibility[BUYER_COUNTRY],
+        [CURRENCY]: mockSubmittedData.quoteEligibility[CURRENCY],
+        [CREDIT_PERIOD]: mockSubmittedData.quoteEligibility[CREDIT_PERIOD],
+        [POLICY_TYPE]: mockSubmittedData.quoteEligibility[POLICY_TYPE],
+        [POLICY_LENGTH]: mockSubmittedData.quoteEligibility[POLICY_LENGTH],
       };
 
       expected[QUOTE.PREMIUM_RATE_PERCENTAGE] = expectedPremiumRate;
 
-      const contractValueAmount = Object.values(getContractValue(mockSubmittedData))[0];
+      const contractValueAmount = Object.values(getContractValue(mockSubmittedData.quoteEligibility))[0];
 
       expected[QUOTE.ESTIMATED_COST] = calculateEstimatedCost(expectedPremiumRate, contractValueAmount);
 

--- a/src/ui/server/generate-quote/index.ts
+++ b/src/ui/server/generate-quote/index.ts
@@ -2,7 +2,7 @@ import { FIELD_IDS } from '../constants';
 import { isSinglePolicyType, isMultiPolicyType } from '../helpers/policy-type';
 import { getPremiumRate } from './get-premium-rate';
 import { getPercentageOfNumber } from '../helpers/number';
-import { Quote, SubmittedData } from '../../types';
+import { Quote, SubmittedData, SubmittedDataQuoteEligibility } from '../../types';
 
 const { BUYER_COUNTRY, CONTRACT_VALUE, CREDIT_PERIOD, CURRENCY, MAX_AMOUNT_OWED, PERCENTAGE_OF_COVER, POLICY_TYPE, POLICY_LENGTH } = FIELD_IDS;
 
@@ -11,7 +11,7 @@ const { BUYER_COUNTRY, CONTRACT_VALUE, CREDIT_PERIOD, CURRENCY, MAX_AMOUNT_OWED,
  * @param {Object} Submitted data/answers
  * @returns {Number} Contract value or max amount owed, depending on policy type
  */
-const getContractValue = (submittedData: SubmittedData) => {
+const getContractValue = (submittedData: SubmittedDataQuoteEligibility) => {
   if (isSinglePolicyType(submittedData[POLICY_TYPE])) {
     return {
       [CONTRACT_VALUE]: submittedData[CONTRACT_VALUE],
@@ -32,7 +32,7 @@ const getContractValue = (submittedData: SubmittedData) => {
  * @param {Object} Submitted data/answers
  * @returns {Number} Percentage of cover % of Contract value or max amount owed
  */
-const getInsuredFor = (submittedData: SubmittedData): number => {
+const getInsuredFor = (submittedData: SubmittedDataQuoteEligibility): number => {
   let contractValue;
 
   if (isSinglePolicyType(submittedData[POLICY_TYPE])) {
@@ -95,17 +95,17 @@ const calculateEstimatedCost = (premiumRate: number, contractValue: number) => N
  * @returns {Object} Quote with premium rate and estimated cost
  */
 const generateQuote = (submittedData: SubmittedData): Quote => {
-  const contractValue = getContractValue(submittedData);
+  const contractValue = getContractValue(submittedData.quoteEligibility);
 
   const mapped = {
     ...contractValue,
-    percentageOfCover: submittedData[PERCENTAGE_OF_COVER],
-    insuredFor: getInsuredFor(submittedData),
-    buyerCountry: submittedData[BUYER_COUNTRY],
-    currency: submittedData[CURRENCY],
-    creditPeriodInMonths: submittedData[CREDIT_PERIOD],
-    policyType: submittedData[POLICY_TYPE],
-    policyLength: submittedData[POLICY_LENGTH],
+    percentageOfCover: submittedData.quoteEligibility[PERCENTAGE_OF_COVER],
+    insuredFor: getInsuredFor(submittedData.quoteEligibility),
+    buyerCountry: submittedData.quoteEligibility[BUYER_COUNTRY],
+    currency: submittedData.quoteEligibility[CURRENCY],
+    creditPeriodInMonths: submittedData.quoteEligibility[CREDIT_PERIOD],
+    policyType: submittedData.quoteEligibility[POLICY_TYPE],
+    policyLength: submittedData.quoteEligibility[POLICY_LENGTH],
   };
 
   const totalMonths = getTotalMonths(mapped[POLICY_TYPE], mapped[POLICY_LENGTH], mapped[CREDIT_PERIOD]);

--- a/src/ui/server/helpers/data-content-mappings/map-answers-to-content.ts
+++ b/src/ui/server/helpers/data-content-mappings/map-answers-to-content.ts
@@ -5,7 +5,7 @@ import mapCountry from './map-country';
 import mapCost from './map-cost';
 import mapPeriodMonths from './map-period-months';
 import mapPolicyLength from './map-policy-length';
-import { SubmittedData } from '../../../types';
+import { SubmittedDataInsuranceEligibility, SubmittedDataQuoteEligibility } from '../../../types';
 
 const {
   BUYER_COUNTRY,
@@ -40,7 +40,7 @@ const mapPolicyType = (answer: string) => {
 
 const mapPercentageOfCover = (answer: number) => `${answer}%`;
 
-const mapAnswersToContent = (answers: SubmittedData) => {
+const mapAnswersToContent = (answers: SubmittedDataQuoteEligibility | SubmittedDataInsuranceEligibility) => {
   const mapped = {
     [VALID_EXPORTER_LOCATION]: {
       text: SUMMARY_ANSWERS[VALID_EXPORTER_LOCATION],

--- a/src/ui/server/helpers/data-content-mappings/map-cost.test.ts
+++ b/src/ui/server/helpers/data-content-mappings/map-cost.test.ts
@@ -1,7 +1,7 @@
 import mapCost from './map-cost';
 import formatCurrency from '../format-currency';
 import { FIELD_IDS, FIELD_VALUES } from '../../constants';
-import { SubmittedData } from '../../../types';
+import { SubmittedDataQuoteEligibility } from '../../../types';
 
 const { CONTRACT_VALUE, CURRENCY, MAX_AMOUNT_OWED, POLICY_TYPE } = FIELD_IDS;
 
@@ -14,7 +14,7 @@ describe('server/helpers/data-content-mappings/map-cost', () => {
           isoCode: 'GBP',
         },
         [CONTRACT_VALUE]: 10,
-      } as SubmittedData;
+      } as SubmittedDataQuoteEligibility;
 
       const result = mapCost(mockDataSinglePolicyType);
 
@@ -36,7 +36,7 @@ describe('server/helpers/data-content-mappings/map-cost', () => {
           isoCode: 'GBP',
         },
         [MAX_AMOUNT_OWED]: 10,
-      } as SubmittedData;
+      } as SubmittedDataQuoteEligibility;
 
       const result = mapCost(mockDataMultiPolicyType);
 

--- a/src/ui/server/helpers/data-content-mappings/map-cost.ts
+++ b/src/ui/server/helpers/data-content-mappings/map-cost.ts
@@ -1,11 +1,11 @@
 import { FIELD_IDS } from '../../constants';
 import { isSinglePolicyType, isMultiPolicyType } from '../policy-type';
 import formatCurrency from '../format-currency';
-import { Quote, SubmittedData } from '../../../types';
+import { Quote, SubmittedDataQuoteEligibility, SubmittedDataInsuranceEligibility } from '../../../types';
 
 const { CONTRACT_VALUE, CURRENCY, POLICY_TYPE, MAX_AMOUNT_OWED } = FIELD_IDS;
 
-const mapCost = (answers: SubmittedData | Quote) => {
+const mapCost = (answers: SubmittedDataQuoteEligibility | SubmittedDataInsuranceEligibility | Quote) => {
   let mapped;
 
   if (isSinglePolicyType(answers[POLICY_TYPE])) {

--- a/src/ui/server/helpers/data-content-mappings/map-country.test.ts
+++ b/src/ui/server/helpers/data-content-mappings/map-country.test.ts
@@ -4,7 +4,7 @@ import { mockSession } from '../../test-mocks';
 
 describe('server/helpers/map-country', () => {
   it('should return country name', () => {
-    const country = mockSession.submittedData[FIELD_IDS.BUYER_COUNTRY];
+    const country = mockSession.submittedData.quoteEligibility[FIELD_IDS.BUYER_COUNTRY];
 
     const result = mapCountry(country);
 

--- a/src/ui/server/helpers/sanitise-data.ts
+++ b/src/ui/server/helpers/sanitise-data.ts
@@ -1,6 +1,6 @@
 import { isNumber } from './number';
 import { stripCommas } from './string';
-import { RequestBody, SubmittedData } from '../../types';
+import { RequestBody, SubmittedDataQuoteEligibility, SubmittedDataInsuranceEligibility } from '../../types';
 
 const shouldChangeToNumber = (value: string | number) => {
   if (typeof value === 'string' && isNumber(value)) {
@@ -37,7 +37,7 @@ const sanitiseValue = (value: string | number | boolean) => {
 };
 
 const sanitiseData = (formData: RequestBody) => {
-  const sanitised = {} as SubmittedData;
+  const sanitised = {} as SubmittedDataQuoteEligibility | SubmittedDataInsuranceEligibility;
   const keys = Object.keys(formData);
 
   keys.forEach((key) => {

--- a/src/ui/server/helpers/sanitise-data.ts
+++ b/src/ui/server/helpers/sanitise-data.ts
@@ -1,6 +1,6 @@
 import { isNumber } from './number';
 import { stripCommas } from './string';
-import { RequestBody, SubmittedDataQuoteEligibility, SubmittedDataInsuranceEligibility } from '../../types';
+import { RequestBody } from '../../types';
 
 const shouldChangeToNumber = (value: string | number) => {
   if (typeof value === 'string' && isNumber(value)) {
@@ -37,7 +37,8 @@ const sanitiseValue = (value: string | number | boolean) => {
 };
 
 const sanitiseData = (formData: RequestBody) => {
-  const sanitised = {} as SubmittedDataQuoteEligibility | SubmittedDataInsuranceEligibility;
+  // const sanitised = {} as SubmittedDataQuoteEligibility | SubmittedDataInsuranceEligibility;
+  const sanitised = {};
   const keys = Object.keys(formData);
 
   keys.forEach((key) => {

--- a/src/ui/server/helpers/summary-lists/answers-summary-list.test.ts
+++ b/src/ui/server/helpers/summary-lists/answers-summary-list.test.ts
@@ -24,7 +24,7 @@ const {
 describe('server/helpers/summary-lists/answers-summary-list', () => {
   describe('generateFieldGroups - no policy type', () => {
     it('should map over each field group with value from submittedData', () => {
-      const mockAnswersContent = mapAnswersToContent(mockSession.submittedData);
+      const mockAnswersContent = mapAnswersToContent(mockSession.submittedData.quoteEligibility);
       delete mockAnswersContent[SINGLE_POLICY_TYPE];
       delete mockAnswersContent[SINGLE_POLICY_LENGTH];
 
@@ -70,7 +70,7 @@ describe('server/helpers/summary-lists/answers-summary-list', () => {
       it(`should add a ${SINGLE_POLICY_TYPE} object to POLICY_DETAILS`, () => {
         const mockAnswersContent = {
           ...mapAnswersToContent({
-            ...mockSession.submittedData,
+            ...mockSession.submittedData.quoteEligibility,
             [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.SINGLE,
           }),
         };
@@ -94,7 +94,7 @@ describe('server/helpers/summary-lists/answers-summary-list', () => {
 
       it(`should add a ${SINGLE_POLICY_LENGTH} object to POLICY_DETAILS`, () => {
         const mockAnswersContent = {
-          ...mapAnswersToContent(mockSession.submittedData),
+          ...mapAnswersToContent(mockSession.submittedData.quoteEligibility),
           [SINGLE_POLICY_TYPE]: {
             text: FIELD_VALUES.POLICY_TYPE.SINGLE,
           },
@@ -119,7 +119,7 @@ describe('server/helpers/summary-lists/answers-summary-list', () => {
 
       it(`should add ${CONTRACT_VALUE} object to POLICY_DETAILS`, () => {
         const mockAnswersContent = {
-          ...mapAnswersToContent(mockSession.submittedData),
+          ...mapAnswersToContent(mockSession.submittedData.quoteEligibility),
           [SINGLE_POLICY_TYPE]: {
             text: FIELD_VALUES.POLICY_TYPE.SINGLE,
           },
@@ -144,7 +144,7 @@ describe('server/helpers/summary-lists/answers-summary-list', () => {
 
       it(`should add ${PERCENTAGE_OF_COVER} object to POLICY_DETAILS`, () => {
         const mockAnswersContent = {
-          ...mapAnswersToContent(mockSession.submittedData),
+          ...mapAnswersToContent(mockSession.submittedData.quoteEligibility),
           [SINGLE_POLICY_TYPE]: {
             text: FIELD_VALUES.POLICY_TYPE.SINGLE,
           },
@@ -173,7 +173,7 @@ describe('server/helpers/summary-lists/answers-summary-list', () => {
 
       beforeEach(() => {
         mockAnswersContent = {
-          ...mapAnswersToContent(mockSession.submittedData),
+          ...mapAnswersToContent(mockSession.submittedData.quoteEligibility),
           [MULTI_POLICY_TYPE]: {
             text: FIELD_VALUES.POLICY_TYPE.MULTI,
           },
@@ -308,7 +308,7 @@ describe('server/helpers/summary-lists/answers-summary-list', () => {
 
     it('returns an array of objects mapped to submitted data', () => {
       const mockMultiPolicySubmittedData = {
-        ...mockSession.submittedData,
+        ...mockSession.submittedData.quoteEligibility,
         [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.MULTI,
         [POLICY_LENGTH]: FIELD_VALUES.POLICY_LENGTH.MULTI,
         [MAX_AMOUNT_OWED]: 1234,
@@ -372,7 +372,7 @@ describe('server/helpers/summary-lists/answers-summary-list', () => {
 
   describe('answersSummaryList', () => {
     it('should return an object with multiple summary lists', () => {
-      const mockAnswersContent = mapAnswersToContent(mockSession.submittedData);
+      const mockAnswersContent = mapAnswersToContent(mockSession.submittedData.quoteEligibility);
 
       const fieldGroups = generateFieldGroups(mockAnswersContent);
 

--- a/src/ui/server/helpers/task-list/index.test.ts
+++ b/src/ui/server/helpers/task-list/index.test.ts
@@ -1,12 +1,12 @@
 import generateTaskList, { generateTaskStatuses, generateSimplifiedTaskList } from '.';
 import { taskStatus } from './task-helpers';
 import generateGroupsAndTasks from './generate-groups-and-tasks';
-import { TaskListDataTask, SubmittedData } from '../../../types';
+import { TaskListDataTask, SubmittedDataInsuranceEligibility } from '../../../types';
 
 describe('server/helpers/task-list', () => {
   const mockSubmittedData = {
-    quoteEligibility: {},
-    insuranceEligibility: {},
+    wantCoverOverMaxAmount: false,
+    wantCoverOverMaxPeriod: false,
   };
 
   describe('generateTaskStatuses', () => {
@@ -15,7 +15,7 @@ describe('server/helpers/task-list', () => {
 
       const result = generateTaskStatuses(mockTaskListData, mockSubmittedData);
 
-      const mapTask = (task: TaskListDataTask, submittedData: SubmittedData) => ({
+      const mapTask = (task: TaskListDataTask, submittedData: SubmittedDataInsuranceEligibility) => ({
         ...task,
         status: taskStatus(task, submittedData),
       });

--- a/src/ui/server/helpers/task-list/index.test.ts
+++ b/src/ui/server/helpers/task-list/index.test.ts
@@ -4,7 +4,10 @@ import generateGroupsAndTasks from './generate-groups-and-tasks';
 import { TaskListDataTask, SubmittedData } from '../../../types';
 
 describe('server/helpers/task-list', () => {
-  const mockSubmittedData = {};
+  const mockSubmittedData = {
+    quoteEligibility: {},
+    insuranceEligibility: {},
+  };
 
   describe('generateTaskStatuses', () => {
     it('should return an array of groups and tasks with task statuses', () => {

--- a/src/ui/server/helpers/task-list/index.ts
+++ b/src/ui/server/helpers/task-list/index.ts
@@ -1,5 +1,5 @@
 import { taskStatus } from './task-helpers';
-import { TaskListData, TaskListDataTask, TaskListGroup, SubmittedData } from '../../../types';
+import { TaskListData, TaskListDataTask, TaskListGroup, SubmittedDataInsuranceEligibility } from '../../../types';
 
 /**
  * generateTaskStatuses
@@ -7,7 +7,7 @@ import { TaskListData, TaskListDataTask, TaskListGroup, SubmittedData } from '..
  * @param {Object} submittedData Submitted application data
  * @returns {Object} Task list groups and tasks with added task statuses.
  */
-export const generateTaskStatuses = (taskListData: TaskListData, submittedData: SubmittedData): TaskListData => {
+export const generateTaskStatuses = (taskListData: TaskListData, submittedData: SubmittedDataInsuranceEligibility): TaskListData => {
   const tasksList = taskListData.map((group) => {
     return {
       ...group,
@@ -47,7 +47,7 @@ export const generateSimplifiedTaskList = (taskList: TaskListData): Array<TaskLi
  * @param {Object} submittedData Submitted application data
  * @returns {Array} generateSimplifiedTaskList- Array of groups and tasks with only the data required for UI consumption.
  */
-const generateTaskList = (groupsAndTasks: TaskListData, submittedData: SubmittedData): Array<TaskListGroup> => {
+const generateTaskList = (groupsAndTasks: TaskListData, submittedData: SubmittedDataInsuranceEligibility): Array<TaskListGroup> => {
   // add task statuses
   const withStatuses = generateTaskStatuses(groupsAndTasks, submittedData);
 

--- a/src/ui/server/helpers/task-list/task-helpers.test.ts
+++ b/src/ui/server/helpers/task-list/task-helpers.test.ts
@@ -4,8 +4,8 @@ import { TASKS } from '../../content-strings';
 
 describe('server/helpers/task-helpers', () => {
   const mockSubmittedData = {
-    amount: 1234,
-    policyType: 'mock',
+    wantCoverOverMaxAmount: true,
+    wantCoverOverMaxPeriod: true,
   };
 
   describe('getGroupById', () => {
@@ -46,11 +46,11 @@ describe('server/helpers/task-helpers', () => {
 
   describe('getSubmittedFields', () => {
     it('should return fields that are provided and also in provided submitted fields', () => {
-      const mockFields = ['amount', 'contractValue', 'policyType'];
+      const mockFields = ['wantCoverOverMaxAmount', 'wantCoverOverMaxPeriod', 'mockField'];
 
       const result = getSubmittedFields(mockFields, mockSubmittedData);
 
-      const expected = ['amount', 'policyType'];
+      const expected = ['wantCoverOverMaxAmount', 'wantCoverOverMaxPeriod'];
 
       expect(result).toEqual(expected);
     });
@@ -67,10 +67,10 @@ describe('server/helpers/task-helpers', () => {
   describe('taskIsInProgress', () => {
     describe('when all relevant fields have NOT been submitted', () => {
       it('should return true', () => {
-        const mockFields = ['amount', 'policyType'];
+        const mockFields = ['wantCoverOverMaxAmount', 'wantCoverOverMaxPeriod'];
 
         const mockSubmittedDataIncomplete = {
-          amount: mockSubmittedData.amount,
+          wantCoverOverMaxAmount: mockSubmittedData.wantCoverOverMaxAmount,
         };
 
         const result = taskIsInProgress(mockFields, mockSubmittedDataIncomplete);
@@ -81,7 +81,7 @@ describe('server/helpers/task-helpers', () => {
 
     describe('when all relevant fields have been submitted', () => {
       it('should return false', () => {
-        const mockFields = ['amount', 'policyType'];
+        const mockFields = ['wantCoverOverMaxAmount', 'wantCoverOverMaxPeriod'];
 
         const result = taskIsInProgress(mockFields, mockSubmittedData);
 
@@ -93,7 +93,7 @@ describe('server/helpers/task-helpers', () => {
   describe('taskIsComplete', () => {
     describe('when all relevant fields have been submitted', () => {
       it('should return true', () => {
-        const mockFields = ['amount', 'policyType'];
+        const mockFields = ['wantCoverOverMaxAmount', 'wantCoverOverMaxPeriod'];
 
         const result = taskIsComplete(mockFields, mockSubmittedData);
 
@@ -103,7 +103,7 @@ describe('server/helpers/task-helpers', () => {
 
     describe('when all relevant fields have NOT been submitted', () => {
       it('should return false', () => {
-        const mockFields = ['amount', 'policyType', 'mockField'];
+        const mockFields = ['wantCoverOverMaxAmount', 'wantCoverOverMaxPeriod', 'mockField'];
 
         const result = taskIsComplete(mockFields, mockSubmittedData);
 
@@ -115,7 +115,7 @@ describe('server/helpers/task-helpers', () => {
   describe('areTaskDependenciesMet', () => {
     describe('when all dependencies are in submitted data', () => {
       it('should return true', () => {
-        const mockDeps = ['amount', 'policyType'];
+        const mockDeps = ['wantCoverOverMaxAmount', 'wantCoverOverMaxPeriod'];
 
         const result = areTaskDependenciesMet(mockDeps, mockSubmittedData);
 
@@ -156,7 +156,7 @@ describe('server/helpers/task-helpers', () => {
           title: 'Mock',
           id: 'mock',
           fields: ['fieldA', 'fieldB'],
-          dependencies: ['amount', 'policyType'],
+          dependencies: ['wantCoverOverMaxAmount', 'wantCoverOverMaxPeriod'],
         };
 
         const result = taskStatus(mockTask, mockSubmittedData);
@@ -171,11 +171,11 @@ describe('server/helpers/task-helpers', () => {
           title: 'Mock',
           id: 'mock',
           fields: ['fieldA', 'fieldB'],
-          dependencies: ['amount'],
+          dependencies: ['wantCoverOverMaxAmount'],
         };
 
         const mockSubmittedDataHalfComplete = {
-          amount: mockSubmittedData.amount,
+          wantCoverOverMaxAmount: mockSubmittedData.wantCoverOverMaxAmount,
           fieldA: 'mock',
         };
 
@@ -190,7 +190,7 @@ describe('server/helpers/task-helpers', () => {
         const mockTask = {
           title: 'Mock',
           id: 'mock',
-          fields: ['amount', 'policyType'],
+          fields: ['wantCoverOverMaxAmount', 'wantCoverOverMaxPeriod'],
           dependencies: [],
         };
 

--- a/src/ui/server/helpers/task-list/task-helpers.ts
+++ b/src/ui/server/helpers/task-list/task-helpers.ts
@@ -1,4 +1,4 @@
-import { SubmittedData, TaskListData, TaskListDataGroup, TaskListDataTask } from '../../../types';
+import { SubmittedDataInsuranceEligibility, TaskListData, TaskListDataGroup, TaskListDataTask } from '../../../types';
 import { TASKS } from '../../content-strings';
 
 /**
@@ -25,7 +25,7 @@ export const getTaskById = (groupTasks: Array<TaskListDataTask>, taskId: string)
  * @param {Object} submittedData Submitted application data
  * @returns {Array} array of submitted field ids.
  */
-export const getSubmittedFields = (fields: Array<string>, submittedData: SubmittedData): Array<string> => {
+export const getSubmittedFields = (fields: Array<string>, submittedData: SubmittedDataInsuranceEligibility): Array<string> => {
   const submittedFields = [] as Array<string>;
 
   if (fields) {
@@ -45,7 +45,7 @@ export const getSubmittedFields = (fields: Array<string>, submittedData: Submitt
  * @param {Object} submittedData Submitted application data
  * @returns {Boolean}
  */
-export const taskIsInProgress = (taskFields: Array<string>, submittedData: SubmittedData) => {
+export const taskIsInProgress = (taskFields: Array<string>, submittedData: SubmittedDataInsuranceEligibility) => {
   const submittedFields = getSubmittedFields(taskFields, submittedData);
 
   if (submittedFields.length > 0 && submittedFields.length < taskFields.length) {
@@ -61,7 +61,7 @@ export const taskIsInProgress = (taskFields: Array<string>, submittedData: Submi
  * @param {Object} submittedData Submitted application data
  * @returns {Boolean}
  */
-export const taskIsComplete = (taskFields: Array<string>, submittedData: SubmittedData): boolean => {
+export const taskIsComplete = (taskFields: Array<string>, submittedData: SubmittedDataInsuranceEligibility): boolean => {
   const submittedFields = getSubmittedFields(taskFields, submittedData);
 
   if (submittedFields && submittedFields.length && taskFields && taskFields.length) {
@@ -79,7 +79,7 @@ export const taskIsComplete = (taskFields: Array<string>, submittedData: Submitt
  * @param {Object} submittedData Submitted application data
  * @returns {Boolean}
  */
-export const areTaskDependenciesMet = (dependencies: Array<string>, submittedData: SubmittedData): boolean => {
+export const areTaskDependenciesMet = (dependencies: Array<string>, submittedData: SubmittedDataInsuranceEligibility): boolean => {
   const totalDependencies = (dependencies && dependencies.length) || 0;
 
   let validDependencies = [];
@@ -108,7 +108,7 @@ export const areTaskDependenciesMet = (dependencies: Array<string>, submittedDat
  * @param {Object} submittedData Submitted application data
  * @returns {String} Task status - cannot start/start now/in progress/completed
  */
-export const taskStatus = (task: TaskListDataTask, submittedData: SubmittedData): string => {
+export const taskStatus = (task: TaskListDataTask, submittedData: SubmittedDataInsuranceEligibility): string => {
   const { dependencies, fields } = task;
 
   const dependenciesMet = areTaskDependenciesMet(dependencies, submittedData);

--- a/src/ui/server/helpers/update-submitted-data/quote/index.test.ts
+++ b/src/ui/server/helpers/update-submitted-data/quote/index.test.ts
@@ -1,7 +1,7 @@
-import { mapSubmittedData, updateSubmittedData } from './update-submitted-data';
-import { FIELD_IDS, FIELD_VALUES } from '../constants';
-import { sanitiseData } from './sanitise-data';
-import { RequestBody, SubmittedData } from '../../types';
+import { mapSubmittedData, updateSubmittedData } from '.';
+import { FIELD_IDS, FIELD_VALUES } from '../../../constants';
+import { sanitiseData } from '../../sanitise-data';
+import { RequestBody, SubmittedDataQuoteEligibility } from '../../../../types';
 
 const { CREDIT_PERIOD, CONTRACT_VALUE, MAX_AMOUNT_OWED, MULTI_POLICY_LENGTH, POLICY_LENGTH, POLICY_TYPE } = FIELD_IDS;
 
@@ -58,7 +58,7 @@ describe('server/helpers/update-submitted-data', () => {
         const mockExistingData = {
           [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.MULTI,
           [MAX_AMOUNT_OWED]: 200,
-        } as SubmittedData;
+        } as SubmittedDataQuoteEligibility;
 
         const result = mapSubmittedData({ ...mockExistingData, ...mockFormData });
 
@@ -146,7 +146,7 @@ describe('server/helpers/update-submitted-data', () => {
 
         const mockExistingData = {
           mock: true,
-        } as SubmittedData;
+        } as SubmittedDataQuoteEligibility;
 
         const result = updateSubmittedData(mockFormData, mockExistingData);
 

--- a/src/ui/server/helpers/update-submitted-data/quote/index.ts
+++ b/src/ui/server/helpers/update-submitted-data/quote/index.ts
@@ -1,7 +1,7 @@
-import { FIELD_IDS, FIELD_VALUES } from '../constants';
-import { isSinglePolicyType, isMultiPolicyType } from './policy-type';
-import { sanitiseData } from './sanitise-data';
-import { RequestBody, SubmittedData } from '../../types';
+import { FIELD_IDS, FIELD_VALUES } from '../../../constants';
+import { isSinglePolicyType, isMultiPolicyType } from '../../policy-type';
+import { sanitiseData } from '../../sanitise-data';
+import { RequestBody, SubmittedDataQuoteEligibility } from '../../../../types';
 
 const { CREDIT_PERIOD, CONTRACT_VALUE, MAX_AMOUNT_OWED, MULTI_POLICY_LENGTH, POLICY_LENGTH, POLICY_TYPE, SINGLE_POLICY_LENGTH } = FIELD_IDS;
 
@@ -13,7 +13,7 @@ const { CREDIT_PERIOD, CONTRACT_VALUE, MAX_AMOUNT_OWED, MULTI_POLICY_LENGTH, POL
  * Delete contract value if policy type is multi.
  * Delete maximum amount owed if policy type is single.
  */
-const mapSubmittedData = (submittedData: SubmittedData) => {
+const mapSubmittedData = (submittedData: SubmittedDataQuoteEligibility): SubmittedDataQuoteEligibility => {
   const mapped = submittedData;
 
   if (isSinglePolicyType(submittedData[POLICY_TYPE])) {
@@ -40,7 +40,7 @@ const mapSubmittedData = (submittedData: SubmittedData) => {
  * updateSubmittedData
  * update session data with sanitised form data
  */
-const updateSubmittedData = (formData: RequestBody, existingData: SubmittedData) => {
+const updateSubmittedData = (formData: RequestBody, existingData?: SubmittedDataQuoteEligibility): SubmittedDataQuoteEligibility => {
   const submittedFormData = formData;
   delete submittedFormData._csrf;
 

--- a/src/ui/server/middleware/required-data-provided.test.ts
+++ b/src/ui/server/middleware/required-data-provided.test.ts
@@ -71,10 +71,13 @@ describe('middleware/required-data-provided', () => {
     describe('when policy type is single', () => {
       it('should return an array of all required fields with single policy specific fields', () => {
         const mockSubmittedData = {
-          [FIELD_IDS.POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.SINGLE,
+          quoteEligibility: {
+            [FIELD_IDS.POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.SINGLE,
+          },
+          insuranceEligibility: {},
         };
 
-        const result = allRequiredData(mockSubmittedData);
+        const result = allRequiredData(mockSubmittedData.quoteEligibility);
 
         const expected = {
           [BUYER_COUNTRY]: [],
@@ -121,10 +124,13 @@ describe('middleware/required-data-provided', () => {
     describe('when policy type is multi', () => {
       it('should return an array of all required fields with single policy specific fields', () => {
         const mockSubmittedData = {
-          [FIELD_IDS.POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.MULTI,
+          quoteEligibility: {
+            [FIELD_IDS.POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.MULTI,
+          },
+          insuranceEligibility: {},
         };
 
-        const result = allRequiredData(mockSubmittedData);
+        const result = allRequiredData(mockSubmittedData.quoteEligibility);
 
         const expected = {
           [BUYER_COUNTRY]: [],
@@ -195,7 +201,7 @@ describe('middleware/required-data-provided', () => {
   describe('hasRequiredData', () => {
     describe('when total amount of submitted fields matches the total of required fields', () => {
       it('should return true', () => {
-        const result = hasRequiredData(EXPORTER_LOCATION_CHANGE, mockSession.submittedData);
+        const result = hasRequiredData(EXPORTER_LOCATION_CHANGE, mockSession.submittedData.quoteEligibility);
 
         expect(result).toEqual(true);
       });
@@ -316,7 +322,10 @@ describe('middleware/required-data-provided', () => {
         req.originalUrl = TELL_US_ABOUT_YOUR_POLICY;
         req.session = {
           submittedData: {
-            [FIELD_IDS.VALID_EXPORTER_LOCATION]: true,
+            quoteEligibility: {
+              [FIELD_IDS.VALID_EXPORTER_LOCATION]: true,
+            },
+            insuranceEligibility: {},
           },
         };
 
@@ -330,7 +339,12 @@ describe('middleware/required-data-provided', () => {
     describe('when there is no submittedData in session', () => {
       it(`should redirect to ${NEED_TO_START_AGAIN}`, () => {
         req.originalUrl = TELL_US_ABOUT_YOUR_POLICY;
-        req.session = { submittedData: {} };
+        req.session = {
+          submittedData: {
+            quoteEligibility: {},
+            insuranceEligibility: {},
+          },
+        };
 
         requiredDataProvided(req, res, nextSpy);
 

--- a/src/ui/server/middleware/required-data-provided.ts
+++ b/src/ui/server/middleware/required-data-provided.ts
@@ -1,5 +1,5 @@
 import { FIELD_IDS, ROUTES } from '../constants';
-import { Request, RequiredDataState, Response, SubmittedData } from '../../types';
+import { Request, RequiredDataState, Response, SubmittedDataQuoteEligibility } from '../../types';
 import { isSinglePolicyType, isMultiPolicyType } from '../helpers/policy-type';
 
 const { ROOT, COOKIES, PROBLEM_WITH_SERVICE, QUOTE } = ROUTES;
@@ -59,7 +59,7 @@ export const routeIsKnown = (knownRoutes: Array<string>, route: string): boolean
  * @param {Object} all submitted data
  * @returns {Object}
  */
-export const allRequiredData = (submittedData: SubmittedData): RequiredDataState => {
+export const allRequiredData = (submittedData: SubmittedDataQuoteEligibility): RequiredDataState => {
   const requiredDataState = {} as RequiredDataState;
 
   requiredDataState[BUYER_COUNTRY] = [];
@@ -93,7 +93,7 @@ export const allRequiredData = (submittedData: SubmittedData): RequiredDataState
   return requiredDataState;
 };
 
-export const generateRequiredDataState = (submittedData: SubmittedData): RequiredDataState => {
+export const generateRequiredDataState = (submittedData: SubmittedDataQuoteEligibility): RequiredDataState => {
   const requiredDataState = {} as RequiredDataState;
 
   const required = allRequiredData(submittedData);
@@ -123,7 +123,7 @@ export const generateRequiredDataState = (submittedData: SubmittedData): Require
  * @param {Object} all submitted data
  * @returns {Boolean}
  */
-export const hasRequiredData = (route: string, submittedData: SubmittedData) => {
+export const hasRequiredData = (route: string, submittedData: SubmittedDataQuoteEligibility) => {
   const requiredDataState = generateRequiredDataState(submittedData);
 
   const requiredData = requiredDataState[route];
@@ -177,7 +177,7 @@ export const requiredDataProvided = (req: Request, res: Response, next: () => vo
   if (req.session && req.session.submittedData) {
     const { submittedData } = req.session;
 
-    if (!hasRequiredData(url, submittedData)) {
+    if (!hasRequiredData(url, submittedData.quoteEligibility)) {
       return res.redirect(NEED_TO_START_AGAIN);
     }
   } else if (!hasRequiredData(url, {})) {

--- a/src/ui/server/test-mocks/index.ts
+++ b/src/ui/server/test-mocks/index.ts
@@ -20,7 +20,10 @@ const mockReq = () => {
     originalUrl: 'mock',
     redirect: jest.fn(),
     session: {
-      submittedData: {},
+      submittedData: {
+        quoteEligibility: {},
+        insuranceEligibility: {},
+      },
     },
   };
 

--- a/src/ui/server/test-mocks/mock-answers.ts
+++ b/src/ui/server/test-mocks/mock-answers.ts
@@ -1,5 +1,5 @@
 import { FIELD_IDS, FIELD_VALUES } from '../constants';
-import { SubmittedData } from '../../types';
+import { SubmittedDataQuoteEligibility } from '../../types';
 
 const {
   VALID_BUYER_BODY,
@@ -25,6 +25,6 @@ const mockAnswers = {
   [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.SINGLE,
   [POLICY_LENGTH]: 2,
   [PERCENTAGE_OF_COVER]: 90,
-} as SubmittedData;
+} as SubmittedDataQuoteEligibility;
 
 export default mockAnswers;

--- a/src/ui/server/test-mocks/mock-session.ts
+++ b/src/ui/server/test-mocks/mock-session.ts
@@ -1,21 +1,25 @@
 import { API, FIELD_IDS } from '../constants';
 import mockAnswers from './mock-answers';
+import { RequestSession } from '../../types';
 
 const { BUYER_COUNTRY, CURRENCY } = FIELD_IDS;
 
 const mockSession = {
   submittedData: {
-    ...mockAnswers,
-    [BUYER_COUNTRY]: {
-      name: mockAnswers[BUYER_COUNTRY],
-      isoCode: 'FRA',
-      riskCategory: API.MAPPINGS.RISK.STANDARD,
+    quoteEligibility: {
+      ...mockAnswers,
+      [BUYER_COUNTRY]: {
+        name: mockAnswers[BUYER_COUNTRY],
+        isoCode: 'FRA',
+        riskCategory: API.MAPPINGS.RISK.STANDARD,
+      },
+      [CURRENCY]: {
+        name: 'UK Sterling',
+        isoCode: 'GBP',
+      },
     },
-    [CURRENCY]: {
-      name: 'UK Sterling',
-      isoCode: 'GBP',
-    },
+    insuranceEligibility: {},
   },
-};
+} as RequestSession;
 
 export default mockSession;

--- a/src/ui/types/index.d.ts
+++ b/src/ui/types/index.d.ts
@@ -8,7 +8,7 @@ import { RequiredDataState } from './required-data-state';
 import { PricingGrid, PricingGridMonth, PricingGridRate } from './pricing-grid';
 import { Quote, QuoteContent } from './quote';
 import { SelectOption } from './select-option';
-import { SubmittedData } from './submitted-data';
+import { SubmittedDataQuoteEligibility, SubmittedDataInsuranceEligibility, SubmittedData } from './submitted-data';
 import { SummaryListItem, SummaryListItemData } from './summary-list';
 import { TaskList, TaskListData, TaskListDataTask, TaskListDataGroup, TaskListGroup, TaskListTask } from './task-list';
 import {
@@ -50,6 +50,8 @@ export {
   SelectOption,
   SingleInputPageVariablesInput,
   SingleInputPageVariables,
+  SubmittedDataQuoteEligibility,
+  SubmittedDataInsuranceEligibility,
   SubmittedData,
   SummaryListItemData,
   SummaryListItem,

--- a/src/ui/types/submitted-data.d.ts
+++ b/src/ui/types/submitted-data.d.ts
@@ -1,7 +1,7 @@
 import { Country } from './country';
 import { Currency } from './currency';
 
-type SubmittedData = {
+type SubmittedDataQuoteEligibility = {
   amount?: number;
   buyerCountry?: Country;
   contractValue?: number;
@@ -14,4 +14,13 @@ type SubmittedData = {
   policyLength?: number;
 };
 
-export { SubmittedData };
+type SubmittedDataInsuranceEligibility = {
+  
+};
+
+type SubmittedData = {
+  quoteEligibility: SubmittedDataQuoteEligibility;
+  insuranceEligibility: SubmittedDataInsuranceEligibility;
+};
+
+export { SubmittedDataQuoteEligibility, SubmittedDataInsuranceEligibility, SubmittedData };

--- a/src/ui/types/submitted-data.d.ts
+++ b/src/ui/types/submitted-data.d.ts
@@ -15,7 +15,8 @@ type SubmittedDataQuoteEligibility = {
 };
 
 type SubmittedDataInsuranceEligibility = {
-  
+  wantCoverOverMaxAmount?: boolean;
+  wantCoverOverMaxPeriod?: boolean;
 };
 
 type SubmittedData = {


### PR DESCRIPTION
This PR updates `req.session.submittedData` so that all quote eligibility answers are stored in `req.session.submittedData.quoteEligibility`.

Also:

- Add a placeholder object for the application: `req.session.submittedData.insuranceEligibility`.
- Update task list helpers to consume insurance eligibility field names instead of quote eligibility.