### PR TITLE
fix(EMS-523): Buyer country change not updating and not rendering in Insurance eligibility when previously submitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.14.4](https://github.com/UK-Export-Finance/exip/compare/v1.14.3...v1.14.4) (2022-10-28)
+
+
+### Bug Fixes
+
+* **EMS-378:** update Content-Security-Policy to allow GA scripts ([c0539e4](https://github.com/UK-Export-Finance/exip/commit/c0539e443f2725e0a9b7ec653782296f0611e686))
+
+## [1.14.3](https://github.com/UK-Export-Finance/exip/compare/v1.14.2...v1.14.3) (2022-10-27)
+
+
+### Bug Fixes
+
+* **EMS-379:** fix issue where buyer country would not update when JS is disabled ([#141](https://github.com/UK-Export-Finance/exip/issues/141)) ([397378b](https://github.com/UK-Export-Finance/exip/commit/397378b18638f8a14e579437a0a4ad966c2bfb8e))
+
 ## [1.14.2](https://github.com/UK-Export-Finance/exip/compare/v1.14.1...v1.14.2) (2022-10-20)
 
 

--- a/e2e-tests/constants/field-ids.js
+++ b/e2e-tests/constants/field-ids.js
@@ -3,7 +3,6 @@ const FIELD_IDS = {
   VALID_BUYER_BODY: 'validBuyerBody',
   VALID_EXPORTER_LOCATION: 'validExporterLocation',
   BUYER_COUNTRY: 'buyerCountry',
-  COUNTRY: 'country',
   HAS_MINIMUM_UK_GOODS_OR_SERVICES: 'hasMinimumUkGoodsOrServices',
   AMOUNT_CURRENCY: 'amountAndCurrency',
   CURRENCY: 'currency',

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -9,7 +9,6 @@ const MAX_COVER_AMOUNT = PRODUCT.MAX_COVER_AMOUNT_IN_GBP.toLocaleString('en', {
 
 const ERROR_MESSAGES = {
   [FIELD_IDS.BUYER_COUNTRY]: 'Select where your buyer is based',
-  [FIELD_IDS.COUNTRY]: 'Select where your buyer is based',
   [FIELD_IDS.VALID_BUYER_BODY]: 'Select if your buyer is a government or public sector body',
   [FIELD_IDS.VALID_EXPORTER_LOCATION]: 'Select if your company is based in the UK, Channel Islands, Isle of Man or not',
   [FIELD_IDS.HAS_MINIMUM_UK_GOODS_OR_SERVICES]: {

--- a/e2e-tests/content-strings/fields.js
+++ b/e2e-tests/content-strings/fields.js
@@ -3,17 +3,15 @@ const FIELD_VALUES = require('../constants/field-values');
 const LINKS = require('./links');
 
 const FIELDS = {
-  [FIELD_IDS.COUNTRY]: {
+  [FIELD_IDS.BUYER_COUNTRY]: {
     HINT: 'Cover is based on the country your buyer is located in, not the destination of your goods or services.',
+    SUMMARY: {
+      TITLE: 'Buyer is based in',
+    },
   },
   [FIELD_IDS.VALID_EXPORTER_LOCATION]: {
     SUMMARY: {
       TITLE: 'Your company',
-    },
-  },
-  [FIELD_IDS.BUYER_COUNTRY]: {
-    SUMMARY: {
-      TITLE: 'Buyer is based in',
     },
   },
   [FIELD_IDS.HAS_MINIMUM_UK_GOODS_OR_SERVICES]: {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-country-only-apply-offline.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-country-only-apply-offline.spec.js
@@ -50,7 +50,7 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
     it('should NOT have the originally submitted answer selected', () => {
       partials.backLink().click();
 
-      buyerCountryPage.hiddenInput().should('not.have.attr', 'value', COUNTRY_NAME_APPLY_OFFLINE_ONLY);
+      buyerCountryPage.results().should('have.length', 0);
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-unsupported-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-unsupported-country.spec.js
@@ -62,7 +62,7 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
     it('should NOT have the originally submitted answer selected', () => {
       partials.backLink().click();
 
-      buyerCountryPage.hiddenInput().should('not.have.attr', 'value', COUNTRY_NAME_UNSUPPORTED);
+      buyerCountryPage.results().should('have.length', 0);
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
@@ -87,10 +87,6 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
       checkAutocompleteInput.rendersMultipleResults();
     });
 
-    it('adds the country name to a hidden input value after searching', () => {
-      checkAutocompleteInput.addsCountryNameToHiddenInput();
-    });
-
     it('allows user to remove a selected country and search again', () => {
       checkAutocompleteInput.allowsUserToRemoveCountryAndSearchAgain();
     });
@@ -142,7 +138,10 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
           partials.backLink().click();
 
           const expectedValue = 'Algeria';
-          buyerCountryPage.hiddenInput().should('have.attr', 'value', expectedValue);
+
+          buyerCountryPage.results().invoke('text').then((text) => {
+            expect(text.trim()).equal(expectedValue);
+          });
         });
       });
     });

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
@@ -75,10 +75,6 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
       checkAutocompleteInput.rendersMultipleResults();
     });
 
-    it('adds the country name to a hidden input value after searching', () => {
-      checkAutocompleteInput.addsCountryNameToHiddenInput();
-    });
-
     it('allows user to remove a selected country and search again', () => {
       checkAutocompleteInput.allowsUserToRemoveCountryAndSearchAgain();
     });

--- a/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-export-fields.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-export-fields.spec.js
@@ -51,7 +51,9 @@ context('Change your answers (export fields) - as an exporter, I want to change 
     it('has originally submitted answer selected', () => {
       const expectedValue = submissionData[BUYER_COUNTRY];
 
-      buyerCountryPage.hiddenInput().should('have.attr', 'value', expectedValue);
+      buyerCountryPage.results().invoke('text').then((text) => {
+        expect(text.trim()).equal(expectedValue);
+      });
     });
 
     it('has a hash tag and heading/label ID in the URL so that the element gains focus and user has context of what they want to change', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
@@ -302,7 +302,9 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
         });
 
         it('clears the session', () => {
-          buyerCountryPage.hiddenInput().should('have.attr', 'value', '');
+          // buyer country auto complete stores the selected value in the first list item of the 'results' list.
+          // Therefore, if it's not defined, nothing has been selected/submitted.
+          buyerCountryPage.results().should('not.exist');
         });
       });
     });

--- a/e2e-tests/cypress/e2e/pages/shared/buyerCountry.js
+++ b/e2e-tests/cypress/e2e/pages/shared/buyerCountry.js
@@ -1,12 +1,11 @@
 import { FIELD_IDS } from '../../../../constants';
 
 const buyerCountryPage = {
-  hint: () => cy.get(`[data-cy="${FIELD_IDS.COUNTRY}-hint"]`),
-  searchInput: () => cy.get(`#${FIELD_IDS.COUNTRY}`),
-  hiddenInput: () => cy.get(`#${FIELD_IDS.BUYER_COUNTRY}`),
-  results: () => cy.get(`#${FIELD_IDS.COUNTRY} + ul li`),
+  hint: () => cy.get(`[data-cy="${FIELD_IDS.BUYER_COUNTRY}-hint"]`),
+  searchInput: () => cy.get(`#${FIELD_IDS.BUYER_COUNTRY}`),
+  results: () => cy.get(`#${FIELD_IDS.BUYER_COUNTRY} + ul li`),
   noResults: () => cy.get('.autocomplete__option--no-results'),
-  errorMessage: () => cy.get(`[data-cy="${FIELD_IDS.COUNTRY}-error-message"]`),
+  errorMessage: () => cy.get(`[data-cy="${FIELD_IDS.BUYER_COUNTRY}-error-message"]`),
 };
 
 export default buyerCountryPage;

--- a/e2e-tests/cypress/support/check-buyer-country-form.js
+++ b/e2e-tests/cypress/support/check-buyer-country-form.js
@@ -16,7 +16,7 @@ const checkPageTitleAndHeading = () => {
 
 const checkInputHint = () => {
   buyerCountryPage.hint().invoke('text').then((text) => {
-    expect(text.trim()).equal(FIELDS[FIELD_IDS.COUNTRY].HINT);
+    expect(text.trim()).equal(FIELDS[FIELD_IDS.BUYER_COUNTRY].HINT);
   });
 };
 
@@ -56,21 +56,6 @@ const checkAutocompleteInput = {
 
     results.should('have.length.greaterThan', 1);
   },
-  addsCountryNameToHiddenInput: () => {
-    buyerCountryPage.searchInput().type('Algeria');
-
-    const noResults = buyerCountryPage.noResults();
-    noResults.should('not.exist');
-
-    const results = buyerCountryPage.results();
-
-    // select the first result (Algeria)
-    results.first().click();
-
-    // check hidden input value
-    const expectedValue = 'Algeria';
-    buyerCountryPage.hiddenInput().should('have.attr', 'value', expectedValue);
-  },
   allowsUserToRemoveCountryAndSearchAgain: () => {
     buyerCountryPage.searchInput().type('Algeria');
     const results = buyerCountryPage.results();
@@ -86,7 +71,10 @@ const checkAutocompleteInput = {
 
     // check hidden input value
     const expectedValue = 'Brazil';
-    buyerCountryPage.hiddenInput().should('have.attr', 'value', expectedValue);
+
+    buyerCountryPage.results().invoke('text').then((text) => {
+      expect(text.trim()).equal(expectedValue);
+    });
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uk-export-finance/exip",
-  "version": "1.14.2",
+  "version": "1.14.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uk-export-finance/exip",
-      "version": "1.14.2",
+      "version": "1.14.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uk-export-finance/exip",
-  "version": "1.14.2",
+  "version": "1.14.4",
   "description": "Export Insurance Policies",
   "engineStrict": true,
   "engines": {

--- a/src/ui/server/constants/field-ids.ts
+++ b/src/ui/server/constants/field-ids.ts
@@ -3,7 +3,6 @@ export const FIELD_IDS = {
   VALID_BUYER_BODY: 'validBuyerBody',
   VALID_EXPORTER_LOCATION: 'validExporterLocation',
   BUYER_COUNTRY: 'buyerCountry',
-  COUNTRY: 'country',
   HAS_MINIMUM_UK_GOODS_OR_SERVICES: 'hasMinimumUkGoodsOrServices',
   AMOUNT_CURRENCY: 'amountAndCurrency',
   CURRENCY: 'currency',

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -9,7 +9,6 @@ const MAX_COVER_AMOUNT = formatCurrency(PRODUCT.MAX_COVER_AMOUNT_IN_GBP, 'GBP', 
 
 export const ERROR_MESSAGES = {
   [FIELD_IDS.BUYER_COUNTRY]: 'Select where your buyer is based',
-  [FIELD_IDS.COUNTRY]: 'Select where your buyer is based',
   [FIELD_IDS.VALID_BUYER_BODY]: 'Select if your buyer is a government or public sector body',
   [FIELD_IDS.VALID_EXPORTER_LOCATION]: 'Select if your company is based in the UK, Channel Islands, Isle of Man or not',
   [FIELD_IDS.HAS_MINIMUM_UK_GOODS_OR_SERVICES]: {

--- a/src/ui/server/content-strings/fields.ts
+++ b/src/ui/server/content-strings/fields.ts
@@ -2,17 +2,15 @@ import { FIELD_IDS, FIELD_VALUES } from '../constants';
 import { LINKS } from './links';
 
 export const FIELDS = {
-  [FIELD_IDS.COUNTRY]: {
+  [FIELD_IDS.BUYER_COUNTRY]: {
     HINT: 'Cover is based on the country your buyer is located in, not the destination of your goods or services.',
+    SUMMARY: {
+      TITLE: 'Buyer is based in',
+    },
   },
   [FIELD_IDS.VALID_EXPORTER_LOCATION]: {
     SUMMARY: {
       TITLE: 'Your company',
-    },
-  },
-  [FIELD_IDS.BUYER_COUNTRY]: {
-    SUMMARY: {
-      TITLE: 'Buyer is based in',
     },
   },
   [FIELD_IDS.HAS_MINIMUM_UK_GOODS_OR_SERVICES]: {

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
@@ -36,7 +36,7 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
   describe('PAGE_VARIABLES', () => {
     it('should have correct properties', () => {
       const expected = {
-        FIELD_ID: FIELD_IDS.COUNTRY,
+        FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
         PAGE_CONTENT_STRINGS: PAGES.BUYER_COUNTRY,
       };
 

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
@@ -64,7 +64,6 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
       const expectedVariables = {
         ...singleInputPageVariables(PAGE_VARIABLES),
         BACK_LINK: req.headers.referer,
-        HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
         countries: mapCountries(mockCountriesResponse),
         submittedValues: req.session.submittedData.insuranceEligibility,
       };
@@ -78,12 +77,11 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
 
         await get(req, res);
 
-        const expectedCountries = mapCountries(mockCountriesResponse, req.session.submittedData.quoteEligibility[FIELD_IDS.BUYER_COUNTRY].isoCode);
+        const expectedCountries = mapCountries(mockCountriesResponse, req.session.submittedData.insuranceEligibility[FIELD_IDS.BUYER_COUNTRY].isoCode);
 
         const expectedVariables = {
           ...singleInputPageVariables(PAGE_VARIABLES),
           BACK_LINK: req.headers.referer,
-          HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
           countries: expectedCountries,
           submittedValues: req.session.submittedData.insuranceEligibility,
         };
@@ -145,7 +143,6 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
         expect(res.render).toHaveBeenCalledWith(TEMPLATES.SHARED_PAGES.BUYER_COUNTRY, {
           ...singleInputPageVariables(PAGE_VARIABLES),
           BACK_LINK: req.headers.referer,
-          HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
           countries: mapCountries(mockCountriesResponse),
           validationErrors: generateValidationErrors(req.body),
         });
@@ -181,8 +178,6 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
         await post(req, res);
 
         const expectedPopulatedData = {
-          // TODO: why is this in quote version of buyer country?
-          // ...validBody,
           [FIELD_IDS.BUYER_COUNTRY]: {
             name: selectedCountry?.name,
             isoCode: selectedCountry?.isoCode,

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
@@ -9,7 +9,7 @@ import { canApplyOnline, canApplyOffline, cannotApply } from '../../../../helper
 import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Request, Response } from '../../../../../types';
 
-const FIELD_ID = FIELD_IDS.COUNTRY;
+const FIELD_ID = FIELD_IDS.BUYER_COUNTRY;
 
 export const PAGE_VARIABLES = {
   FIELD_ID,
@@ -59,7 +59,7 @@ export const post = async (req: Request, res: Response) => {
     });
   }
 
-  const submittedCountryName = req.body[FIELD_IDS.BUYER_COUNTRY] || req.body[FIELD_IDS.COUNTRY];
+  const submittedCountryName = req.body[FIELD_IDS.BUYER_COUNTRY] || req.body[FIELD_IDS.BUYER_COUNTRY];
 
   const country = getCountryByName(mappedCountries, submittedCountryName);
 

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
@@ -17,20 +17,32 @@ export const PAGE_VARIABLES = {
 };
 
 export const get = async (req: Request, res: Response) => {
+  const { submittedData } = req.session;
   const countries = await api.getCountries();
 
   if (!countries || !countries.length) {
     return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
   }
 
-  const mappedCountries = mapCountries(countries);
+  let countryValue;
+
+  if (submittedData && submittedData.insuranceEligibility[FIELD_IDS.BUYER_COUNTRY]) {
+    countryValue = submittedData.insuranceEligibility[FIELD_IDS.BUYER_COUNTRY];
+  }
+
+  let mappedCountries;
+
+  if (countryValue) {
+    mappedCountries = mapCountries(countries, countryValue.isoCode);
+  } else {
+    mappedCountries = mapCountries(countries);
+  }
 
   return res.render(TEMPLATES.SHARED_PAGES.BUYER_COUNTRY, {
     ...singleInputPageVariables({
       ...PAGE_VARIABLES,
       BACK_LINK: req.headers.referer,
     }),
-    HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
     countries: mappedCountries,
     submittedValues: req.session.submittedData.insuranceEligibility,
   });
@@ -53,13 +65,12 @@ export const post = async (req: Request, res: Response) => {
         ...PAGE_VARIABLES,
         BACK_LINK: req.headers.referer,
       }),
-      HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
       countries: mappedCountries,
       validationErrors,
     });
   }
 
-  const submittedCountryName = req.body[FIELD_IDS.BUYER_COUNTRY] || req.body[FIELD_IDS.BUYER_COUNTRY];
+  const submittedCountryName = req.body[FIELD_IDS.BUYER_COUNTRY];
 
   const country = getCountryByName(mappedCountries, submittedCountryName);
 

--- a/src/ui/server/controllers/quote/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.test.ts
@@ -277,7 +277,6 @@ describe('controllers/quote/buyer-country', () => {
         await post(req, res);
 
         const expectedPopulatedData = {
-          ...validBody,
           [FIELD_IDS.BUYER_COUNTRY]: {
             name: selectedCountry?.name,
             isoCode: selectedCountry?.isoCode,

--- a/src/ui/server/controllers/quote/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.test.ts
@@ -36,7 +36,7 @@ describe('controllers/quote/buyer-country', () => {
   describe('PAGE_VARIABLES', () => {
     it('should have correct properties', () => {
       const expected = {
-        FIELD_ID: FIELD_IDS.COUNTRY,
+        FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
         PAGE_CONTENT_STRINGS: PAGES.BUYER_COUNTRY,
       };
 
@@ -108,7 +108,6 @@ describe('controllers/quote/buyer-country', () => {
 
       const expectedVariables = {
         ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: getBackLink(req.headers.referer) }),
-        HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
         countries: mapCountries(mockCountriesResponse),
         submittedValues: req.session.submittedData.quoteEligibility,
         isChangeRoute: isChangeRoute(req.originalUrl),
@@ -127,7 +126,6 @@ describe('controllers/quote/buyer-country', () => {
 
         const expectedVariables = {
           ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: getBackLink(req.headers.referer) }),
-          HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
           countries: expectedCountries,
           submittedValues: req.session.submittedData.quoteEligibility,
           isChangeRoute: isChangeRoute(req.originalUrl),
@@ -189,7 +187,6 @@ describe('controllers/quote/buyer-country', () => {
 
         expect(res.render).toHaveBeenCalledWith(TEMPLATES.SHARED_PAGES.BUYER_COUNTRY, {
           ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: getBackLink(req.headers.referer) }),
-          HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
           countries: mapCountries(mockCountriesResponse),
           validationErrors: generateValidationErrors(req.body),
           isChangeRoute: isChangeRoute(req.originalUrl),
@@ -310,15 +307,14 @@ describe('controllers/quote/buyer-country', () => {
       });
     });
 
-    describe(`when the country is supported for an online quote, submitted with ${FIELD_IDS.COUNTRY} (no JS) and there are no validation errors`, () => {
+    describe(`when the country is supported for an online quote, submitted with ${FIELD_IDS.BUYER_COUNTRY} (no JS) and there are no validation errors`, () => {
       const selectedCountryName = mockAnswers[FIELD_IDS.BUYER_COUNTRY];
       const mappedCountries = mapCountries(mockCountriesResponse);
 
       const selectedCountry = getCountryByName(mappedCountries, selectedCountryName);
 
       const validBody = {
-        [FIELD_IDS.BUYER_COUNTRY]: '',
-        [FIELD_IDS.COUNTRY]: selectedCountryName,
+        [FIELD_IDS.BUYER_COUNTRY]: selectedCountryName,
       };
 
       beforeEach(() => {

--- a/src/ui/server/controllers/quote/buyer-country/index.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.ts
@@ -11,7 +11,7 @@ import { updateSubmittedData } from '../../../helpers/update-submitted-data/quot
 import { Request, Response } from '../../../../types';
 
 export const PAGE_VARIABLES = {
-  FIELD_ID: FIELD_IDS.COUNTRY,
+  FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
   PAGE_CONTENT_STRINGS: PAGES.BUYER_COUNTRY,
 };
 
@@ -70,7 +70,6 @@ export const get = async (req: Request, res: Response) => {
 
   return res.render(TEMPLATES.SHARED_PAGES.BUYER_COUNTRY, {
     ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: getBackLink(req.headers.referer) }),
-    HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
     countries: mappedCountries,
     submittedValues: req.session.submittedData?.quoteEligibility,
     isChangeRoute: isChangeRoute(req.originalUrl),
@@ -91,14 +90,13 @@ export const post = async (req: Request, res: Response) => {
   if (validationErrors) {
     return res.render(TEMPLATES.SHARED_PAGES.BUYER_COUNTRY, {
       ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: getBackLink(req.headers.referer) }),
-      HIDDEN_FIELD_ID: FIELD_IDS.BUYER_COUNTRY,
       countries: mappedCountries,
       validationErrors,
       isChangeRoute: isChangeRoute(req.originalUrl),
     });
   }
 
-  const submittedCountryName = req.body[FIELD_IDS.BUYER_COUNTRY] || req.body[FIELD_IDS.COUNTRY];
+  const submittedCountryName = req.body[FIELD_IDS.BUYER_COUNTRY];
 
   const country = getCountryByName(mappedCountries, submittedCountryName);
 

--- a/src/ui/server/helpers/page-variables/single-input/index.test.ts
+++ b/src/ui/server/helpers/page-variables/single-input/index.test.ts
@@ -28,7 +28,7 @@ describe('server/helpers/page-variables/single-input', () => {
 
   describe('when a FIELD_ID exists in content string fields', () => {
     it('should also return FIELD_HINT', () => {
-      mock.FIELD_ID = FIELD_IDS.COUNTRY;
+      mock.FIELD_ID = FIELD_IDS.BUYER_COUNTRY;
       const result = singleInputPageVariables(mock);
 
       const expected = FIELDS[mock.FIELD_ID].HINT;

--- a/src/ui/server/middleware/headers/security.ts
+++ b/src/ui/server/middleware/headers/security.ts
@@ -28,7 +28,7 @@ export const security = (req: Request, res: Response, next: () => void) => {
   res.setHeader('X-Content-Type-Options', 'nosniff');
   res.setHeader(
     'Content-Security-Policy',
-    "default-src 'none';connect-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self';form-action 'self';frame-ancestors 'self';img-src 'self';object-src 'none';script-src 'self' 'unsafe-inline';script-src-attr 'self' 'unsafe-inline';style-src 'self';upgrade-insecure-requests",
+    "default-src 'none';connect-src https://region1.google-analytics.com 'self';base-uri 'self';block-all-mixed-content;font-src 'self';form-action 'self';frame-ancestors 'self';img-src 'self';object-src 'none';script-src https://www.googletagmanager.com 'self' 'unsafe-inline';script-src-attr 'self' 'unsafe-inline';style-src 'self';upgrade-insecure-requests",
   );
   res.setHeader('Cache-Control', 'no-cache, must-revalidate, max-age=604800');
   res.setHeader('Referrer-Policy', 'same-origin');

--- a/src/ui/server/shared-validation/buyer-country/index.test.ts
+++ b/src/ui/server/shared-validation/buyer-country/index.test.ts
@@ -13,43 +13,17 @@ describe('shared-validation/buyer-country', () => {
       });
     });
 
-    describe(`when both ${FIELD_IDS.BUYER_COUNTRY} and ${FIELD_IDS.COUNTRY} are provided`, () => {
-      describe(`when ${FIELD_IDS.COUNTRY} does NOT have a value`, () => {
+    describe(`when ${FIELD_IDS.BUYER_COUNTRY} is provided`, () => {
+      describe(`when ${FIELD_IDS.BUYER_COUNTRY} does NOT have a value`, () => {
         it('should return true', () => {
           const mockBody = {
             [FIELD_IDS.BUYER_COUNTRY]: '',
-            [FIELD_IDS.COUNTRY]: '',
           };
 
           const result = hasErrors(mockBody);
 
           expect(result).toEqual(true);
         });
-      });
-
-      describe(`when ${FIELD_IDS.COUNTRY} has a value`, () => {
-        it('should return false', () => {
-          const mockBody = {
-            [FIELD_IDS.BUYER_COUNTRY]: '',
-            [FIELD_IDS.COUNTRY]: 'Australia',
-          };
-
-          const result = hasErrors(mockBody);
-
-          expect(result).toEqual(false);
-        });
-      });
-    });
-
-    describe(`when only ${FIELD_IDS.BUYER_COUNTRY} is provided and there is no value`, () => {
-      it('should return true', () => {
-        const mockBody = {
-          [FIELD_IDS.BUYER_COUNTRY]: '',
-        };
-
-        const result = hasErrors(mockBody);
-
-        expect(result).toEqual(true);
       });
     });
 
@@ -69,7 +43,7 @@ describe('shared-validation/buyer-country', () => {
       it('should return validation errors', () => {
         const result = validation({});
 
-        const expected = generateValidationErrors(FIELD_IDS.COUNTRY, CONTENT_STRINGS.ERROR_MESSAGES[FIELD_IDS.COUNTRY]);
+        const expected = generateValidationErrors(FIELD_IDS.BUYER_COUNTRY, CONTENT_STRINGS.ERROR_MESSAGES[FIELD_IDS.BUYER_COUNTRY]);
 
         expect(result).toEqual(expected);
       });
@@ -79,7 +53,7 @@ describe('shared-validation/buyer-country', () => {
       it('should return validation errors', () => {
         const result = validation({});
 
-        const expected = generateValidationErrors(FIELD_IDS.COUNTRY, CONTENT_STRINGS.ERROR_MESSAGES[FIELD_IDS.COUNTRY]);
+        const expected = generateValidationErrors(FIELD_IDS.BUYER_COUNTRY, CONTENT_STRINGS.ERROR_MESSAGES[FIELD_IDS.BUYER_COUNTRY]);
 
         expect(result).toEqual(expected);
       });

--- a/src/ui/server/shared-validation/buyer-country/index.ts
+++ b/src/ui/server/shared-validation/buyer-country/index.ts
@@ -9,19 +9,7 @@ const hasErrors = (formBody: RequestBody) => {
     return true;
   }
 
-  const keys = Object.keys(formBody);
-  if (keys.includes(FIELD_IDS.BUYER_COUNTRY) && keys.includes(FIELD_IDS.COUNTRY)) {
-    // form submitted without client side JS
-
-    if (!objectHasProperty(formBody, FIELD_IDS.COUNTRY)) {
-      return true;
-    }
-
-    return false;
-  }
-
   if (!objectHasProperty(formBody, FIELD_IDS.BUYER_COUNTRY)) {
-    // form submitted with client side JS
     return true;
   }
 
@@ -32,7 +20,7 @@ const validation = (formBody: RequestBody) => {
   let errors;
 
   if (hasErrors(formBody)) {
-    errors = generateValidationErrors(FIELD_IDS.COUNTRY, ERROR_MESSAGES[FIELD_IDS.COUNTRY]);
+    errors = generateValidationErrors(FIELD_IDS.BUYER_COUNTRY, ERROR_MESSAGES[FIELD_IDS.BUYER_COUNTRY]);
 
     return errors;
   }

--- a/src/ui/templates/shared-pages/buyer-country.njk
+++ b/src/ui/templates/shared-pages/buyer-country.njk
@@ -97,12 +97,7 @@
     var element = document.getElementById('{{ FIELD_ID }}');
     accessibleAutocomplete.enhanceSelectElement({
       selectElement: element,
-      defaultValue: '',
-      onConfirm: function(event) {
-        if (event) {
-          document.getElementById('{{ HIDDEN_FIELD_ID }}').value = event;
-        }
-      }
+      defaultValue: ''
     });
   </script>
 


### PR DESCRIPTION
This PR fixes merges the `main` branch into `main-application`, thereby fixing an issue where Buyer Country would not change when going through a "change" journey in the Quote tool when JS is disabled.

Also:
- Updated the buyer country controller in Insurance eligibility so that a previously submitted country will now be pre-populated.
- Update E2E tests to use the new buyer country helpers/assertion functions used.