### PR TITLE
feat(EMS-573): Policy and exports - Multiple contract policy - total sales field

### DIFF
--- a/database/exip.sql
+++ b/database/exip.sql
@@ -346,6 +346,7 @@ CREATE TABLE IF NOT EXISTS `PolicyAndExport` (
   `totalValueOfContract` int DEFAULT NULL,
   `creditPeriodWithBuyer` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
 	`totalMonthsOfCover` int DEFAULT NULL,
+	`totalSalesToBuyer` int DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `PolicyAndExport_application_idx` (`application`),
   CONSTRAINT `PolicyAndExport_application_fkey` FOREIGN KEY (`application`) REFERENCES `Application` (`id`) ON DELETE SET NULL ON UPDATE CASCADE

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -123,6 +123,12 @@ export const ERROR_MESSAGES = {
           [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.MULTIPLE.TOTAL_MONTHS_OF_COVER]: {
             IS_EMPTY: 'Select how many months you want to be insured for',
           },
+          [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.MULTIPLE.TOTAL_SALES_TO_BUYER]: {
+            IS_EMPTY: 'Enter your estimated sales as a whole number - do not enter decimals',
+            NOT_A_NUMBER: 'Enter your estimated sales as a whole number - do not enter decimals',
+            NOT_A_WHOLE_NUMBER: 'Enter your estimated sales as a whole number - do not enter decimals',
+            BELOW_MINIMUM: 'Your estimated sales must be 1 or more',
+          },
         },
       },
     },

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -106,14 +106,14 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  // it('passes the audits', () => {
-  //   cy.lighthouse({
-  //     accessibility: 100,
-  //     performance: 75,
-  //     'best-practices': 100,
-  //     seo: 70,
-  //   });
-  // });
+  it('passes the audits', () => {
+    cy.lighthouse({
+      accessibility: 100,
+      performance: 75,
+      'best-practices': 100,
+      seo: 70,
+    });
+  });
 
   it('renders a back link with correct url', () => {
     partials.backLink().should('exist');
@@ -327,6 +327,8 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
         multipleContractPolicyPage[TOTAL_MONTHS_OF_COVER].inputOptionSelected().invoke('text').then((text) => {
           expect(text.trim()).equal('2 months');
         });
+
+        multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().should('have.value', '1000');
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-total-months-of-cover.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-total-months-of-cover.spec.js
@@ -33,7 +33,7 @@ const {
   },
 } = ERROR_MESSAGES;
 
-context('Insurance - Policy and exports - Multiple contract policy page - form validation - policy currency code', () => {
+context('Insurance - Policy and exports - Multiple contract policy page - form validation - total months of cover', () => {
   let referenceNumber;
 
   before(() => {
@@ -66,7 +66,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
   const field = multipleContractPolicyPage[TOTAL_MONTHS_OF_COVER];
 
-  describe('when policy currency code is not provided', () => {
+  describe('when total months of cover is not provided', () => {
     it('should render a validation error', () => {
       submitButton().click();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-total-sales-to-buyer.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-total-sales-to-buyer.spec.js
@@ -1,0 +1,135 @@
+import { submitButton } from '../../../../../pages/shared';
+import { typeOfPolicyPage, multipleContractPolicyPage } from '../../../../../pages/insurance/policy-and-export';
+import partials from '../../../../../partials';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import { FIELD_IDS, ROUTES } from '../../../../../../../constants';
+import getReferenceNumber from '../../../../../helpers/get-reference-number';
+import checkText from '../../../../../helpers/check-text';
+
+const { taskList } = partials.insurancePartials;
+
+const multiplePolicyFieldId = FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.POLICY_TYPE;
+const multiplePolicyField = typeOfPolicyPage[multiplePolicyFieldId].multiple;
+
+const { INSURANCE } = ROUTES;
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: {
+        MULTIPLE: { TOTAL_SALES_TO_BUYER },
+      },
+    },
+  },
+} = FIELD_IDS;
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: {
+        MULTIPLE: CONTRACT_ERROR_MESSAGES,
+      },
+    },
+  },
+} = ERROR_MESSAGES;
+
+context('Insurance - Policy and exports - Multiple contract policy page - form validation - policy currency code', () => {
+  let referenceNumber;
+
+  before(() => {
+    cy.visit(INSURANCE.START, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    cy.submitInsuranceEligibilityAndStartApplication();
+
+    taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+
+    multiplePolicyField.input().click();
+    submitButton().click();
+
+    getReferenceNumber().then((id) => {
+      referenceNumber = id;
+      const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE.ROOT}/${referenceNumber}${INSURANCE.POLICY_AND_EXPORTS.MULTIPLE_CONTRACT_POLICY}`;
+
+      cy.url().should('eq', expectedUrl);
+    });
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
+  const field = multipleContractPolicyPage[TOTAL_SALES_TO_BUYER];
+
+  describe('when total sales to buyer is not provided', () => {
+    it('should render a validation error', () => {
+      submitButton().click();
+
+      checkText(
+        partials.errorSummaryListItems().eq(2),
+        CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].IS_EMPTY,
+      );
+
+      checkText(
+        field.errorMessage(),
+        `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].IS_EMPTY}`,
+      );
+    });
+  });
+
+  describe('when total sales to buyer is not a number', () => {
+    it('should render a validation error', () => {
+      multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().clear().type('ten!');
+      submitButton().click();
+
+      checkText(
+        partials.errorSummaryListItems().eq(2),
+        CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].NOT_A_NUMBER,
+      );
+
+      checkText(
+        field.errorMessage(),
+        `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].NOT_A_NUMBER}`,
+      );
+    });
+  });
+
+  describe('when total sales to buyer contains a decimal', () => {
+    it('should render a validation error', () => {
+      multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().clear().type('1.2');
+      submitButton().click();
+
+      checkText(
+        partials.errorSummaryListItems().eq(2),
+        CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].NOT_A_WHOLE_NUMBER,
+      );
+
+      checkText(
+        field.errorMessage(),
+        `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].NOT_A_WHOLE_NUMBER}`,
+      );
+    });
+  });
+
+  describe('when total sales to buyer is below the minimum', () => {
+    it('should render a validation error', () => {
+      multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().clear().type('0');
+      submitButton().click();
+
+      checkText(
+        partials.errorSummaryListItems().eq(2),
+        CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].BELOW_MINIMUM,
+      );
+
+      checkText(
+        field.errorMessage(),
+        `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].BELOW_MINIMUM}`,
+      );
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
@@ -18,7 +18,10 @@ const {
     POLICY_AND_EXPORTS: {
       CONTRACT_POLICY: {
         REQUESTED_START_DATE,
-        MULTIPLE: { TOTAL_MONTHS_OF_COVER },
+        MULTIPLE: {
+          TOTAL_MONTHS_OF_COVER,
+          TOTAL_SALES_TO_BUYER,
+        },
       },
     },
   },
@@ -68,7 +71,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
     partials.errorSummaryListItems().should('exist');
 
-    const TOTAL_REQUIRED_FIELDS = 2;
+    const TOTAL_REQUIRED_FIELDS = 3;
     partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);
 
     checkText(
@@ -79,6 +82,11 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
     checkText(
       partials.errorSummaryListItems().eq(1),
       CONTRACT_ERROR_MESSAGES.MULTIPLE[TOTAL_MONTHS_OF_COVER].IS_EMPTY,
+    );
+
+    checkText(
+      partials.errorSummaryListItems().eq(2),
+      CONTRACT_ERROR_MESSAGES.MULTIPLE[TOTAL_SALES_TO_BUYER].IS_EMPTY,
     );
   });
 });

--- a/e2e-tests/cypress/support/insurance/complete-and-submit-multiple-contract-policy-form.js
+++ b/e2e-tests/cypress/support/insurance/complete-and-submit-multiple-contract-policy-form.js
@@ -12,7 +12,10 @@ const {
     POLICY_AND_EXPORTS: {
       CONTRACT_POLICY: {
         REQUESTED_START_DATE,
-        MULTIPLE: { TOTAL_MONTHS_OF_COVER },
+        MULTIPLE: {
+          TOTAL_MONTHS_OF_COVER,
+          TOTAL_SALES_TO_BUYER,
+        },
       },
     },
   },
@@ -27,6 +30,7 @@ export default () => {
   multipleContractPolicyPage[REQUESTED_START_DATE].yearInput().type(getYear(startDate));
 
   multipleContractPolicyPage[TOTAL_MONTHS_OF_COVER].input().select('2');
+  multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().type('1000');
 
   submitButton().click();
 };

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -186,7 +186,8 @@ var lists = {
       }),
       creditPeriodWithBuyer: (0, import_fields.text)(),
       policyCurrencyCode: (0, import_fields.text)(),
-      totalMonthsOfCover: (0, import_fields.integer)()
+      totalMonthsOfCover: (0, import_fields.integer)(),
+      totalSalesToBuyer: (0, import_fields.integer)()
     },
     access: import_access.allowAll
   },

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -209,6 +209,7 @@ type PolicyAndExport {
   creditPeriodWithBuyer: String
   policyCurrencyCode: String
   totalMonthsOfCover: Int
+  totalSalesToBuyer: Int
 }
 
 input PolicyAndExportWhereUniqueInput {
@@ -228,6 +229,7 @@ input PolicyAndExportWhereInput {
   creditPeriodWithBuyer: StringFilter
   policyCurrencyCode: StringFilter
   totalMonthsOfCover: IntNullableFilter
+  totalSalesToBuyer: IntNullableFilter
 }
 
 input StringFilter {
@@ -267,6 +269,7 @@ input PolicyAndExportOrderByInput {
   creditPeriodWithBuyer: OrderDirection
   policyCurrencyCode: OrderDirection
   totalMonthsOfCover: OrderDirection
+  totalSalesToBuyer: OrderDirection
 }
 
 input PolicyAndExportUpdateInput {
@@ -278,6 +281,7 @@ input PolicyAndExportUpdateInput {
   creditPeriodWithBuyer: String
   policyCurrencyCode: String
   totalMonthsOfCover: Int
+  totalSalesToBuyer: Int
 }
 
 input PolicyAndExportUpdateArgs {
@@ -294,6 +298,7 @@ input PolicyAndExportCreateInput {
   creditPeriodWithBuyer: String
   policyCurrencyCode: String
   totalMonthsOfCover: Int
+  totalSalesToBuyer: Int
 }
 
 type Country {

--- a/src/api/schema.prisma
+++ b/src/api/schema.prisma
@@ -51,6 +51,7 @@ model PolicyAndExport {
   creditPeriodWithBuyer            String        @default("")
   policyCurrencyCode               String        @default("")
   totalMonthsOfCover               Int?
+  totalSalesToBuyer                Int?
   from_Application_policyAndExport Application[] @relation("Application_policyAndExport")
 
   @@index([applicationId])

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -159,6 +159,7 @@ export const lists = {
       creditPeriodWithBuyer: text(),
       policyCurrencyCode: text(),
       totalMonthsOfCover: integer(),
+      totalSalesToBuyer: integer(),
     },
     access: allowAll,
   },

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -15,6 +15,7 @@
         "@types/cookie-parser": "^1.4.3",
         "@types/csurf": "^1.11.2",
         "@types/express-session": "^1.17.5",
+        "@types/is-url": "^1.2.30",
         "@types/morgan": "^1.9.3",
         "@types/node": "^18.11.9",
         "@types/nunjucks": "^3.2.1",
@@ -36,6 +37,7 @@
         "govuk-frontend": "^4.4.0",
         "graphql": "^15.8.0",
         "graphql-tag": "^2.12.6",
+        "is-url": "^1.2.4",
         "joi": "^17.7.0",
         "morgan": "1.10.0",
         "node-notifier": "^10.0.1",
@@ -4170,6 +4172,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/is-url": {
+      "version": "1.2.30",
+      "resolved": "https://registry.npmjs.org/@types/is-url/-/is-url-1.2.30.tgz",
+      "integrity": "sha512-AnlNFwjzC8XLda5VjRl4ItSd8qp8pSNowvsut0WwQyBWHpOxjxRJm8iO6uETWqEyLdYdb9/1j+Qd9gQ4l5I4fw=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -8631,6 +8638,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
@@ -18695,6 +18707,11 @@
         "@types/node": "*"
       }
     },
+    "@types/is-url": {
+      "version": "1.2.30",
+      "resolved": "https://registry.npmjs.org/@types/is-url/-/is-url-1.2.30.tgz",
+      "integrity": "sha512-AnlNFwjzC8XLda5VjRl4ItSd8qp8pSNowvsut0WwQyBWHpOxjxRJm8iO6uETWqEyLdYdb9/1j+Qd9gQ4l5I4fw=="
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -22005,6 +22022,11 @@
       "requires": {
         "has-symbols": "^1.0.2"
       }
+    },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
     },
     "is-weakref": {
       "version": "1.0.2",

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -123,6 +123,12 @@ export const ERROR_MESSAGES = {
           [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.MULTIPLE.TOTAL_MONTHS_OF_COVER]: {
             IS_EMPTY: 'Select how many months you want to be insured for',
           },
+          [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.MULTIPLE.TOTAL_SALES_TO_BUYER]: {
+            IS_EMPTY: 'Enter your estimated sales as a whole number - do not enter decimals',
+            NOT_A_NUMBER: 'Enter your estimated sales as a whole number - do not enter decimals',
+            NOT_A_WHOLE_NUMBER: 'Enter your estimated sales as a whole number - do not enter decimals',
+            BELOW_MINIMUM: 'Your estimated sales must be 1 or more',
+          },
         },
       },
     },

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/index.test.ts
@@ -201,7 +201,8 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy', () 
       [`${REQUESTED_START_DATE}-day`]: '1',
       [`${REQUESTED_START_DATE}-month`]: getMonth(add(date, { months: 1 })),
       [`${REQUESTED_START_DATE}-year`]: getYear(add(date, { years: 1 })),
-      [TOTAL_MONTHS_OF_COVER]: 1,
+      [TOTAL_MONTHS_OF_COVER]: '1',
+      [TOTAL_SALES_TO_BUYER]: '1000',
     };
 
     describe('when there are no validation errors', () => {

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/index.ts
@@ -1,7 +1,8 @@
 import requestedStartDateRules from '../../../../../../shared-validation/requested-start-date';
 import totalMonthsOfCoverRules from './total-months-of-cover';
+import totalSalesToBuyerRules from './total-sales-to-buyer';
 import { ValidationErrors } from '../../../../../../../types';
 
-const rules = [requestedStartDateRules, totalMonthsOfCoverRules] as Array<() => ValidationErrors>;
+const rules = [requestedStartDateRules, totalMonthsOfCoverRules, totalSalesToBuyerRules] as Array<() => ValidationErrors>;
 
 export default rules;

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer.test.ts
@@ -1,0 +1,97 @@
+import totalContractValueRules from './total-sales-to-buyer';
+import { FIELD_IDS } from '../../../../../../constants';
+import { ERROR_MESSAGES } from '../../../../../../content-strings';
+import generateValidationErrors from '../../../../../../helpers/validation';
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: {
+        MULTIPLE: { TOTAL_SALES_TO_BUYER: FIELD_ID },
+      },
+    },
+  },
+} = FIELD_IDS;
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: {
+        MULTIPLE: { [FIELD_ID]: ERROR_MESSAGE },
+      },
+    },
+  },
+} = ERROR_MESSAGES;
+
+describe('controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer', () => {
+  const mockErrors = {
+    summary: [],
+    errorList: {},
+  };
+
+  describe('when the field is not provided', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {};
+
+      const result = totalContractValueRules(mockSubmittedData, mockErrors);
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when total sales to buyer is not a number', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        [FIELD_ID]: 'One hundred!',
+      };
+
+      const result = totalContractValueRules(mockSubmittedData, mockErrors);
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when total sales to buyer contains a decimal', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        [FIELD_ID]: '123.456',
+      };
+
+      const result = totalContractValueRules(mockSubmittedData, mockErrors);
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_WHOLE_NUMBER, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when total sales to buyer is below the minimum', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        [FIELD_ID]: '0',
+      };
+
+      const result = totalContractValueRules(mockSubmittedData, mockErrors);
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when there are no validation errors', () => {
+    it('should return the provided errors object', () => {
+      const mockSubmittedData = {
+        [FIELD_ID]: '10000',
+      };
+
+      const result = totalContractValueRules(mockSubmittedData, mockErrors);
+
+      expect(result).toEqual(mockErrors);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer.ts
@@ -1,0 +1,64 @@
+import { FIELD_IDS } from '../../../../../../constants';
+import { ERROR_MESSAGES } from '../../../../../../content-strings';
+import generateValidationErrors from '../../../../../../helpers/validation';
+import { objectHasProperty } from '../../../../../../helpers/object';
+import { isNumber, numberHasDecimal } from '../../../../../../helpers/number';
+import { RequestBody } from '../../../../../../../types';
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: {
+        MULTIPLE: { TOTAL_SALES_TO_BUYER: FIELD_ID },
+      },
+    },
+  },
+} = FIELD_IDS;
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: {
+        MULTIPLE: { [FIELD_ID]: ERROR_MESSAGE },
+      },
+    },
+  },
+} = ERROR_MESSAGES;
+
+const MINIMUM = 1;
+
+/**
+ * totalSalesToBuyerRules
+ * Check submitted form data for errors with the total sales to buyer field
+ * Returns generateValidationErrors if there are any errors.
+ * @param {Express.Response.body} Express response body
+ * @param {Object} Errors object from previous validation errors
+ * @returns {Object} Validation errors
+ */
+const totalSalesToBuyerRules = (formBody: RequestBody, errors: object) => {
+  const updatedErrors = errors;
+
+  // check if the field is empty.
+  if (!objectHasProperty(formBody, FIELD_ID)) {
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+  }
+
+  // check if the field is not a number
+  if (!isNumber(formBody[FIELD_ID])) {
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, errors);
+  }
+
+  // check if the field is not a whole number
+  if (numberHasDecimal(formBody[FIELD_ID])) {
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_WHOLE_NUMBER, errors);
+  }
+
+  // check if the field is below the minimum
+  if (Number(formBody[FIELD_ID]) < MINIMUM) {
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, errors);
+  }
+
+  return updatedErrors;
+};
+
+export default totalSalesToBuyerRules;

--- a/src/ui/server/graphql/queries/application.ts
+++ b/src/ui/server/graphql/queries/application.ts
@@ -34,6 +34,7 @@ const applicationQuery = gql`
           creditPeriodWithBuyer
           policyCurrencyCode
           totalMonthsOfCover
+          totalSalesToBuyer
         }
       }
     }


### PR DESCRIPTION
This PR adds "total sales to buyer" field validation and data saving to the Multiple contract policy page.

## Summary of changes

- Add `totalSalesToBuyer` to the schema and DB dump.
- Add validation handling for if the field is submitted without a value or has an incorrect value.
- Also fixed some naming typos.
