### PR TITLE
feat(EMS-576): Policy and exports - Multiple contract policy - currency field

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -347,10 +347,9 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
         });
 
         multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().should('have.value', application.POLICY_AND_EXPORTS[TOTAL_SALES_TO_BUYER]);
-
         multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().should('have.value', application.POLICY_AND_EXPORTS[MAXIMUM_BUYER_WILL_OWE]);
-
         multipleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().should('have.value', application.POLICY_AND_EXPORTS[CREDIT_PERIOD_WITH_BUYER]);
+        multipleContractPolicyPage[POLICY_CURRENCY_CODE].inputOptionSelected().contains(application.POLICY_AND_EXPORTS[POLICY_CURRENCY_CODE]);
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-policy-currency-code.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-policy-currency-code.spec.js
@@ -1,5 +1,5 @@
 import { submitButton } from '../../../../../pages/shared';
-import { typeOfPolicyPage } from '../../../../../pages/insurance/policy-and-export';
+import { typeOfPolicyPage, multipleContractPolicyPage } from '../../../../../pages/insurance/policy-and-export';
 import partials from '../../../../../partials';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { FIELD_IDS, ROUTES } from '../../../../../../../constants';
@@ -9,7 +9,7 @@ import checkText from '../../../../../helpers/check-text';
 const { taskList } = partials.insurancePartials;
 
 const multiplePolicyFieldId = FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.POLICY_TYPE;
-const multiplePolicyField = typeOfPolicyPage[multiplePolicyFieldId].multiple;
+const multiplePolicyField = typeOfPolicyPage[multiplePolicyFieldId].single;
 
 const { INSURANCE } = ROUTES;
 
@@ -17,14 +17,7 @@ const {
   INSURANCE: {
     POLICY_AND_EXPORTS: {
       CONTRACT_POLICY: {
-        REQUESTED_START_DATE,
-        CREDIT_PERIOD_WITH_BUYER,
         POLICY_CURRENCY_CODE,
-        MULTIPLE: {
-          TOTAL_MONTHS_OF_COVER,
-          TOTAL_SALES_TO_BUYER,
-          MAXIMUM_BUYER_WILL_OWE,
-        },
       },
     },
   },
@@ -38,7 +31,7 @@ const {
   },
 } = ERROR_MESSAGES;
 
