### PR TITLE
feat(EMS-510): Policy and exports - Single contract policy - policy currency code validation

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -90,6 +90,9 @@ export const ERROR_MESSAGES = {
           IS_EMPTY: 'Enter the credit period you have with your buyer',
           ABOVE_MAXIMUM: 'The credit period you have with your buyer cannot be more than 1000 characters.',
         },
+        [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.POLICY_CURRENCY_CODE]: {
+          IS_EMPTY: 'Select currency you’d like your policy to be issued in',
+        },
         SINGLE: {
           [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.REQUESTED_START_DATE]: {
             IS_EMPTY: 'Enter a policy start date in the correct format - for example, 06 11 2023',

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/save-and-back.spec.js
@@ -40,7 +40,7 @@ const {
 context('Insurance - Policy and exports - Type of policy page - Save and go back', () => {
   let referenceNumber;
   const date = new Date();
-  const futureDate = add(date, { days: 1, months: 3 });
+  const futureDate = add(date, { months: 3 });
 
   before(() => {
     cy.visit(ROUTES.INSURANCE.START, {
@@ -142,7 +142,7 @@ context('Insurance - Policy and exports - Type of policy page - Save and go back
     const field = singleContractPolicyPage[REQUESTED_START_DATE];
 
     before(() => {
-      field.dayInput().type(getDate(futureDate));
+      field.dayInput().type('1');
       field.monthInput().type(getMonth(futureDate));
       field.yearInput().type(getYear(futureDate));
 
@@ -172,7 +172,7 @@ context('Insurance - Policy and exports - Type of policy page - Save and go back
       });
 
       it('should have the submitted values', () => {
-        field.dayInput().should('have.value', getDate(futureDate));
+        field.dayInput().should('have.value', '1');
         field.monthInput().should('have.value', getMonth(futureDate));
         field.yearInput().should('have.value', getYear(futureDate));
       });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
@@ -276,6 +276,7 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
 
       singleContractPolicyPage[TOTAL_CONTRACT_VALUE].input().type('10000');
       singleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().type('mock free text');
+      singleContractPolicyPage[POLICY_CURRENCY_CODE].input().select('GBP');
 
       submitButton().click();
 
@@ -316,6 +317,7 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
 
         singleContractPolicyPage[TOTAL_CONTRACT_VALUE].input().should('have.value', '10000');
         singleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().should('have.value', 'mock free text');
+        singleContractPolicyPage[POLICY_CURRENCY_CODE].inputOptionSelected().contains('GBP');
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-policy-currency-code.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-policy-currency-code.spec.js
@@ -1,5 +1,5 @@
 import { submitButton } from '../../../../../pages/shared';
-import { typeOfPolicyPage } from '../../../../../pages/insurance/policy-and-export';
+import { typeOfPolicyPage, singleContractPolicyPage } from '../../../../../pages/insurance/policy-and-export';
 import partials from '../../../../../partials';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { FIELD_IDS, ROUTES } from '../../../../../../../constants';
@@ -17,13 +17,7 @@ const {
   INSURANCE: {
     POLICY_AND_EXPORTS: {
       CONTRACT_POLICY: {
-        REQUESTED_START_DATE,
-        CREDIT_PERIOD_WITH_BUYER,
         POLICY_CURRENCY_CODE,
-        SINGLE: {
-          CONTRACT_COMPLETION_DATE,
-          TOTAL_CONTRACT_VALUE,
-        },
       },
     },
   },
@@ -37,7 +31,7 @@ const {
   },
 } = ERROR_MESSAGES;
 
-context('Insurance - Policy and exports - Single contract policy page - form validation', () => {
+context('Insurance - Policy and exports - Single contract policy page - form validation - policy currency code', () => {
   let referenceNumber;
 
   before(() => {
@@ -68,37 +62,21 @@ context('Insurance - Policy and exports - Single contract policy page - form val
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('should render validation errors for all required fields', () => {
-    submitButton().click();
+  const field = singleContractPolicyPage[POLICY_CURRENCY_CODE];
 
-    partials.errorSummaryListItems().should('exist');
+  describe('when policy currency code is not provided', () => {
+    it('should render a validation error', () => {
+      submitButton().click();
 
-    const TOTAL_REQUIRED_FIELDS = 5;
-    partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);
+      checkText(
+        partials.errorSummaryListItems().eq(4),
+        CONTRACT_ERROR_MESSAGES[POLICY_CURRENCY_CODE].IS_EMPTY,
+      );
 
-    checkText(
-      partials.errorSummaryListItems().eq(0),
-      CONTRACT_ERROR_MESSAGES.SINGLE[REQUESTED_START_DATE].IS_EMPTY,
-    );
-
-    checkText(
-      partials.errorSummaryListItems().eq(1),
-      CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].IS_EMPTY,
-    );
-
-    checkText(
-      partials.errorSummaryListItems().eq(2),
-      CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].IS_EMPTY,
-    );
-
-    checkText(
-      partials.errorSummaryListItems().eq(3),
-      CONTRACT_ERROR_MESSAGES[CREDIT_PERIOD_WITH_BUYER].IS_EMPTY,
-    );
-
-    checkText(
-      partials.errorSummaryListItems().eq(4),
-      CONTRACT_ERROR_MESSAGES[POLICY_CURRENCY_CODE].IS_EMPTY,
-    );
+      checkText(
+        field.errorMessage(),
+        `Error: ${CONTRACT_ERROR_MESSAGES[POLICY_CURRENCY_CODE].IS_EMPTY}`,
+      );
+    });
   });
 });

--- a/e2e-tests/cypress/e2e/pages/insurance/policy-and-export/singleContractPolicy.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/policy-and-export/singleContractPolicy.js
@@ -52,6 +52,7 @@ const singleContractPolicy = {
     inputOption: () => cy.get(`[data-cy="${POLICY_CURRENCY_CODE}-input"]`).find('option'),
     inputFirstOption: () => cy.get(`[data-cy="${POLICY_CURRENCY_CODE}-input"]`).find('option').eq(0),
     inputOptionSelected: () => cy.get(`[data-cy="${POLICY_CURRENCY_CODE}-input"]`).find(':selected'),
+    errorMessage: () => cy.get(`[data-cy="${POLICY_CURRENCY_CODE}-error-message"]`),
   },
 };
 

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -90,6 +90,9 @@ export const ERROR_MESSAGES = {
           IS_EMPTY: 'Enter the credit period you have with your buyer',
           ABOVE_MAXIMUM: 'The credit period you have with your buyer cannot be more than 1000 characters.',
         },
+        [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.POLICY_CURRENCY_CODE]: {
+          IS_EMPTY: 'Select currency you’d like your policy to be issued in',
+        },
         SINGLE: {
           [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.REQUESTED_START_DATE]: {
             IS_EMPTY: 'Enter a policy start date in the correct format - for example, 06 11 2023',

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/index.test.ts
@@ -120,6 +120,38 @@ describe('controllers/insurance/policy-and-export/single-contract-policy', () =>
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
     });
 
+    describe('when a policy currency code has been previously submitted', () => {
+      const mockApplicationWithCurrencyCode = {
+        ...mockApplication,
+        policyAndExport: {
+          ...mockApplication.policyAndExport,
+          [POLICY_CURRENCY_CODE]: mockCurrencies[0].isoCode,
+        },
+      };
+
+      beforeEach(() => {
+        res.locals.application = mockApplicationWithCurrencyCode;
+      });
+
+      it('should render template with currencies mapped to submitted currency', async () => {
+        await get(req, res);
+
+        const expectedCurrencies = mapCurrencies(mockCurrencies, mockApplicationWithCurrencyCode.policyAndExport[POLICY_CURRENCY_CODE]);
+
+        const expectedVariables = {
+          ...insuranceCorePageVariables({
+            PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY_AND_EXPORTS.SINGLE_CONTRACT_POLICY,
+            BACK_LINK: req.headers.referer,
+          }),
+          ...pageVariables(refNumber),
+          application: mapApplicationToFormFields(mockApplicationWithCurrencyCode),
+          currencies: expectedCurrencies,
+        };
+
+        expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
+      });
+    });
+
     describe('when there is no application', () => {
       beforeEach(() => {
         res.locals = { csrfToken: '1234' };

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/index.ts
@@ -86,7 +86,13 @@ export const get = async (req: Request, res: Response) => {
       return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
     }
 
-    const mappedCurrencies = mapCurrencies(currencies);
+    let mappedCurrencies;
+
+    if (application.policyAndExport[POLICY_CURRENCY_CODE]) {
+      mappedCurrencies = mapCurrencies(currencies, application.policyAndExport[POLICY_CURRENCY_CODE]);
+    } else {
+      mappedCurrencies = mapCurrencies(currencies);
+    }
 
     return res.render(TEMPLATE, {
       ...insuranceCorePageVariables({

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/save-and-back/index.test.ts
@@ -5,13 +5,14 @@ import { Request, Response } from '../../../../../../types';
 import mapSubmittedData from '../map-submitted-data';
 import generateValidationErrors from '../validation';
 import save from '../../save-data';
-import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockApplication, mockCurrencies, mockReq, mockRes } from '../../../../../test-mocks';
 
 const {
   POLICY_AND_EXPORTS: {
     CONTRACT_POLICY: {
       REQUESTED_START_DATE,
       CREDIT_PERIOD_WITH_BUYER,
+      POLICY_CURRENCY_CODE,
       SINGLE: { CONTRACT_COMPLETION_DATE, TOTAL_CONTRACT_VALUE },
     },
   },
@@ -44,6 +45,7 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/save-an
     [`${CONTRACT_COMPLETION_DATE}-year`]: getYear(add(date, { years: 1, months: 6 })),
     [TOTAL_CONTRACT_VALUE]: '150000',
     [CREDIT_PERIOD_WITH_BUYER]: 'Example',
+    [POLICY_CURRENCY_CODE]: mockCurrencies[0].isoCode,
   };
 
   beforeEach(() => {

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/index.ts
@@ -2,7 +2,8 @@ import requestedStartDateRules from './requested-start-date';
 import contractCompletionDateRules from './contract-completion-date';
 import totalContractValueRules from './total-contract-value';
 import creditPeriodWithBuyerRules from './credit-period-with-buyer';
+import policyCurrencyCodeRules from './policy-currency-code';
 
-const rules = [requestedStartDateRules, contractCompletionDateRules, totalContractValueRules, creditPeriodWithBuyerRules];
+const rules = [requestedStartDateRules, contractCompletionDateRules, totalContractValueRules, creditPeriodWithBuyerRules, policyCurrencyCodeRules];
 
 export default rules;

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/index.ts
@@ -5,6 +5,8 @@ import creditPeriodWithBuyerRules from './credit-period-with-buyer';
 import policyCurrencyCodeRules from './policy-currency-code';
 import { ValidationErrors } from '../../../../../../../types';
 
-const rules = [requestedStartDateRules, contractCompletionDateRules, totalContractValueRules, creditPeriodWithBuyerRules, policyCurrencyCodeRules] as Array<() => ValidationErrors>;
+const rules = [requestedStartDateRules, contractCompletionDateRules, totalContractValueRules, creditPeriodWithBuyerRules, policyCurrencyCodeRules];
 
-export default rules;
+const validationRules = rules as Array<() => ValidationErrors>;
+
+export default validationRules;

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/policy-currency-code.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/policy-currency-code.test.ts
@@ -1,0 +1,52 @@
+import policyCurrencyCodeRules from './policy-currency-code';
+import { FIELD_IDS } from '../../../../../../constants';
+import { ERROR_MESSAGES } from '../../../../../../content-strings';
+import generateValidationErrors from '../../../../../../helpers/validation';
+import { mockCurrencies } from '../../../../../../test-mocks';
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: { POLICY_CURRENCY_CODE: FIELD_ID },
+    },
+  },
+} = FIELD_IDS;
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: { [FIELD_ID]: ERROR_MESSAGE },
+    },
+  },
+} = ERROR_MESSAGES;
+
+describe('controllers/insurance/policy-and-export/single-contract-policy/validation/rules/policy-currency-code', () => {
+  const mockErrors = {
+    summary: [],
+    errorList: {},
+  };
+
+  describe('when the field is not provided', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {};
+
+      const result = policyCurrencyCodeRules(mockSubmittedData, mockErrors);
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when there are no validation errors', () => {
+    it('should return the provided errors object', () => {
+      const mockSubmittedData = {
+        [FIELD_ID]: mockCurrencies[0].isoCode,
+      };
+
+      const result = policyCurrencyCodeRules(mockSubmittedData, mockErrors);
+
+      expect(result).toEqual(mockErrors);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/policy-currency-code.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/policy-currency-code.ts
@@ -1,0 +1,42 @@
+import { FIELD_IDS } from '../../../../../../constants';
+import { ERROR_MESSAGES } from '../../../../../../content-strings';
+import generateValidationErrors from '../../../../../../helpers/validation';
+import { objectHasProperty } from '../../../../../../helpers/object';
+import { RequestBody } from '../../../../../../../types';
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: { POLICY_CURRENCY_CODE: FIELD_ID },
+    },
+  },
+} = FIELD_IDS;
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: { [FIELD_ID]: ERROR_MESSAGE },
+    },
+  },
+} = ERROR_MESSAGES;
+
+/**
+ * policyCurrencyCodeRules
+ * Check submitted form data for errors with the policy currency code field
+ * Returns generateValidationErrors if there are any errors.
+ * @param {Express.Response.body} Express response body
+ * @param {Object} Errors object from previous validation errors
+ * @returns {Object} Validation errors
+ */
+const policyCurrencyCodeRules = (formBody: RequestBody, errors: object) => {
+  const updatedErrors = errors;
+
+  // check if the field is empty.
+  if (!objectHasProperty(formBody, FIELD_ID)) {
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+  }
+
+  return updatedErrors;
+};
+
+export default policyCurrencyCodeRules;

--- a/src/ui/server/graphql/queries/application.ts
+++ b/src/ui/server/graphql/queries/application.ts
@@ -32,6 +32,7 @@ const applicationQuery = gql`
           contractCompletionDate
           totalValueOfContract
           creditPeriodWithBuyer
+          policyCurrencyCode
         }
       }
     }

--- a/src/ui/templates/insurance/policy-and-exports/single-contract-policy.njk
+++ b/src/ui/templates/insurance/policy-and-exports/single-contract-policy.njk
@@ -147,6 +147,12 @@
           classes: "govuk-grid-column-one-quarter-from-desktop",
           attributes: {
             "data-cy": FIELDS.POLICY_CURRENCY_CODE.ID + "-input"
+          },
+          errorMessage: validationErrors.errorList[FIELDS.POLICY_CURRENCY_CODE.ID] and {
+            text: validationErrors.errorList[FIELDS.POLICY_CURRENCY_CODE.ID].text,
+            attributes: {
+              "data-cy": FIELDS.POLICY_CURRENCY_CODE.ID + "-error-message"
+            }
           }
         }) }}
 


### PR DESCRIPTION
This PR adds "contract currency code" field validation to the Single contract policy page and ensures that a previously submitted value is displayed in the form. 

## Summary of changes

- Add validation rule to check that the field is not empty.
- Add policy currency code to the graphQL mutation.
- Add tests.
- Update "save and go back" unit test to ensure the functionality works when the form has every valid field provided.
