### PR TITLE
feat(EMS-575): Policy and exports - Multiple contract policy - credit period field

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -349,6 +349,8 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
         multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().should('have.value', application.POLICY_AND_EXPORTS[TOTAL_SALES_TO_BUYER]);
 
         multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().should('have.value', application.POLICY_AND_EXPORTS[MAXIMUM_BUYER_WILL_OWE]);
+
+        multipleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().should('have.value', application.POLICY_AND_EXPORTS[CREDIT_PERIOD_WITH_BUYER]);
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-credit-period-with-buyer.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-credit-period-with-buyer.spec.js
@@ -1,5 +1,5 @@
 import { submitButton } from '../../../../../pages/shared';
-import { typeOfPolicyPage } from '../../../../../pages/insurance/policy-and-export';
+import { typeOfPolicyPage, multipleContractPolicyPage } from '../../../../../pages/insurance/policy-and-export';
 import partials from '../../../../../partials';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { FIELD_IDS, ROUTES } from '../../../../../../../constants';
@@ -8,8 +8,8 @@ import checkText from '../../../../../helpers/check-text';
 
 const { taskList } = partials.insurancePartials;
 
-const multiplePolicyFieldId = FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.POLICY_TYPE;
-const multiplePolicyField = typeOfPolicyPage[multiplePolicyFieldId].multiple;
+const multipleePolicyFieldId = FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.POLICY_TYPE;
+const multipleePolicyField = typeOfPolicyPage[multipleePolicyFieldId].multiple;
 
 const { INSURANCE } = ROUTES;
 
@@ -17,13 +17,7 @@ const {
   INSURANCE: {
     POLICY_AND_EXPORTS: {
       CONTRACT_POLICY: {
-        REQUESTED_START_DATE,
         CREDIT_PERIOD_WITH_BUYER,
-        MULTIPLE: {
-          TOTAL_MONTHS_OF_COVER,
-          TOTAL_SALES_TO_BUYER,
-          MAXIMUM_BUYER_WILL_OWE,
-        },
       },
     },
   },
@@ -37,7 +31,7 @@ const {
   },
 } = ERROR_MESSAGES;
 
