### PR TITLE
fix(EMS-531, 536, 551, 524): various copy issues

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -12,7 +12,7 @@ const ERROR_MESSAGES = {
   [FIELD_IDS.VALID_BUYER_BODY]: 'Select if your buyer is a government or public sector body',
   [FIELD_IDS.VALID_EXPORTER_LOCATION]: 'Select if your company is based in the UK, Channel Islands, Isle of Man or not',
   [FIELD_IDS.HAS_MINIMUM_UK_GOODS_OR_SERVICES]: {
-    IS_EMPTY: 'Select whether at least 20% of your export contract value is made up from UK goods and services',
+    IS_EMPTY: 'Select if 20% of your export contract value is made up from UK goods/services or not',
   },
   [FIELD_IDS.CURRENCY]: {
     IS_EMPTY: 'Select currency',

--- a/e2e-tests/content-strings/fields.js
+++ b/e2e-tests/content-strings/fields.js
@@ -15,8 +15,7 @@ const FIELDS = {
     },
   },
   [FIELD_IDS.HAS_MINIMUM_UK_GOODS_OR_SERVICES]: {
-    LABEL: 'Percentage of your export that is UK content',
-    HINT: 'Enter the UK content of your export as a percentage.',
+    HINT: 'You can include your profit margin as part of the contract value.',
     SUMMARY: {
       TITLE: 'UK goods or services',
     },

--- a/e2e-tests/content-strings/fields.js
+++ b/e2e-tests/content-strings/fields.js
@@ -167,12 +167,8 @@ const FIELDS = {
       },
     },
   },
-  INSURANCE: {
-    ELIGIBILITY: {
-      [FIELD_IDS.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT]: {
-        HINT: 'This is known as the pre-credit period.',
-      }
-    },
+  [FIELD_IDS.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD]: {
+    HINT: 'This is known as the pre-credit period.',
   },
 };
 

