### PR TITLE
chore(EMS-786): update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Whilst the automatically generated graphQL API and database is fantastic, there 
 
 This can be easily achieved by creating a [custom schema](https://github.com/UK-Export-Finance/exip/blob/main-application/src/api/custom-schema.ts). We then import this in the [keystone config](https://github.com/UK-Export-Finance/exip/blob/main-application/src/api/keystone.ts#L19) and it magically merges our custom schema with the automatically generated schema.
 
-## Why and how we use Keystone
+## Why we use Keystone
 
 We decided to use Keystone because it provides us with so much functionality out of the box. We do not want to setup and build another CRUD API from scratch. Whilst building an API manually gives us more control, there is overhead for building specific features and maintaining the API.
 
@@ -190,7 +190,7 @@ With Keystone, we get all of this (including things like pagination), by writing
 
 Keystone also provides us with an admin UI for the database. Whilst we don't really use this, there are some potential opportunities for this to be used by non-technical people.
 
-## How and when the UI calls API
+## How and when the UI calls the API
 
 ### When an application page is loaded
 

--- a/README.md
+++ b/README.md
@@ -15,22 +15,22 @@ This repo is based on [template-typescript-package](https://github.com/UK-Export
 - Node version 16 or highr with a corresponding `npm`.
 - Make sure you have an `.env` Use `.env.sample` as a base. Some sensitive variables need to be shared from the team.
 - Run `npm install` in the root directory
-- Run `npm install` in the `src/ui`
+- Run `npm install --legacy-peer-deps` in the `src/ui`
 
 ## Tech stack
 
 - Node, NPM
 - Typescript
-- Keystone (GraphQL API, database)
-- Cypress (E2E tests)
-- GovUK design systems
-- Nunjucks (UI templates)
-- Webpack
-- Jest
-- ESlint, Prettier
-- Husky, commitlint, lint-staged
-- release-please-action
-- Github actions
+- [Keystone (GraphQL API, database)](keystonejs.com)
+- [Cypress (E2E tests)](https://www.cypress.io)
+- [GovUK design systems](design-system.service.gov.uk)
+- [Nunjucks (UI templates)](https://mozilla.github.io/nunjucks/templating.html)
+- [Webpack](https://webpack.js.org)
+- [Jest](https://jestjs.io/)
+- [ESlint](https://eslint.org), [Prettier](https://prettier.io)
+- [Husky](https://typicode.github.io/husky), [commitlint](https://commitlint.js.org), [lint-staged](https://github.com/okonet/lint-staged)
+- [release-please-action](https://github.com/google-github-actions/release-please-action)
+- [Github actions](https://github.com/features/actions)
 
 ## Running locally
 
@@ -133,6 +133,86 @@ npm run lint
 ```shell
 npm run lint:fix
 ```
+
+## What is Keystone?
+
+Keystone is a very powerful headless CMS. After a very simple installation/configuration, Keystone allows you to define a [schema](https://github.com/UK-Export-Finance/exip/blob/main-application/src/api/schema.ts). The schema then automatically generates a graphQL schema, a graphQL resolver, and updates the database with the fields that have been defined in the schema. For example, if the schema has this `Currencies` definition:
+
+```js
+export const lists = {
+  Currencies: {
+    fields: {
+      name: text(),
+      isoCode: text(),
+    },
+  },
+};
+```
+
+Keystone will automatically generate the following graphQL resolvers in the background:
+
+### Mutations
+
+- `createCountry`
+- `createCountries`
+- `updateCountry`
+- `updateCountries`
+- `deleteCountry`
+- `deleteCountries`
+
+### Queries
+
+- `countries`
+- `country`
+- `countriesCount`
+
+Keystone will also automatically create a countries table in the database with any fields listed in the keystone schema as columns in the said table.
+
+### Keystone hooks
+
+Keystone also has some functionality called hooks. Hooks allow you to perform "before and after" or side effects. For example, `resolveInput` allows you to modify or add some data before it is saved in the database, `afterOperation` allows you to trigger something after data is saved. 
+
+You can learn more about hooks in the [official documentation](https://keystonejs.com/docs/guides/hooks)
+
+We do not use hooks very extensively, we currently only use hooks when an application is created.
+
+### Customising the schema / automatically generated GraphQL API
+
+Whilst the automatically generated graphQL API and database is fantastic, there are use cases where we want to create our own graphQL resolver that has no interest in the database. For example, 3rd party API calls to companies house.
+
+This can be easily achieved by creating a [custom schema](https://github.com/UK-Export-Finance/exip/blob/main-application/src/api/custom-schema.ts). We then import this in the [keystone config](https://github.com/UK-Export-Finance/exip/blob/main-application/src/api/keystone.ts#L19) and it magically merges our custom schema with the automatically generated schema.
+
+## Why and how we use Keystone
+
+We decided to use Keystone because it provides us with so much functionality out of the box. We do not want to setup and build another CRUD API from scratch. Whilst building an API manually gives us more control, there is overhead for building specific features and maintaining the API.
+
+With Keystone, we get all of this (including things like pagination), by writing few lines of code in the Keystone schema.
+
+Keystone also provides us with an admin UI for the database. Whilst we don't really use this, there are some potential opportunities for this to be used by non-technical people.
+
+## How and when the UI calls API
+
+### When an application page is loaded
+
+We have some middleware that fetches the application from the API. This middleware calls the API via [this file](https://github.com/UK-Export-Finance/exip/blob/main-application/src/ui/server/middleware/insurance/get-application/index.ts#L63). We use apollo to run the GraphQL query.
+
+The API automatically handles the request (thanks to Keystone) and returns the application.
+
+The middleware assigns the application to `res.locals` so that it can be consumed by the proceeding controller.
+
+### When a user submits a form in the application flow
+
+The following happens:
+
+1. The UI's POST contoller checks for validation errors.
+
+2. If all is OK, call a ["save data" function](https://github.com/UK-Export-Finance/exip/blob/main-application/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.ts#L83).
+
+3. The [save data function](https://github.com/UK-Export-Finance/exip/blob/main-application/src/ui/server/controllers/insurance/policy-and-export/save-data/index.ts) filters out any invalid fields and sanitises all other fields.
+
+4. The save data function then calls the API. The actual call is made [here](https://github.com/UK-Export-Finance/exip/blob/main-application/src/ui/server/api/keystone/application/index.ts#L91). We use apollo to run a GraphQL mutation.
+
+5. The API automatically handles the request (thanks to Keystone) and updates the database columns provided in the GraphQL mutation, for the specified application.
 
 ## Core principles
 
@@ -287,14 +367,6 @@ Note: Pages with a single form field (for example eligibility pages) are a littl
 Github actions will then run a build and push of container images to Azure, which will be picked up and deployed automatically by the Dev environment.
 
 E2E tests for GHA have been setup to run in parallel. When these run you will see duplicates of each job with a number denoting the instance.
-
-## Deployment
-
-Currently, there is only a single staging environment.
-
-A docker image needs to be built, tagged and pushed to docker hub. Then the azure app can be restarted to pick up the latest.
-
-Contact the team for more information.
 
 ## Product definitions for eligibility
 

--- a/src/ui/server/controllers/insurance/policy-and-export/save-data/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/save-data/index.ts
@@ -5,7 +5,8 @@ import { Application, RequestBody } from '../../../../../types';
 
 /**
  * policyAndExport
- * Strip invalid fields from submitted form data and update the application
+ * Strip invalid fields from submitted form data and update the application.
+ * This is used for any save functionality in the Policy and export section of the application.
  * @param {Object} Application
  * @param {Express.Request.body} Form data
  * @param {Express.Request.body} Field error list


### PR DESCRIPTION
## Summary of changes

- Add links to the tech stack list
- Add a section briefly explaining what keystone does, including:
  - What keystone generates when we add something to the keystone schema
  - What keystone hooks are
  - How we customise the generated graphql schema
  - Why we use keystone
  - How and when the UI calls the API
- Remove the deployment section as this has changed and is currently undergoing discussions of what we should/shouldn't put in the README.

Also, improved the documentation/description for the policy and export's "save data" function.

Quick link of the updated README in generated format: https://github.com/UK-Export-Finance/exip/blob/f393d29dae0c5885591d400c263e753a8c5d70d7/README.md
