### PR TITLE
feat(EMS-609): add countries graphql query

### DIFF
--- a/src/ui/server/api/keystone/application/index.ts
+++ b/src/ui/server/api/keystone/application/index.ts
@@ -2,7 +2,7 @@ import { ApolloError } from 'apollo-client';
 import { ApolloResponse, SubmittedDataInsuranceEligibility } from '../../../../types';
 import apollo from '../../../graphql/apollo';
 import eligibility from './eligibility';
-import country from '../country';
+import countries from '../countries';
 import createApplicationMutation from '../../../graphql/mutations/create-application';
 import getApplicationQuery from '../../../graphql/queries/application';
 import updateApplicationPolicyAndExportMutation from '../../../graphql/mutations/update-application/policy-and-export';
@@ -45,7 +45,7 @@ const application = {
 
         const { id: eligibilityId } = newApplication.eligibility;
 
-        const buyerCountry = await country.get(buyerCountryIsoCode);
+        const buyerCountry = await countries.get(buyerCountryIsoCode);
 
         await eligibility.update(eligibilityId, {
           ...eligibilityAnswers,

--- a/src/ui/server/api/keystone/countries/index.ts
+++ b/src/ui/server/api/keystone/countries/index.ts
@@ -1,9 +1,35 @@
 import { ApolloError } from 'apollo-client';
 import apollo from '../../../graphql/apollo';
 import { ApolloResponse } from '../../../../types';
+import getCountries from '../../../graphql/queries/countries';
 import getCountriesByIsoCodeQuery from '../../../graphql/queries/countries-by-iso-code';
 
-const country = {
+const countries = {
+  getAll: async () => {
+    try {
+      console.info('Getting countries');
+
+      const response = (await apollo('POST', getCountries, {})) as ApolloResponse;
+
+      if (response.errors) {
+        console.error('GraphQL error getting countries ', response.errors);
+      }
+
+      if (response?.networkError?.result?.errors) {
+        console.error('GraphQL network error getting countries ', response.networkError.result.errors);
+      }
+
+      if (response?.data?.countries) {
+        return response.data.countries[0];
+      }
+
+      if (response instanceof ApolloError) {
+        throw new Error('Getting countries');
+      }
+    } catch {
+      throw new Error('Getting countries');
+    }
+  },
   get: async (isoCode: string) => {
     try {
       console.info('Getting country');
@@ -33,4 +59,4 @@ const country = {
   },
 };
 
-export default country;
+export default countries;

--- a/src/ui/server/api/keystone/index.ts
+++ b/src/ui/server/api/keystone/index.ts
@@ -1,11 +1,11 @@
 import application from './application';
-import country from './country';
+import countries from './countries';
 import getCompaniesHouseInformation from './get-companies-house-information';
 import page from './page';
 
 const keystone = {
   application,
-  country,
+  countries,
   getCompaniesHouseInformation,
   page,
 };

--- a/src/ui/server/graphql/queries/countries-by-iso-code.ts
+++ b/src/ui/server/graphql/queries/countries-by-iso-code.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 
-const countriesQuery = gql`
+const countriesByIsoCodeQuery = gql`
   query ($isoCode: String) {
     countries(where: { isoCode: { equals: $isoCode } }) {
       id
@@ -10,4 +10,4 @@ const countriesQuery = gql`
   }
 `;
 
-export default countriesQuery;
+export default countriesByIsoCodeQuery;

--- a/src/ui/server/graphql/queries/countries.ts
+++ b/src/ui/server/graphql/queries/countries.ts
@@ -1,0 +1,13 @@
+import gql from 'graphql-tag';
+
+const countriesQuery = gql`
+  query {
+    countries {
+      id
+      name
+      isoCode
+    }
+  }
+`;
+
+export default countriesQuery;


### PR DESCRIPTION
This PR adds a countries graphql query - required for at least 2 pages. So now we have:

- `countries.getAll()`
- `countries.get(isoCode)`

Also fixed a typo in the "get country by iSO code" query. 