### PR TITLE
feat(EMS-574): Policy and exports - Multiple contract policy - estimated max amount owed field

### DIFF
--- a/database/exip.sql
+++ b/database/exip.sql
@@ -347,6 +347,7 @@ CREATE TABLE IF NOT EXISTS `PolicyAndExport` (
   `creditPeriodWithBuyer` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
 	`totalMonthsOfCover` int DEFAULT NULL,
 	`totalSalesToBuyer` int DEFAULT NULL,
+	`maximumBuyerWillOwe` int DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `PolicyAndExport_application_idx` (`application`),
   CONSTRAINT `PolicyAndExport_application_fkey` FOREIGN KEY (`application`) REFERENCES `Application` (`id`) ON DELETE SET NULL ON UPDATE CASCADE

--- a/e2e-tests/constants/application.js
+++ b/e2e-tests/constants/application.js
@@ -13,5 +13,6 @@ export const APPLICATION = {
       MAXIMUM: 499999,
     },
     TOTAL_MONTHS_OF_COVER: 12,
+    MAXIMUM_BUYER_CAN_OWE: 499999,
   },
 };

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -129,6 +129,13 @@ export const ERROR_MESSAGES = {
             NOT_A_WHOLE_NUMBER: 'Enter your estimated sales as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your estimated sales must be 1 or more',
           },
+          [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.MULTIPLE.MAXIMUM_BUYER_WILL_OWE]: {
+            IS_EMPTY: 'Enter maximum the buyer will owe as a whole number - do not enter decimals',
+            NOT_A_NUMBER: 'Enter maximum the buyer will owe as a whole number - do not enter decimals',
+            NOT_A_WHOLE_NUMBER: 'Enter maximum the buyer will owe as a whole number - do not enter decimals',
+            BELOW_MINIMUM: 'The maximum the buyer will owe must be 1 or more',
+            ABOVE_MAXIMUM: 'The maximum the buyer will owe cannot be more than £499.999',
+          },
         },
       },
     },