-context('Insurance - Policy and exports - Multiple contract policy page - form validation', () => {
+context('Insurance - Policy and exports - Multiple contract policy page - form validation - policy currency code', () => {
   let referenceNumber;
 
   before(() => {
@@ -69,42 +62,21 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('should render validation errors for all required fields', () => {
-    submitButton().click();
+  const field = singleContractPolicyPage[POLICY_CURRENCY_CODE];
 
-    partials.errorSummaryListItems().should('exist');
+  describe('when policy currency code is not provided', () => {
+    it('should render a validation error', () => {
+      submitButton().click();
 
-    const TOTAL_REQUIRED_FIELDS = 6;
-    partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);
+      checkText(
+        partials.errorSummaryListItems().eq(5),
+        CONTRACT_ERROR_MESSAGES[POLICY_CURRENCY_CODE].IS_EMPTY,
+      );
 
-    checkText(
-      partials.errorSummaryListItems().eq(0),
-      CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].IS_EMPTY,
-    );
-
-    checkText(
-      partials.errorSummaryListItems().eq(1),
-      CONTRACT_ERROR_MESSAGES.MULTIPLE[TOTAL_MONTHS_OF_COVER].IS_EMPTY,
-    );
-
-    checkText(
-      partials.errorSummaryListItems().eq(2),
-      CONTRACT_ERROR_MESSAGES.MULTIPLE[TOTAL_SALES_TO_BUYER].IS_EMPTY,
-    );
-
-    checkText(
-      partials.errorSummaryListItems().eq(3),
-      CONTRACT_ERROR_MESSAGES.MULTIPLE[MAXIMUM_BUYER_WILL_OWE].IS_EMPTY,
-    );
-
-    checkText(
-      partials.errorSummaryListItems().eq(4),
-      CONTRACT_ERROR_MESSAGES[CREDIT_PERIOD_WITH_BUYER].IS_EMPTY,
-    );
-
-    checkText(
-      partials.errorSummaryListItems().eq(5),
-      CONTRACT_ERROR_MESSAGES[POLICY_CURRENCY_CODE].IS_EMPTY,
-    );
+      checkText(
+        field.errorMessage(),
+        `Error: ${CONTRACT_ERROR_MESSAGES[POLICY_CURRENCY_CODE].IS_EMPTY}`,
+      );
+    });
   });
 });

--- a/e2e-tests/cypress/support/insurance/complete-and-submit-multiple-contract-policy-form.js
+++ b/e2e-tests/cypress/support/insurance/complete-and-submit-multiple-contract-policy-form.js
@@ -9,6 +9,7 @@ const {
       CONTRACT_POLICY: {
         REQUESTED_START_DATE,
         CREDIT_PERIOD_WITH_BUYER,
+        POLICY_CURRENCY_CODE,
         MULTIPLE: {
           TOTAL_MONTHS_OF_COVER,
           TOTAL_SALES_TO_BUYER,
@@ -28,6 +29,8 @@ export default () => {
   multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().type(application.POLICY_AND_EXPORTS[TOTAL_SALES_TO_BUYER]);
   multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().type(application.POLICY_AND_EXPORTS[MAXIMUM_BUYER_WILL_OWE]);
   multipleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().type(application.POLICY_AND_EXPORTS[CREDIT_PERIOD_WITH_BUYER]);
+
+  multipleContractPolicyPage[POLICY_CURRENCY_CODE].input().select(application.POLICY_AND_EXPORTS[POLICY_CURRENCY_CODE]);
 
   submitButton().click();
 };

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/index.ts
@@ -93,7 +93,13 @@ export const get = async (req: Request, res: Response) => {
       return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
     }
 
-    const mappedCurrencies = mapCurrencies(currencies);
+    let mappedCurrencies;
+
+    if (application.policyAndExport[POLICY_CURRENCY_CODE]) {
+      mappedCurrencies = mapCurrencies(currencies, application.policyAndExport[POLICY_CURRENCY_CODE]);
+    } else {
+      mappedCurrencies = mapCurrencies(currencies);
+    }
 
     let mappedTotalMonthsOfCover;
 
@@ -147,9 +153,21 @@ export const post = async (req: Request, res: Response) => {
         return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
       }
 
-      const mappedCurrencies = mapCurrencies(currencies);
+      let mappedCurrencies;
 
-      const mappedtotalMonthsOfCover = mapTotalMonthsOfCover(totalMonthsOfCoverOptions);
+      if (req.body[POLICY_CURRENCY_CODE]) {
+        mappedCurrencies = mapCurrencies(currencies, req.body[POLICY_CURRENCY_CODE]);
+      } else {
+        mappedCurrencies = mapCurrencies(currencies);
+      }
+
+      let mappedTotalMonthsOfCover;
+
+      if (req.body[TOTAL_MONTHS_OF_COVER]) {
+        mappedTotalMonthsOfCover = mapTotalMonthsOfCover(totalMonthsOfCoverOptions, req.body[TOTAL_MONTHS_OF_COVER]);
+      } else {
+        mappedTotalMonthsOfCover = mapTotalMonthsOfCover(totalMonthsOfCoverOptions);
+      }
 
       return res.render(TEMPLATE, {
         ...insuranceCorePageVariables({
@@ -160,7 +178,7 @@ export const post = async (req: Request, res: Response) => {
         application: mapApplicationToFormFields(application),
         submittedValues: req.body,
         currencies: mappedCurrencies,
-        monthOptions: mappedtotalMonthsOfCover,
+        monthOptions: mappedTotalMonthsOfCover,
         validationErrors,
       });
     } catch (err) {

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/index.ts
@@ -1,11 +1,19 @@
 import requestedStartDateRules from '../../../../../../shared-validation/requested-start-date';
 import creditPeriodWithBuyerRules from '../../../../../../shared-validation/credit-period-with-buyer';
+import policyCurrencyCodeRules from '../../../../../../shared-validation/policy-currency-code';
 import totalMonthsOfCoverRules from './total-months-of-cover';
 import totalSalesToBuyerRules from './total-sales-to-buyer';
 import maximumBuyerWillOweRules from './maximum-buyer-will-owe';
 import { ValidationErrors } from '../../../../../../../types';
 
-const rules = [requestedStartDateRules, totalMonthsOfCoverRules, totalSalesToBuyerRules, maximumBuyerWillOweRules, creditPeriodWithBuyerRules];
+const rules = [
+  requestedStartDateRules,
+  totalMonthsOfCoverRules,
+  totalSalesToBuyerRules,
+  maximumBuyerWillOweRules,
+  creditPeriodWithBuyerRules,
+  policyCurrencyCodeRules,
+];
 
 const validationRules = rules as Array<() => ValidationErrors>;
 

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/index.ts
@@ -1,8 +1,8 @@
 import requestedStartDateRules from '../../../../../../shared-validation/requested-start-date';
 import creditPeriodWithBuyerRules from '../../../../../../shared-validation/credit-period-with-buyer';
+import policyCurrencyCodeRules from '../../../../../../shared-validation/policy-currency-code';
 import contractCompletionDateRules from './contract-completion-date';
 import totalContractValueRules from './total-contract-value';
-import policyCurrencyCodeRules from './policy-currency-code';
 import { ValidationErrors } from '../../../../../../../types';
 
 const rules = [requestedStartDateRules, contractCompletionDateRules, totalContractValueRules, creditPeriodWithBuyerRules, policyCurrencyCodeRules];

--- a/src/ui/server/shared-validation/policy-currency-code/index.test.ts
+++ b/src/ui/server/shared-validation/policy-currency-code/index.test.ts
@@ -1,8 +1,8 @@
-import policyCurrencyCodeRules from './policy-currency-code';
-import { FIELD_IDS } from '../../../../../../constants';
-import { ERROR_MESSAGES } from '../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../helpers/validation';
-import { mockCurrencies } from '../../../../../../test-mocks';
+import policyCurrencyCodeRules from '.';
+import { FIELD_IDS } from '../../constants';
+import { ERROR_MESSAGES } from '../../content-strings';
+import generateValidationErrors from '../../helpers/validation';
+import { mockCurrencies } from '../../test-mocks';
 
 const {
   INSURANCE: {
@@ -20,7 +20,7 @@ const {
   },
 } = ERROR_MESSAGES;
 
-describe('controllers/insurance/policy-and-export/single-contract-policy/validation/rules/policy-currency-code', () => {
+describe('shared-validation/policy-currency-code', () => {
   const mockErrors = {
     summary: [],
     errorList: {},

--- a/src/ui/server/shared-validation/policy-currency-code/index.ts
+++ b/src/ui/server/shared-validation/policy-currency-code/index.ts
@@ -1,8 +1,8 @@
-import { FIELD_IDS } from '../../../../../../constants';
-import { ERROR_MESSAGES } from '../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../helpers/validation';
-import { objectHasProperty } from '../../../../../../helpers/object';
-import { RequestBody } from '../../../../../../../types';
+import { FIELD_IDS } from '../../constants';
+import { ERROR_MESSAGES } from '../../content-strings';
+import generateValidationErrors from '../../helpers/validation';
+import { objectHasProperty } from '../../helpers/object';
+import { RequestBody } from '../../../types';
 
 const {
   INSURANCE: {


### PR DESCRIPTION
This PR adds validation to the "currency" field in the multiple contract policy page.

## Changes

- Move the currency code validation function used in "single contract policy" into the shared validation directory.
- Consume the currency code validation in "multiple contract policy" validation.
- Add/update tests.
- Also ensured that the "months of cover" and currency code is rendered correctly in the form if submitted.