-context('Insurance - Policy and exports - Multiple contract policy page - form validation', () => {
+context('Insurance - Policy and exports - Multiple contract policy page - form validation - credit period with buyer', () => {
   let referenceNumber;
 
   before(() => {
@@ -52,7 +46,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
     taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
 
-    multiplePolicyField.input().click();
+    multipleePolicyField.input().click();
     submitButton().click();
 
     getReferenceNumber().then((id) => {
@@ -68,37 +62,38 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('should render validation errors for all required fields', () => {
-    submitButton().click();
+  const field = multipleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER];
 
-    partials.errorSummaryListItems().should('exist');
+  describe('when credit period with buyer is not provided', () => {
+    it('should render a validation error', () => {
+      submitButton().click();
 
-    const TOTAL_REQUIRED_FIELDS = 5;
-    partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);
+      checkText(
+        partials.errorSummaryListItems().eq(4),
+        CONTRACT_ERROR_MESSAGES[CREDIT_PERIOD_WITH_BUYER].IS_EMPTY,
+      );
 
-    checkText(
-      partials.errorSummaryListItems().eq(0),
-      CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].IS_EMPTY,
-    );
+      checkText(
+        field.errorMessage(),
+        `Error: ${CONTRACT_ERROR_MESSAGES[CREDIT_PERIOD_WITH_BUYER].IS_EMPTY}`,
+      );
+    });
+  });
 
-    checkText(
-      partials.errorSummaryListItems().eq(1),
-      CONTRACT_ERROR_MESSAGES.MULTIPLE[TOTAL_MONTHS_OF_COVER].IS_EMPTY,
-    );
+  describe('when total contract value is above the maximum', () => {
+    it('should render a validation error', () => {
+      field.input().type('a'.repeat(1001), { delay: 0 });
+      submitButton().click();
 
-    checkText(
-      partials.errorSummaryListItems().eq(2),
-      CONTRACT_ERROR_MESSAGES.MULTIPLE[TOTAL_SALES_TO_BUYER].IS_EMPTY,
-    );
+      checkText(
+        partials.errorSummaryListItems().eq(4),
+        CONTRACT_ERROR_MESSAGES[CREDIT_PERIOD_WITH_BUYER].ABOVE_MAXIMUM,
+      );
 
-    checkText(
-      partials.errorSummaryListItems().eq(3),
-      CONTRACT_ERROR_MESSAGES.MULTIPLE[MAXIMUM_BUYER_WILL_OWE].IS_EMPTY,
-    );
-
-    checkText(
-      partials.errorSummaryListItems().eq(4),
-      CONTRACT_ERROR_MESSAGES[CREDIT_PERIOD_WITH_BUYER].IS_EMPTY,
-    );
+      checkText(
+        field.errorMessage(),
+        `Error: ${CONTRACT_ERROR_MESSAGES[CREDIT_PERIOD_WITH_BUYER].ABOVE_MAXIMUM}`,
+      );
+    });
   });
 });

--- a/e2e-tests/cypress/support/insurance/complete-and-submit-multiple-contract-policy-form.js
+++ b/e2e-tests/cypress/support/insurance/complete-and-submit-multiple-contract-policy-form.js
@@ -8,6 +8,7 @@ const {
     POLICY_AND_EXPORTS: {
       CONTRACT_POLICY: {
         REQUESTED_START_DATE,
+        CREDIT_PERIOD_WITH_BUYER,
         MULTIPLE: {
           TOTAL_MONTHS_OF_COVER,
           TOTAL_SALES_TO_BUYER,
@@ -26,6 +27,7 @@ export default () => {
   multipleContractPolicyPage[TOTAL_MONTHS_OF_COVER].input().select(application.POLICY_AND_EXPORTS[TOTAL_MONTHS_OF_COVER]);
   multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().type(application.POLICY_AND_EXPORTS[TOTAL_SALES_TO_BUYER]);
   multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().type(application.POLICY_AND_EXPORTS[MAXIMUM_BUYER_WILL_OWE]);
+  multipleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().type(application.POLICY_AND_EXPORTS[CREDIT_PERIOD_WITH_BUYER]);
 
   submitButton().click();
 };

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/index.test.ts
@@ -204,6 +204,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy', () 
       [TOTAL_MONTHS_OF_COVER]: '1',
       [TOTAL_SALES_TO_BUYER]: '1000',
       [MAXIMUM_BUYER_WILL_OWE]: '500',
+      [CREDIT_PERIOD_WITH_BUYER]: 'Mock',
     };
 
     describe('when there are no validation errors', () => {

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/index.ts
@@ -1,9 +1,12 @@
 import requestedStartDateRules from '../../../../../../shared-validation/requested-start-date';
+import creditPeriodWithBuyerRules from '../../../../../../shared-validation/credit-period-with-buyer';
 import totalMonthsOfCoverRules from './total-months-of-cover';
 import totalSalesToBuyerRules from './total-sales-to-buyer';
 import maximumBuyerWillOweRules from './maximum-buyer-will-owe';
 import { ValidationErrors } from '../../../../../../../types';
 
-const rules = [requestedStartDateRules, totalMonthsOfCoverRules, totalSalesToBuyerRules, maximumBuyerWillOweRules] as Array<() => ValidationErrors>;
+const rules = [requestedStartDateRules, totalMonthsOfCoverRules, totalSalesToBuyerRules, maximumBuyerWillOweRules, creditPeriodWithBuyerRules];
 
-export default rules;
+const validationRules = rules as Array<() => ValidationErrors>;
+
+export default validationRules;

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/index.ts
@@ -1,7 +1,7 @@
 import requestedStartDateRules from '../../../../../../shared-validation/requested-start-date';
+import creditPeriodWithBuyerRules from '../../../../../../shared-validation/credit-period-with-buyer';
 import contractCompletionDateRules from './contract-completion-date';
 import totalContractValueRules from './total-contract-value';
-import creditPeriodWithBuyerRules from './credit-period-with-buyer';
 import policyCurrencyCodeRules from './policy-currency-code';
 import { ValidationErrors } from '../../../../../../../types';
 

--- a/src/ui/server/shared-validation/credit-period-with-buyer/index.test.ts
+++ b/src/ui/server/shared-validation/credit-period-with-buyer/index.test.ts
@@ -1,7 +1,7 @@
-import creditPeriodWithBuyerRules, { MAXIMUM } from './credit-period-with-buyer';
-import { FIELD_IDS } from '../../../../../../constants';
-import { ERROR_MESSAGES } from '../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../helpers/validation';
+import creditPeriodWithBuyerRules, { MAXIMUM } from '.';
+import { FIELD_IDS } from '../../constants';
+import { ERROR_MESSAGES } from '../../content-strings';
+import generateValidationErrors from '../../helpers/validation';
 
 const {
   INSURANCE: {
@@ -19,7 +19,7 @@ const {
   },
 } = ERROR_MESSAGES;
 
-describe('controllers/insurance/policy-and-export/single-contract-policy/validation/rules/credit-period-with-buyer', () => {
+describe('shared-validation/credit-period-with-buyer', () => {
   const mockErrors = {
     summary: [],
     errorList: {},

--- a/src/ui/server/shared-validation/credit-period-with-buyer/index.ts
+++ b/src/ui/server/shared-validation/credit-period-with-buyer/index.ts
@@ -1,8 +1,8 @@
-import { FIELD_IDS } from '../../../../../../constants';
-import { ERROR_MESSAGES } from '../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../helpers/validation';
-import { objectHasProperty } from '../../../../../../helpers/object';
-import { RequestBody } from '../../../../../../../types';
+import { FIELD_IDS } from '../../constants';
+import { ERROR_MESSAGES } from '../../content-strings';
+import generateValidationErrors from '../../helpers/validation';
+import { objectHasProperty } from '../../helpers/object';
+import { RequestBody } from '../../../types';
 
 const {
   INSURANCE: {


### PR DESCRIPTION
This PR adds the "credit period" field to the multiple contract policy page.

## Changes

- Move the credit period validation function used in "single contract policy" into the shared validation directory.
- Consume the credit period validation in "multiple contract policy" validation.
- Add/update tests.