--- a/e2e-tests/content-strings/fields/insurance/policy-and-exports/index.js
+++ b/e2e-tests/content-strings/fields/insurance/policy-and-exports/index.js
@@ -75,10 +75,15 @@ export const POLICY_AND_EXPORT_FIELDS = {
       },
       [CONTRACT_POLICY.MULTIPLE.MAXIMUM_BUYER_WILL_OWE]: {
         LABEL: 'Estimate the maximum amount your buyer will owe you at any single point during this time',
-        HINT_LIST: [
-          'For example, your total sales might be £250,000 but the maximum the buyer will owe you at any single point is £100,000.',
-          'Enter a whole number - do not enter decimals',
-        ],
+        HINT: {
+          FOR_EXAMPLE: 'For example, your total sales might be £250,000 but the maximum the buyer will owe you at any single point is £100,000.',
+          NEED_MORE_COVER: 'If you need cover for more than £499,999, ',
+          FILL_IN_FORM: {
+            TEXT: 'fill in this form instead.',
+            HREF: LINKS.EXTERNAL.NBI_FORM,
+          },
+          NO_DECIMALS: 'Enter a whole number - do not enter decimals.',
+        },
       },
     },
   },

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -1,9 +1,4 @@
 import {
-  add,
-  getMonth,
-  getYear,
-} from 'date-fns';
-import {
   headingCaption,
   heading,
   submitButton,
@@ -26,6 +21,7 @@ import {
   SUPPORTED_CURRENCIES,
 } from '../../../../../../constants';
 import getReferenceNumber from '../../../../helpers/get-reference-number';
+import application from '../../../../../fixtures/application';
 
 const { taskList } = partials.insurancePartials;
 
@@ -312,9 +308,6 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
   });
 
   describe('form submission', () => {
-    const date = new Date();
-    const startDate = add(date, { months: 3 });
-
     it(`should redirect to ${ABOUT_GOODS_OR_SERVICES}`, () => {
       cy.completeAndSubmitMultipleContractPolicyForm();
 
@@ -345,17 +338,17 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
       it('should have the submitted values', () => {
         goToPageDirectly(referenceNumber);
 
-        multipleContractPolicyPage[REQUESTED_START_DATE].dayInput().should('have.value', '1');
-        multipleContractPolicyPage[REQUESTED_START_DATE].monthInput().should('have.value', getMonth(startDate));
-        multipleContractPolicyPage[REQUESTED_START_DATE].yearInput().should('have.value', getYear(startDate));
+        multipleContractPolicyPage[REQUESTED_START_DATE].dayInput().should('have.value', application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].day);
+        multipleContractPolicyPage[REQUESTED_START_DATE].monthInput().should('have.value', application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].month);
+        multipleContractPolicyPage[REQUESTED_START_DATE].yearInput().should('have.value', application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].year);
 
         multipleContractPolicyPage[TOTAL_MONTHS_OF_COVER].inputOptionSelected().invoke('text').then((text) => {
-          expect(text.trim()).equal('2 months');
+          expect(text.trim()).equal(`${application.POLICY_AND_EXPORTS[TOTAL_MONTHS_OF_COVER]} months`);
         });
 
-        multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().should('have.value', '1000');
+        multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().should('have.value', application.POLICY_AND_EXPORTS[TOTAL_SALES_TO_BUYER]);
 
-        multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().should('have.value', '500');
+        multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().should('have.value', application.POLICY_AND_EXPORTS[MAXIMUM_BUYER_WILL_OWE]);
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -217,12 +217,37 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
     field.input().should('exist');
   });
 
-  it('renders `maximum buyer will owe` prefix and input', () => {
+  it('renders `maximum buyer will owe` label, hint, prefix, input', () => {
     const fieldId = MAXIMUM_BUYER_WILL_OWE;
     const field = multipleContractPolicyPage[fieldId];
+    const { HINT } = CONTRACT_POLICY.MULTIPLE[fieldId];
 
-    field.prefix().invoke('text').then((text) => {
-      expect(text.trim()).equal('£');
+    field.label().should('exist');
+    field.label().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTRACT_POLICY.MULTIPLE[fieldId].LABEL);
+    });
+
+    field.label().invoke('text').then((text) => {
+      expect(text.trim()).equal(CONTRACT_POLICY.MULTIPLE[fieldId].LABEL);
+    });
+
+    field.hint.forExample().invoke('text').then((text) => {
+      expect(text.trim()).equal(HINT.FOR_EXAMPLE);
+    });
+
+    field.hint.needMoreCover().invoke('text').then((text) => {
+      const expected = `${HINT.NEED_MORE_COVER} ${HINT.FILL_IN_FORM.TEXT}`;
+      expect(text.trim()).equal(expected);
+    });
+
+    field.hint.fillInFormLink().invoke('text').then((text) => {
+      expect(text.trim()).equal(HINT.FILL_IN_FORM.TEXT);
+    });
+
+    field.hint.fillInFormLink().should('have.attr', 'href', HINT.FILL_IN_FORM.HREF);
+
+    field.hint.noDecimals().invoke('text').then((text) => {
+      expect(text.trim()).equal(HINT.NO_DECIMALS);
     });
 
     field.input().should('exist');
@@ -329,6 +354,8 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
         });
 
         multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().should('have.value', '1000');
+
+        multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().should('have.value', '500');
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-maximum-buyer-will-owe.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-maximum-buyer-will-owe.spec.js
@@ -2,7 +2,7 @@ import { submitButton } from '../../../../../pages/shared';
 import { typeOfPolicyPage, multipleContractPolicyPage } from '../../../../../pages/insurance/policy-and-export';
 import partials from '../../../../../partials';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import { FIELD_IDS, ROUTES } from '../../../../../../../constants';
+import { APPLICATION, FIELD_IDS, ROUTES } from '../../../../../../../constants';
 import getReferenceNumber from '../../../../../helpers/get-reference-number';
 import checkText from '../../../../../helpers/check-text';
 
@@ -17,7 +17,7 @@ const {
   INSURANCE: {
     POLICY_AND_EXPORTS: {
       CONTRACT_POLICY: {
-        MULTIPLE: { TOTAL_SALES_TO_BUYER },
+        MULTIPLE: { MAXIMUM_BUYER_WILL_OWE },
       },
     },
   },
@@ -33,7 +33,7 @@ const {
   },
 } = ERROR_MESSAGES;
 
-context('Insurance - Policy and exports - Multiple contract policy page - form validation - total sales to buyer', () => {
+context('Insurance - Policy and exports - Multiple contract policy page - form validation - maximum buyer will owe', () => {
   let referenceNumber;
 
   before(() => {
@@ -64,71 +64,90 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  const field = multipleContractPolicyPage[TOTAL_SALES_TO_BUYER];
+  const field = multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE];
 
   describe('when total sales to buyer is not provided', () => {
     it('should render a validation error', () => {
       submitButton().click();
 
       checkText(
-        partials.errorSummaryListItems().eq(2),
-        CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].IS_EMPTY,
+        partials.errorSummaryListItems().eq(3),
+        CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].IS_EMPTY,
       );
 
       checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].IS_EMPTY}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].IS_EMPTY}`,
       );
     });
   });
 
   describe('when total sales to buyer is not a number', () => {
     it('should render a validation error', () => {
-      multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().clear().type('ten!');
+      multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().clear().type('ten!');
       submitButton().click();
 
       checkText(
-        partials.errorSummaryListItems().eq(2),
-        CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].NOT_A_NUMBER,
+        partials.errorSummaryListItems().eq(3),
+        CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].NOT_A_NUMBER,
       );
 
       checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].NOT_A_NUMBER}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].NOT_A_NUMBER}`,
       );
     });
   });
 
   describe('when total sales to buyer contains a decimal', () => {
     it('should render a validation error', () => {
-      multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().clear().type('1.2');
+      multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().clear().type('1.2');
       submitButton().click();
 
       checkText(
-        partials.errorSummaryListItems().eq(2),
-        CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].NOT_A_WHOLE_NUMBER,
+        partials.errorSummaryListItems().eq(3),
+        CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].NOT_A_WHOLE_NUMBER,
       );
 
       checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].NOT_A_WHOLE_NUMBER}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].NOT_A_WHOLE_NUMBER}`,
       );
     });
   });
 
   describe('when total sales to buyer is below the minimum', () => {
     it('should render a validation error', () => {
-      multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().clear().type('0');
+      multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().clear().type('0');
       submitButton().click();
 
       checkText(
-        partials.errorSummaryListItems().eq(2),
-        CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].BELOW_MINIMUM,
+        partials.errorSummaryListItems().eq(3),
+        CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].BELOW_MINIMUM,
       );
 
       checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].BELOW_MINIMUM}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].BELOW_MINIMUM}`,
