### PR TITLE
feat(EMS-746): Company details page submit validation

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-submit.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-submit.spec.js
@@ -1,3 +1,4 @@
+import { companyDetails } from '../../../../pages/your-business';
 import { submitButton, yesRadioInput, inlineErrorMessage } from '../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import partials from '../../../../partials';
@@ -6,6 +7,9 @@ import getReferenceNumber from '../../../../helpers/get-reference-number';
 
 const {
   EXPORTER_BUSINESS: {
+    COMPANY_HOUSE: {
+      INPUT,
+    },
     YOUR_COMPANY: {
       TRADING_NAME,
     },
@@ -48,9 +52,86 @@ describe("Your business - company house search - As an Exporter I want to enter 
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  describe('trading name', () => {
-    it('should display validation errors if trading name question is not answered', () => {
+  describe('all page errors', () => {
+    it('should display validation errors if trading name question and companies house input are not answered', () => {
       submitButton().click();
+      partials.errorSummaryListItems().should('have.length', 2);
+
+      partials.errorSummaryListItems().first().invoke('text')
+        .then((text) => {
+          expect(text.trim()).equal(COMPANY_DETAILS_ERRORS[INPUT].INCORRECT_FORMAT);
+        });
+
+      partials.errorSummaryListItems().eq(1).invoke('text')
+        .then((text) => {
+          expect(text.trim()).equal(COMPANY_DETAILS_ERRORS[TRADING_NAME].IS_EMPTY);
+        });
+    });
+
+    it('should focus to the companies house input section when clicking the companies house error', () => {
+      partials.errorSummaryListItemLinks().first().click();
+      companyDetails.companiesHouseSearch().first().should('have.focus');
+    });
+
+    it('should display the validation error for companies house input in companies house section', () => {
+      companyDetails.companiesHouseSearchError().invoke('text')
+        .then((text) => {
+          expect(text.trim()).equal(`Error: ${COMPANY_DETAILS_ERRORS[INPUT].INCORRECT_FORMAT}`);
+        });
+    });
+
+    it('should focus to the trading name section when clicking the error', () => {
+      partials.errorSummaryListItemLinks().eq(1).click();
+      yesRadioInput().first().should('have.focus');
+    });
+
+    it('should display the validation error for trading name in radio error summary', () => {
+      inlineErrorMessage().invoke('text')
+        .then((text) => {
+          expect(text.trim()).equal(`Error: ${COMPANY_DETAILS_ERRORS[TRADING_NAME].IS_EMPTY}`);
+        });
+    });
+
+    it('should display companies house error and trading name error when companies house incorrectly entered', () => {
+      companyDetails.companiesHouseSearch().clear().type('123456!');
+      companyDetails.companiesHouseSearchButton().click();
+
+      submitButton().click();
+      partials.errorSummaryListItems().first().invoke('text')
+        .then((text) => {
+          expect(text.trim()).equal(COMPANY_DETAILS_ERRORS[INPUT].INCORRECT_FORMAT);
+        });
+
+      partials.errorSummaryListItems().eq(1).invoke('text')
+        .then((text) => {
+          expect(text.trim()).equal(COMPANY_DETAILS_ERRORS[TRADING_NAME].IS_EMPTY);
+        });
+    });
+
+    it('should display companies house error and trading name error when companies house not found', () => {
+      companyDetails.companiesHouseSearch().clear().type('123456');
+      companyDetails.companiesHouseSearchButton().click();
+
+      submitButton().click();
+      partials.errorSummaryListItems().first().invoke('text')
+        .then((text) => {
+          expect(text.trim()).equal(COMPANY_DETAILS_ERRORS[INPUT].NOT_FOUND);
+        });
+
+      partials.errorSummaryListItems().eq(1).invoke('text')
+        .then((text) => {
+          expect(text.trim()).equal(COMPANY_DETAILS_ERRORS[TRADING_NAME].IS_EMPTY);
+        });
+    });
+  });
+
+  describe('trading name error', () => {
+    const companiesHouseNumber = '8989898';
+
+    it('should display validation errors if trading name question is not answered', () => {
+      companyDetails.companiesHouseSearch().clear().type(companiesHouseNumber);
+      submitButton().click();
+      partials.errorSummaryListItems().should('have.length', 1);
       partials.errorSummaryListItems().first().invoke('text')
         .then((text) => {
           expect(text.trim()).equal(COMPANY_DETAILS_ERRORS[TRADING_NAME].IS_EMPTY);
@@ -58,7 +139,7 @@ describe("Your business - company house search - As an Exporter I want to enter 
     });
 
     it('should focus to the trading name section when clicking the error', () => {
-      partials.errorSummaryListItemLinks().eq(0).click();
+      partials.errorSummaryListItemLinks().first().click();
       yesRadioInput().first().should('have.focus');
     });
 

--- a/e2e-tests/cypress/e2e/pages/your-business/companies-house-search/companyDetails.js
+++ b/e2e-tests/cypress/e2e/pages/your-business/companies-house-search/companyDetails.js
@@ -16,10 +16,10 @@ const companyDetails = {
   tradingAddress: () => cy.get('[data-cy="trading-address'),
   tradingAddressLabel: () => cy.get('[data-cy="trading-address-heading'),
 
-  companyWebsiteLabel: () => cy.get('[data-cy="company-website-heading'),
+  companyWebsiteLabel: () => cy.get('[data-cy="company-website-label'),
   companyWebsite: () => cy.get('[data-cy="company-website'),
 
-  phoneNumberLabel: () => cy.get('[data-cy="company-phone-heading'),
+  phoneNumberLabel: () => cy.get('[data-cy="company-phone-label'),
   phoneNumberHint: () => cy.get('[data-cy="company-phone-hint'),
   phoneNumber: () => cy.get('[data-cy="company-phone'),
 };

--- a/src/ui/server/controllers/insurance/business/company-details/helpers/companies-house-search.helper.test.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/helpers/companies-house-search.helper.test.ts
@@ -79,7 +79,7 @@ describe('controllers/insurance/business/companies-details/helpers/companies-hou
     const expected = {
       validationErrors: {},
       [COMPANY_HOUSE.INPUT]: formBody[COMPANY_HOUSE.INPUT],
-      error: true,
+      apiError: true,
     };
 
     expect(response).toEqual(expected);
@@ -98,7 +98,7 @@ describe('controllers/insurance/business/companies-details/helpers/companies-hou
     const expected = {
       validationErrors: {},
       [COMPANY_HOUSE.INPUT]: formBody[COMPANY_HOUSE.INPUT],
-      error: true,
+      apiError: true,
     };
 
     expect(response).toEqual(expected);

--- a/src/ui/server/controllers/insurance/business/company-details/helpers/companies-house-search.helper.test.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/helpers/companies-house-search.helper.test.ts
@@ -1,0 +1,165 @@
+import companiesHouseSearch from './companies-house-search.helper';
+import { ERROR_MESSAGES } from '../../../../../content-strings';
+import { FIELD_IDS } from '../../../../../constants';
+import generateValidationErrors from '../../../../../helpers/validation';
+import api from '../../../../../api';
+import { RequestBody } from '../../../../../../types';
+import { mockCompany } from '../../../../../test-mocks';
+
+const {
+  EXPORTER_BUSINESS: { COMPANY_HOUSE },
+} = FIELD_IDS.INSURANCE;
+
+const { EXPORTER_BUSINESS: EXPORTER_BUSINESS_ERROR } = ERROR_MESSAGES.INSURANCE;
+
+describe('controllers/insurance/business/companies-details/helpers/companies-house-search', () => {
+  let formBody: RequestBody;
+
+  it('should return object with validationErrors and companiesHouseNumber if companiesHouseNumber is an empty string', async () => {
+    formBody = {
+      [COMPANY_HOUSE.INPUT]: '',
+    };
+
+    const response = await companiesHouseSearch(formBody);
+
+    const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].INCORRECT_FORMAT;
+
+    const expected = {
+      validationErrors: generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessage, {}),
+      [COMPANY_HOUSE.INPUT]: formBody[COMPANY_HOUSE.INPUT],
+    };
+
+    expect(response).toEqual(expected);
+  });
+
+  it('should return object with validationErrors and companiesHouseNumber if companiesHouseNumber is null', async () => {
+    formBody = {
+      [COMPANY_HOUSE.INPUT]: null,
+    };
+
+    const response = await companiesHouseSearch(formBody);
+
+    const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].INCORRECT_FORMAT;
+
+    const expected = {
+      validationErrors: generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessage, {}),
+      [COMPANY_HOUSE.INPUT]: formBody[COMPANY_HOUSE.INPUT],
+    };
+
+    expect(response).toEqual(expected);
+  });
+
+  it('should return object with validationErrors and companiesHouseNumber if companiesHouseNumber has special characters', async () => {
+    formBody = {
+      [COMPANY_HOUSE.INPUT]: '12345 !',
+    };
+
+    const response = await companiesHouseSearch(formBody);
+
+    const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].INCORRECT_FORMAT;
+
+    const expected = {
+      validationErrors: generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessage, {}),
+      [COMPANY_HOUSE.INPUT]: formBody[COMPANY_HOUSE.INPUT],
+    };
+
+    expect(response).toEqual(expected);
+  });
+
+  it('should return object with companiesHouseNumber and error set to true if api call has an error', async () => {
+    formBody = {
+      [COMPANY_HOUSE.INPUT]: '123456',
+    };
+
+    const getCompaniesHouseResponse = jest.fn(() => Promise.reject());
+    api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
+
+    const response = await companiesHouseSearch(formBody);
+
+    const expected = {
+      validationErrors: {},
+      [COMPANY_HOUSE.INPUT]: formBody[COMPANY_HOUSE.INPUT],
+      error: true,
+    };
+
+    expect(response).toEqual(expected);
+  });
+
+  it('should return object with companiesHouseNumber and error set to true if api response is null', async () => {
+    formBody = {
+      [COMPANY_HOUSE.INPUT]: '123456',
+    };
+
+    const getCompaniesHouseResponse = jest.fn(() => Promise.resolve(null));
+    api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
+
+    const response = await companiesHouseSearch(formBody);
+
+    const expected = {
+      validationErrors: {},
+      [COMPANY_HOUSE.INPUT]: formBody[COMPANY_HOUSE.INPUT],
+      error: true,
+    };
+
+    expect(response).toEqual(expected);
+  });
+
+  it('should return object with validationErrors, companiesHouseNumber if api response has success as false', async () => {
+    formBody = {
+      [COMPANY_HOUSE.INPUT]: '123456',
+    };
+
+    const getCompaniesHouseResponse = jest.fn(() => Promise.resolve({ success: false }));
+    api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
+
+    const response = await companiesHouseSearch(formBody);
+
+    const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].NOT_FOUND;
+
+    const expected = {
+      validationErrors: generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessage, {}),
+      [COMPANY_HOUSE.INPUT]: formBody[COMPANY_HOUSE.INPUT],
+    };
+
+    expect(response).toEqual(expected);
+  });
+
+  it('should return object with validationErrors, companiesHouseNumber if api response has apiError as true', async () => {
+    formBody = {
+      [COMPANY_HOUSE.INPUT]: '123456',
+    };
+
+    const getCompaniesHouseResponse = jest.fn(() => Promise.resolve({ apiError: true, success: false }));
+    api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
+
+    const response = await companiesHouseSearch(formBody);
+
+    const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].TECHNICAL_ISSUES;
+
+    const expected = {
+      validationErrors: generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessage, {}),
+      [COMPANY_HOUSE.INPUT]: formBody[COMPANY_HOUSE.INPUT],
+    };
+
+    expect(response).toEqual(expected);
+  });
+
+  it('should return object with company and companiesHouseNumber if company found', async () => {
+    formBody = {
+      [COMPANY_HOUSE.INPUT]: '123456',
+    };
+
+    const getCompaniesHouseResponse = jest.fn(() => Promise.resolve(mockCompany));
+    api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
+
+    const response = await companiesHouseSearch(formBody);
+
+    const expected = {
+      validationErrors: {},
+      [COMPANY_HOUSE.INPUT]: formBody[COMPANY_HOUSE.INPUT],
+      company: mockCompany,
+    };
+
+    expect(response).toEqual(expected);
+  });
+});

--- a/src/ui/server/controllers/insurance/business/company-details/helpers/companies-house-search.helper.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/helpers/companies-house-search.helper.ts
@@ -6,9 +6,9 @@ import { RequestBody, CompanyHouseResponse } from '../../../../../../types';
 /**
  * helper which takes formBody containing companies house number
  * runs validation and makes api call to keystone getCompaniesHouseInformation
- * runs validation on response and returns companyResponse or validation errors or error
+ * runs validation on response and returns companyResponse or validation errors or apiError
  * @param {RequestBody} formBody
- * @returns {object} validationErrors, error flag, companiesHouseNumber and companyResponse
+ * @returns {object} validationErrors, apiError flag, companiesHouseNumber and companyResponse
  */
 const companiesHouseSearch = async (formBody: RequestBody) => {
   const { companiesHouseNumber } = formBody;
@@ -32,7 +32,7 @@ const companiesHouseSearch = async (formBody: RequestBody) => {
     } catch (error) {
       console.error('Error posting to companies house API', { error });
       return {
-        error: true,
+        apiError: true,
         companiesHouseNumber,
         validationErrors: {},
       };
@@ -59,7 +59,7 @@ const companiesHouseSearch = async (formBody: RequestBody) => {
   }
 
   return {
-    error: true,
+    apiError: true,
     companiesHouseNumber,
     validationErrors: {},
   };

--- a/src/ui/server/controllers/insurance/business/company-details/helpers/companies-house-search.helper.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/helpers/companies-house-search.helper.ts
@@ -1,0 +1,68 @@
+import api from '../../../../../api';
+import companiesHouseValidation from '../validation/companies-house';
+import companyHouseResponseValidation from '../validation/companies-house-response';
+import { RequestBody, CompanyHouseResponse } from '../../../../../../types';
+
+/**
+ * helper which takes formBody containing companies house number
+ * runs validation and makes api call to keystone getCompaniesHouseInformation
+ * runs validation on response and returns companyResponse or validation errors or error
+ * @param {RequestBody} formBody
+ * @returns {object} validationErrors, error flag, companiesHouseNumber and companyResponse
+ */
+const companiesHouseSearch = async (formBody: RequestBody) => {
+  const { companiesHouseNumber } = formBody;
+
+  // checks input is correctly formatted
+  const validationErrors = companiesHouseValidation(formBody);
+
+  if (validationErrors) {
+    return {
+      validationErrors,
+      companiesHouseNumber,
+    };
+  }
+
+  let company = {} as CompanyHouseResponse;
+
+  // if number provided, then sends to companies house API as keystone query
+  if (companiesHouseNumber) {
+    try {
+      company = await api.keystone.getCompaniesHouseInformation(companiesHouseNumber);
+    } catch (error) {
+      console.error('Error posting to companies house API', { error });
+      return {
+        error: true,
+        companiesHouseNumber,
+        validationErrors: {},
+      };
+    }
+  }
+
+  // if company exists and has a value
+  if (company && Object.keys(company).length) {
+    // checks that success flag is not false and apiError flag is not set
+    const responseValidationErrors = companyHouseResponseValidation(company);
+
+    if (responseValidationErrors) {
+      return {
+        validationErrors: responseValidationErrors,
+        companiesHouseNumber,
+      };
+    }
+
+    return {
+      company,
+      companiesHouseNumber,
+      validationErrors: {},
+    };
+  }
+
+  return {
+    error: true,
+    companiesHouseNumber,
+    validationErrors: {},
+  };
+};
+
+export default companiesHouseSearch;

--- a/src/ui/server/controllers/insurance/business/company-details/index.POST.test.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.POST.test.ts
@@ -1,0 +1,199 @@
+import { Request, Response } from '../../../../../types';
+import { pageVariables, post } from '.';
+import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
+import corePageVariables from '../../../../helpers/page-variables/core/insurance';
+import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
+import generateValidationErrors from '../../../../helpers/validation';
+import api from '../../../../api';
+import { mockReq, mockRes, mockCompany, mockApplication } from '../../../../test-mocks';
+import { sanitiseValue } from '../../../../helpers/sanitise-data';
+
+const {
+  EXPORTER_BUSINESS: {
+    COMPANY_HOUSE,
+    YOUR_COMPANY: { TRADING_NAME },
+  },
+} = FIELD_IDS.INSURANCE;
+
+const { COMPANY_DETAILS } = PAGES.INSURANCE.EXPORTER_BUSINESS;
+const { COMPANY_DETAILS: companyDetailsTemplate } = TEMPLATES.INSURANCE.EXPORTER_BUSINESS;
+
+const { EXPORTER_BUSINESS: EXPORTER_BUSINESS_ERROR } = ERROR_MESSAGES.INSURANCE;
+
+describe('controllers/insurance/business/companies-details', () => {
+  let req: Request;
+  let res: Response;
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+
+    res.locals.application = mockApplication;
+  });
+
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('post', () => {
+    it('should display validation errors when there is no trading name or companies house number', async () => {
+      req.body = {};
+
+      const submittedValues = {
+        [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
+        [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
+      };
+
+      await post(req, res);
+
+      const errorMessageTradingName = EXPORTER_BUSINESS_ERROR[TRADING_NAME].IS_EMPTY;
+      const errorMessageCompanyHouseIncorrect = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].INCORRECT_FORMAT;
+
+      let validationErrors = generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessageCompanyHouseIncorrect, {});
+      validationErrors = generateValidationErrors(TRADING_NAME, errorMessageTradingName, validationErrors);
+
+      expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
+        ...corePageVariables({
+          PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
+          BACK_LINK: req.headers.referer,
+        }),
+        ...pageVariables(mockApplication.referenceNumber),
+        validationErrors,
+        submittedValues,
+      });
+    });
+
+    it('should display validation errors when there is no trading name and api error for companies house', async () => {
+      req.body = {
+        companiesHouseNumber: '123456',
+      };
+
+      const submittedValues = {
+        [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
+        [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
+      };
+
+      const getCompaniesHouseResponse = jest.fn(() => Promise.resolve({ apiError: true }));
+      api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
+
+      await post(req, res);
+
+      const errorMessageTradingName = EXPORTER_BUSINESS_ERROR[TRADING_NAME].IS_EMPTY;
+      const errorMessageCompanyHouseIssue = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].TECHNICAL_ISSUES;
+
+      let validationErrors = generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessageCompanyHouseIssue, {});
+      validationErrors = generateValidationErrors(TRADING_NAME, errorMessageTradingName, validationErrors);
+
+      expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
+        ...corePageVariables({
+          PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
+          BACK_LINK: req.headers.referer,
+        }),
+        ...pageVariables(mockApplication.referenceNumber),
+        validationErrors,
+        submittedValues,
+      });
+    });
+
+    it('should display validation errors when there is no trading name and company not found', async () => {
+      req.body = {
+        companiesHouseNumber: '123456',
+      };
+
+      const submittedValues = {
+        [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
+        [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
+      };
+
+      const getCompaniesHouseResponse = jest.fn(() => Promise.resolve({ success: false }));
+      api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
+
+      await post(req, res);
+
+      const errorMessageTradingName = EXPORTER_BUSINESS_ERROR[TRADING_NAME].IS_EMPTY;
+      const errorMessageCompanyHouseIssue = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].NOT_FOUND;
+
+      let validationErrors = generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessageCompanyHouseIssue, {});
+      validationErrors = generateValidationErrors(TRADING_NAME, errorMessageTradingName, validationErrors);
+
+      expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
+        ...corePageVariables({
+          PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
+          BACK_LINK: req.headers.referer,
+        }),
+        ...pageVariables(mockApplication.referenceNumber),
+        validationErrors,
+        submittedValues,
+      });
+    });
+
+    it('should display validation error for trading name when there is no trading name and company is found', async () => {
+      req.body = {
+        companiesHouseNumber: '123456',
+      };
+
+      const submittedValues = {
+        [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
+        [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
+      };
+
+      const getCompaniesHouseResponse = jest.fn(() => Promise.resolve(mockCompany));
+      api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
+
+      await post(req, res);
+
+      const errorMessageTradingName = EXPORTER_BUSINESS_ERROR[TRADING_NAME].IS_EMPTY;
+
+      expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
+        ...corePageVariables({
+          PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
+          BACK_LINK: req.headers.referer,
+        }),
+        ...pageVariables(mockApplication.referenceNumber),
+        validationErrors: generateValidationErrors(TRADING_NAME, errorMessageTradingName, {}),
+        submittedValues,
+      });
+    });
+
+    it('should display validation error for companies house when company house error but trading name radio is selected', async () => {
+      req.body = {
+        companiesHouseNumber: '123456',
+        [TRADING_NAME]: 'true',
+      };
+
+      const submittedValues = {
+        [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
+        [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
+      };
+
+      const getCompaniesHouseResponse = jest.fn(() => Promise.resolve({ apiError: true }));
+      api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
+
+      await post(req, res);
+
+      const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].TECHNICAL_ISSUES;
+
+      expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
+        ...corePageVariables({
+          PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
+          BACK_LINK: req.headers.referer,
+        }),
+        ...pageVariables(mockApplication.referenceNumber),
+        validationErrors: generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessage, {}),
+        submittedValues,
+      });
+    });
+
+    describe('when there is no application', () => {
+      beforeEach(() => {
+        res.locals = { csrfToken: '1234' };
+      });
+
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, () => {
+        post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/business/company-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.test.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from '../../../../../types';
-import { pageVariables, get, postCompaniesHouseSearch, post } from '.';
+import { pageVariables, get, postCompaniesHouseSearch } from '.';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import corePageVariables from '../../../../helpers/page-variables/core/insurance';
 import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
@@ -7,14 +7,10 @@ import generateValidationErrors from '../../../../helpers/validation';
 import api from '../../../../api';
 import { companyHouseSummaryList } from '../../../../helpers/summary-lists/company-house-summary-list';
 import { mockReq, mockRes, mockCompany, mockApplication } from '../../../../test-mocks';
-import { sanitiseValue } from '../../../../helpers/sanitise-data';
 
 const { EXPORTER_BUSINESS } = FIELD_IDS.INSURANCE;
 const {
-  EXPORTER_BUSINESS: {
-    COMPANY_HOUSE,
-    YOUR_COMPANY: { TRADING_NAME },
-  },
+  EXPORTER_BUSINESS: { COMPANY_HOUSE },
 } = FIELD_IDS.INSURANCE;
 
 const { COMPANY_DETAILS } = PAGES.INSURANCE.EXPORTER_BUSINESS;
@@ -257,168 +253,6 @@ describe('controllers/insurance/business/companies-details', () => {
 
       it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, () => {
         postCompaniesHouseSearch(req, res);
-
-        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
-      });
-    });
-  });
-
-  describe('post', () => {
-    it('should display validation errors when there is no trading name or companies house number', async () => {
-      req.body = {};
-
-      const submittedValues = {
-        [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
-        [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
-      };
-
-      await post(req, res);
-
-      const errorMessageTradingName = EXPORTER_BUSINESS_ERROR[TRADING_NAME].IS_EMPTY;
-      const errorMessageCompanyHouseIncorrect = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].INCORRECT_FORMAT;
-
-      let validationErrors = generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessageCompanyHouseIncorrect, {});
-      validationErrors = generateValidationErrors(TRADING_NAME, errorMessageTradingName, validationErrors);
-
-      expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
-        ...corePageVariables({
-          PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
-          BACK_LINK: req.headers.referer,
-        }),
-        ...pageVariables(mockApplication.referenceNumber),
-        validationErrors,
-        submittedValues,
-      });
-    });
-
-    it('should display validation errors when there is no trading name and api error for companies house', async () => {
-      req.body = {
-        companiesHouseNumber: '123456',
-      };
-
-      const submittedValues = {
-        [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
-        [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
-      };
-
-      const getCompaniesHouseResponse = jest.fn(() => Promise.resolve({ apiError: true }));
-      api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
-
-      await post(req, res);
-
-      const errorMessageTradingName = EXPORTER_BUSINESS_ERROR[TRADING_NAME].IS_EMPTY;
-      const errorMessageCompanyHouseIssue = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].TECHNICAL_ISSUES;
-
-      let validationErrors = generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessageCompanyHouseIssue, {});
-      validationErrors = generateValidationErrors(TRADING_NAME, errorMessageTradingName, validationErrors);
-
-      expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
-        ...corePageVariables({
-          PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
-          BACK_LINK: req.headers.referer,
-        }),
-        ...pageVariables(mockApplication.referenceNumber),
-        validationErrors,
-        submittedValues,
-      });
-    });
-
-    it('should display validation errors when there is no trading name and company not found', async () => {
-      req.body = {
-        companiesHouseNumber: '123456',
-      };
-
-      const submittedValues = {
-        [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
-        [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
-      };
-
-      const getCompaniesHouseResponse = jest.fn(() => Promise.resolve({ success: false }));
-      api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
-
-      await post(req, res);
-
-      const errorMessageTradingName = EXPORTER_BUSINESS_ERROR[TRADING_NAME].IS_EMPTY;
-      const errorMessageCompanyHouseIssue = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].NOT_FOUND;
-
-      let validationErrors = generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessageCompanyHouseIssue, {});
-      validationErrors = generateValidationErrors(TRADING_NAME, errorMessageTradingName, validationErrors);
-
-      expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
-        ...corePageVariables({
-          PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
-          BACK_LINK: req.headers.referer,
-        }),
-        ...pageVariables(mockApplication.referenceNumber),
-        validationErrors,
-        submittedValues,
-      });
-    });
-
-    it('should display validation error for trading anme when there is no trading name and company is found', async () => {
-      req.body = {
-        companiesHouseNumber: '123456',
-      };
-
-      const submittedValues = {
-        [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
-        [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
-      };
-
-      const getCompaniesHouseResponse = jest.fn(() => Promise.resolve(mockCompany));
-      api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
-
-      await post(req, res);
-
-      const errorMessageTradingName = EXPORTER_BUSINESS_ERROR[TRADING_NAME].IS_EMPTY;
-
-      expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
-        ...corePageVariables({
-          PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
-          BACK_LINK: req.headers.referer,
-        }),
-        ...pageVariables(mockApplication.referenceNumber),
-        validationErrors: generateValidationErrors(TRADING_NAME, errorMessageTradingName, {}),
-        submittedValues,
-      });
-    });
-
-    it('should display validation error for companies house when company house error but trading name radio is selected', async () => {
-      req.body = {
-        companiesHouseNumber: '123456',
-        [TRADING_NAME]: 'true',
-      };
-
-      const submittedValues = {
-        [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
-        [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
-      };
-
-      const getCompaniesHouseResponse = jest.fn(() => Promise.resolve({ apiError: true }));
-      api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
-
-      await post(req, res);
-
-      const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].TECHNICAL_ISSUES;
-
-      expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
-        ...corePageVariables({
-          PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
-          BACK_LINK: req.headers.referer,
-        }),
-        ...pageVariables(mockApplication.referenceNumber),
-        validationErrors: generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessage, {}),
-        submittedValues,
-      });
-    });
-
-    describe('when there is no application', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-      });
-
-      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
 
         expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
       });

