### PR TITLE
fix(EMS-616): Refresh req.session.submittedData in buyer country controllers

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/switch-between-services/via-buyer-country-routes/complete-insurance-eligibility-then-get-a-quote.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/switch-between-services/via-buyer-country-routes/complete-insurance-eligibility-then-get-a-quote.spec.js
@@ -1,0 +1,68 @@
+import { submitButton } from '../../../pages/shared';
+import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms'
+import {
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+  completeInsuredPeriodForm,
+  completeOtherPartiesForm,
+  completeLetterOfCreditForm,
+  completePreCreditPeriodForm,
+  completeCompaniesHouseNumberForm,
+  completeEligibleToApplyOnlineForm,
+} from '../../../../support/insurance/eligibility/forms';
+import { ROUTES } from '../../../../../constants';
+
+context('Complete insurance eligibility, get a quote and then re-visit the insurance eligibility - all by visiting the buyer country form instead of via `start now` route', () => {
+  before(() => {
+    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    completeAndSubmitBuyerCountryForm();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
+    completeInsuredAmountForm();
+    completeInsuredPeriodForm();
+    completeOtherPartiesForm();
+    completeLetterOfCreditForm();
+    completePreCreditPeriodForm();
+    completeCompaniesHouseNumberForm();
+    completeEligibleToApplyOnlineForm();
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
+  it('allows an exporter to get a quote when visiting the buyer country page directly', () => {
+    cy.visit(ROUTES.QUOTE.BUYER_COUNTRY, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    cy.submitAnswersHappyPathSinglePolicy();
+    submitButton().click();
+
+    cy.url().should('include', ROUTES.QUOTE.YOUR_QUOTE);
+  });
+
+  it('allows an exporter to start another insurance eligibility when visiting the buyer country page directly', () => {
+    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    completeAndSubmitBuyerCountryForm();
+
+    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION);
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/switch-between-services/via-buyer-country-routes/get-a-quote-then-complete-insurance-eligibility.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/switch-between-services/via-buyer-country-routes/get-a-quote-then-complete-insurance-eligibility.spec.js
@@ -1,5 +1,5 @@
-import { submitButton } from '../pages/shared';
-import { completeAndSubmitBuyerCountryForm } from '../../support/forms'
+import { submitButton } from '../../../pages/shared';
+import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms'
 import {
   completeExporterLocationForm,
   completeUkGoodsAndServicesForm,
@@ -10,8 +10,8 @@ import {
   completePreCreditPeriodForm,
   completeCompaniesHouseNumberForm,
   completeEligibleToApplyOnlineForm,
-} from '../../support/insurance/eligibility/forms';
-import { ROUTES } from '../../../constants';
+} from '../../../../support/insurance/eligibility/forms';
+import { ROUTES } from '../../../../../constants';
 
 context('Get a quote, complete insurance eligibility and then re-visit the quote tool - all by visiting the buyer country form instead of via `start now` route', () => {
   before(() => {

--- a/e2e-tests/cypress/e2e/journeys/switch-between-services/via-buyer-country-routes/get-a-quote-then-complete-insurance-eligibility.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/switch-between-services/via-buyer-country-routes/get-a-quote-then-complete-insurance-eligibility.spec.js
@@ -1,0 +1,68 @@
+import { submitButton } from '../pages/shared';
+import { completeAndSubmitBuyerCountryForm } from '../../support/forms'
+import {
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+  completeInsuredPeriodForm,
+  completeOtherPartiesForm,
+  completeLetterOfCreditForm,
+  completePreCreditPeriodForm,
+  completeCompaniesHouseNumberForm,
+  completeEligibleToApplyOnlineForm,
+} from '../../support/insurance/eligibility/forms';
+import { ROUTES } from '../../../constants';
+
+context('Get a quote, complete insurance eligibility and then re-visit the quote tool - all by visiting the buyer country form instead of via `start now` route', () => {
+  before(() => {
+    cy.visit(ROUTES.QUOTE.BUYER_COUNTRY, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    cy.submitAnswersHappyPathSinglePolicy();
+    submitButton().click();
+
+    cy.url().should('include', ROUTES.QUOTE.YOUR_QUOTE);
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
+  it('allows an exporter to complete insurance eligibility when visiting the buyer country page directly', () => {
+    cy.visit(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    completeAndSubmitBuyerCountryForm();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
+    completeInsuredAmountForm();
+    completeInsuredPeriodForm();
+    completeOtherPartiesForm();
+    completeLetterOfCreditForm();
+    completePreCreditPeriodForm();
+    completeCompaniesHouseNumberForm();
+    completeEligibleToApplyOnlineForm();
+  });
+
+  it('allows an exporter to get another quote when visiting the buyer country page directly', () => {
+    cy.visit(ROUTES.QUOTE.BUYER_COUNTRY, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    completeAndSubmitBuyerCountryForm();
+
+    cy.url().should('include', ROUTES.QUOTE.BUYER_BODY);
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/switch-between-services/via-start-now-routes/complete-insurance-eligibility-then-get-a-quote.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/switch-between-services/via-start-now-routes/complete-insurance-eligibility-then-get-a-quote.spec.js
@@ -1,0 +1,76 @@
+import { submitButton } from '../../../pages/shared';
+import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms'
+import {
+  completeStartForm,
+  completeCheckIfEligibleForm,
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+  completeInsuredPeriodForm,
+  completeOtherPartiesForm,
+  completeLetterOfCreditForm,
+  completePreCreditPeriodForm,
+  completeCompaniesHouseNumberForm,
+  completeEligibleToApplyOnlineForm,
+} from '../../../../support/insurance/eligibility/forms';
+import { ROUTES } from '../../../../../constants';
+
+context('Complete insurance eligibility, get a quote and then re-visit the insurance eligibility - all via `start now` route/beginning of the flow', () => {
+  before(() => {
+    cy.visit(ROUTES.INSURANCE.START, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    completeStartForm();
+    completeCheckIfEligibleForm();
+    completeAndSubmitBuyerCountryForm();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
+    completeInsuredAmountForm();
+    completeInsuredPeriodForm();
+    completeOtherPartiesForm();
+    completeLetterOfCreditForm();
+    completePreCreditPeriodForm();
+    completeCompaniesHouseNumberForm();
+    completeEligibleToApplyOnlineForm();
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
+  it('allows an exporter to get a quote when visiting the beginning of the flow', () => {
+    cy.visit(ROUTES.ROOT, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    cy.url().should('include', ROUTES.QUOTE.BUYER_COUNTRY);
+
+    cy.submitAnswersHappyPathSinglePolicy();
+    submitButton().click();
+
+    cy.url().should('include', ROUTES.QUOTE.YOUR_QUOTE);
+  });
+
+  it('allows an exporter to start another insurance eligibility when visiting the beginning of the flow', () => {
+    cy.visit(ROUTES.INSURANCE.START, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    completeStartForm();
+    completeCheckIfEligibleForm();
+    completeAndSubmitBuyerCountryForm();
+
+    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION);
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/switch-between-services/via-start-now-routes/get-a-quote-then-complete-insurance-eligibility.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/switch-between-services/via-start-now-routes/get-a-quote-then-complete-insurance-eligibility.spec.js
@@ -1,0 +1,72 @@
+import { submitButton } from '../../../pages/shared';
+import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms'
+import {
+  completeStartForm,
+  completeCheckIfEligibleForm,
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+  completeInsuredPeriodForm,
+  completeOtherPartiesForm,
+  completeLetterOfCreditForm,
+  completePreCreditPeriodForm,
+  completeCompaniesHouseNumberForm,
+  completeEligibleToApplyOnlineForm,
+} from '../../../../support/insurance/eligibility/forms';
+import { ROUTES } from '../../../../../constants';
+
+context('Get a quote, Complete insurance eligibility and then re-visit the quote tool - all via `start now` route/beginning of the flow', () => {
+  before(() => {
+    cy.visit(ROUTES.ROOT, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    cy.submitAnswersHappyPathSinglePolicy();
+    submitButton().click();
+
+    cy.url().should('include', ROUTES.QUOTE.YOUR_QUOTE);
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
+  it('allows an exporter to complete insurance eligibility when visiting the beginning of the flow', () => {
+    cy.visit(ROUTES.INSURANCE.START, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    completeStartForm();
+    completeCheckIfEligibleForm();
+    completeAndSubmitBuyerCountryForm();
+    completeExporterLocationForm();
+    completeUkGoodsAndServicesForm();
+    completeInsuredAmountForm();
+    completeInsuredPeriodForm();
+    completeOtherPartiesForm();
+    completeLetterOfCreditForm();
+    completePreCreditPeriodForm();
+    completeCompaniesHouseNumberForm();
+    completeEligibleToApplyOnlineForm();
+  });
+
+  it('allows an exporter to start another quote when visiting the beginning of the flow', () => {
+    cy.visit(ROUTES.ROOT, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    completeAndSubmitBuyerCountryForm();
+
+    cy.url().should('include', ROUTES.QUOTE.BUYER_BODY);
+  });
+});

--- a/e2e-tests/cypress/support/insurance/eligibility/forms.js
+++ b/e2e-tests/cypress/support/insurance/eligibility/forms.js
@@ -48,4 +48,6 @@ export const completeCompaniesHouseNumberForm = () => {
   submitButton().click();
 };
 
-
+export const completeEligibleToApplyOnlineForm = () => {
+  submitButton().click();
+};

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
@@ -71,6 +71,42 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
       expect(res.render).toHaveBeenCalledWith(TEMPLATES.SHARED_PAGES.BUYER_COUNTRY, expectedVariables);
     });
 
+    describe('when a there is no submittedData in req.session', () => {
+      it('should add empty submittedData.insuranceEligibility to the session', async () => {
+        // @ts-ignore
+        req.session = {};
+
+        await get(req, res);
+
+        const expected = {
+          ...req.session,
+          submittedData: {
+            insuranceEligibility: {},
+          },
+        };
+
+        expect(req.session).toEqual(expected);
+      });
+    });
+
+    describe('when a there is no insuranceEligibility in req.session.submittedData', () => {
+      it('should add empty submittedData.insuranceEligibility to the session and retain existing req.session.submittedData', async () => {
+        // @ts-ignore
+        req.session.submittedData = {
+          quoteEligibility: {},
+        };
+
+        await get(req, res);
+
+        const expected = {
+          ...req.session.submittedData,
+          insuranceEligibility: {},
+        };
+
+        expect(req.session.submittedData).toEqual(expected);
+      });
+    });
+
     describe('when a country has been submitted', () => {
       it('should render template with countries mapped to submitted country', async () => {
         req.session.submittedData = mockSession.submittedData;

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
@@ -17,7 +17,13 @@ export const PAGE_VARIABLES = {
 };
 
 export const get = async (req: Request, res: Response) => {
-  const { submittedData } = req.session;
+  if (!req.session.submittedData || !req.session.submittedData.insuranceEligibility) {
+    req.session.submittedData = {
+      ...req.session.submittedData,
+      insuranceEligibility: {},
+    };
+  }
+
   const countries = await api.getCountries();
 
   if (!countries || !countries.length) {
@@ -26,8 +32,8 @@ export const get = async (req: Request, res: Response) => {
 
   let countryValue;
 
-  if (submittedData && submittedData.insuranceEligibility[FIELD_IDS.BUYER_COUNTRY]) {
-    countryValue = submittedData.insuranceEligibility[FIELD_IDS.BUYER_COUNTRY];
+  if (req.session.submittedData && req.session.submittedData.insuranceEligibility[FIELD_IDS.BUYER_COUNTRY]) {
+    countryValue = req.session.submittedData.insuranceEligibility[FIELD_IDS.BUYER_COUNTRY];
   }
 
   let mappedCountries;

--- a/src/ui/server/controllers/quote/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.test.ts
@@ -116,6 +116,42 @@ describe('controllers/quote/buyer-country', () => {
       expect(res.render).toHaveBeenCalledWith(TEMPLATES.SHARED_PAGES.BUYER_COUNTRY, expectedVariables);
     });
 
+    describe('when a there is no submittedData in req.session', () => {
+      it('should add empty submittedData.quoteEligibility to the session', async () => {
+        // @ts-ignore
+        req.session = {};
+
+        await get(req, res);
+
+        const expected = {
+          ...req.session,
+          submittedData: {
+            quoteEligibility: {},
+          },
+        };
+
+        expect(req.session).toEqual(expected);
+      });
+    });
+
+    describe('when a there is no quoteEligibility in req.session.submittedData', () => {
+      it('should add empty submittedData.quoteEligibility to the session and retain existing req.session.submittedData', async () => {
+        // @ts-ignore
+        req.session.submittedData = {
+          insuranceEligibility: {},
+        };
+
+        await get(req, res);
+
+        const expected = {
+          ...req.session.submittedData,
+          quoteEligibility: {},
+        };
+
+        expect(req.session.submittedData).toEqual(expected);
+      });
+    });
+
     describe('when a country has been submitted', () => {
       it('should render template with countries mapped to submitted country', async () => {
         req.session.submittedData = mockSession.submittedData;

--- a/src/ui/server/controllers/quote/buyer-country/index.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.ts
@@ -47,7 +47,13 @@ export const getBackLink = (referer?: string): string => {
 };
 
 export const get = async (req: Request, res: Response) => {
-  const { submittedData } = req.session;
+  if (!req.session.submittedData || !req.session.submittedData.quoteEligibility) {
+    req.session.submittedData = {
+      ...req.session.submittedData,
+      quoteEligibility: {},
+    };
+  }
+
   const countries = await api.getCountries();
 
   if (!countries || !countries.length) {
@@ -56,8 +62,8 @@ export const get = async (req: Request, res: Response) => {
 
   let countryValue;
 
-  if (submittedData && submittedData.quoteEligibility[FIELD_IDS.BUYER_COUNTRY]) {
-    countryValue = submittedData.quoteEligibility[FIELD_IDS.BUYER_COUNTRY];
+  if (req.session.submittedData.quoteEligibility[FIELD_IDS.BUYER_COUNTRY]) {
+    countryValue = req.session.submittedData.quoteEligibility[FIELD_IDS.BUYER_COUNTRY];
   }
 
   let mappedCountries;

--- a/src/ui/server/controllers/root/index.test.ts
+++ b/src/ui/server/controllers/root/index.test.ts
@@ -13,7 +13,7 @@ describe('controllers/root', () => {
   });
 
   describe('get', () => {
-    it('should add an empty submittedData object to the session', () => {
+    it('should add empty submittedData structure to the session', () => {
       req.session = {
         submittedData: {
           quoteEligibility: {
@@ -29,9 +29,7 @@ describe('controllers/root', () => {
 
       expect(req.session.submittedData).toEqual({
         quoteEligibility: {},
-        insuranceEligibility: {
-          [FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER]: true,
-        },
+        insuranceEligibility: {},
       });
     });
 

--- a/src/ui/server/controllers/root/index.ts
+++ b/src/ui/server/controllers/root/index.ts
@@ -2,10 +2,11 @@ import { ROUTES } from '../../constants';
 import { Request, Response } from '../../../types';
 
 const get = (req: Request, res: Response) => {
-  // new quote eligibility data in session
+  // clean session data
   req.session.submittedData = {
     ...req.session.submittedData,
     quoteEligibility: {},
+    insuranceEligibility: {},
   };
 
   return res.redirect(ROUTES.QUOTE.BUYER_COUNTRY);


### PR DESCRIPTION
This PR fixes an issue where the server could crash when visiting the buyer country pages in the quote tool and insurance eligibility.

## Changes
- Refresh `req.session.submittedData` in the buyer country controllers when the required object does not exist.

## Improved test coverage

Added tests for the following scenarios, in a single session:
- Get a quote, complete insurance eligibility, then go back to the quote tool. 
- Complete insurance eligibility, get a quote, then go back to insurance eligibility.

Also have tests for the same as above, but by visiting the buyer country page directly, instead of going via a 'start now' page or root URL. Each milestone (get a quote, complete insurance eligibility, go back to ...), starts by visiting the appropriate buyer country page/route directly.