+      );
+    });
+  });
+
+  describe('when total sales to buyer is above the maximum', () => {
+    it('should render a validation error', () => {
+      const MAXIMUM = APPLICATION.POLICY_AND_EXPORT.MAXIMUM_BUYER_CAN_OWE;
+
+      multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().clear().type(MAXIMUM + 1);
+      submitButton().click();
+
+      checkText(
+        partials.errorSummaryListItems().eq(3),
+        CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].ABOVE_MAXIMUM,
+      );
+
+      checkText(
+        field.errorMessage(),
+        `Error: ${CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].ABOVE_MAXIMUM}`,
       );
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
@@ -21,6 +21,7 @@ const {
         MULTIPLE: {
           TOTAL_MONTHS_OF_COVER,
           TOTAL_SALES_TO_BUYER,
+          MAXIMUM_BUYER_WILL_OWE,
         },
       },
     },
@@ -71,7 +72,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
     partials.errorSummaryListItems().should('exist');
 
-    const TOTAL_REQUIRED_FIELDS = 3;
+    const TOTAL_REQUIRED_FIELDS = 4;
     partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);
 
     checkText(
@@ -87,6 +88,11 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
     checkText(
       partials.errorSummaryListItems().eq(2),
       CONTRACT_ERROR_MESSAGES.MULTIPLE[TOTAL_SALES_TO_BUYER].IS_EMPTY,
+    );
+
+    checkText(
+      partials.errorSummaryListItems().eq(3),
+      CONTRACT_ERROR_MESSAGES.MULTIPLE[MAXIMUM_BUYER_WILL_OWE].IS_EMPTY,
     );
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
@@ -1,9 +1,4 @@
 import {
-  add,
-  getMonth,
-  getYear,
-} from 'date-fns';
-import {
   headingCaption,
   heading,
   submitButton,
@@ -21,6 +16,7 @@ import {
 import { POLICY_AND_EXPORT_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy-and-exports';
 import { FIELD_IDS, ROUTES, SUPPORTED_CURRENCIES } from '../../../../../../constants';
 import getReferenceNumber from '../../../../helpers/get-reference-number';
+import application from '../../../../../fixtures/application';
 
 const { taskList } = partials.insurancePartials;
 
@@ -262,10 +258,6 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
   });
 
   describe('form submission', () => {
-    const date = new Date();
-    const startDate = add(date, { months: 3 });
-    const endDate = add(startDate, { months: 6 });
-
     it(`should redirect to ${ABOUT_GOODS_OR_SERVICES}`, () => {
       cy.completeAndSubmitSingleContractPolicyForm();
 
@@ -296,17 +288,17 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
       it('should have the submitted values', () => {
         goToPageDirectly(referenceNumber);
 
-        singleContractPolicyPage[REQUESTED_START_DATE].dayInput().should('have.value', '1');
-        singleContractPolicyPage[REQUESTED_START_DATE].monthInput().should('have.value', getMonth(startDate));
-        singleContractPolicyPage[REQUESTED_START_DATE].yearInput().should('have.value', getYear(startDate));
+        singleContractPolicyPage[REQUESTED_START_DATE].dayInput().should('have.value', application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].day);
+        singleContractPolicyPage[REQUESTED_START_DATE].monthInput().should('have.value', application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].month);
+        singleContractPolicyPage[REQUESTED_START_DATE].yearInput().should('have.value', application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].year);
 
-        singleContractPolicyPage[CONTRACT_COMPLETION_DATE].dayInput().should('have.value', '1');
-        singleContractPolicyPage[CONTRACT_COMPLETION_DATE].monthInput().should('have.value', getMonth(endDate));
-        singleContractPolicyPage[CONTRACT_COMPLETION_DATE].yearInput().should('have.value', getYear(endDate));
+        singleContractPolicyPage[CONTRACT_COMPLETION_DATE].dayInput().should('have.value', application.POLICY_AND_EXPORTS[CONTRACT_COMPLETION_DATE].day);
+        singleContractPolicyPage[CONTRACT_COMPLETION_DATE].monthInput().should('have.value', application.POLICY_AND_EXPORTS[CONTRACT_COMPLETION_DATE].month);
+        singleContractPolicyPage[CONTRACT_COMPLETION_DATE].yearInput().should('have.value', application.POLICY_AND_EXPORTS[CONTRACT_COMPLETION_DATE].year);
 
-        singleContractPolicyPage[TOTAL_CONTRACT_VALUE].input().should('have.value', '10000');
-        singleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().should('have.value', 'mock free text');
-        singleContractPolicyPage[POLICY_CURRENCY_CODE].inputOptionSelected().contains('GBP');
+        singleContractPolicyPage[TOTAL_CONTRACT_VALUE].input().should('have.value', application.POLICY_AND_EXPORTS[TOTAL_CONTRACT_VALUE]);
+        singleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().should('have.value', application.POLICY_AND_EXPORTS[CREDIT_PERIOD_WITH_BUYER]);
+        singleContractPolicyPage[POLICY_CURRENCY_CODE].inputOptionSelected().contains(application.POLICY_AND_EXPORTS[POLICY_CURRENCY_CODE]);
       });
     });
   });