--- a/e2e-tests/content-strings/pages/index.js
+++ b/e2e-tests/content-strings/pages/index.js
@@ -7,7 +7,7 @@ const BUYER_COUNTRY = {
 };
 
 const EXPORTER_LOCATION = {
-  PAGE_TITLE: 'Is your company based inside the UK, Channel Islands or Isle of Man?',
+  PAGE_TITLE: 'Are you exporting from a business base inside the UK, Channel Islands or Isle of Man?',
 };
 
 const UK_GOODS_OR_SERVICES = {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -1,9 +1,10 @@
-import { heading, yesRadio, yesRadioInput, noRadio, noRadioInput, inlineErrorMessage, submitButton } from '../../../../pages/shared';
+import { heading, yesNoRadioHint, yesRadio, yesRadioInput, noRadio, noRadioInput, inlineErrorMessage, submitButton } from '../../../../pages/shared';
 import { insurance } from '../../../../pages';
 import partials from '../../../../partials';
 import {
   ORGANISATION,
   BUTTONS,
+  FIELDS,
   LINKS,
   PAGES,
   ERROR_MESSAGES,
@@ -101,6 +102,14 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
 
     heading().invoke('text').then((text) => {
       expect(text.trim()).equal(CONTENT_STRINGS.PAGE_TITLE);
+    });
+  });
+
+  it('renders radio button hint', () => {
+    yesNoRadioHint().should('exist');
+
+    yesNoRadioHint().invoke('text').then((text) => {
+      expect(text.trim()).equal(FIELDS[FIELD_IDS.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD].HINT);
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -1,8 +1,9 @@
-import { exporterLocationPage, ukGoodsOrServicesPage, heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton } from '../../../../pages/shared';
+import { exporterLocationPage, ukGoodsOrServicesPage, heading, yesNoRadioHint, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import {
   ORGANISATION,
   BUTTONS,
+  FIELDS,
   LINKS,
   PAGES,
   ERROR_MESSAGES,
@@ -84,6 +85,14 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
 
     heading().invoke('text').then((text) => {
       expect(text.trim()).equal(CONTENT_STRINGS.PAGE_TITLE);
+    });
+  });
+
+  it('renders radio button hint', () => {
+    yesNoRadioHint().should('exist');
+
+    yesNoRadioHint().invoke('text').then((text) => {
+      expect(text.trim()).equal(FIELDS[FIELD_IDS.HAS_MINIMUM_UK_GOODS_OR_SERVICES].HINT);
     });
   });
 

--- a/e2e-tests/cypress/e2e/pages/shared/index.js
+++ b/e2e-tests/cypress/e2e/pages/shared/index.js
@@ -6,6 +6,7 @@ const ukGoodsOrServicesPage = require('./ukGoodsOrServices');
 
 module.exports = {
   heading: () => cy.get('[data-cy="heading"]'),
+  yesNoRadioHint: () => cy.get(`[data-cy="yes-no-input-hint"]`),
   yesRadio: () => cy.get(`[data-cy="yes"]`),
   yesRadioInput: () => cy.get(`[data-cy="yes-input"]`),
   noRadio: () => cy.get(`[data-cy="no"]`),

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -12,7 +12,7 @@ export const ERROR_MESSAGES = {
   [FIELD_IDS.VALID_BUYER_BODY]: 'Select if your buyer is a government or public sector body',
   [FIELD_IDS.VALID_EXPORTER_LOCATION]: 'Select if your company is based in the UK, Channel Islands, Isle of Man or not',
   [FIELD_IDS.HAS_MINIMUM_UK_GOODS_OR_SERVICES]: {
-    IS_EMPTY: 'Select whether at least 20% of your export contract value is made up from UK goods and services',
+    IS_EMPTY: 'Select if 20% of your export contract value is made up from UK goods/services or not',
   },
   [FIELD_IDS.CURRENCY]: {
     IS_EMPTY: 'Select currency',

--- a/src/ui/server/content-strings/fields.ts
+++ b/src/ui/server/content-strings/fields.ts
@@ -167,4 +167,7 @@ export const FIELDS = {
       },
     },
   },
+  [FIELD_IDS.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD]: {
+    HINT: 'This is known as the pre-credit period.',
+  },
 };

--- a/src/ui/server/content-strings/fields.ts
+++ b/src/ui/server/content-strings/fields.ts
@@ -14,8 +14,7 @@ export const FIELDS = {
     },
   },
   [FIELD_IDS.HAS_MINIMUM_UK_GOODS_OR_SERVICES]: {
-    LABEL: 'Percentage of your export that is UK content',
-    HINT: 'Enter the UK content of your export as a percentage.',
+    HINT: 'You can include your profit margin as part of the contract value.',
     SUMMARY: {
       TITLE: 'UK goods or services',
     },

--- a/src/ui/server/content-strings/pages/index.ts
+++ b/src/ui/server/content-strings/pages/index.ts
@@ -7,7 +7,7 @@ const BUYER_COUNTRY = {
 };
 
 const EXPORTER_LOCATION = {
-  PAGE_TITLE: 'Is your company based inside the UK, Channel Islands or Isle of Man?',
+  PAGE_TITLE: 'Are you exporting from a business base inside the UK, Channel Islands or Isle of Man?',
 };
 
 const UK_GOODS_OR_SERVICES = {

--- a/src/ui/server/controllers/quote/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.test.ts
@@ -306,54 +306,6 @@ describe('controllers/quote/buyer-country', () => {
       });
     });
 
-    describe(`when the country is supported for an online quote, submitted with ${FIELD_IDS.BUYER_COUNTRY} (no JS) and there are no validation errors`, () => {
-      const selectedCountryName = mockAnswers[FIELD_IDS.BUYER_COUNTRY];
-      const mappedCountries = mapCountries(mockCountriesResponse);
-
-      const selectedCountry = getCountryByName(mappedCountries, selectedCountryName);
-
-      const validBody = {
-        [FIELD_IDS.BUYER_COUNTRY]: selectedCountryName,
-      };
-
-      beforeEach(() => {
-        req.body = validBody;
-      });
-
-      it('should update the session with submitted data, popluated with country object', async () => {
-        await post(req, res);
-
-        const expectedPopulatedData = {
-          ...validBody,
-          [FIELD_IDS.BUYER_COUNTRY]: {
-            name: selectedCountry?.name,
-            isoCode: selectedCountry?.isoCode,
-            riskCategory: selectedCountry?.riskCategory,
-          },
-        };
-
-        const expected = updateSubmittedData(expectedPopulatedData, req.session.submittedData.quoteEligibility);
-
-        expect(req.session.submittedData.quoteEligibility).toEqual(expected);
-      });
-
-      it(`should redirect to ${ROUTES.QUOTE.BUYER_BODY}`, async () => {
-        await post(req, res);
-
-        expect(res.redirect).toHaveBeenCalledWith(ROUTES.QUOTE.BUYER_BODY);
-      });
-
-      describe("when the url's last substring is `change`", () => {
-        it(`should redirect to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`, async () => {
-          req.originalUrl = 'mock/change';
-
-          await post(req, res);
-
-          expect(res.redirect).toHaveBeenCalledWith(ROUTES.QUOTE.CHECK_YOUR_ANSWERS);
-        });
-      });
-    });
-
     describe('when the CIS (country information system) API has no data', () => {
       beforeEach(() => {
         // @ts-ignore

--- a/src/ui/templates/components/yes-no-radio-buttons.njk
+++ b/src/ui/templates/components/yes-no-radio-buttons.njk
@@ -4,6 +4,7 @@
 
   {% set fieldId = params.fieldId %}
   {% set heading = params.heading %}
+  {% set hintText = params.hintText %}
   {% set submittedAnswer = params.submittedAnswer %}
   {% set errorMessage = params.errorMessage %}
 
@@ -14,6 +15,12 @@
     fieldset: {
       legend: {
         html: "<h1 class='govuk-heading-l' id='heading' data-cy='heading'>" + heading + "</h1>"
+      }
+    },
+    hint: {
+      text: hintText,
+      attributes: {
+        'data-cy': 'yes-no-input-hint'
       }
     },
     items: [

--- a/src/ui/templates/insurance/eligibility/pre-credit-period.njk
+++ b/src/ui/templates/insurance/eligibility/pre-credit-period.njk
@@ -37,6 +37,7 @@
         {{ yesNoRadioButtons.render({
           fieldId: FIELD_ID,
           heading: CONTENT_STRINGS.PAGE_TITLE,
+          hintText: FIELD_HINT,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]
         }) }}

--- a/src/ui/templates/insurance/eligibility/uk-goods-or-services.njk
+++ b/src/ui/templates/insurance/eligibility/uk-goods-or-services.njk
@@ -37,6 +37,7 @@
         {{ yesNoRadioButtons.render({
           fieldId: FIELD_ID,
           heading: CONTENT_STRINGS.PAGE_TITLE,
+          hintText: FIELD_HINT,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]
         }) }}
@@ -44,7 +45,7 @@
       </div>
     </div>
 
-    {% set calculateContractValuePercentageHtml %}
+    {% set detailsHtml %}
       {% include "partials/uk-goods-and-services-calculate-description.njk" %}
     {% endset %}
 
@@ -53,7 +54,7 @@
 
         {{ govukDetails({
           summaryText: CONTENT_STRINGS.UK_GOODS_AND_SERVICES_CALCULATE_DESCRIPTION.INTRO,
-          html: calculateContractValuePercentageHtml,
+          html: detailsHtml,
           attributes: {
             "data-cy": "goods-and-services-calculate"
           }


### PR DESCRIPTION
This PR fixes or adds various copy/field hints in insurance eligibility and shared pages in quote and insurance eligibility.

- Fix/add hint to “pre credit” period form used in insurance eligibility.
- Fix/update both instances of “exporter location” page/field to use the same, new title.
- Fix/update error message used in “minimum UK goods or services” form.
- Fix/add hint to “minimum UK goods or services” form in insurance eligibility.
- Remove now unused test in quote - buyer country controller after merging `main` into `main-application`