--- a/src/ui/server/controllers/insurance/business/company-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.test.ts
@@ -26,14 +26,6 @@ const { COMPANY_HOUSE_SEARCH, COMPANY_DETAILS: COMPANY_DETAILS_ROUTE } = EXPORTE
 
 const { EXPORTER_BUSINESS: EXPORTER_BUSINESS_ERROR } = ERROR_MESSAGES.INSURANCE;
 
-// const PAGE_VARIABLES = {
-//   POST_ROUTES: {
-//     COMPANIES_HOUSE: COMPANY_HOUSE_SEARCH,
-//     COMPANY_DETAILS: COMPANY_DETAILS_ROUTE,
-//   },
-//   FIELDS: EXPORTER_BUSINESS,
-// };
-
 describe('controllers/insurance/business/companies-details', () => {
   let req: Request;
   let res: Response;
@@ -93,7 +85,7 @@ describe('controllers/insurance/business/companies-details', () => {
 
   describe('postCompaniesHouseSearch', () => {
     describe('when there are validation errors', () => {
-      it('should render template with validation errors when companies house input is empty', () => {
+      it('should render template with validation errors when companies house input is empty', async () => {
         req.body = {
           companiesHouseNumber: '',
         };
@@ -102,7 +94,7 @@ describe('controllers/insurance/business/companies-details', () => {
           [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
         };
 
-        postCompaniesHouseSearch(req, res);
+        await postCompaniesHouseSearch(req, res);
 
         const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].INCORRECT_FORMAT;
         expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
@@ -116,7 +108,7 @@ describe('controllers/insurance/business/companies-details', () => {
         });
       });
 
-      it('should render template with validation errors when companies house input is less than 6 numbers', () => {
+      it('should render template with validation errors when companies house input is less than 6 numbers', async () => {
         req.body = {
           companiesHouseNumber: '1234',
         };
@@ -125,7 +117,7 @@ describe('controllers/insurance/business/companies-details', () => {
           [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
         };
 
-        postCompaniesHouseSearch(req, res);
+        await postCompaniesHouseSearch(req, res);
 
         const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].INCORRECT_FORMAT;
         expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
@@ -139,7 +131,7 @@ describe('controllers/insurance/business/companies-details', () => {
         });
       });
 
-      it('should render template with validation errors when companies house input has special characters', () => {
+      it('should render template with validation errors when companies house input has special characters', async () => {
         req.body = {
           companiesHouseNumber: '123456!',
         };
@@ -148,7 +140,7 @@ describe('controllers/insurance/business/companies-details', () => {
           [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
         };
 
-        postCompaniesHouseSearch(req, res);
+        await postCompaniesHouseSearch(req, res);
 
         const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].INCORRECT_FORMAT;
         expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
@@ -238,6 +230,7 @@ describe('controllers/insurance/business/companies-details', () => {
           ...pageVariables(mockApplication.referenceNumber),
           SUMMARY_LIST: companyHouseSummaryList(mockCompany),
           submittedValues,
+          validationErrors: {},
         });
       });
     });
@@ -248,7 +241,7 @@ describe('controllers/insurance/business/companies-details', () => {
           companiesHouseNumber: '123456',
         };
 
-        const getCompaniesHouseResponse = jest.fn(() => Promise.resolve(null));
+        const getCompaniesHouseResponse = jest.fn(() => Promise.reject());
         api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
 
         await postCompaniesHouseSearch(req, res);
@@ -271,7 +264,7 @@ describe('controllers/insurance/business/companies-details', () => {
   });
 
   describe('post', () => {
-    it('should display validation errors when there is no trading name', () => {
+    it('should display validation errors when there is no trading name or companies house number', async () => {
       req.body = {};
 
       const submittedValues = {
@@ -279,16 +272,142 @@ describe('controllers/insurance/business/companies-details', () => {
         [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
       };
 
-      post(req, res);
+      await post(req, res);
 
-      const errorMessage = EXPORTER_BUSINESS_ERROR[TRADING_NAME].IS_EMPTY;
+      const errorMessageTradingName = EXPORTER_BUSINESS_ERROR[TRADING_NAME].IS_EMPTY;
+      const errorMessageCompanyHouseIncorrect = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].INCORRECT_FORMAT;
+
+      let validationErrors = generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessageCompanyHouseIncorrect, {});
+      validationErrors = generateValidationErrors(TRADING_NAME, errorMessageTradingName, validationErrors);
+
       expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
         ...corePageVariables({
           PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
           BACK_LINK: req.headers.referer,
         }),
         ...pageVariables(mockApplication.referenceNumber),
-        validationErrors: generateValidationErrors(TRADING_NAME, errorMessage, {}),
+        validationErrors,
+        submittedValues,
+      });
+    });
+
+    it('should display validation errors when there is no trading name and api error for companies house', async () => {
+      req.body = {
+        companiesHouseNumber: '123456',
+      };
+
+      const submittedValues = {
+        [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
+        [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
+      };
+
+      const getCompaniesHouseResponse = jest.fn(() => Promise.resolve({ apiError: true }));
+      api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
+
+      await post(req, res);
+
+      const errorMessageTradingName = EXPORTER_BUSINESS_ERROR[TRADING_NAME].IS_EMPTY;
+      const errorMessageCompanyHouseIssue = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].TECHNICAL_ISSUES;
+
+      let validationErrors = generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessageCompanyHouseIssue, {});
+      validationErrors = generateValidationErrors(TRADING_NAME, errorMessageTradingName, validationErrors);
+
+      expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
+        ...corePageVariables({
+          PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
+          BACK_LINK: req.headers.referer,
+        }),
+        ...pageVariables(mockApplication.referenceNumber),
+        validationErrors,
+        submittedValues,
+      });
+    });
+
+    it('should display validation errors when there is no trading name and company not found', async () => {
+      req.body = {
+        companiesHouseNumber: '123456',
+      };
+
+      const submittedValues = {
+        [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
+        [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
+      };
+
+      const getCompaniesHouseResponse = jest.fn(() => Promise.resolve({ success: false }));
+      api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
+
+      await post(req, res);
+
+      const errorMessageTradingName = EXPORTER_BUSINESS_ERROR[TRADING_NAME].IS_EMPTY;
+      const errorMessageCompanyHouseIssue = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].NOT_FOUND;
+
+      let validationErrors = generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessageCompanyHouseIssue, {});
+      validationErrors = generateValidationErrors(TRADING_NAME, errorMessageTradingName, validationErrors);
+
+      expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
+        ...corePageVariables({
+          PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
+          BACK_LINK: req.headers.referer,
+        }),
+        ...pageVariables(mockApplication.referenceNumber),
+        validationErrors,
+        submittedValues,
+      });
+    });
+
+    it('should display validation error for trading anme when there is no trading name and company is found', async () => {
+      req.body = {
+        companiesHouseNumber: '123456',
+      };
+
+      const submittedValues = {
+        [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
+        [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
+      };
+
+      const getCompaniesHouseResponse = jest.fn(() => Promise.resolve(mockCompany));
+      api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
+
+      await post(req, res);
+
+      const errorMessageTradingName = EXPORTER_BUSINESS_ERROR[TRADING_NAME].IS_EMPTY;
+
+      expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
+        ...corePageVariables({
+          PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
+          BACK_LINK: req.headers.referer,
+        }),
+        ...pageVariables(mockApplication.referenceNumber),
+        validationErrors: generateValidationErrors(TRADING_NAME, errorMessageTradingName, {}),
+        submittedValues,
+      });
+    });
+
+    it('should display validation error for companies house when company house error but trading name radio is selected', async () => {
+      req.body = {
+        companiesHouseNumber: '123456',
+        [TRADING_NAME]: 'true',
+      };
+
+      const submittedValues = {
+        [COMPANY_HOUSE.INPUT]: req.body[COMPANY_HOUSE.INPUT],
+        [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
+      };
+
+      const getCompaniesHouseResponse = jest.fn(() => Promise.resolve({ apiError: true }));
+      api.keystone.getCompaniesHouseInformation = getCompaniesHouseResponse;
+
+      await post(req, res);
+
+      const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].TECHNICAL_ISSUES;
+
+      expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
+        ...corePageVariables({
+          PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
+          BACK_LINK: req.headers.referer,
+        }),
+        ...pageVariables(mockApplication.referenceNumber),
+        validationErrors: generateValidationErrors(COMPANY_HOUSE.INPUT, errorMessage, {}),
         submittedValues,
       });
     });

--- a/src/ui/server/controllers/insurance/business/company-details/index.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.ts
@@ -17,7 +17,7 @@ const {
 } = FIELD_IDS.INSURANCE;
 
 const { COMPANY_DETAILS } = PAGES.INSURANCE.EXPORTER_BUSINESS;
-const { COMPANY_DETAILS: companyDetailsTemplate } = TEMPLATES.INSURANCE.EXPORTER_BUSINESS;
+const { COMPANY_DETAILS: TEMPLATE } = TEMPLATES.INSURANCE.EXPORTER_BUSINESS;
 
 const { INSURANCE_ROOT, EXPORTER_BUSINESS: EXPORTER_BUSINESS_ROUTES } = ROUTES.INSURANCE;
 
@@ -44,7 +44,7 @@ const get = async (req: Request, res: Response) => {
     return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
   }
 
-  return res.render(companyDetailsTemplate, {
+  return res.render(TEMPLATE, {
     ...insuranceCorePageVariables({
       PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
       BACK_LINK: req.headers.referer,
@@ -78,14 +78,14 @@ const postCompaniesHouseSearch = async (req: Request, res: Response) => {
 
     // checks if input is correctly formatted before searching
     const response = await companiesHouseSearch(body);
-    const { validationErrors, error, company } = response;
+    const { validationErrors, apiError, company } = response;
 
-    if (error) {
+    if (apiError) {
       return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
     }
 
-    if (Object.keys(validationErrors).length) {
-      return res.render(companyDetailsTemplate, {
+    if (validationErrors && Object.keys(validationErrors).length) {
+      return res.render(TEMPLATE, {
         ...insuranceCorePageVariables({
           PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
           BACK_LINK: req.headers.referer,
@@ -100,7 +100,7 @@ const postCompaniesHouseSearch = async (req: Request, res: Response) => {
       // populates summary list with company information
       const summaryList = companyHouseSummaryList(company);
 
-      return res.render(companyDetailsTemplate, {
+      return res.render(TEMPLATE, {
         ...insuranceCorePageVariables({
           PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
           BACK_LINK: req.headers.referer,
@@ -138,10 +138,10 @@ const post = async (req: Request, res: Response) => {
     // runs companiesHouse validation and api call first for companiesHouse input
     const response = await companiesHouseSearch(body);
 
-    const { error, companiesHouseNumber } = response;
+    const { apiError, companiesHouseNumber } = response;
 
     // if error, then there is problem with api/service to redirect
-    if (error) {
+    if (apiError) {
       return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
     }
 
@@ -158,8 +158,8 @@ const post = async (req: Request, res: Response) => {
     validationErrors = companyDetailsValidation(body, validationErrors);
 
     // if any errors then render template with errors
-    if (Object.keys(validationErrors).length) {
-      return res.render(companyDetailsTemplate, {
+    if (validationErrors && Object.keys(validationErrors).length) {
+      return res.render(TEMPLATE, {
         ...insuranceCorePageVariables({
           PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
           BACK_LINK: req.headers.referer,
@@ -171,7 +171,7 @@ const post = async (req: Request, res: Response) => {
     }
 
     // TODO: Remove once page complete.  For testing purposes
-    return res.render(companyDetailsTemplate, {
+    return res.render(TEMPLATE, {
       ...insuranceCorePageVariables({
         PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
         BACK_LINK: req.headers.referer,

--- a/src/ui/server/controllers/insurance/business/company-details/validation/companies-house/index.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/companies-house/index.ts
@@ -9,7 +9,6 @@ import { RequestBody } from '../../../../../../../types';
  */
 const validation = (formBody: RequestBody) => {
   let errors!: object;
-
   for (let i = 0; i < companiesHouseRules.length; i += 1) {
     errors = companiesHouseRules[i](formBody, errors);
   }

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/index.test.ts
@@ -6,7 +6,7 @@ describe('controllers/insurance/business/company-details/validation/company-deta
   it('should return an array of results from rule functions', () => {
     const mockSubmittedData = {} as RequestBody;
 
-    const result = validation(mockSubmittedData);
+    const result = validation(mockSubmittedData, {});
 
     let expectedErrorsObj!: object;
 

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/index.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/index.ts
@@ -7,14 +7,14 @@ import { RequestBody } from '../../../../../../../types';
  * @param {Express.Request.body} responseBody containing an object with the company details response body
  * @returns {object} object containing errors or blank object
  */
-const validation = (responseBody: RequestBody) => {
-  let errors!: object;
+const validation = (responseBody: RequestBody, errors: object) => {
+  let updatedErrors = errors;
 
   for (let i = 0; i < companyDetailsResponseRules.length; i += 1) {
-    errors = companyDetailsResponseRules[i](responseBody, errors);
+    updatedErrors = companyDetailsResponseRules[i](responseBody, errors);
   }
 
-  return errors;
+  return updatedErrors;
 };
 
 export default validation;

--- a/src/ui/templates/insurance/your-business/company-details.njk
+++ b/src/ui/templates/insurance/your-business/company-details.njk
@@ -30,17 +30,17 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters-from-desktop">
-        <span class="govuk-caption-xl" data-cy="heading-caption">
-          {{CONTENT_STRINGS.HEADING_CAPTION}}
-        </span>
-      <h1 class="govuk-heading-xl" data-cy="heading">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
-    </div>
+    <form method="POST" novalidate>
+      <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-    <div class="govuk-grid-column-three-quarters-from-desktop">
-      <form action="{{POST_ROUTES.COMPANIES_HOUSE}}" method="POST">
+      <div class="govuk-grid-column-three-quarters-from-desktop">
+          <span class="govuk-caption-xl" data-cy="heading-caption">
+            {{CONTENT_STRINGS.HEADING_CAPTION}}
+          </span>
+        <h1 class="govuk-heading-xl" data-cy="heading">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
+      </div>
 
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+      <div class="govuk-grid-column-three-quarters-from-desktop">
         <div class="companies-house-search">
 
           {{ govukInput({
@@ -76,31 +76,28 @@
             text: CONTENT_STRINGS.BUTTONS.SEARCH,
             classes: "govuk-button--secondary",
             attributes: {
-              'data-cy': 'companies-house-search-button'
+              'data-cy': 'companies-house-search-button',
+              'formaction': POST_ROUTES.COMPANIES_HOUSE
             }
           }) }}
         </div>
-      </form>
 
-      <p class="govuk-!-margin-bottom-6"><a class="govuk-link" href="/" data-cy="do-not-have-number">{{CONTENT_STRINGS.NO_COMPANY_HOUSE_NUMER}}</a></p>
-    </div>
-
-    {% if SUMMARY_LIST %}
-      <div class="govuk-grid-column-three-quarters-from-desktop">
-        <h3 class="govuk-fieldset__legend--m" data-cy="your-business-heading">{{CONTENT_STRINGS.YOUR_BUSINESS_HEADING}}</h3>
-
-        {{ govukSummaryList({
-          classes: 'govuk-!-margin-bottom-9',
-          rows: SUMMARY_LIST.COMPANY_DETAILS.ROWS,
-           attributes: {
-            'data-cy': 'companies-house-summary-list'
-          }
-        }) }}
+        <p class="govuk-!-margin-bottom-6"><a class="govuk-link" href="/" data-cy="do-not-have-number">{{CONTENT_STRINGS.NO_COMPANY_HOUSE_NUMER}}</a></p>
       </div>
-    {% endif %}
 
-    <form action="{{POST_ROUTES.COMPANY_DETAILS}}" method="POST" novalidate>
-      <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+      {% if SUMMARY_LIST %}
+        <div class="govuk-grid-column-three-quarters-from-desktop">
+          <h3 class="govuk-fieldset__legend--m" data-cy="your-business-heading">{{CONTENT_STRINGS.YOUR_BUSINESS_HEADING}}</h3>
+
+          {{ govukSummaryList({
+            classes: 'govuk-!-margin-bottom-9',
+            rows: SUMMARY_LIST.COMPANY_DETAILS.ROWS,
+            attributes: {
+              'data-cy': 'companies-house-summary-list'
+            }
+          }) }}
+        </div>
+      {% endif %}
 
       <div class="govuk-grid-column-three-quarters-from-desktop">
         {{ yesNoRadioButtons.render({
@@ -131,7 +128,7 @@
             classes: "govuk-label--m",
             isPageHeading: false,
             attributes: {
-            'data-cy': 'company-website-heading'
+            'data-cy': 'company-website-label'
           }
           },
           id: FIELDS.YOUR_COMPANY.WEBSITE,
@@ -151,7 +148,7 @@
             classes: "govuk-label--m",
             isPageHeading: false,
             attributes: {
-            'data-cy': 'company-phone-heading'
+            'data-cy': 'company-phone-label'
             }
           },
           hint: {
@@ -175,7 +172,8 @@
           {{ govukButton({
             text: CONTENT_STRINGS.BUTTONS.CONTINUE,
             attributes: {
-              'data-cy': 'submit-button'
+              'data-cy': 'submit-button',
+              'formaction' : POST_ROUTES.COMPANY_DETAILS
             }
           }) }}
 
@@ -188,7 +186,6 @@
           }) }}
         </div>
       </div>
-
     </form>
   </div>
 

--- a/src/ui/templates/insurance/your-business/company-details.njk
+++ b/src/ui/templates/insurance/your-business/company-details.njk
@@ -128,8 +128,8 @@
             classes: "govuk-label--m",
             isPageHeading: false,
             attributes: {
-            'data-cy': 'company-website-label'
-          }
+              'data-cy': 'company-website-label'
+            }
           },
           id: FIELDS.YOUR_COMPANY.WEBSITE,
           name: FIELDS.YOUR_COMPANY.WEBSITE,
@@ -178,11 +178,11 @@
           }) }}
 
           {{ govukButton({
-              text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-              classes: "govuk-button--secondary",
-              attributes: {
-                'data-cy': 'save-and-back-button'
-              }
+            text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
+            classes: "govuk-button--secondary",
+            attributes: {
+              'data-cy': 'save-and-back-button'
+            }
           }) }}
         </div>
       </div>


### PR DESCRIPTION
# Changes made:
* Changed companies detail template to be single form
* Added routes to search and submit button for different endpoints (companies house search or company details page post)
* Added companies house search helper which makes api call and returns validation errors/company
* Added tests
* Added to e2e tests