--- a/e2e-tests/cypress/e2e/pages/insurance/policy-and-export/multipleContractPolicy.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/policy-and-export/multipleContractPolicy.js
@@ -44,7 +44,14 @@ const multipleContractPolicy = {
   },
   [MAXIMUM_BUYER_WILL_OWE]: {
     label: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-label"]`),
-    hint: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-hint"]`),
+    hint: {
+      forExample: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-hint-for-example"]`),
+      needMoreCover: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-hint-need-more-cover"]`),
+      fillInFormLink: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-hint-fill-in-form-link"]`),
+      noDecimals: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-hint-no-decimals"]`),
+    },
+    text: () => cy.get('[data-cy="details-1"]'),
+    link: () => cy.get('[data-cy="details-1"]  a'),
     prefix: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-prefix"]`),
     input: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-input"]`),
     errorMessage: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-error-message"]`),

--- a/e2e-tests/cypress/fixtures/application.js
+++ b/e2e-tests/cypress/fixtures/application.js
@@ -1,0 +1,50 @@
+import {
+  add,
+  getMonth,
+  getYear,
+} from 'date-fns';
+import { FIELD_IDS } from '../../constants';
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: {
+        REQUESTED_START_DATE,
+        CREDIT_PERIOD_WITH_BUYER,
+        POLICY_CURRENCY_CODE,
+        SINGLE: { CONTRACT_COMPLETION_DATE, TOTAL_CONTRACT_VALUE },
+        MULTIPLE: { TOTAL_MONTHS_OF_COVER, TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE },
+      },
+    },
+  },
+} = FIELD_IDS;
+
+/**
+ * Application data we use and assert in E2E tests.
+ */
+const date = new Date();
+const startDate = add(date, { months: 3 });
+const endDate = add(startDate, { months: 6 });
+
+const application = {
+  POLICY_AND_EXPORTS: {
+    [REQUESTED_START_DATE]: {
+      day: '1',
+      month: getMonth(startDate),
+      year: getYear(startDate),
+    },
+    [CONTRACT_COMPLETION_DATE]: {
+      day: '1',
+      month: getMonth(endDate),
+      year: getYear(endDate),
+    },
+    [TOTAL_CONTRACT_VALUE]: '10000',
+    [CREDIT_PERIOD_WITH_BUYER]: 'mock free text',
+    [POLICY_CURRENCY_CODE]: 'GBP',
+    [TOTAL_MONTHS_OF_COVER]: '2',
+    [TOTAL_SALES_TO_BUYER]: '1000',
+    [MAXIMUM_BUYER_WILL_OWE]: '500',
+  },
+};
+
+export default application;

