### PR TITLE
chore: High vulnerability - `jpeg-js` updated from `0.4.3` to `0.4.4`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6044,9 +6044,9 @@
       }
     },
     "node_modules/jpeg-js": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
-      "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q=="
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="
     },
     "node_modules/js-library-detector": {
       "version": "6.5.0",
@@ -14127,9 +14127,9 @@
       }
     },
     "jpeg-js": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
-      "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q=="
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="
     },
     "js-library-detector": {
       "version": "6.5.0",


### PR DESCRIPTION
## Introduction
* `jpeg-js` has a high vulnerability as being raised by `npm audit`.

## Resolution
* `npm audit fix`, updated package version to `0.4.4`.

## Pending
* No fix is currently available for moderator vulnerability master package `got <11.8.5`.