### PR TITLE
feat(EMS-511): save insurance eligibility answers in session storage

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/apply-offline-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/apply-offline-page.spec.js
@@ -4,6 +4,9 @@ import partials from '../../../partials';
 import { LINKS, ORGANISATION, PAGES } from '../../../../../content-strings';
 import CONSTANTS from '../../../../../constants';
 
+import { completeStartForm, completeCheckIfEligibleForm } from '../../../../support/insurance/eligibility/forms';
+import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
+
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE;
 const { ACTIONS } = CONTENT_STRINGS;
 
@@ -13,14 +16,15 @@ const COUNTRY_NAME_APPLY_OFFLINE_ONLY = 'Angola';
 
 context('Insurance Eligibility - apply offline exit page', () => {
   beforeEach(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
-    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY);
+    completeStartForm();
+    completeCheckIfEligibleForm();
 
     buyerCountryPage.searchInput().type(COUNTRY_NAME_APPLY_OFFLINE_ONLY);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-country-only-apply-offline.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-country-only-apply-offline.spec.js
@@ -40,4 +40,12 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
 
     partials.backLink().should('have.attr', 'href', expected);
   });
+
+  describe('when going back to the page', () => {
+    it('should have the originally submitted answer selected', () => {
+      partials.backLink().click();
+
+      buyerCountryPage.hiddenInput().should('have.attr', 'value', COUNTRY_NAME_APPLY_OFFLINE_ONLY);
+    });
+  });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-country-only-apply-offline.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-country-only-apply-offline.spec.js
@@ -2,7 +2,7 @@ import { buyerCountryPage, submitButton } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
-import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility';
+import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.CANNOT_APPLY;
 const { ROUTES } = CONSTANTS;

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-country-only-apply-offline.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-country-only-apply-offline.spec.js
@@ -29,6 +29,11 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
     submitButton().click();
   });
 
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
   it('redirects to `apply offline` exit page', () => {
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   });
@@ -42,10 +47,10 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
   });
 
   describe('when going back to the page', () => {
-    it('should have the originally submitted answer selected', () => {
+    it('should NOT have the originally submitted answer selected', () => {
       partials.backLink().click();
 
-      buyerCountryPage.hiddenInput().should('have.attr', 'value', COUNTRY_NAME_APPLY_OFFLINE_ONLY);
+      buyerCountryPage.hiddenInput().should('not.have.attr', 'value', COUNTRY_NAME_APPLY_OFFLINE_ONLY);
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-country-only-apply-offline.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-country-only-apply-offline.spec.js
@@ -2,6 +2,7 @@ import { buyerCountryPage, submitButton } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
+import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility';
 
 const CONTENT_STRINGS = PAGES.CANNOT_APPLY;
 const { ROUTES } = CONSTANTS;
@@ -10,14 +11,15 @@ const COUNTRY_NAME_APPLY_OFFLINE_ONLY = 'Angola';
 
 context('Buyer country page - as an exporter, I want to check if UKEF issue export insurance cover for where my buyer is based - submit country that can only apply offline/via a physical form', () => {
   before(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
-    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY);
+    completeStartForm();
+    completeCheckIfEligibleForm();
 
     buyerCountryPage.searchInput().type(COUNTRY_NAME_APPLY_OFFLINE_ONLY);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-unsupported-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-unsupported-country.spec.js
@@ -3,6 +3,7 @@ import { insurance } from '../../../../pages';
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
+import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility';
 
 const CONTENT_STRINGS = PAGES.CANNOT_APPLY;
 const { REASON } = CONTENT_STRINGS;
@@ -13,14 +14,15 @@ const COUNTRY_NAME_UNSUPPORTED = 'France';
 
 context('Insurance - Buyer location page - as an exporter, I want to check if UKEF offer export insurance policy for where my buyer is based - submit unsupported country', () => {
   before(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
-    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY);
+    completeStartForm();
+    completeCheckIfEligibleForm();
 
     buyerCountryPage.searchInput().type(COUNTRY_NAME_UNSUPPORTED);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-unsupported-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-unsupported-country.spec.js
@@ -32,6 +32,11 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
     submitButton().click();
   });
 
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
   it('redirects to `cannot apply` exit page', () => {
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY);
   });
@@ -54,10 +59,10 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
   });
 
   describe('when going back to the page', () => {
-    it('should have the originally submitted answer selected', () => {
+    it('should NOT have the originally submitted answer selected', () => {
       partials.backLink().click();
 
-      buyerCountryPage.hiddenInput().should('have.attr', 'value', COUNTRY_NAME_UNSUPPORTED);
+      buyerCountryPage.hiddenInput().should('not.have.attr', 'value', COUNTRY_NAME_UNSUPPORTED);
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-unsupported-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-unsupported-country.spec.js
@@ -3,7 +3,7 @@ import { insurance } from '../../../../pages';
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
-import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility';
+import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.CANNOT_APPLY;
 const { REASON } = CONTENT_STRINGS;

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-unsupported-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-unsupported-country.spec.js
@@ -52,4 +52,12 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
 
     partials.backLink().should('have.attr', 'href', expected);
   });
+
+  describe('when going back to the page', () => {
+    it('should have the originally submitted answer selected', () => {
+      partials.backLink().click();
+
+      buyerCountryPage.hiddenInput().should('have.attr', 'value', COUNTRY_NAME_UNSUPPORTED);
+    });
+  });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
@@ -10,6 +10,7 @@ import {
   PAGES,
 } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
+import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility';
 import {
   checkPageTitleAndHeading,
   checkInputHint,
@@ -24,14 +25,15 @@ const { ROUTES, FIELD_IDS } = CONSTANTS;
 
 context('Insurance - Buyer location page - as an exporter, I want to check if UKEF offer export insurance policy for where my buyer is based', () => {
   beforeEach(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
-    submitButton().click();
+    completeStartForm();
+    completeCheckIfEligibleForm();
 
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY);
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
@@ -10,7 +10,7 @@ import {
   PAGES,
 } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
-import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility';
+import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility/forms';
 import {
   checkPageTitleAndHeading,
   checkInputHint,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
@@ -124,15 +124,26 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
     });
 
     describe('when submitting with a supported country', () => {
-      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION}`, () => {
+      beforeEach(() => {
         buyerCountryPage.searchInput().type('Algeria');
 
         const results = buyerCountryPage.results();
         results.first().click();
 
         submitButton().click();
+      });
 
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION}`, () => {
         cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION);
+      });
+
+      describe('when going back to the page', () => {
+        it('should have the originally submitted answer selected', () => {
+          partials.backLink().click();
+
+          const expectedValue = 'Algeria';
+          buyerCountryPage.hiddenInput().should('have.attr', 'value', expectedValue);
+        });
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
@@ -8,7 +8,6 @@ import {
 } from '../../../../../content-strings';
 import CONSTANTS from '../../../../../constants';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../support/insurance/eligibility/forms';
-import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
 
 const CONTENT_STRINGS = PAGES.CANNOT_APPLY;
 const { ACTIONS } = CONTENT_STRINGS;
@@ -28,7 +27,12 @@ context('Insurance Eligibility - Cannot apply exit page', () => {
 
     completeStartForm();
     completeCheckIfEligibleForm();
-    completeAndSubmitBuyerCountryForm();
+
+    buyerCountryPage.searchInput().type(COUNTRY_NAME_UNSUPPORTED);
+    const results = buyerCountryPage.results();
+    results.first().click();
+
+    submitButton().click();
 
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY);
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
@@ -7,6 +7,8 @@ import {
   PAGES,
 } from '../../../../../content-strings';
 import CONSTANTS from '../../../../../constants';
+import { completeStartForm, completeCheckIfEligibleForm } from '../../../../support/insurance/eligibility/forms';
+import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
 
 const CONTENT_STRINGS = PAGES.CANNOT_APPLY;
 const { ACTIONS } = CONTENT_STRINGS;
@@ -17,21 +19,16 @@ const COUNTRY_NAME_UNSUPPORTED = 'France';
 
 context('Insurance Eligibility - Cannot apply exit page', () => {
   beforeEach(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
-    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY);
-
-    buyerCountryPage.searchInput().type(COUNTRY_NAME_UNSUPPORTED);
-
-    const results = buyerCountryPage.results();
-    results.first().click();
-
-    submitButton().click();
+    completeStartForm();
+    completeCheckIfEligibleForm();
+    completeAndSubmitBuyerCountryForm();
 
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY);
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
@@ -7,7 +7,7 @@ import { completeStartForm, completeCheckIfEligibleForm } from '../../../../supp
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE;
 
-context('Insurance Eligibility - start page', () => {
+context('Insurance Eligibility - check if eligible page', () => {
   before(() => {
     cy.visit(ROUTES.INSURANCE.START, {
       auth: {
@@ -17,10 +17,9 @@ context('Insurance Eligibility - start page', () => {
     });
 
     completeStartForm();
-    
-    completeCheckIfEligibleForm();
+    // completeCheckIfEligibleForm();
 
-    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY);
+    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE);
   });
 
   beforeEach(() => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
@@ -3,7 +3,7 @@ import { insurance } from '../../../pages';
 import partials from '../../../partials';
 import { BUTTONS, LINKS, ORGANISATION, PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
-import { completeStartForm } from '../../../../support/insurance/eligibility/forms';
+import { completeStartForm, completeCheckIfEligibleForm } from '../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE;
 
@@ -17,6 +17,8 @@ context('Insurance Eligibility - start page', () => {
     });
 
     completeStartForm();
+    
+    completeCheckIfEligibleForm();
 
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY);
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
@@ -3,6 +3,7 @@ import { insurance } from '../../../pages';
 import partials from '../../../partials';
 import { BUTTONS, LINKS, ORGANISATION, PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
+import { completeStartForm } from '../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE;
 
@@ -15,7 +16,9 @@ context('Insurance Eligibility - start page', () => {
       },
     });
 
-    submitButton().click();
+    completeStartForm();
+
+    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY);
   });
 
   beforeEach(() => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
@@ -1,4 +1,4 @@
-import { cannotApplyPage, yesRadio, noRadio, submitButton } from '../../../../pages/shared';
+import { cannotApplyPage, noRadio, submitButton } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
@@ -37,6 +37,9 @@ context('Insurance - Eligibility - Companies house number page - I want to check
     completeOtherPartiesForm();
     completeLetterOfCreditForm();
     completePreCreditPeriodForm();
+
+    noRadio().click();
+    submitButton().click();
   });
 
   it('redirects to exit page', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
@@ -3,44 +3,40 @@ import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+import {
+  completeStartForm,
+  completeCheckIfEligibleForm,
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+  completeInsuredPeriodForm,
+  completeOtherPartiesForm,
+  completeLetterOfCreditForm,
+  completePreCreditPeriodForm,
+} from '../../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
 context('Insurance - Eligibility - Companies house number page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction if I do not have UK Companies House Registration Number - submit `no companies house number`', () => {
   before(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
-
-    yesRadio().click();
-    submitButton().click();
-
-    yesRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
+    completeInsuredAmountForm();
+    completeInsuredPeriodForm();
+    completeOtherPartiesForm();
+    completeLetterOfCreditForm();
+    completePreCreditPeriodForm();
   });
 
   it('redirects to exit page', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
@@ -1,4 +1,4 @@
-import { cannotApplyPage, noRadio, submitButton } from '../../../../pages/shared';
+import { cannotApplyPage, noRadio, noRadioInput, submitButton } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
@@ -59,6 +59,14 @@ context('Insurance - Eligibility - Companies house number page - I want to check
       const expected = `${CONTENT_STRINGS.REASON.INTRO} ${CONTENT_STRINGS.REASON.NO_COMPANIES_HOUSE_NUMBER}`;
 
       expect(text.trim()).equal(expected);
+    });
+  });
+
+  describe('when going back to the page', () => {
+    it('should have the originally submitted answer selected', () => {
+      partials.backLink().click();
+
+      noRadioInput().should('be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
@@ -42,6 +42,11 @@ context('Insurance - Eligibility - Companies house number page - I want to check
     submitButton().click();
   });
 
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
   it('redirects to exit page', () => {
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   });
@@ -63,10 +68,10 @@ context('Insurance - Eligibility - Companies house number page - I want to check
   });
 
   describe('when going back to the page', () => {
-    it('should have the originally submitted answer selected', () => {
+    it('should NOT have the originally submitted answer selected', () => {
       partials.backLink().click();
 
-      noRadioInput().should('be.checked');
+      noRadioInput().should('not.be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
@@ -10,41 +10,40 @@ import {
 } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+import {
+  completeStartForm,
+  completeCheckIfEligibleForm,
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+  completeInsuredPeriodForm,
+  completeOtherPartiesForm,
+  completeLetterOfCreditForm,
+  completePreCreditPeriodForm,
+} from '../../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
 context('Insurance - Eligibility - Companies house number page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction if I do not have UK Companies House Registration Number', () => {
   before(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
-
-    yesRadio().click();
-    submitButton().click();
-
-    yesRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
+    completeInsuredAmountForm();
+    completeInsuredPeriodForm();
+    completeOtherPartiesForm();
+    completeLetterOfCreditForm();
+    completePreCreditPeriodForm();
 
     const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
@@ -158,13 +158,23 @@ context('Insurance - Eligibility - Companies house number page - I want to check
     });
 
     describe('when submitting the answer as `yes`', () => {
-      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE}`, () => {
+      beforeEach(() => {
         yesRadio().click();
         submitButton().click();
+      });
 
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE}`, () => {
         const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE}`;
 
         cy.url().should('eq', expected);
+      });
+
+      describe('when going back to the page', () => {
+        it('should have the originally submitted answer selected', () => {
+          partials.backLink().click();
+
+          yesRadioInput().should('be.checked');
+        });
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
@@ -158,7 +158,7 @@ context('Insurance - Eligibility - Companies house number page - I want to check
     });
 
     describe('when submitting the answer as `yes`', () => {
-      beforeEach(() => {
+      before(() => {
         yesRadio().click();
         submitButton().click();
       });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online.spec.js
@@ -7,50 +7,26 @@ import {
   PAGES,
 } from '../../../../../content-strings';
 import CONSTANTS from '../../../../../constants';
-import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
+import { completeAndSubmitBuyerCountryForm } from '../../../../support/insurance/eligibility/submit-answers-happy-path';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE;
 const { ROUTES } = CONSTANTS;
 
 context('Insurance - Eligibility - You are eligible to apply online page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction', () => {
   before(() => {
-  cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
-    auth: {
-      username: Cypress.config('basicAuthKey'),
-      password: Cypress.config('basicAuthSecret'),
-    },
+    cy.visit(ROUTES.INSURANCE.START, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    cy.submitInsuranceEligibilityAnswersHappyPath();
+
+    const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE}`;
+
+    cy.url().should('eq', expected);
   });
-
-  completeAndSubmitBuyerCountryForm();
-
-  yesRadio().click();
-  submitButton().click();
-
-  yesRadio().click();
-  submitButton().click();
-
-  noRadio().click();
-  submitButton().click();
-
-  noRadio().click();
-  submitButton().click();
-
-  noRadio().click();
-  submitButton().click();
-
-  noRadio().click();
-  submitButton().click();
-
-  noRadio().click();
-  submitButton().click();
-
-  yesRadio().click();
-  submitButton().click();
-
-  const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE}`;
-
-  cy.url().should('eq', expected);
-});
 
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('_csrf');

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location-answer-no.spec.js
@@ -27,6 +27,11 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
     submitButton().click();
   });
 
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
   it('redirects to exit page', () => {
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY);
   });
@@ -48,10 +53,10 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
   });
 
   describe('when going back to the page', () => {
-    it('should have the originally submitted answer selected', () => {
+    it('should NOT have the originally submitted answer selected', () => {
       partials.backLink().click();
 
-      noRadioInput().should('be.checked');
+      noRadioInput().should('not.be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location-answer-no.spec.js
@@ -3,19 +3,22 @@ import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.QUOTE.CANNOT_APPLY;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
 context('Insurance - Exporter location page - as an exporter, I want to check if my company can get UKEF issue export insurance cover - submit `not based inside the UK`', () => {
   before(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
 
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION);

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location-answer-no.spec.js
@@ -1,4 +1,4 @@
-import { cannotApplyPage, exporterLocationPage, noRadio, submitButton } from '../../../../pages/shared';
+import { cannotApplyPage, exporterLocationPage, noRadio, noRadioInput, submitButton } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
@@ -44,6 +44,14 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
       const expected = `${CONTENT_STRINGS.REASON.INTRO} ${CONTENT_STRINGS.REASON.UNSUPPORTED_COMPANY_COUNTRY}`;
 
       expect(text.trim()).equal(expected);
+    });
+  });
+
+  describe('when going back to the page', () => {
+    it('should have the originally submitted answer selected', () => {
+      partials.backLink().click();
+
+      noRadioInput().should('be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
@@ -121,11 +121,21 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
     });
 
     describe('when submitting the answer as `yes`', () => {
-      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES}`, () => {
+      beforeEach(() => {
         yesRadio().click();
         submitButton().click();
+      });
 
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES}`, () => {
         cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES);
+      });
+
+      describe('when going back to the page', () => {
+        it('should have the originally submitted answer selected', () => {
+          partials.backLink().click();
+
+          yesRadioInput().should('be.checked');
+        });
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
@@ -9,19 +9,22 @@ import {
 } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.EXPORTER_LOCATION;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
 context('Insurance - Exporter location page - as an exporter, I want to check if my company can get UKEF issue export insurance cover', () => {
   beforeEach(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
 
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION);

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount-answer-yes.spec.js
@@ -1,4 +1,4 @@
-import { cannotApplyPage, yesRadio, submitButton } from '../../../../pages/shared';
+import { cannotApplyPage, yesRadio, yesRadioInput, submitButton } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
@@ -48,6 +48,14 @@ context('Insurance - Insured amount page - I want to check if I can use online s
       const expected = `${CONTENT_STRINGS.REASON.INTRO} ${CONTENT_STRINGS.REASON.WANT_COVER_OVER_MAX_AMOUNT}`;
 
       expect(text.trim()).equal(expected);
+    });
+  });
+
+  describe('when going back to the page', () => {
+    it('should have the originally submitted answer selected', () => {
+      partials.backLink().click();
+
+      yesRadioInput().should('be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount-answer-yes.spec.js
@@ -3,26 +3,29 @@ import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
-
+import {
+  completeStartForm,
+  completeCheckIfEligibleForm,
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+} from '../../../../../support/insurance/eligibility/forms';
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
 context('Insurance - Insured amount page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction that is less than the maxium amount of cover available online - submit `cover over max amount`', () => {
   before(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
-
-    yesRadio().click();
-    submitButton().click();
-
-    yesRadio().click();
-    submitButton().click();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
 
     yesRadio().click();
     submitButton().click();

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount-answer-yes.spec.js
@@ -31,6 +31,11 @@ context('Insurance - Insured amount page - I want to check if I can use online s
     submitButton().click();
   });
 
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
   it('redirects to exit page', () => {
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   });
@@ -52,10 +57,10 @@ context('Insurance - Insured amount page - I want to check if I can use online s
   });
 
   describe('when going back to the page', () => {
-    it('should have the originally submitted answer selected', () => {
+    it('should NOT have the originally submitted answer selected', () => {
       partials.backLink().click();
 
-      yesRadioInput().should('be.checked');
+      yesRadioInput().should('not.be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
@@ -145,13 +145,23 @@ context('Insurance - Insured amount page - I want to check if I can use online s
     });
 
     describe('when submitting the answer as `no`', () => {
-      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD}`, () => {
+      beforeEach(() => {
         noRadio().click();
         submitButton().click();
+      });
 
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD}`, () => {
         const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD}`;
 
         cy.url().should('eq', expected);
+      });
+
+      describe('when going back to the page', () => {
+        it('should have the originally submitted answer selected', () => {
+          partials.backLink().click();
+
+          noRadioInput().should('be.checked');
+        });
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
@@ -9,26 +9,30 @@ import {
 } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+import {
+  completeStartForm,
+  completeCheckIfEligibleForm,
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+} from '../../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
 context('Insurance - Insured amount page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction that is less than the maxium amount of cover available online', () => {
   before(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
-
-    yesRadio().click();
-    submitButton().click();
-
-    yesRadio().click();
-    submitButton().click();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
 
     const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
@@ -1,4 +1,4 @@
-import { heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton } from '../../../../pages/shared';
+import { heading, yesRadio, yesRadioInput, noRadio, noRadioInput, inlineErrorMessage, submitButton } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import {
   ORGANISATION,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit-answer-yes.spec.js
@@ -3,35 +3,36 @@ import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+import {
+  completeStartForm,
+  completeCheckIfEligibleForm,
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+  completeInsuredPeriodForm,
+  completeOtherPartiesForm,
+} from '../../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
 context('Insurance - Eligibility - Letter of credit page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction that is paid via letter of credit - submit `paid by letter of credit`', () => {
   before(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
-
-    yesRadio().click();
-    submitButton().click();
-
-    yesRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
+    completeInsuredAmountForm();
+    completeInsuredPeriodForm();
+    completeOtherPartiesForm();
 
     yesRadio().click();
     submitButton().click();

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit-answer-yes.spec.js
@@ -38,6 +38,11 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
     submitButton().click();
   });
 
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
   it('redirects to exit page', () => {
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   });
@@ -59,10 +64,10 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
   });
 
   describe('when going back to the page', () => {
-    it('should have the originally submitted answer selected', () => {
+    it('should NOT have the originally submitted answer selected', () => {
       partials.backLink().click();
 
-      yesRadioInput().should('be.checked');
+      yesRadioInput().should('not.be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit-answer-yes.spec.js
@@ -1,4 +1,4 @@
-import { cannotApplyPage, yesRadio, noRadio, submitButton } from '../../../../pages/shared';
+import { cannotApplyPage, yesRadio, yesRadioInput, noRadio, submitButton } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
@@ -55,6 +55,14 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
       const expected = `${CONTENT_STRINGS.REASON.INTRO} ${CONTENT_STRINGS.REASON.WILL_BE_PAID_BY_LETTER_OF_CREDIT}`;
 
       expect(text.trim()).equal(expected);
+    });
+  });
+
+  describe('when going back to the page', () => {
+    it('should have the originally submitted answer selected', () => {
+      partials.backLink().click();
+
+      yesRadioInput().should('be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
@@ -1,4 +1,4 @@
-import { heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton } from '../../../../pages/shared';
+import { heading, yesRadio, yesRadioInput, noRadio, noRadioInput, inlineErrorMessage, submitButton } from '../../../../pages/shared';
 import { insurance } from '../../../../pages';
 import partials from '../../../../partials';
 import {
@@ -154,7 +154,7 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
     });
 
     describe('when submitting the answer as `no`', () => {
-      beforeEach(() => {
+      before(() => {
         noRadio().click();
         submitButton().click();
       });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
@@ -154,13 +154,23 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
     });
 
     describe('when submitting the answer as `no`', () => {
-      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD}`, () => {
+      beforeEach(() => {
         noRadio().click();
         submitButton().click();
+      });
 
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD}`, () => {
         const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD}`;
 
         cy.url().should('eq', expected);
+      });
+
+      describe('when going back to the page', () => {
+        it('should have the originally submitted answer selected', () => {
+          partials.backLink().click();
+
+          noRadioInput().should('be.checked');
+        });
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
@@ -10,35 +10,36 @@ import {
 } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+import {
+  completeStartForm,
+  completeCheckIfEligibleForm,
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+  completeInsuredPeriodForm,
+  completeOtherPartiesForm,
+} from '../../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
 context('Insurance - Eligibility - Letter of credit page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction that is paid via letter of credit', () => {
   before(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
-
-    yesRadio().click();
-    submitButton().click();
-
-    yesRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
+    completeInsuredAmountForm();
+    completeInsuredPeriodForm();
+    completeOtherPartiesForm();
 
     const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties-answer-yes.spec.js
@@ -4,32 +4,34 @@ import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+import {
+  completeStartForm,
+  completeCheckIfEligibleForm,
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+  completeInsuredPeriodForm,
+} from '../../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
 context('Insurance - Insured amount page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction that is less than the maxium amount of cover available online - submit `cover over max amount`', () => {
   before(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
-
-    yesRadio().click();
-    submitButton().click();
-
-    yesRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
+    completeInsuredAmountForm();
+    completeInsuredPeriodForm();
 
     yesRadio().click();
     submitButton().click();

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties-answer-yes.spec.js
@@ -1,4 +1,4 @@
-import { cannotApplyPage, yesRadio, noRadio, submitButton } from '../../../../pages/shared';
+import { cannotApplyPage, yesRadio, yesRadioInput, noRadio, submitButton } from '../../../../pages/shared';
 import { insurance } from '../../../../pages';
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
@@ -54,6 +54,14 @@ context('Insurance - Insured amount page - I want to check if I can use online s
       const expected = `${CONTENT_STRINGS.REASON.INTRO} ${CONTENT_STRINGS.REASON.OTHER_PARTIES_INVOLVED}`;
 
       expect(text.trim()).equal(expected);
+    });
+  });
+
+  describe('when going back to the page', () => {
+    it('should have the originally submitted answer selected', () => {
+      partials.backLink().click();
+
+      yesRadioInput().should('be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties-answer-yes.spec.js
@@ -37,6 +37,11 @@ context('Insurance - Insured amount page - I want to check if I can use online s
     submitButton().click();
   });
 
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
   it('redirects to exit page', () => {
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   });
@@ -58,10 +63,10 @@ context('Insurance - Insured amount page - I want to check if I can use online s
   });
 
   describe('when going back to the page', () => {
-    it('should have the originally submitted answer selected', () => {
+    it('should NOT have the originally submitted answer selected', () => {
       partials.backLink().click();
 
-      yesRadioInput().should('be.checked');
+      yesRadioInput().should('not.be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
@@ -10,32 +10,34 @@ import {
 } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+import {
+  completeStartForm,
+  completeCheckIfEligibleForm,
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+  completeInsuredPeriodForm,
+} from '../../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
 context('Insurance - Other parties page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction if there are other parties involved in the export', () => {
   before(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
-
-    yesRadio().click();
-    submitButton().click();
-
-    yesRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
+    completeInsuredAmountForm();
+    completeInsuredPeriodForm();
 
     const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
@@ -194,13 +194,23 @@ context('Insurance - Other parties page - I want to check if I can use online se
     });
 
     describe('when submitting the answer as `no`', () => {
-      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`, () => {
+      beforeEach(() => {
         noRadio().click();
         submitButton().click();
+      });
 
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`, () => {
         const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`;
 
         cy.url().should('eq', expected);
+      });
+
+      describe('when going back to the page', () => {
+        it('should have the originally submitted answer selected', () => {
+          partials.backLink().click();
+
+          noRadioInput().should('be.checked');
+        });
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
@@ -1,4 +1,4 @@
-import { heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton } from '../../../../pages/shared';
+import { heading, yesRadio, yesRadioInput, noRadio, noRadioInput, inlineErrorMessage, submitButton } from '../../../../pages/shared';
 import { insurance } from '../../../../pages';
 import partials from '../../../../partials';
 import {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period-answer-yes.spec.js
@@ -41,6 +41,11 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
     submitButton().click();
   });
 
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
   it('redirects to exit page', () => {
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   });
@@ -62,10 +67,10 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
   });
 
   describe('when going back to the page', () => {
-    it('should have the originally submitted answer selected', () => {
+    it('should NOT have the originally submitted answer selected', () => {
       partials.backLink().click();
 
-      yesRadioInput().should('be.checked');
+      yesRadioInput().should('not.be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period-answer-yes.spec.js
@@ -1,4 +1,4 @@
-import { cannotApplyPage, yesRadio, noRadio, submitButton } from '../../../../pages/shared';
+import { cannotApplyPage, yesRadio, yesRadioInput, noRadio, submitButton } from '../../../../pages/shared';
 import { insurance } from '../../../../pages';
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
@@ -58,6 +58,14 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
       const expected = `${CONTENT_STRINGS.REASON.INTRO} ${CONTENT_STRINGS.REASON.NEED_PRE_CREDIT_PERIOD_COVER}`;
 
       expect(text.trim()).equal(expected);
+    });
+  });
+
+  describe('when going back to the page', () => {
+    it('should have the originally submitted answer selected', () => {
+      partials.backLink().click();
+
+      yesRadioInput().should('be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period-answer-yes.spec.js
@@ -4,38 +4,38 @@ import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+import {
+  completeStartForm,
+  completeCheckIfEligibleForm,
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+  completeInsuredPeriodForm,
+  completeOtherPartiesForm,
+  completeLetterOfCreditForm,
+} from '../../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
 context('Insurance - Eligibility - Pre-credit period page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction that is paid via letter of credit - submit `need pre-credit period cover`', () => {
   before(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
-
-    yesRadio().click();
-    submitButton().click();
-
-    yesRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
+    completeInsuredAmountForm();
+    completeInsuredPeriodForm();
+    completeOtherPartiesForm();
+    completeLetterOfCreditForm();
 
     yesRadio().click();
     submitButton().click();

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -1,4 +1,4 @@
-import { heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton } from '../../../../pages/shared';
+import { heading, yesRadio, yesRadioInput, noRadio, noRadioInput, inlineErrorMessage, submitButton } from '../../../../pages/shared';
 import { insurance } from '../../../../pages';
 import partials from '../../../../partials';
 import {
@@ -208,7 +208,7 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
     });
 
     describe('when submitting the answer as `no`', () => {
-      beforeEach(() => {
+      before(() => {
         noRadio().click();
         submitButton().click();
       });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -208,13 +208,23 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
     });
 
     describe('when submitting the answer as `no`', () => {
-      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`, () => {
+      beforeEach(() => {
         noRadio().click();
         submitButton().click();
+      });
 
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`, () => {
         const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`;
 
         cy.url().should('eq', expected);
+      });
+
+      describe('when going back to the page', () => {
+        it('should have the originally submitted answer selected', () => {
+          partials.backLink().click();
+
+          noRadioInput().should('be.checked');
+        });
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -10,38 +10,38 @@ import {
 } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+import {
+  completeStartForm,
+  completeCheckIfEligibleForm,
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+  completeInsuredPeriodForm,
+  completeOtherPartiesForm,
+  completeLetterOfCreditForm,
+} from '../../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD;
 const { ROUTES, FIELD_IDS } = CONSTANTS;
 
 context('Insurance - Eligibility - Pre-credit period page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction that is paid via letter of credit', () => {
   before(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
-
-    yesRadio().click();
-    submitButton().click();
-
-    yesRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
+    completeInsuredAmountForm();
+    completeInsuredPeriodForm();
+    completeOtherPartiesForm();
+    completeLetterOfCreditForm();
 
     const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/speak-to-ukef-efm.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/speak-to-ukef-efm.spec.js
@@ -3,6 +3,13 @@ import { insurance } from '../../../pages';
 import partials from '../../../partials';
 import { LINKS, ORGANISATION, PAGES } from '../../../../../content-strings';
 import CONSTANTS from '../../../../../constants';
+import {
+  completeStartForm,
+  completeCheckIfEligibleForm,
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+ } from '../../../../support/insurance/eligibility/forms';
 import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM;
@@ -14,23 +21,21 @@ const COUNTRY_NAME_APPLY_OFFLINE_ONLY = 'Angola';
 
 context('Insurance Eligibility - speak to UKEF EFM exit page', () => {
   beforeEach(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
+    completeInsuredAmountForm();
 
-    yesRadio().click();
-    submitButton().click();
-
-    yesRadio().click();
-    submitButton().click();
-
-    noRadio().click();
-    submitButton().click();
+    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD);
 
     yesRadio().click();
     submitButton().click();

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
@@ -2,6 +2,7 @@ import { cannotApplyPage, yesRadio, noRadio, submitButton } from '../../../../pa
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
+import { completeStartForm, completeCheckIfEligibleForm, completeExporterLocationForm } from '../../../../../support/insurance/eligibility/forms';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
 
 const CONTENT_STRINGS = PAGES.QUOTE.CANNOT_APPLY;
@@ -9,21 +10,17 @@ const { ROUTES } = CONSTANTS;
 
 context('Insurance - UK goods or services page - as an exporter, I want to check if my export value is eligible for UKEF export insurance cover - submit `no - UK goods/services is below the minimum`', () => {
   beforeEach(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
-
-    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION);
-
-    yesRadio().click();
-    submitButton().click();
-
-    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES);
+    completeExporterLocationForm()
 
     noRadio().click();
     submitButton().click();

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
@@ -1,4 +1,4 @@
-import { cannotApplyPage, yesRadio, noRadio, submitButton } from '../../../../pages/shared';
+import { cannotApplyPage, noRadio, noRadioInput, submitButton } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
@@ -45,6 +45,14 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
       const expected = `${CONTENT_STRINGS.REASON.INTRO} ${CONTENT_STRINGS.REASON.NOT_ENOUGH_UK_GOODS_OR_SERVICES}`;
 
       expect(text.trim()).equal(expected);
+    });
+  });
+
+  describe('when going back to the page', () => {
+    it('should have the originally submitted answer selected', () => {
+      partials.backLink().click();
+
+      noRadioInput().should('be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
@@ -26,6 +26,11 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
     submitButton().click();
   });
 
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
   it('redirects to exit page', () => {
     const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY}`;
 
@@ -49,10 +54,10 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
   });
 
   describe('when going back to the page', () => {
-    it('should have the originally submitted answer selected', () => {
+    it('should NOT have the originally submitted answer selected', () => {
       partials.backLink().click();
 
-      noRadioInput().should('be.checked');
+      noRadioInput().should('not.be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -172,7 +172,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
     });
 
     describe('when submitting the answer as `yes`', () => {
-      beforeEach(() => {
+      before(() => {
         yesRadio().click();
         submitButton().click();
       });
@@ -184,6 +184,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
       describe('when going back to the page', () => {
         it('should have the originally submitted answer selected', () => {
           partials.backLink().click();
+          cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES);
 
           yesRadioInput().should('be.checked');
         });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -9,6 +9,7 @@ import {
 } from '../../../../../../content-strings';
 import CONSTANTS from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
+import { completeStartForm, completeCheckIfEligibleForm, completeExporterLocationForm } from '../../../../../support/insurance/eligibility/forms';
 import ukGoodsAndServicesCalculateDescription from '../../../../../support/check-uk-goods-and-services-calculate-description';
 import ukGoodsAndServicesDescription from '../../../../../support/check-uk-goods-and-services-description';
 
@@ -17,19 +18,17 @@ const { ROUTES, FIELD_IDS } = CONSTANTS;
 
 context('Insurance - UK goods or services page - as an exporter, I want to check if my export value is eligible for UKEF export insurance cover', () => {
   before(() => {
-    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+    cy.visit(ROUTES.INSURANCE.START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),
       },
     });
 
+    completeStartForm();
+    completeCheckIfEligibleForm();
     completeAndSubmitBuyerCountryForm();
-
-    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION);
-
-    yesRadio().click();
-    submitButton().click();
+    completeExporterLocationForm();
 
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES);
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -172,11 +172,21 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
     });
 
     describe('when submitting the answer as `yes`', () => {
-      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT}`, () => {
+      beforeEach(() => {
         yesRadio().click();
         submitButton().click();
+      });
 
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT}`, () => {
         cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT);
+      });
+
+      describe('when going back to the page', () => {
+        it('should have the originally submitted answer selected', () => {
+          partials.backLink().click();
+
+          yesRadioInput().should('be.checked');
+        });
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
@@ -6,7 +6,7 @@ import { ROUTES } from '../../../../constants';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.START;
 
-context('Insurance - start page', () => {
+context('Insurance Eligibility - start page', () => {
   before(() => {
     cy.visit(ROUTES.INSURANCE.START, {
       auth: {

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -13,6 +13,7 @@ import analytics from '../support/analytics';
 Cypress.Commands.add('login', require('./login'));
 Cypress.Commands.add('checkPhaseBanner', require('./check-phase-banner'));
 
+// TODO: rename
 Cypress.Commands.add('submitAnswersHappyPathSinglePolicy', require('./quote/submit-answers-happy-path-single-policy'));
 Cypress.Commands.add('submitAnswersHappyPathMultiPolicy', require('./quote/submit-answers-happy-path-multi-policy'));
 
@@ -28,3 +29,5 @@ Cypress.Commands.add('checkCookiesConsentBannerIsVisible', analytics.checkCookie
 Cypress.Commands.add('checkCookiesConsentBannerDoesNotExist', analytics.checkCookiesConsentBannerDoesNotExist);
 
 Cypress.Commands.add('rejectAnalyticsCookies', analytics.rejectAnalyticsCookies);
+
+Cypress.Commands.add('submitInsuranceEligibilityAnswersHappyPath', require('./insurance/eligibility/submit-answers-happy-path'));

--- a/e2e-tests/cypress/support/insurance/eligibility/forms.js
+++ b/e2e-tests/cypress/support/insurance/eligibility/forms.js
@@ -1,0 +1,51 @@
+import { yesRadio, noRadio, submitButton } from '../../../e2e/pages/shared';
+
+export const completeStartForm = () => {
+  submitButton().click();
+};
+
+export const completeCheckIfEligibleForm = () => {
+  submitButton().click();
+};
+
+export const completeExporterLocationForm = () => {
+  yesRadio().click();
+  submitButton().click();
+};
+
+export const completeUkGoodsAndServicesForm = () => {
+  yesRadio().click();
+  submitButton().click();
+};
+
+export const completeInsuredAmountForm = () => {
+  noRadio().click();
+  submitButton().click();
+};
+
+export const completeInsuredPeriodForm = () => {
+  noRadio().click();
+  submitButton().click();
+};
+
+export const completeOtherPartiesForm = () => {
+  noRadio().click();
+  submitButton().click();
+};
+
+export const completeLetterOfCreditForm = () => {
+  noRadio().click();
+  submitButton().click();
+};
+
+export const completePreCreditPeriodForm = () => {
+  noRadio().click();
+  submitButton().click();
+};
+
+export const completeCompaniesHouseNumberForm = () => {
+  yesRadio().click();
+  submitButton().click();
+};
+
+

--- a/e2e-tests/cypress/support/insurance/eligibility/submit-answers-happy-path.js
+++ b/e2e-tests/cypress/support/insurance/eligibility/submit-answers-happy-path.js
@@ -1,0 +1,27 @@
+import {
+  completeStartForm,
+  completeCheckIfEligibleForm,
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+  completeInsuredPeriodForm,
+  completeOtherPartiesForm,
+  completeLetterOfCreditForm,
+  completePreCreditPeriodForm,
+  completeCompaniesHouseNumberForm,
+} from './forms';
+import { completeAndSubmitBuyerCountryForm } from '../../forms'
+
+export default () => {
+  completeStartForm();
+  completeCheckIfEligibleForm();
+  completeAndSubmitBuyerCountryForm();
+  completeExporterLocationForm();
+  completeUkGoodsAndServicesForm();
+  completeInsuredAmountForm();
+  completeInsuredPeriodForm();
+  completeOtherPartiesForm();
+  completeLetterOfCreditForm();
+  completePreCreditPeriodForm();
+  completeCompaniesHouseNumberForm();
+};

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
@@ -66,6 +66,7 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
         BACK_LINK: req.headers.referer,
         HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
         countries: mapCountries(mockCountriesResponse),
+        submittedValues: req.session.submittedData.insuranceEligibility,
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATES.SHARED_PAGES.BUYER_COUNTRY, expectedVariables);
@@ -84,6 +85,7 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
           BACK_LINK: req.headers.referer,
           HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
           countries: expectedCountries,
+          submittedValues: req.session.submittedData.insuranceEligibility,
         };
 
         expect(res.render).toHaveBeenCalledWith(TEMPLATES.SHARED_PAGES.BUYER_COUNTRY, expectedVariables);

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
@@ -188,9 +188,12 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
           },
         };
 
-        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+        const expected = {
+          ...req.session.submittedData,
+          insuranceEligibility: updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility),
+        };
 
-        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
+        expect(req.session.submittedData).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION}`, async () => {

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
@@ -75,7 +75,10 @@ export const post = async (req: Request, res: Response) => {
       },
     };
 
-    req.session.submittedData.insuranceEligibility = updateSubmittedData(populatedData, req.session.submittedData.insuranceEligibility);
+    req.session.submittedData = {
+      ...req.session.submittedData,
+      insuranceEligibility: updateSubmittedData(populatedData, req.session.submittedData.insuranceEligibility),
+    };
 
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION);
   }

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
@@ -32,6 +32,7 @@ export const get = async (req: Request, res: Response) => {
     }),
     HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
     countries: mappedCountries,
+    submittedValues: req.session.submittedData.insuranceEligibility,
   });
 };
 

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
@@ -6,10 +6,13 @@ import singleInputPageVariables from '../../../../helpers/page-variables/single-
 import { validation as generateValidationErrors } from '../../../../shared-validation/buyer-country';
 import getCountryByName from '../../../../helpers/get-country-by-name';
 import { canApplyOnline, canApplyOffline, cannotApply } from '../../../../helpers/country-support';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 
+const FIELD_ID = FIELD_IDS.COUNTRY;
+
 export const PAGE_VARIABLES = {
-  FIELD_ID: FIELD_IDS.COUNTRY,
+  FIELD_ID,
   PAGE_CONTENT_STRINGS: PAGES.BUYER_COUNTRY,
 };
 
@@ -64,6 +67,16 @@ export const post = async (req: Request, res: Response) => {
   }
 
   if (canApplyOnline(country)) {
+    const populatedData = {
+      [FIELD_IDS.BUYER_COUNTRY]: {
+        name: country.name,
+        isoCode: country.isoCode,
+        riskCategory: country.riskCategory,
+      },
+    };
+
+    req.session.submittedData.insuranceEligibility = updateSubmittedData(populatedData, req.session.submittedData.insuranceEligibility);
+
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION);
   }
 

--- a/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.test.ts
@@ -87,9 +87,12 @@ describe('controllers/insurance/eligibility/companies-house-number', () => {
           [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
         };
 
-        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+        const expected = {
+          ...req.session.submittedData,
+          insuranceEligibility: updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility),
+        };
 
-        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
+        expect(req.session.submittedData).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.test.ts
@@ -3,6 +3,7 @@ import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes } from '../../../../test-mocks';
 
@@ -56,14 +57,14 @@ describe('controllers/insurance/eligibility/companies-house-number', () => {
         };
       });
 
-      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE}`, async () => {
-        await post(req, res);
+      it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE}`, () => {
+        post(req, res);
 
         expect(res.redirect).toHaveBeenCalledWith(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
       });
 
-      it('should add exitReason to req.flash', async () => {
-        await post(req, res);
+      it('should add exitReason to req.flash', () => {
+        post(req, res);
 
         const expectedReason = PAGES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE.REASON.NO_COMPANIES_HOUSE_NUMBER;
         expect(req.flash).toHaveBeenCalledWith('exitReason', expectedReason);
@@ -77,6 +78,18 @@ describe('controllers/insurance/eligibility/companies-house-number', () => {
 
       beforeEach(() => {
         req.body = validBody;
+      });
+
+      it('should update the session with submitted data, populated with the answer', () => {
+        post(req, res);
+
+        const expectedPopulatedData = {
+          [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
+        };
+
+        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+
+        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.test.ts
@@ -31,10 +31,10 @@ describe('controllers/insurance/eligibility/companies-house-number', () => {
     it('should render template', () => {
       get(req, res);
 
-      expect(res.render).toHaveBeenCalledWith(
-        TEMPLATES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER,
-        singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
-      );
+      expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER, {
+        ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+        submittedValues: req.session.submittedData.insuranceEligibility,
+      });
     });
   });
 

--- a/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.ts
@@ -2,6 +2,7 @@ import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 
 const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER;
@@ -38,6 +39,8 @@ const post = (req: Request, res: Response) => {
 
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   }
+
+  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE);
 };

--- a/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.ts
@@ -13,7 +13,10 @@ const PAGE_VARIABLES = {
 };
 
 const get = (req: Request, res: Response) =>
-  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER, singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }));
+  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER, {
+    ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+    submittedValues: req.session.submittedData.insuranceEligibility,
+  });
 
 const post = (req: Request, res: Response) => {
   const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY);

--- a/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/companies-house-number/index.ts
@@ -40,7 +40,10 @@ const post = (req: Request, res: Response) => {
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   }
 
-  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
+  req.session.submittedData = {
+    ...req.session.submittedData,
+    insuranceEligibility: updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility),
+  };
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE);
 };

--- a/src/ui/server/controllers/insurance/eligibility/exporter-location/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/exporter-location/index.test.ts
@@ -87,9 +87,12 @@ describe('controllers/insurance/eligibility/exporter-location', () => {
           [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
         };
 
-        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+        const expected = {
+          ...req.session.submittedData,
+          insuranceEligibility: updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility),
+        };
 
-        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
+        expect(req.session.submittedData).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/exporter-location/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/exporter-location/index.test.ts
@@ -31,10 +31,10 @@ describe('controllers/insurance/eligibility/exporter-location', () => {
     it('should render template', () => {
       get(req, res);
 
-      expect(res.render).toHaveBeenCalledWith(
-        TEMPLATES.SHARED_PAGES.EXPORTER_LOCATION,
-        singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
-      );
+      expect(res.render).toHaveBeenCalledWith(TEMPLATES.SHARED_PAGES.EXPORTER_LOCATION, {
+        ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+        submittedValues: req.session.submittedData.insuranceEligibility,
+      });
     });
   });
 

--- a/src/ui/server/controllers/insurance/eligibility/exporter-location/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/exporter-location/index.test.ts
@@ -3,6 +3,7 @@ import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes } from '../../../../test-mocks';
 
@@ -77,6 +78,18 @@ describe('controllers/insurance/eligibility/exporter-location', () => {
 
       beforeEach(() => {
         req.body = validBody;
+      });
+
+      it('should update the session with submitted data, populated with the answer', () => {
+        post(req, res);
+
+        const expectedPopulatedData = {
+          [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
+        };
+
+        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+
+        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/exporter-location/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/exporter-location/index.ts
@@ -2,6 +2,7 @@ import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 
 const FIELD_ID = FIELD_IDS.VALID_EXPORTER_LOCATION;
@@ -34,6 +35,8 @@ const post = (req: Request, res: Response) => {
 
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY);
   }
+
+  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES);
 };

--- a/src/ui/server/controllers/insurance/eligibility/exporter-location/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/exporter-location/index.ts
@@ -36,7 +36,10 @@ const post = (req: Request, res: Response) => {
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY);
   }
 
-  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
+  req.session.submittedData = {
+    ...req.session.submittedData,
+    insuranceEligibility: updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility),
+  };
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES);
 };

--- a/src/ui/server/controllers/insurance/eligibility/exporter-location/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/exporter-location/index.ts
@@ -13,7 +13,10 @@ const PAGE_VARIABLES = {
 };
 
 const get = (req: Request, res: Response) =>
-  res.render(TEMPLATES.SHARED_PAGES.EXPORTER_LOCATION, singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }));
+  res.render(TEMPLATES.SHARED_PAGES.EXPORTER_LOCATION, {
+    ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+    submittedValues: req.session.submittedData.insuranceEligibility,
+  });
 
 const post = (req: Request, res: Response) => {
   const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES[FIELD_ID]);

--- a/src/ui/server/controllers/insurance/eligibility/insured-amount/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/insured-amount/index.test.ts
@@ -87,9 +87,12 @@ describe('controllers/insurance/eligibility/insured-amount', () => {
           [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
         };
 
-        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+        const expected = {
+          ...req.session.submittedData,
+          insuranceEligibility: updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility),
+        };
 
-        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
+        expect(req.session.submittedData).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/insured-amount/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/insured-amount/index.test.ts
@@ -31,10 +31,10 @@ describe('controllers/insurance/eligibility/insured-amount', () => {
     it('should render template', () => {
       get(req, res);
 
-      expect(res.render).toHaveBeenCalledWith(
-        TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT,
-        singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
-      );
+      expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT, {
+        ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+        submittedValues: req.session.submittedData.insuranceEligibility,
+      });
     });
   });
 

--- a/src/ui/server/controllers/insurance/eligibility/insured-amount/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/insured-amount/index.test.ts
@@ -3,6 +3,7 @@ import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes } from '../../../../test-mocks';
 
@@ -77,6 +78,18 @@ describe('controllers/insurance/eligibility/insured-amount', () => {
 
       beforeEach(() => {
         req.body = validBody;
+      });
+
+      it('should update the session with submitted data, populated with the answer', () => {
+        post(req, res);
+
+        const expectedPopulatedData = {
+          [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
+        };
+
+        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+
+        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/insured-amount/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/insured-amount/index.ts
@@ -40,7 +40,10 @@ const post = (req: Request, res: Response) => {
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   }
 
-  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
+  req.session.submittedData = {
+    ...req.session.submittedData,
+    insuranceEligibility: updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility),
+  };
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD);
 };

--- a/src/ui/server/controllers/insurance/eligibility/insured-amount/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/insured-amount/index.ts
@@ -13,7 +13,10 @@ const PAGE_VARIABLES = {
 };
 
 const get = (req: Request, res: Response) =>
-  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT, singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }));
+  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT, {
+    ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+    submittedValues: req.session.submittedData.insuranceEligibility,
+  });
 
 const post = (req: Request, res: Response) => {
   const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY);

--- a/src/ui/server/controllers/insurance/eligibility/insured-amount/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/insured-amount/index.ts
@@ -2,6 +2,7 @@ import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 
 const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_AMOUNT;
@@ -38,6 +39,8 @@ const post = (req: Request, res: Response) => {
 
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   }
+
+  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD);
 };

--- a/src/ui/server/controllers/insurance/eligibility/insured-period/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/insured-period/index.test.ts
@@ -3,6 +3,7 @@ import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes } from '../../../../test-mocks';
 
@@ -77,6 +78,18 @@ describe('controllers/insurance/eligibility/insured-period', () => {
 
       beforeEach(() => {
         req.body = validBody;
+      });
+
+      it('should update the session with submitted data, populated with the answer', () => {
+        post(req, res);
+
+        const expectedPopulatedData = {
+          [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
+        };
+
+        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+
+        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/insured-period/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/insured-period/index.test.ts
@@ -31,10 +31,10 @@ describe('controllers/insurance/eligibility/insured-period', () => {
     it('should render template', () => {
       get(req, res);
 
-      expect(res.render).toHaveBeenCalledWith(
-        TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
-        singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
-      );
+      expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, {
+        ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+        submittedValues: req.session.submittedData.insuranceEligibility,
+      });
     });
   });
 

--- a/src/ui/server/controllers/insurance/eligibility/insured-period/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/insured-period/index.test.ts
@@ -87,9 +87,12 @@ describe('controllers/insurance/eligibility/insured-period', () => {
           [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
         };
 
-        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+        const expected = {
+          ...req.session.submittedData,
+          insuranceEligibility: updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility),
+        };
 
-        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
+        expect(req.session.submittedData).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/insured-period/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/insured-period/index.ts
@@ -2,6 +2,7 @@ import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 
 const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_PERIOD;
@@ -38,6 +39,8 @@ const post = (req: Request, res: Response) => {
 
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM);
   }
+
+  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED);
 };

--- a/src/ui/server/controllers/insurance/eligibility/insured-period/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/insured-period/index.ts
@@ -40,7 +40,10 @@ const post = (req: Request, res: Response) => {
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.SPEAK_TO_UKEF_EFM);
   }
 
-  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
+  req.session.submittedData = {
+    ...req.session.submittedData,
+    insuranceEligibility: updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility),
+  };
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED);
 };

--- a/src/ui/server/controllers/insurance/eligibility/insured-period/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/insured-period/index.ts
@@ -13,7 +13,10 @@ const PAGE_VARIABLES = {
 };
 
 const get = (req: Request, res: Response) =>
-  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }));
+  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.INSURED_PERIOD, {
+    ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+    submittedValues: req.session.submittedData.insuranceEligibility,
+  });
 
 const post = (req: Request, res: Response) => {
   const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY);

--- a/src/ui/server/controllers/insurance/eligibility/letter-of-credit/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/letter-of-credit/index.test.ts
@@ -3,6 +3,7 @@ import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes } from '../../../../test-mocks';
 
@@ -77,6 +78,18 @@ describe('controllers/insurance/eligibility/letter-of-credit', () => {
 
       beforeEach(() => {
         req.body = validBody;
+      });
+
+      it('should update the session with submitted data, populated with the answer', () => {
+        post(req, res);
+
+        const expectedPopulatedData = {
+          [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
+        };
+
+        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+
+        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/letter-of-credit/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/letter-of-credit/index.test.ts
@@ -31,10 +31,10 @@ describe('controllers/insurance/eligibility/letter-of-credit', () => {
     it('should render template', () => {
       get(req, res);
 
-      expect(res.render).toHaveBeenCalledWith(
-        TEMPLATES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT,
-        singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
-      );
+      expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT, {
+        ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+        submittedValues: req.session.submittedData.insuranceEligibility,
+      });
     });
   });
 

--- a/src/ui/server/controllers/insurance/eligibility/letter-of-credit/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/letter-of-credit/index.test.ts
@@ -87,9 +87,12 @@ describe('controllers/insurance/eligibility/letter-of-credit', () => {
           [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
         };
 
-        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+        const expected = {
+          ...req.session.submittedData,
+          insuranceEligibility: updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility),
+        };
 
-        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
+        expect(req.session.submittedData).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/letter-of-credit/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/letter-of-credit/index.ts
@@ -2,6 +2,7 @@ import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 
 const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT;
@@ -38,6 +39,8 @@ const post = (req: Request, res: Response) => {
 
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   }
+
+  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD);
 };

--- a/src/ui/server/controllers/insurance/eligibility/letter-of-credit/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/letter-of-credit/index.ts
@@ -13,7 +13,10 @@ const PAGE_VARIABLES = {
 };
 
 const get = (req: Request, res: Response) =>
-  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT, singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }));
+  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT, {
+    ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+    submittedValues: req.session.submittedData.insuranceEligibility,
+  });
 
 const post = (req: Request, res: Response) => {
   const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY);

--- a/src/ui/server/controllers/insurance/eligibility/letter-of-credit/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/letter-of-credit/index.ts
@@ -40,7 +40,10 @@ const post = (req: Request, res: Response) => {
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   }
 
-  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
+  req.session.submittedData = {
+    ...req.session.submittedData,
+    insuranceEligibility: updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility),
+  };
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD);
 };

--- a/src/ui/server/controllers/insurance/eligibility/other-parties/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/other-parties/index.test.ts
@@ -87,9 +87,12 @@ describe('controllers/insurance/eligibility/other-parties', () => {
           [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
         };
 
-        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+        const expected = {
+          ...req.session.submittedData,
+          insuranceEligibility: updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility),
+        };
 
-        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
+        expect(req.session.submittedData).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/other-parties/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/other-parties/index.test.ts
@@ -31,10 +31,10 @@ describe('controllers/insurance/eligibility/other-parties', () => {
     it('should render template', () => {
       get(req, res);
 
-      expect(res.render).toHaveBeenCalledWith(
-        TEMPLATES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED,
-        singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
-      );
+      expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED, {
+        ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+        submittedValues: req.session.submittedData.insuranceEligibility,
+      });
     });
   });
 

--- a/src/ui/server/controllers/insurance/eligibility/other-parties/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/other-parties/index.test.ts
@@ -3,6 +3,7 @@ import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes } from '../../../../test-mocks';
 
@@ -77,6 +78,18 @@ describe('controllers/insurance/eligibility/other-parties', () => {
 
       beforeEach(() => {
         req.body = validBody;
+      });
+
+      it('should update the session with submitted data, populated with the answer', () => {
+        post(req, res);
+
+        const expectedPopulatedData = {
+          [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
+        };
+
+        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+
+        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/other-parties/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/other-parties/index.ts
@@ -13,7 +13,10 @@ const PAGE_VARIABLES = {
 };
 
 const get = (req: Request, res: Response) =>
-  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED, singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }));
+  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED, {
+    ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+    submittedValues: req.session.submittedData.insuranceEligibility,
+  });
 
 const post = (req: Request, res: Response) => {
   const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY);

--- a/src/ui/server/controllers/insurance/eligibility/other-parties/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/other-parties/index.ts
@@ -40,7 +40,10 @@ const post = (req: Request, res: Response) => {
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   }
 
-  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
+  req.session.submittedData = {
+    ...req.session.submittedData,
+    insuranceEligibility: updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility),
+  };
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT);
 };

--- a/src/ui/server/controllers/insurance/eligibility/other-parties/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/other-parties/index.ts
@@ -2,6 +2,7 @@ import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 
 const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED;
@@ -38,6 +39,8 @@ const post = (req: Request, res: Response) => {
 
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   }
+
+  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT);
 };

--- a/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.test.ts
@@ -3,6 +3,7 @@ import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes } from '../../../../test-mocks';
 
@@ -77,6 +78,18 @@ describe('controllers/insurance/eligibility/pre-credit-period', () => {
 
       beforeEach(() => {
         req.body = validBody;
+      });
+
+      it('should update the session with submitted data, populated with the answer', () => {
+        post(req, res);
+
+        const expectedPopulatedData = {
+          [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
+        };
+
+        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+
+        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.test.ts
@@ -31,10 +31,10 @@ describe('controllers/insurance/eligibility/pre-credit-period', () => {
     it('should render template', () => {
       get(req, res);
 
-      expect(res.render).toHaveBeenCalledWith(
-        TEMPLATES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD,
-        singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
-      );
+      expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD, {
+        ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+        submittedValues: req.session.submittedData.insuranceEligibility,
+      });
     });
   });
 

--- a/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.test.ts
@@ -87,9 +87,12 @@ describe('controllers/insurance/eligibility/pre-credit-period', () => {
           [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
         };
 
-        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+        const expected = {
+          ...req.session.submittedData,
+          insuranceEligibility: updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility),
+        };
 
-        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
+        expect(req.session.submittedData).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.ts
@@ -40,7 +40,10 @@ const post = (req: Request, res: Response) => {
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   }
 
-  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
+  req.session.submittedData = {
+    ...req.session.submittedData,
+    insuranceEligibility: updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility),
+  };
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER);
 };

--- a/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.ts
@@ -2,6 +2,7 @@ import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 
 const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD;
@@ -38,6 +39,8 @@ const post = (req: Request, res: Response) => {
 
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.APPLY_OFFLINE);
   }
+
+  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER);
 };

--- a/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/pre-credit-period/index.ts
@@ -13,7 +13,10 @@ const PAGE_VARIABLES = {
 };
 
 const get = (req: Request, res: Response) =>
-  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD, singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }));
+  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD, {
+    ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+    submittedValues: req.session.submittedData.insuranceEligibility,
+  });
 
 const post = (req: Request, res: Response) => {
   const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY);

--- a/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.test.ts
@@ -35,10 +35,10 @@ describe('controllers/insurance/eligibility/uk-goods-or-services', () => {
     it('should render template', () => {
       get(req, res);
 
-      expect(res.render).toHaveBeenCalledWith(
-        TEMPLATES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES,
-        singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
-      );
+      expect(res.render).toHaveBeenCalledWith(TEMPLATES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES, {
+        ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+        submittedValues: req.session.submittedData.insuranceEligibility,
+      });
     });
   });
 

--- a/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.test.ts
@@ -3,6 +3,7 @@ import { PAGES, UK_GOODS_AND_SERVICES_CALCULATE_DESCRIPTION, UK_GOODS_AND_SERVIC
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes } from '../../../../test-mocks';
 
@@ -81,6 +82,18 @@ describe('controllers/insurance/eligibility/uk-goods-or-services', () => {
 
       beforeEach(() => {
         req.body = validBody;
+      });
+
+      it('should update the session with submitted data, populated with the answer', () => {
+        post(req, res);
+
+        const expectedPopulatedData = {
+          [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
+        };
+
+        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+
+        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.test.ts
@@ -91,9 +91,12 @@ describe('controllers/insurance/eligibility/uk-goods-or-services', () => {
           [PAGE_VARIABLES.FIELD_ID]: validBody[PAGE_VARIABLES.FIELD_ID],
         };
 
-        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility);
+        const expected = {
+          ...req.session.submittedData,
+          insuranceEligibility: updateSubmittedData(expectedPopulatedData, req.session.submittedData.insuranceEligibility),
+        };
 
-        expect(req.session.submittedData.insuranceEligibility).toEqual(expected);
+        expect(req.session.submittedData).toEqual(expected);
       });
 
       it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT}`, () => {

--- a/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.ts
@@ -2,6 +2,7 @@ import { PAGES, UK_GOODS_AND_SERVICES_CALCULATE_DESCRIPTION, UK_GOODS_AND_SERVIC
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 
 const FIELD_ID = FIELD_IDS.HAS_MINIMUM_UK_GOODS_OR_SERVICES;
@@ -41,6 +42,8 @@ const post = (req: Request, res: Response) => {
 
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY);
   }
+
+  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT);
 };

--- a/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.ts
@@ -43,7 +43,10 @@ const post = (req: Request, res: Response) => {
     return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY);
   }
 
-  req.session.submittedData.insuranceEligibility = updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility);
+  req.session.submittedData = {
+    ...req.session.submittedData,
+    insuranceEligibility: updateSubmittedData({ [FIELD_ID]: answer }, req.session.submittedData.insuranceEligibility),
+  };
 
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT);
 };

--- a/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/uk-goods-or-services/index.ts
@@ -17,7 +17,10 @@ const PAGE_VARIABLES = {
 };
 
 const get = (req: Request, res: Response) =>
-  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES, singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }));
+  res.render(TEMPLATES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES, {
+    ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer }),
+    submittedValues: req.session.submittedData.insuranceEligibility,
+  });
 
 const post = (req: Request, res: Response) => {
   const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES[FIELD_ID].IS_EMPTY);

--- a/src/ui/server/controllers/insurance/start/index.test.ts
+++ b/src/ui/server/controllers/insurance/start/index.test.ts
@@ -1,7 +1,7 @@
 import { get, post } from '.';
 import { PAGES } from '../../../content-strings';
-import { ROUTES, TEMPLATES } from '../../../constants';
 import insuranceCorePageVariables from '../../../helpers/page-variables/core/insurance';
+import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
 import { mockReq, mockRes } from '../../../test-mocks';
 import { Request, Response } from '../../../../types';
 
@@ -15,6 +15,28 @@ describe('controllers/insurance/start', () => {
   });
 
   describe('get', () => {
+    it('should add an empty submittedData object to the session', () => {
+      req.session = {
+        submittedData: {
+          quoteEligibility: {
+            [FIELD_IDS.CREDIT_PERIOD]: 1,
+          },
+          insuranceEligibility: {
+            [FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER]: true,
+          },
+        },
+      };
+
+      get(req, res);
+
+      expect(req.session.submittedData).toEqual({
+        quoteEligibility: {
+          [FIELD_IDS.CREDIT_PERIOD]: 1,
+        },
+        insuranceEligibility: {},
+      });
+    });
+
     it('should render template', () => {
       get(req, res);
 

--- a/src/ui/server/controllers/insurance/start/index.ts
+++ b/src/ui/server/controllers/insurance/start/index.ts
@@ -3,13 +3,20 @@ import { ROUTES, TEMPLATES } from '../../../constants';
 import { Request, Response } from '../../../../types';
 import insuranceCorePageVariables from '../../../helpers/page-variables/core/insurance';
 
-const get = (req: Request, res: Response) =>
-  res.render(TEMPLATES.INSURANCE.START, {
+const get = (req: Request, res: Response) => {
+  // new insurance eligibility data in session
+  req.session.submittedData = {
+    ...req.session.submittedData,
+    insuranceEligibility: {},
+  };
+
+  return res.render(TEMPLATES.INSURANCE.START, {
     ...insuranceCorePageVariables({
       PAGE_CONTENT_STRINGS: PAGES.INSURANCE.START,
       BACK_LINK: req.headers.referer,
     }),
   });
+};
 
 const post = (req: Request, res: Response) => {
   return res.redirect(ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE);

--- a/src/ui/server/controllers/root/index.test.ts
+++ b/src/ui/server/controllers/root/index.test.ts
@@ -19,7 +19,9 @@ describe('controllers/root', () => {
           quoteEligibility: {
             [FIELD_IDS.CREDIT_PERIOD]: 1,
           },
-          insuranceEligibility: {},
+          insuranceEligibility: {
+            [FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER]: true,
+          },
         },
       };
 
@@ -27,7 +29,9 @@ describe('controllers/root', () => {
 
       expect(req.session.submittedData).toEqual({
         quoteEligibility: {},
-        insuranceEligibility: {},
+        insuranceEligibility: {
+          [FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER]: true,
+        },
       });
     });
 

--- a/src/ui/server/controllers/root/index.ts
+++ b/src/ui/server/controllers/root/index.ts
@@ -2,10 +2,10 @@ import { ROUTES } from '../../constants';
 import { Request, Response } from '../../../types';
 
 const get = (req: Request, res: Response) => {
-  // new submitted data session
+  // new quote eligibility data in session
   req.session.submittedData = {
+    ...req.session.submittedData,
     quoteEligibility: {},
-    insuranceEligibility: {},
   };
 
   return res.redirect(ROUTES.QUOTE.BUYER_COUNTRY);

--- a/src/ui/server/helpers/update-submitted-data/insurance/index.test.ts
+++ b/src/ui/server/helpers/update-submitted-data/insurance/index.test.ts
@@ -1,0 +1,77 @@
+import { updateSubmittedData } from '.';
+import { sanitiseData } from '../../sanitise-data';
+import { RequestBody, SubmittedDataInsuranceEligibility } from '../../../../types';
+
+describe('server/helpers/update-submitted-data/insurance', () => {
+  describe('updateSubmittedData', () => {
+    describe('when there is existing data', () => {
+      it('should return an object with existing and new, sanitised form data', () => {
+        const mockFormData = {
+          a: true,
+        } as RequestBody;
+
+        const mockExistingData = {
+          mock: true,
+        } as SubmittedDataInsuranceEligibility;
+
+        const result = updateSubmittedData(mockFormData, mockExistingData);
+
+        const expected = sanitiseData({
+          ...mockExistingData,
+          ...mockFormData,
+        });
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('when there is no existing data', () => {
+      it('should return an object with new, sanitised form data', () => {
+        const mockFormData = {
+          a: true,
+        } as RequestBody;
+
+        const mockExistingData = {};
+
+        const result = updateSubmittedData(mockFormData, mockExistingData);
+
+        const expected = sanitiseData({
+          ...mockExistingData,
+          ...mockFormData,
+        });
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    it('should not return _csrf from provided form data', () => {
+      const mockFormData = {
+        _csrf: '123',
+        a: true,
+      } as RequestBody;
+
+      const mockExistingData = {};
+
+      const result = updateSubmittedData(mockFormData, mockExistingData);
+
+      const expected = sanitiseData({
+        ...mockExistingData,
+        a: true,
+      });
+
+      expect(result).toEqual(expected);
+    });
+
+    describe('when there is no existing or provided data', () => {
+      it('should return empty object', () => {
+        const mockFormData = {
+          _csrf: '123',
+        } as RequestBody;
+
+        const result = updateSubmittedData(mockFormData, {});
+
+        expect(result).toEqual({});
+      });
+    });
+  });
+});

--- a/src/ui/server/helpers/update-submitted-data/insurance/index.ts
+++ b/src/ui/server/helpers/update-submitted-data/insurance/index.ts
@@ -1,0 +1,22 @@
+import { sanitiseData } from '../../sanitise-data';
+import { RequestBody, SubmittedDataInsuranceEligibility } from '../../../../types';
+
+/*
+ * updateSubmittedData
+ * update insurance eligibility session data with sanitised form data
+ */
+const updateSubmittedData = (formData: RequestBody, existingData?: SubmittedDataInsuranceEligibility): SubmittedDataInsuranceEligibility => {
+  const submittedFormData = formData;
+  delete submittedFormData._csrf;
+
+  const modifiedData = {
+    ...existingData,
+    ...submittedFormData,
+  };
+
+  const sanitised = sanitiseData(modifiedData);
+
+  return sanitised;
+};
+
+export { updateSubmittedData };

--- a/src/ui/server/helpers/update-submitted-data/quote/index.test.ts
+++ b/src/ui/server/helpers/update-submitted-data/quote/index.test.ts
@@ -5,7 +5,7 @@ import { RequestBody, SubmittedDataQuoteEligibility } from '../../../../types';
 
 const { CREDIT_PERIOD, CONTRACT_VALUE, MAX_AMOUNT_OWED, MULTI_POLICY_LENGTH, POLICY_LENGTH, POLICY_TYPE } = FIELD_IDS;
 
-describe('server/helpers/update-submitted-data', () => {
+describe('server/helpers/update-submitted-data/quote', () => {
   describe('mapSubmittedData', () => {
     describe(`when ${POLICY_TYPE} is 'single'`, () => {
       it('should return policy length field with single specific fields', () => {

--- a/src/ui/server/helpers/update-submitted-data/quote/index.ts
+++ b/src/ui/server/helpers/update-submitted-data/quote/index.ts
@@ -38,7 +38,7 @@ const mapSubmittedData = (submittedData: SubmittedDataQuoteEligibility): Submitt
 
 /*
  * updateSubmittedData
- * update session data with sanitised form data
+ * update quote eligibility session data with sanitised form data
  */
 const updateSubmittedData = (formData: RequestBody, existingData?: SubmittedDataQuoteEligibility): SubmittedDataQuoteEligibility => {
   const submittedFormData = formData;

--- a/src/ui/templates/components/yes-no-radio-buttons.njk
+++ b/src/ui/templates/components/yes-no-radio-buttons.njk
@@ -38,6 +38,9 @@
             "data-cy": "no"
           }
         },
+        attributes: {
+          "data-cy": "no-input"
+        },
         checked: submittedAnswer === false
       }
     ],

--- a/src/ui/types/submitted-data.d.ts
+++ b/src/ui/types/submitted-data.d.ts
@@ -1,23 +1,31 @@
 import { Country } from './country';
 import { Currency } from './currency';
 
-type SubmittedDataQuoteEligibility = {
-  amount?: number;
+type SharedEligibility = {
   buyerCountry?: Country;
+  hasMinimumUkGoodsOrServices?: boolean;
+  validExporterLocation?: boolean;
+};
+
+interface SubmittedDataQuoteEligibility extends SharedEligibility {
+  amount?: number;
   contractValue?: number;
   creditPeriodInMonths?: number;
   currency?: Currency;
-  hasMinimumUkGoodsOrServices?: boolean;
   maximumContractAmountOwed?: number;
   percentageOfCover?: number;
   policyType?: string;
   policyLength?: number;
-};
+}
 
-type SubmittedDataInsuranceEligibility = {
+interface SubmittedDataInsuranceEligibility extends SharedEligibility {
+  haveCompaniesHouseNumber?: boolean;
+  otherPartiesInvolved?: boolean;
+  paidByLetterOfCredit?: boolean;
+  needPreCreditPeriodCover?: boolean;
   wantCoverOverMaxAmount?: boolean;
   wantCoverOverMaxPeriod?: boolean;
-};
+}
 
 type SubmittedData = {
   quoteEligibility: SubmittedDataQuoteEligibility;


### PR DESCRIPTION
This PR saves all insurance eligibility answers in local session storage, under `req.session.submittedData.insuranceEligibility`.

## Changes
- Extract `update-submitted-data` into `quote/` and `insurance/`directories
- Call `updateSubmittedData` in all insurance eligibility POSTs when a user is _not_ taken to an exit page.
- Add E2E tests to ensure that submitted data is passed to the page when navigating back.
- Create E2E helper functions to complete each form in the insurance eligibility flow.
- Update all E2E tests for insurance eligibility to go through the actual user flow page by page instead of navigating directly.