--- a/e2e-tests/cypress/support/insurance/complete-and-submit-multiple-contract-policy-form.js
+++ b/e2e-tests/cypress/support/insurance/complete-and-submit-multiple-contract-policy-form.js
@@ -1,11 +1,7 @@
-import {
-  add,
-  getMonth,
-  getYear,
-} from 'date-fns';
 import { FIELD_IDS } from '../../../constants';
 import { multipleContractPolicyPage } from '../../e2e/pages/insurance/policy-and-export';
 import { submitButton } from '../../e2e/pages/shared';
+import application from '../../fixtures/application';
 
 const {
   INSURANCE: {
@@ -23,16 +19,13 @@ const {
 } = FIELD_IDS;
 
 export default () => {
-  const date = new Date();
-  const startDate = add(date, { months: 3 });
+  multipleContractPolicyPage[REQUESTED_START_DATE].dayInput().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].day);
+  multipleContractPolicyPage[REQUESTED_START_DATE].monthInput().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].month);
+  multipleContractPolicyPage[REQUESTED_START_DATE].yearInput().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].year);
 
-  multipleContractPolicyPage[REQUESTED_START_DATE].dayInput().type('1');
-  multipleContractPolicyPage[REQUESTED_START_DATE].monthInput().type(getMonth(startDate));
-  multipleContractPolicyPage[REQUESTED_START_DATE].yearInput().type(getYear(startDate));
-
-  multipleContractPolicyPage[TOTAL_MONTHS_OF_COVER].input().select('2');
-  multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().type('1000');
-  multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().type('500');
+  multipleContractPolicyPage[TOTAL_MONTHS_OF_COVER].input().select(application.POLICY_AND_EXPORTS[TOTAL_MONTHS_OF_COVER]);
+  multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().type(application.POLICY_AND_EXPORTS[TOTAL_SALES_TO_BUYER]);
+  multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().type(application.POLICY_AND_EXPORTS[MAXIMUM_BUYER_WILL_OWE]);
 
   submitButton().click();
 };

--- a/e2e-tests/cypress/support/insurance/complete-and-submit-multiple-contract-policy-form.js
+++ b/e2e-tests/cypress/support/insurance/complete-and-submit-multiple-contract-policy-form.js
@@ -15,6 +15,7 @@ const {
         MULTIPLE: {
           TOTAL_MONTHS_OF_COVER,
           TOTAL_SALES_TO_BUYER,
+          MAXIMUM_BUYER_WILL_OWE,
         },
       },
     },
@@ -31,6 +32,7 @@ export default () => {
 
   multipleContractPolicyPage[TOTAL_MONTHS_OF_COVER].input().select('2');
   multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().type('1000');
+  multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().type('500');
 
   submitButton().click();
 };

--- a/e2e-tests/cypress/support/insurance/complete-and-submit-single-contract-policy-form.js
+++ b/e2e-tests/cypress/support/insurance/complete-and-submit-single-contract-policy-form.js
@@ -1,11 +1,7 @@
-import {
-  add,
-  getMonth,
-  getYear,
-} from 'date-fns';
 import { FIELD_IDS } from '../../../constants';
 import { singleContractPolicyPage } from '../../e2e/pages/insurance/policy-and-export';
 import { submitButton } from '../../e2e/pages/shared';
+import application from '../../fixtures/application';
 
 const {
   INSURANCE: {
@@ -21,21 +17,17 @@ const {
 } = FIELD_IDS;
 
 export default () => {
-  const date = new Date();
-  const startDate = add(date, { months: 3 });
-  const endDate = add(startDate, { months: 6 });
+  singleContractPolicyPage[REQUESTED_START_DATE].dayInput().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].day);
+  singleContractPolicyPage[REQUESTED_START_DATE].monthInput().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].month);
+  singleContractPolicyPage[REQUESTED_START_DATE].yearInput().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].year);
 
-  singleContractPolicyPage[REQUESTED_START_DATE].dayInput().type('1');
-  singleContractPolicyPage[REQUESTED_START_DATE].monthInput().type(getMonth(startDate));
-  singleContractPolicyPage[REQUESTED_START_DATE].yearInput().type(getYear(startDate));
+  singleContractPolicyPage[CONTRACT_COMPLETION_DATE].dayInput().type(application.POLICY_AND_EXPORTS[CONTRACT_COMPLETION_DATE].day);
+  singleContractPolicyPage[CONTRACT_COMPLETION_DATE].monthInput().type(application.POLICY_AND_EXPORTS[CONTRACT_COMPLETION_DATE].month);
+  singleContractPolicyPage[CONTRACT_COMPLETION_DATE].yearInput().type(application.POLICY_AND_EXPORTS[CONTRACT_COMPLETION_DATE].year);
 
