### PR TITLE
fix(EMS-623): Insurance need to start route

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
@@ -7,6 +7,7 @@ import { completeStartForm, completeCheckIfEligibleForm } from '../../../../supp
 const CONTENT_STRINGS = PAGES.NEED_TO_START_AGAIN_PAGE;
 
 const insuranceStartRoute = ROUTES.INSURANCE.START;
+const buyerCountryRoute = ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY;
 
 context('Insurance Eligibility - Need to start again exit page', () => {
   beforeEach(() => {
@@ -82,10 +83,10 @@ context('Insurance Eligibility - Need to start again exit page', () => {
   });
 
   describe('clicking the submit button', () => {
-    it(`should redirect to ${ROUTES.INSURANCE.START}`, () => {
+    it(`should redirect to ${ROUTES.INSURANCE.buyerCountryRoute}`, () => {
       submitButton().click();
 
-      cy.url().should('include', ROUTES.INSURANCE.START);
+      cy.url().should('include', buyerCountryRoute);
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
@@ -83,10 +83,12 @@ context('Insurance Eligibility - Need to start again exit page', () => {
   });
 
   describe('clicking the submit button', () => {
-    it(`should redirect to ${ROUTES.INSURANCE.buyerCountryRoute}`, () => {
+    it(`should redirect to ${buyerCountryRoute}`, () => {
       submitButton().click();
 
-      cy.url().should('include', buyerCountryRoute);
+      const expected = `${Cypress.config('baseUrl')}${buyerCountryRoute}`;
+
+      cy.url().should('eq', expected);
     });
   });
 });

--- a/src/ui/server/controllers/insurance/eligibility/need-to-start-again/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/need-to-start-again/index.test.ts
@@ -5,6 +5,8 @@ import corePageVariables from '../../../../helpers/page-variables/core/insurance
 import { mockReq, mockRes } from '../../../../test-mocks';
 import { Request, Response } from '../../../../../types';
 
+const buyerCountryRoute = ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY;
+
 describe('controllers/insurance/eligibility/need-to-start-again', () => {
   let req: Request;
   let res: Response;
@@ -29,10 +31,10 @@ describe('controllers/insurance/eligibility/need-to-start-again', () => {
   });
 
   describe('post', () => {
-    it(`should redirect to ${ROUTES.INSURANCE.START}`, async () => {
+    it(`should redirect to ${buyerCountryRoute}`, async () => {
       await post(req, res);
 
-      expect(res.redirect).toHaveBeenCalledWith(ROUTES.INSURANCE.START);
+      expect(res.redirect).toHaveBeenCalledWith(buyerCountryRoute);
     });
   });
 });

--- a/src/ui/server/controllers/insurance/eligibility/need-to-start-again/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/need-to-start-again/index.ts
@@ -9,4 +9,4 @@ export const get = (req: Request, res: Response) =>
     corePageVariables({ PAGE_CONTENT_STRINGS: PAGES.NEED_TO_START_AGAIN_PAGE, BACK_LINK: req.headers.referer }),
   );
 
-export const post = (req: Request, res: Response) => res.redirect(ROUTES.INSURANCE.START);
+export const post = (req: Request, res: Response) => res.redirect(ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY);


### PR DESCRIPTION
# Issue: 
* In the insurance section, need to start again link would take you to insurance start page
* This would wipe all the data stored on filled application

# Changes made: 
* Changed route to countries page on link
* Updated unit and e2e tests