-  singleContractPolicyPage[CONTRACT_COMPLETION_DATE].dayInput().type('1');
-  singleContractPolicyPage[CONTRACT_COMPLETION_DATE].monthInput().type(getMonth(endDate));
-  singleContractPolicyPage[CONTRACT_COMPLETION_DATE].yearInput().type(getYear(endDate));
-
-  singleContractPolicyPage[TOTAL_CONTRACT_VALUE].input().type('10000');
-  singleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().type('mock free text');
-  singleContractPolicyPage[POLICY_CURRENCY_CODE].input().select('GBP');
+  singleContractPolicyPage[TOTAL_CONTRACT_VALUE].input().type(application.POLICY_AND_EXPORTS[TOTAL_CONTRACT_VALUE]);
+  singleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().type(application.POLICY_AND_EXPORTS[CREDIT_PERIOD_WITH_BUYER]);
+  singleContractPolicyPage[POLICY_CURRENCY_CODE].input().select(application.POLICY_AND_EXPORTS[POLICY_CURRENCY_CODE]);
 
   submitButton().click();
 };

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -187,7 +187,8 @@ var lists = {
       creditPeriodWithBuyer: (0, import_fields.text)(),
       policyCurrencyCode: (0, import_fields.text)(),
       totalMonthsOfCover: (0, import_fields.integer)(),
-      totalSalesToBuyer: (0, import_fields.integer)()
+      totalSalesToBuyer: (0, import_fields.integer)(),
+      maximumBuyerWillOwe: (0, import_fields.integer)()
     },
     access: import_access.allowAll
   },

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -210,6 +210,7 @@ type PolicyAndExport {
   policyCurrencyCode: String
   totalMonthsOfCover: Int
   totalSalesToBuyer: Int
+  maximumBuyerWillOwe: Int
 }
 
 input PolicyAndExportWhereUniqueInput {
@@ -230,6 +231,7 @@ input PolicyAndExportWhereInput {
   policyCurrencyCode: StringFilter
   totalMonthsOfCover: IntNullableFilter
   totalSalesToBuyer: IntNullableFilter
+  maximumBuyerWillOwe: IntNullableFilter
 }
 
 input StringFilter {
@@ -270,6 +272,7 @@ input PolicyAndExportOrderByInput {
   policyCurrencyCode: OrderDirection
   totalMonthsOfCover: OrderDirection
   totalSalesToBuyer: OrderDirection
+  maximumBuyerWillOwe: OrderDirection
 }
 
 input PolicyAndExportUpdateInput {
@@ -282,6 +285,7 @@ input PolicyAndExportUpdateInput {
   policyCurrencyCode: String
   totalMonthsOfCover: Int
   totalSalesToBuyer: Int
+  maximumBuyerWillOwe: Int
 }
 
 input PolicyAndExportUpdateArgs {
@@ -299,6 +303,7 @@ input PolicyAndExportCreateInput {
   policyCurrencyCode: String
   totalMonthsOfCover: Int
   totalSalesToBuyer: Int
+  maximumBuyerWillOwe: Int
 }
 
 type Country {

--- a/src/api/schema.prisma
+++ b/src/api/schema.prisma
@@ -52,6 +52,7 @@ model PolicyAndExport {
   policyCurrencyCode               String        @default("")
   totalMonthsOfCover               Int?
   totalSalesToBuyer                Int?
+  maximumBuyerWillOwe              Int?
   from_Application_policyAndExport Application[] @relation("Application_policyAndExport")
 
   @@index([applicationId])

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -160,6 +160,7 @@ export const lists = {
       policyCurrencyCode: text(),
       totalMonthsOfCover: integer(),
       totalSalesToBuyer: integer(),
+      maximumBuyerWillOwe: integer(),
     },
     access: allowAll,
   },

--- a/src/ui/server/constants/application.ts
+++ b/src/ui/server/constants/application.ts
@@ -13,5 +13,6 @@ export const APPLICATION = {
       MAXIMUM: 499999,
     },
     TOTAL_MONTHS_OF_COVER: 12,
+    MAXIMUM_BUYER_CAN_OWE: 499999,
   },
 };

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -129,6 +129,13 @@ export const ERROR_MESSAGES = {
             NOT_A_WHOLE_NUMBER: 'Enter your estimated sales as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your estimated sales must be 1 or more',
           },
+          [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.MULTIPLE.MAXIMUM_BUYER_WILL_OWE]: {
+            IS_EMPTY: 'Enter maximum the buyer will owe as a whole number - do not enter decimals',
+            NOT_A_NUMBER: 'Enter maximum the buyer will owe as a whole number - do not enter decimals',
+            NOT_A_WHOLE_NUMBER: 'Enter maximum the buyer will owe as a whole number - do not enter decimals',
+            BELOW_MINIMUM: 'The maximum the buyer will owe must be 1 or more',
+            ABOVE_MAXIMUM: 'The maximum the buyer will owe cannot be more than £499.999',
+          },
         },
       },
     },

--- a/src/ui/server/content-strings/fields/insurance/policy-and-exports/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy-and-exports/index.ts
@@ -75,10 +75,15 @@ export const FIELDS = {
       },
       [CONTRACT_POLICY.MULTIPLE.MAXIMUM_BUYER_WILL_OWE]: {
         LABEL: 'Estimate the maximum amount your buyer will owe you at any single point during this time',
-        HINT_LIST: [
-          'For example, your total sales might be £250,000 but the maximum the buyer will owe you at any single point is £100,000.',
-          'Enter a whole number - do not enter decimals',
-        ],
+        HINT: {
+          FOR_EXAMPLE: 'For example, your total sales might be £250,000 but the maximum the buyer will owe you at any single point is £100,000.',
+          NEED_MORE_COVER: 'If you need cover for more than £499,999, ',
+          FILL_IN_FORM: {
+            TEXT: 'fill in this form instead.',
+            HREF: LINKS.EXTERNAL.NBI_FORM,
+          },
+          NO_DECIMALS: 'Enter a whole number - do not enter decimals.',
+        },
       },
     },
   },

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/index.test.ts
@@ -203,6 +203,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy', () 
       [`${REQUESTED_START_DATE}-year`]: getYear(add(date, { years: 1 })),
       [TOTAL_MONTHS_OF_COVER]: '1',
       [TOTAL_SALES_TO_BUYER]: '1000',
+      [MAXIMUM_BUYER_WILL_OWE]: '500',
     };
 
     describe('when there are no validation errors', () => {

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/index.ts
@@ -1,8 +1,9 @@
 import requestedStartDateRules from '../../../../../../shared-validation/requested-start-date';
 import totalMonthsOfCoverRules from './total-months-of-cover';
 import totalSalesToBuyerRules from './total-sales-to-buyer';
+import maximumBuyerWillOweRules from './maximum-buyer-will-owe';
 import { ValidationErrors } from '../../../../../../../types';
 
-const rules = [requestedStartDateRules, totalMonthsOfCoverRules, totalSalesToBuyerRules] as Array<() => ValidationErrors>;
+const rules = [requestedStartDateRules, totalMonthsOfCoverRules, totalSalesToBuyerRules, maximumBuyerWillOweRules] as Array<() => ValidationErrors>;
 
 export default rules;

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe.test.ts
@@ -1,0 +1,111 @@
+import maximumBuyerWillOweRules from './maximum-buyer-will-owe';
+import { APPLICATION, FIELD_IDS } from '../../../../../../constants';
+import { ERROR_MESSAGES } from '../../../../../../content-strings';
+import generateValidationErrors from '../../../../../../helpers/validation';
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: {
+        MULTIPLE: { MAXIMUM_BUYER_WILL_OWE: FIELD_ID },
+      },
+    },
+  },
+} = FIELD_IDS;
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: {
+        MULTIPLE: { [FIELD_ID]: ERROR_MESSAGE },
+      },
+    },
+  },
+} = ERROR_MESSAGES;
+
+describe('controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe', () => {
+  const mockErrors = {
+    summary: [],
+    errorList: {},
+  };
+
+  describe('when the field is not provided', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {};
+
+      const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when maximum buyer will owe is not a number', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        [FIELD_ID]: 'One hundred!',
+      };
+
+      const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when maximum buyer will owe contains a decimal', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        [FIELD_ID]: '123.456',
+      };
+
+      const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_WHOLE_NUMBER, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when maximum buyer will owe is below the minimum', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        [FIELD_ID]: '0',
+      };
+
+      const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when maximum buyer will owe is above the minimum', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        [FIELD_ID]: `${APPLICATION.POLICY_AND_EXPORT.MAXIMUM_BUYER_CAN_OWE + 1}`,
+      };
+
+      const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.ABOVE_MAXIMUM, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when there are no validation errors', () => {
+    it('should return the provided errors object', () => {
+      const mockSubmittedData = {
+        [FIELD_ID]: '10000',
+      };
+
+      const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
+
+      expect(result).toEqual(mockErrors);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe.ts
@@ -1,0 +1,70 @@
+import { APPLICATION, FIELD_IDS } from '../../../../../../constants';
+import { ERROR_MESSAGES } from '../../../../../../content-strings';
+import generateValidationErrors from '../../../../../../helpers/validation';
+import { objectHasProperty } from '../../../../../../helpers/object';
+import { isNumber, numberHasDecimal } from '../../../../../../helpers/number';
+import { RequestBody } from '../../../../../../../types';
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: {
+        MULTIPLE: { MAXIMUM_BUYER_WILL_OWE: FIELD_ID },
+      },
+    },
+  },
+} = FIELD_IDS;
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: {
+        MULTIPLE: { [FIELD_ID]: ERROR_MESSAGE },
+      },
+    },
+  },
+} = ERROR_MESSAGES;
+
+const MINIMUM = 1;
+const MAXIMUM = APPLICATION.POLICY_AND_EXPORT.MAXIMUM_BUYER_CAN_OWE;
+
+/**
+ * maximumBuyerWillOweRules
+ * Check submitted form data for errors with the maximum buyer will owe field
+ * Returns generateValidationErrors if there are any errors.
+ * @param {Express.Response.body} Express response body
+ * @param {Object} Errors object from previous validation errors
+ * @returns {Object} Validation errors
+ */
+const maximumBuyerWillOweRules = (formBody: RequestBody, errors: object) => {
+  const updatedErrors = errors;
+
+  // check if the field is empty.
+  if (!objectHasProperty(formBody, FIELD_ID)) {
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+  }
+
+  // check if the field is not a number
+  if (!isNumber(formBody[FIELD_ID])) {
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, errors);
+  }
+
+  // check if the field is not a whole number
+  if (numberHasDecimal(formBody[FIELD_ID])) {
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_WHOLE_NUMBER, errors);
+  }
+
+  // check if the field is below the minimum
+  if (Number(formBody[FIELD_ID]) < MINIMUM) {
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, errors);
+  }
+
+  // check if the field is above the maximum
+  if (Number(formBody[FIELD_ID]) > MAXIMUM) {
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.ABOVE_MAXIMUM, errors);
+  }
+
+  return updatedErrors;
+};
+
+export default maximumBuyerWillOweRules;

--- a/src/ui/server/graphql/queries/application.ts
+++ b/src/ui/server/graphql/queries/application.ts
@@ -35,6 +35,7 @@ const applicationQuery = gql`
           policyCurrencyCode
           totalMonthsOfCover
           totalSalesToBuyer
+          maximumBuyerWillOwe
         }
       }
     }

--- a/src/ui/templates/insurance/policy-and-exports/multiple-contract-policy.njk
+++ b/src/ui/templates/insurance/policy-and-exports/multiple-contract-policy.njk
@@ -123,6 +123,17 @@
           }
         }) }}
 
+
+        {% set maximumBuyerWillOweId = FIELDS.MAXIMUM_BUYER_WILL_OWE.ID %}
+        {% set HINT = FIELDS.MAXIMUM_BUYER_WILL_OWE.HINT %}
+
+        {% set maximumBuyerWillOweHintHtml %}
+          <p data-cy="{{ maximumBuyerWillOweId }}-hint-for-example">{{ HINT.FOR_EXAMPLE }}</p>
+          <p data-cy="{{ maximumBuyerWillOweId }}-hint-need-more-cover">{{ HINT.NEED_MORE_COVER }} <a class="govuk-link govuk-link" href="{{ HINT.FILL_IN_FORM.HREF }}" data-cy="{{ maximumBuyerWillOweId }}-hint-fill-in-form-link">{{ HINT.FILL_IN_FORM.TEXT }}</a></p>
+
+          <p data-cy="{{ maximumBuyerWillOweId }}-hint-no-decimals">{{ HINT.NO_DECIMALS }}</p>
+        {% endset %}
+
         {{ govukInput({
           label: {
             text: FIELDS.MAXIMUM_BUYER_WILL_OWE.LABEL,
@@ -133,10 +144,7 @@
             }
           },
           hint: {
-            text: FIELDS.MAXIMUM_BUYER_WILL_OWE.HINT,
-            attributes: {
-              'data-cy': FIELDS.MAXIMUM_BUYER_WILL_OWE.ID + '-hint'
-            }
+            html: maximumBuyerWillOweHintHtml
           },
           classes: "govuk-input--width-10 govuk-!-margin-bottom-4",
           attributes: {

--- a/src/ui/types/application.ts
+++ b/src/ui/types/application.ts
@@ -24,6 +24,8 @@ interface ApplicationPolicyAndExport {
   creditPeriodWithBuyer?: string;
   policyCurrencyCode?: string;
   totalMonthsOfCover?: number;
+  totalSalesToBuyer?: number;
+  maximumBuyerWillOwe?: number;
 }
 
 interface Application extends ApplicationCore {


### PR DESCRIPTION
This PR adds "estimated max amount owed" field validation and data saving to the Multiple contract policy page.

## Summary of changes

- Add `maximumBuyerWillOwe` to the schema and DB dump.
- Add validation handling for if the field is submitted without a value or has an incorrect value.
- Fix a typo in an E2E test.

## Other improvements

- Create `/fixtures/application` in E2E tests. This can be used moving forwards for storing application values that we type and assert in E2E tests.
- Update single and multiple contract policy tests to consume the fixtures.
