### PR TITLE
feat(EMS-570): Policy and export - multiple contract policy - save and go back. Improve save data approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,20 @@ With Keystone, we get all of this (including things like pagination), by writing
 
 Keystone also provides us with an admin UI for the database. Whilst we don't really use this, there are some potential opportunities for this to be used by non-technical people.
 
+### Requirements for submitting a form
+
+In the majority of pages, we have two submit buttons with different requirements.
+
+#### "Save and continue"
+
+- These primary buttons trigger a check for validation errors and if there are errors, reload the same page with validation errors.
+- If there are no validation errors, we trigger a redirect to the next page of the user flow.
+
+#### "Save and go back"
+
+- These secondary buttons check for validation errors and if there are errors, we strip out the invalid fields and save only valid fields.
+- Regardless of validation errors, a user is taken to the "main home page" of an application.
+
 ## How and when the UI calls the API
 
 ### When an application page is loaded
@@ -206,11 +220,11 @@ The following happens:
 
 1. The UI's POST contoller checks for validation errors.
 
-2. If all is OK, call a ["save data" function](https://github.com/UK-Export-Finance/exip/blob/main-application/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.ts#L83).
+2. If all is OK, call a ["map and save" function](https://github.com/UK-Export-Finance/exip/blob/main-application/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.ts#L83).
 
-3. The [save data function](https://github.com/UK-Export-Finance/exip/blob/main-application/src/ui/server/controllers/insurance/policy-and-export/save-data/index.ts) filters out any invalid fields and sanitises all other fields.
+3. The map and save function maps the submitted form data into a better data structure (e.g day/month/year fields transform into a timestamp) and sends this data to the [save function](https://github.com/UK-Export-Finance/exip/blob/main-application/src/ui/server/controllers/insurance/policy-and-export/map-and-save/index.ts).
 
-4. The save data function then calls the API. The actual call is made [here](https://github.com/UK-Export-Finance/exip/blob/main-application/src/ui/server/api/keystone/application/index.ts#L91). We use apollo to run a GraphQL mutation.
+4. The save data function then filters out any invalid fields (if an error list is provided), sanitises all other fields and finally calls the API. The actual call is made [here](https://github.com/UK-Export-Finance/exip/blob/main-application/src/ui/server/api/keystone/application/index.ts#L91). We use apollo to run a GraphQL mutation.
 
 5. The API automatically handles the request (thanks to Keystone) and updates the database columns provided in the GraphQL mutation, for the specified application.
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -62,6 +62,8 @@ const {
   },
 } = FIELD_IDS;
 
+const task = taskList.prepareApplication.tasks.policyTypeAndExports;
+
 const goToPageDirectly = (referenceNumber) => {
   cy.visit(`${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`, {
     auth: {
@@ -84,7 +86,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
 
     cy.submitInsuranceEligibilityAndStartApplication();
 
-    taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+    task.link().click();
 
     multiplePolicyField.input().click();
     submitButton().click();
@@ -323,8 +325,6 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
             password: Cypress.config('basicAuthSecret'),
           },
         });
-
-        const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
         task.status().invoke('text').then((text) => {
           const expected = TASKS.STATUS.IN_PROGRESS;

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/save-and-back.spec.js
@@ -1,0 +1,182 @@
+import {
+  add,
+  getDate,
+  getMonth,
+  getYear,
+  sub,
+} from 'date-fns';
+import { submitButton, saveAndBackButton } from '../../../../pages/shared';
+import { typeOfPolicyPage, multipleContractPolicyPage } from '../../../../pages/insurance/policy-and-export';
+import partials from '../../../../partials';
+import { TASKS } from '../../../../../../content-strings';
+import { ROUTES, FIELD_IDS } from '../../../../../../constants';
+import getReferenceNumber from '../../../../helpers/get-reference-number';
+import application from '../../../../../fixtures/application';
+
+const { taskList } = partials.insurancePartials;
+
+const multiplePolicyFieldId = FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.POLICY_TYPE;
+const multiplePolicyField = typeOfPolicyPage[multiplePolicyFieldId].multiple;
+
+const {
+  INSURANCE: {
+    ROOT: INSURANCE_ROOT,
+    ALL_SECTIONS,
+    POLICY_AND_EXPORTS: {
+      MULTIPLE_CONTRACT_POLICY,
+    },
+  },
+} = ROUTES;
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: {
+        MULTIPLE: { TOTAL_SALES_TO_BUYER },
+      },
+    },
+  },
+} = FIELD_IDS;
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      CONTRACT_POLICY: {
+        REQUESTED_START_DATE,
+      },
+    },
+  },
+} = FIELD_IDS;
+
+context('Insurance - Policy and exports - Multiple contract policy page - Save and go back', () => {
+  let referenceNumber;
+  const date = new Date();
+  const futureDate = add(date, { months: 3 });
+
+  before(() => {
+    cy.visit(ROUTES.INSURANCE.START, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    cy.submitInsuranceEligibilityAndStartApplication();
+
+    taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+
+    multiplePolicyField.input().click();
+    submitButton().click();
+
+    getReferenceNumber().then((id) => {
+      referenceNumber = id;
+
+      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
+      cy.url().should('eq', expected);
+    });
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
+  describe('when submitting an empty form via `save and go back` button', () => {
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      saveAndBackButton().click();
+
+      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      cy.url().should('eq', expected);
+    });
+
+    it('should retain the `type of policy and exports` task status as `in progress`', () => {
+      const task = taskList.prepareApplication.tasks.policyTypeAndExports;
+
+      task.status().invoke('text').then((text) => {
+        const expected = TASKS.STATUS.IN_PROGRESS;
+
+        expect(text.trim()).equal(expected);
+      });
+    });
+  });
+
+  describe('when entering an invalid total sales to buyer and submitting the form via `save and go back` button', () => {
+    const field = multipleContractPolicyPage[TOTAL_SALES_TO_BUYER];
+    const invalidValue = 'Not a number';
+
+    before(() => {
+      // go back to the page via the task list
+      taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+      submitButton().click();
+
+      field.input().type(invalidValue);
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      saveAndBackButton().click();
+
+      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      cy.url().should('eq', expected);
+    });
+
+    it('should retain the `type of policy and exports` task status as `in progress`', () => {
+      const task = taskList.prepareApplication.tasks.policyTypeAndExports;
+
+      task.status().invoke('text').then((text) => {
+        const expected = TASKS.STATUS.IN_PROGRESS;
+
+        expect(text.trim()).equal(expected);
+      });
+    });
+
+    describe('when going back to the page', () => {
+      before(() => {
+        taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+        submitButton().click();
+      });
+
+      it('should not have saved the submitted value', () => {
+        field.input().should('have.value', '');
+      });
+    });
+  });
+
+  describe('when entering a valid total sales to buyer and submitting the form via `save and go back` button', () => {
+    const field = multipleContractPolicyPage[TOTAL_SALES_TO_BUYER];
+
+    before(() => {
+      field.input().type(application.POLICY_AND_EXPORTS[TOTAL_SALES_TO_BUYER]);
+
+      saveAndBackButton().click();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      cy.url().should('eq', expected);
+    });
+
+    it('should retain the `type of policy and exports` task status as `in progress`', () => {
+      const task = taskList.prepareApplication.tasks.policyTypeAndExports;
+
+      task.status().invoke('text').then((text) => {
+        const expected = TASKS.STATUS.IN_PROGRESS;
+
+        expect(text.trim()).equal(expected);
+      });
+    });
+
+    describe('when going back to the page', () => {
+      before(() => {
+        taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+        submitButton().click();
+      });
+
+      it('should have the submitted value', () => {
+        multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().should('have.value', application.POLICY_AND_EXPORTS[TOTAL_SALES_TO_BUYER]);
+      });
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/save-and-back.spec.js
@@ -1,10 +1,3 @@
-import {
-  add,
-  getDate,
-  getMonth,
-  getYear,
-  sub,
-} from 'date-fns';
 import { submitButton, saveAndBackButton } from '../../../../pages/shared';
 import { typeOfPolicyPage, multipleContractPolicyPage } from '../../../../pages/insurance/policy-and-export';
 import partials from '../../../../partials';
@@ -38,20 +31,8 @@ const {
   },
 } = FIELD_IDS;
 
-const {
-  INSURANCE: {
-    POLICY_AND_EXPORTS: {
-      CONTRACT_POLICY: {
-        REQUESTED_START_DATE,
-      },
-    },
-  },
-} = FIELD_IDS;
-
 context('Insurance - Policy and exports - Multiple contract policy page - Save and go back', () => {
   let referenceNumber;
-  const date = new Date();
-  const futureDate = add(date, { months: 3 });
 
   before(() => {
     cy.visit(ROUTES.INSURANCE.START, {

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/save-and-back.spec.js
@@ -31,6 +31,8 @@ const {
   },
 } = FIELD_IDS;
 
+const task = taskList.prepareApplication.tasks.policyTypeAndExports;
+
 context('Insurance - Policy and exports - Multiple contract policy page - Save and go back', () => {
   let referenceNumber;
 
@@ -72,8 +74,6 @@ context('Insurance - Policy and exports - Multiple contract policy page - Save a
     });
 
     it('should retain the `type of policy and exports` task status as `in progress`', () => {
-      const task = taskList.prepareApplication.tasks.policyTypeAndExports;
-
       task.status().invoke('text').then((text) => {
         const expected = TASKS.STATUS.IN_PROGRESS;
 
@@ -103,8 +103,6 @@ context('Insurance - Policy and exports - Multiple contract policy page - Save a
     });
 
     it('should retain the `type of policy and exports` task status as `in progress`', () => {
-      const task = taskList.prepareApplication.tasks.policyTypeAndExports;
-
       task.status().invoke('text').then((text) => {
         const expected = TASKS.STATUS.IN_PROGRESS;
 
@@ -140,8 +138,6 @@ context('Insurance - Policy and exports - Multiple contract policy page - Save a
     });
 
     it('should retain the `type of policy and exports` task status as `in progress`', () => {
-      const task = taskList.prepareApplication.tasks.policyTypeAndExports;
-
       task.status().invoke('text').then((text) => {
         const expected = TASKS.STATUS.IN_PROGRESS;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/save-and-back.spec.js
@@ -37,6 +37,8 @@ const {
   },
 } = FIELD_IDS;
 
+const task = taskList.prepareApplication.tasks.policyTypeAndExports;
+
 context('Insurance - Policy and exports - Single contract policy page - Save and go back', () => {
   let referenceNumber;
   const date = new Date();
@@ -52,7 +54,7 @@ context('Insurance - Policy and exports - Single contract policy page - Save and
 
     cy.submitInsuranceEligibilityAndStartApplication();
 
-    taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+    task.link().click();
 
     singlePolicyField.input().click();
     submitButton().click();
@@ -80,8 +82,6 @@ context('Insurance - Policy and exports - Single contract policy page - Save and
     });
 
     it('should retain the `type of policy and exports` task status as `in progress`', () => {
-      const task = taskList.prepareApplication.tasks.policyTypeAndExports;
-
       task.status().invoke('text').then((text) => {
         const expected = TASKS.STATUS.IN_PROGRESS;
 
@@ -95,7 +95,7 @@ context('Insurance - Policy and exports - Single contract policy page - Save and
 
     before(() => {
       // go back to the page via the task list
-      taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+      task.link().click();
       submitButton().click();
 
       // enter an invalid date
@@ -115,8 +115,6 @@ context('Insurance - Policy and exports - Single contract policy page - Save and
     });
 
     it('should retain the `type of policy and exports` task status as `in progress`', () => {
-      const task = taskList.prepareApplication.tasks.policyTypeAndExports;
-
       task.status().invoke('text').then((text) => {
         const expected = TASKS.STATUS.IN_PROGRESS;
 
@@ -126,7 +124,7 @@ context('Insurance - Policy and exports - Single contract policy page - Save and
 
     describe('when going back to the page', () => {
       before(() => {
-        taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+        task.link().click();
         submitButton().click();
       });
 
@@ -156,8 +154,6 @@ context('Insurance - Policy and exports - Single contract policy page - Save and
     });
 
     it('should retain the `type of policy and exports` task status as `in progress`', () => {
-      const task = taskList.prepareApplication.tasks.policyTypeAndExports;
-
       task.status().invoke('text').then((text) => {
         const expected = TASKS.STATUS.IN_PROGRESS;
 
@@ -167,7 +163,7 @@ context('Insurance - Policy and exports - Single contract policy page - Save and
 
     describe('when going back to the page', () => {
       before(() => {
-        taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+        task.link().click();
         submitButton().click();
       });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
@@ -63,6 +63,8 @@ const goToPageDirectly = (referenceNumber) => {
   });
 };
 
+const task = taskList.prepareApplication.tasks.policyTypeAndExports;
+
 context('Insurance - Policy and exports - Single contract policy page - As an exporter, I want to enter the type of policy I need for my export contract', () => {
   let referenceNumber;
 
@@ -76,7 +78,7 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
 
     cy.submitInsuranceEligibilityAndStartApplication();
 
-    taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+    task.link().click();
 
     singlePolicyField.input().click();
     submitButton().click();
@@ -273,8 +275,6 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
             password: Cypress.config('basicAuthSecret'),
           },
         });
-
-        const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
         task.status().invoke('text').then((text) => {
           const expected = TASKS.STATUS.IN_PROGRESS;

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/save-and-back.spec.js
@@ -11,6 +11,8 @@ const multiplePolicyField = insurance.policyAndExport.typeOfPolicyPage[FIELD_ID]
 
 const { taskList } = partials.insurancePartials;
 
+const task = taskList.prepareApplication.tasks.policyTypeAndExports;
+
 context('Insurance - Policy and exports - Type of policy page - Save and go back', () => {
   let referenceNumber;
 
@@ -24,7 +26,7 @@ context('Insurance - Policy and exports - Type of policy page - Save and go back
 
     cy.submitInsuranceEligibilityAndStartApplication();
 
-    taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+    task.link().click();
 
     getReferenceNumber().then((id) => {
       referenceNumber = id;
@@ -49,8 +51,6 @@ context('Insurance - Policy and exports - Type of policy page - Save and go back
     });
 
     it('should retain the `type of policy and exports` task status as `not started yet`', () => {
-      const task = taskList.prepareApplication.tasks.policyTypeAndExports;
-
       task.status().invoke('text').then((text) => {
         const expected = TASKS.STATUS.NOT_STARTED_YET;
 
@@ -61,7 +61,7 @@ context('Insurance - Policy and exports - Type of policy page - Save and go back
 
   describe('when selecting an answer and submitting the form via `save and go back` button', () => {
     before(() => {
-      taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+      task.link().click();
     });
 
     it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, () => {
@@ -74,8 +74,6 @@ context('Insurance - Policy and exports - Type of policy page - Save and go back
     });
 
     it('should update the status of task `type of policy and exports`to `in progress`', () => {
-      const task = taskList.prepareApplication.tasks.policyTypeAndExports;
-
       task.status().invoke('text').then((text) => {
         const expected = TASKS.STATUS.IN_PROGRESS;
 
@@ -85,7 +83,7 @@ context('Insurance - Policy and exports - Type of policy page - Save and go back
 
     describe('when going back to the page', () => {
       it('should have the originally submitted answer selected', () => {
-        taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+        task.link().click();
 
         multiplePolicyField.input().should('be.checked');
       });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/type-of-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/type-of-policy.spec.js
@@ -41,6 +41,8 @@ const goToPageDirectly = (referenceNumber) => {
   });
 };
 
+const task = taskList.prepareApplication.tasks.policyTypeAndExports;
+
 context('Insurance - Policy and exports - Type of policy page - As an exporter, I want to enter the type of policy I need for my export contract', () => {
   let referenceNumber;
 
@@ -54,7 +56,7 @@ context('Insurance - Policy and exports - Type of policy page - As an exporter, 
 
     cy.submitInsuranceEligibilityAndStartApplication();
 
-    taskList.prepareApplication.tasks.policyTypeAndExports.link().click();
+    task.link().click();
 
     getReferenceNumber().then((id) => {
       referenceNumber = id;
@@ -261,8 +263,6 @@ context('Insurance - Policy and exports - Type of policy page - As an exporter, 
             password: Cypress.config('basicAuthSecret'),
           },
         });
-
-        const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
         task.status().invoke('text').then((text) => {
           const expected = TASKS.STATUS.IN_PROGRESS;

--- a/src/ui/server/controllers/insurance/policy-and-export/map-and-save/index-api-errors.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/map-and-save/index-api-errors.test.ts
@@ -1,0 +1,36 @@
+import mapAndSave from '.';
+import save from '../save-data';
+import { mockApplication } from '../../../../test-mocks';
+
+describe('controllers/insurance/policy-and-export/map-and-save - api errors', () => {
+  jest.mock('../save-data');
+
+  const mockFormBody = {
+    _csrf: '1234',
+    mock: true,
+  };
+
+  describe('when save application policyAndExport call does not return anything', () => {
+    beforeEach(() => {
+      save.policyAndExport = jest.fn(() => Promise.resolve());
+    });
+
+    it('should return false', async () => {
+      const result = await mapAndSave.policyAndExport(mockFormBody, mockApplication);
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('when save application policyAndExport call fails', () => {
+    beforeEach(() => {
+      save.policyAndExport = jest.fn(() => Promise.reject(new Error('Mock error')));
+    });
+
+    it('should return false', async () => {
+      const result = await mapAndSave.policyAndExport(mockFormBody, mockApplication);
+
+      expect(result).toEqual(false);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/policy-and-export/map-and-save/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/map-and-save/index.test.ts
@@ -1,0 +1,69 @@
+import mapAndSave from '.';
+import { FIELD_IDS } from '../../../../constants';
+import mapSubmittedData from '../map-submitted-data';
+import save from '../save-data';
+import generateValidationErrors from '../single-contract-policy/validation';
+import { mockApplication } from '../../../../test-mocks';
+
+const {
+  POLICY_AND_EXPORTS: {
+    CONTRACT_POLICY: { CREDIT_PERIOD_WITH_BUYER },
+  },
+} = FIELD_IDS.INSURANCE;
+
+describe('controllers/insurance/policy-and-export/map-and-save', () => {
+  jest.mock('../save-data');
+
+  let mockFormBody = {
+    _csrf: '1234',
+    [CREDIT_PERIOD_WITH_BUYER]: 'Example',
+  };
+
+  const mockValidationErrors = generateValidationErrors(mockFormBody);
+
+  const mockSavePolicyAndExportData = jest.fn(() => Promise.resolve({}));
+
+  save.policyAndExport = mockSavePolicyAndExportData;
+
+  describe('when the form has data', () => {
+    describe('when the form has validation errors ', () => {
+      it('should call save.policyAndExport with application, populated submitted data and validationErrors.errorList', async () => {
+        await mapAndSave.policyAndExport(mockFormBody, mockApplication, mockValidationErrors);
+
+        expect(save.policyAndExport).toHaveBeenCalledTimes(1);
+        expect(save.policyAndExport).toHaveBeenCalledWith(mockApplication, mapSubmittedData(mockFormBody), mockValidationErrors?.errorList);
+      });
+
+      it('should return true', async () => {
+        const result = await mapAndSave.policyAndExport(mockFormBody, mockApplication, mockValidationErrors);
+
+        expect(result).toEqual(true);
+      });
+    });
+
+    describe('when the form does NOT have validation errors ', () => {
+      it('should call save.policyAndExport with application and populated submitted data', async () => {
+        await mapAndSave.policyAndExport(mockFormBody, mockApplication);
+
+        expect(save.policyAndExport).toHaveBeenCalledTimes(1);
+        expect(save.policyAndExport).toHaveBeenCalledWith(mockApplication, mapSubmittedData(mockFormBody));
+      });
+
+      it('should return true', async () => {
+        const result = await mapAndSave.policyAndExport(mockFormBody, mockApplication, mockValidationErrors);
+
+        expect(result).toEqual(true);
+      });
+    });
+  });
+
+  describe('when the form does not have any data', () => {
+    it('should return true', async () => {
+      mockFormBody = { _csrf: '1234' };
+
+      const result = await mapAndSave.policyAndExport(mockFormBody, mockApplication, mockValidationErrors);
+
+      expect(result).toEqual(true);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/policy-and-export/map-and-save/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/map-and-save/index.ts
@@ -1,0 +1,43 @@
+import hasFormData from '../../../../helpers/has-form-data';
+import mapSubmittedData from '../map-submitted-data';
+import save from '../save-data';
+import { Application, RequestBody, ValidationErrors } from '../../../../../types';
+
+/**
+ * mapAndSave
+ * Map and save any valid Single contract policy fields
+ * @param {Express.Request.body} Express request body
+ * @param {Object} Validation errors
+ * @returns {Boolean}
+ */
+const policyAndExport = async (formBody: RequestBody, application: Application, validationErrors?: ValidationErrors) => {
+  try {
+    if (hasFormData(formBody)) {
+      const populatedData = mapSubmittedData(formBody);
+
+      let saveResponse;
+
+      if (validationErrors) {
+        saveResponse = await save.policyAndExport(application, populatedData, validationErrors.errorList);
+      } else {
+        saveResponse = await save.policyAndExport(application, populatedData);
+      }
+
+      if (!saveResponse) {
+        return false;
+      }
+
+      return true;
+    }
+
+    return true;
+  } catch (err) {
+    console.error('Error mapping and saving application', { err });
+
+    return false;
+  }
+};
+
+export default {
+  policyAndExport,
+};

--- a/src/ui/server/controllers/insurance/policy-and-export/map-and-save/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/map-and-save/index.ts
@@ -7,6 +7,7 @@ import { Application, RequestBody, ValidationErrors } from '../../../../../types
  * mapAndSave
  * Map and save any valid Single contract policy fields
  * @param {Express.Request.body} Express request body
+ * @param {Object} Application
  * @param {Object} Validation errors
  * @returns {Boolean}
  */

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/index.ts
@@ -9,8 +9,7 @@ import { mapCurrencies } from '../../../../helpers/mappings/map-currencies';
 import mapTotalMonthsOfCover from '../../../../helpers/mappings/map-total-months-of-insurance';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import generateValidationErrors from './validation';
-import mapSubmittedData from '../map-submitted-data';
-import save from '../save-data';
+import mapAndSave from '../map-and-save';
 
 const {
   INSURANCE: {
@@ -191,9 +190,7 @@ export const post = async (req: Request, res: Response) => {
 
   try {
     // save the application
-    const populatedData = mapSubmittedData(req.body);
-
-    const saveResponse = await save.policyAndExport(application, populatedData);
+    const saveResponse = await mapAndSave.policyAndExport(req.body, application);
 
     if (!saveResponse) {
       return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import generateValidationErrors from '../validation';
 import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
 
 const {
-  INSURANCE: { INSURANCE_ROOT },
+  INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS },
 } = ROUTES;
 
 describe('controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back', () => {
@@ -45,22 +45,22 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy/save-
       expect(mapAndSave.policyAndExport).toHaveBeenCalledWith(req.body, res.locals.application, validationErrors);
     });
 
-    it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, async () => {
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
       await post(req, res);
 
-      const expected = `${INSURANCE_ROOT}/${refNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`;
+      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
 
       expect(res.redirect).toHaveBeenCalledWith(expected);
     });
   });
 
   describe('when the form does not have any data', () => {
-    it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, async () => {
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
       req.body = { _csrf: '1234' };
 
       await post(req, res);
 
-      const expected = `${INSURANCE_ROOT}/${refNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`;
+      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
 
       expect(res.redirect).toHaveBeenCalledWith(expected);
     });
@@ -78,29 +78,31 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy/save-
     });
   });
 
-  describe('when the mapAndSave call does not return anything', () => {
-    beforeEach(() => {
-      mockMapAndSave = jest.fn(() => Promise.resolve(false));
-      mapAndSave.policyAndExport = mockMapAndSave;
+  describe('api error handling', () => {
+    describe('when the mapAndSave call does not return anything', () => {
+      beforeEach(() => {
+        mockMapAndSave = jest.fn(() => Promise.resolve(false));
+        mapAndSave.policyAndExport = mockMapAndSave;
+      });
+
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+      });
     });
 
-    it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
-      await post(req, res);
+    describe('when the mapAndSave call fails', () => {
+      beforeEach(() => {
+        mockMapAndSave = jest.fn(() => Promise.reject(new Error('Mock error')));
+        mapAndSave.policyAndExport = mockMapAndSave;
+      });
 
-      expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
-    });
-  });
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
 
-  describe('when the mapAndSave call fails', () => {
-    beforeEach(() => {
-      mockMapAndSave = jest.fn(() => Promise.reject(new Error('Mock error')));
-      mapAndSave.policyAndExport = mockMapAndSave;
-    });
-
-    it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
-      await post(req, res);
-
-      expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+      });
     });
   });
 });

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back/index.test.ts
@@ -9,7 +9,7 @@ const {
   INSURANCE: { INSURANCE_ROOT },
 } = ROUTES;
 
-describe('controllers/insurance/policy-and-export/single-contract-policy/save-and-back', () => {
+describe('controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back', () => {
   let req: Request;
   let res: Response;
 
@@ -42,7 +42,7 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/save-an
       const validationErrors = generateValidationErrors(req.body);
 
       expect(mapAndSave.policyAndExport).toHaveBeenCalledTimes(1);
-      expect(mapAndSave.policyAndExport).toHaveBeenCalledWith(mockFormBody, res.locals.application, validationErrors);
+      expect(mapAndSave.policyAndExport).toHaveBeenCalledWith(req.body, res.locals.application, validationErrors);
     });
 
     it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, async () => {

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back/index.ts
@@ -5,7 +5,7 @@ import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save';
 
 const {
-  INSURANCE: { INSURANCE_ROOT },
+  INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS },
 } = ROUTES;
 
 /**
@@ -41,7 +41,7 @@ export const post = async (req: Request, res: Response) => {
       }
     }
 
-    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`);
+    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`);
   } catch (err) {
     console.error('Error updating application', { err });
 

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back/index.ts
@@ -1,0 +1,50 @@
+import { ROUTES } from '../../../../../constants';
+import { Request, Response } from '../../../../../../types';
+import hasFormData from '../../../../../helpers/has-form-data';
+import generateValidationErrors from '../validation';
+import mapAndSave from '../../map-and-save';
+
+const {
+  INSURANCE: { INSURANCE_ROOT },
+} = ROUTES;
+
+/**
+ * post
+ * Save any valid Multiple contract policy fields and if successful, redirect to the all sections page
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.redirect} All sections page or error page
+ */
+export const post = async (req: Request, res: Response) => {
+  try {
+    const { application } = res.locals;
+
+    if (!application) {
+      return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+    }
+
+    const { referenceNumber } = req.params;
+
+    if (hasFormData(req.body)) {
+      const validationErrors = generateValidationErrors(req.body);
+
+      let saveResponse;
+
+      if (validationErrors) {
+        saveResponse = await mapAndSave.policyAndExport(req.body, application, validationErrors);
+      } else {
+        saveResponse = await mapAndSave.policyAndExport(req.body, application);
+      }
+
+      if (!saveResponse) {
+        return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+      }
+    }
+
+    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`);
+  } catch (err) {
+    console.error('Error updating application', { err });
+
+    return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+  }
+};

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/index.test.ts
@@ -9,8 +9,7 @@ import api from '../../../../api';
 import { mapCurrencies } from '../../../../helpers/mappings/map-currencies';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import generateValidationErrors from './validation';
-import mapSubmittedData from '../map-submitted-data';
-import save from '../save-data';
+import mapAndSave from '../map-and-save';
 import { mockReq, mockRes, mockApplication, mockCurrencies } from '../../../../test-mocks';
 
 const {
@@ -38,7 +37,7 @@ describe('controllers/insurance/policy-and-export/single-contract-policy', () =>
 
   jest.mock('../save-data');
 
-  save.policyAndExport = jest.fn(() => Promise.resolve({}));
+  mapAndSave.policyAndExport = jest.fn(() => Promise.resolve(true));
   let getCurrenciesSpy = jest.fn(() => Promise.resolve(mockCurrencies));
 
   beforeEach(() => {
@@ -232,24 +231,12 @@ describe('controllers/insurance/policy-and-export/single-contract-policy', () =>
         req.body = validBody;
       });
 
-      it('should call save.policyAndExport with application and populated data from req.body', async () => {
+      it('should call mapAndSave.policyAndExport with req.body and application', async () => {
         await post(req, res);
 
-        expect(save.policyAndExport).toHaveBeenCalledTimes(1);
+        expect(mapAndSave.policyAndExport).toHaveBeenCalledTimes(1);
 
-        const expectedPopulatedData = mapSubmittedData(req.body);
-
-        expect(save.policyAndExport).toHaveBeenCalledWith(res.locals.application, expectedPopulatedData);
-      });
-
-      it(`should redirect to ${ABOUT_GOODS_OR_SERVICES}`, async () => {
-        await post(req, res);
-
-        expect(save.policyAndExport).toHaveBeenCalledTimes(1);
-
-        const expectedPopulatedData = mapSubmittedData(req.body);
-
-        expect(save.policyAndExport).toHaveBeenCalledWith(res.locals.application, expectedPopulatedData);
+        expect(mapAndSave.policyAndExport).toHaveBeenCalledWith(req.body, res.locals.application);
       });
 
       it(`should redirect to ${ABOUT_GOODS_OR_SERVICES}`, async () => {
@@ -344,17 +331,16 @@ describe('controllers/insurance/policy-and-export/single-contract-policy', () =>
         });
       });
 
-      describe('save.policyAndExport call', () => {
+      describe('mapAndSave.policyAndExport call', () => {
         beforeEach(() => {
           req.body = validBody;
         });
 
         describe('when no application is returned', () => {
           beforeEach(() => {
-            // @ts-ignore
-            const savePolicyAndExportDataSpy = jest.fn(() => Promise.resolve());
+            const savePolicyAndExportDataSpy = jest.fn(() => Promise.resolve(false));
 
-            save.policyAndExport = savePolicyAndExportDataSpy;
+            mapAndSave.policyAndExport = savePolicyAndExportDataSpy;
           });
 
           it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
@@ -366,9 +352,9 @@ describe('controllers/insurance/policy-and-export/single-contract-policy', () =>
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const savePolicyAndExportDataSpy = jest.fn(() => Promise.reject());
+            const savePolicyAndExportDataSpy = jest.fn(() => Promise.reject(new Error('Mock error')));
 
-            save.policyAndExport = savePolicyAndExportDataSpy;
+            mapAndSave.policyAndExport = savePolicyAndExportDataSpy;
           });
 
           it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/index.ts
@@ -8,8 +8,7 @@ import { objectHasProperty } from '../../../../helpers/object';
 import { mapCurrencies } from '../../../../helpers/mappings/map-currencies';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import generateValidationErrors from './validation';
-import mapSubmittedData from '../map-submitted-data';
-import save from '../save-data';
+import mapAndSave from '../map-and-save';
 
 const {
   INSURANCE: {
@@ -160,9 +159,7 @@ export const post = async (req: Request, res: Response) => {
 
   try {
     // save the application
-    const populatedData = mapSubmittedData(req.body);
-
-    const saveResponse = await save.policyAndExport(application, populatedData);
+    const saveResponse = await mapAndSave.policyAndExport(req.body, application);
 
     if (!saveResponse) {
       return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import generateValidationErrors from '../validation';
 import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
 
 const {
-  INSURANCE: { INSURANCE_ROOT },
+  INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS },
 } = ROUTES;
 
 describe('controllers/insurance/policy-and-export/single-contract-policy/save-and-back', () => {
@@ -45,22 +45,22 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/save-an
       expect(mapAndSave.policyAndExport).toHaveBeenCalledWith(mockFormBody, res.locals.application, validationErrors);
     });
 
-    it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, async () => {
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
       await post(req, res);
 
-      const expected = `${INSURANCE_ROOT}/${refNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`;
+      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
 
       expect(res.redirect).toHaveBeenCalledWith(expected);
     });
   });
 
   describe('when the form does not have any data', () => {
-    it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, async () => {
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
       req.body = { _csrf: '1234' };
 
       await post(req, res);
 
-      const expected = `${INSURANCE_ROOT}/${refNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`;
+      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
 
       expect(res.redirect).toHaveBeenCalledWith(expected);
     });
@@ -78,29 +78,31 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/save-an
     });
   });
 
-  describe('when the mapAndSave call does not return anything', () => {
-    beforeEach(() => {
-      mockMapAndSave = jest.fn(() => Promise.resolve(false));
-      mapAndSave.policyAndExport = mockMapAndSave;
+  describe('api error handling', () => {
+    describe('when the mapAndSave call does not return anything', () => {
+      beforeEach(() => {
+        mockMapAndSave = jest.fn(() => Promise.resolve(false));
+        mapAndSave.policyAndExport = mockMapAndSave;
+      });
+
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+      });
     });
 
-    it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
-      await post(req, res);
+    describe('when the mapAndSave call fails', () => {
+      beforeEach(() => {
+        mockMapAndSave = jest.fn(() => Promise.reject(new Error('Mock error')));
+        mapAndSave.policyAndExport = mockMapAndSave;
+      });
 
-      expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
-    });
-  });
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
 
-  describe('when the mapAndSave call fails', () => {
-    beforeEach(() => {
-      mockMapAndSave = jest.fn(() => Promise.reject(new Error('Mock error')));
-      mapAndSave.policyAndExport = mockMapAndSave;
-    });
-
-    it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
-      await post(req, res);
-
-      expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+      });
     });
   });
 });

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/save-and-back/index.ts
@@ -3,8 +3,9 @@ import { Request, Response } from '../../../../../../types';
 import hasFormData from '../../../../../helpers/has-form-data';
 import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save';
+
 const {
-  INSURANCE: { INSURANCE_ROOT },
+  INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS },
 } = ROUTES;
 
 /**
@@ -27,16 +28,20 @@ export const post = async (req: Request, res: Response) => {
     if (hasFormData(req.body)) {
       const validationErrors = generateValidationErrors(req.body);
 
-      const saved = await mapAndSave.policyAndExport(req.body, application, validationErrors);
+      let saveResponse;
 
-      if (saved) {
-        return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`);
+      if (validationErrors) {
+        saveResponse = await mapAndSave.policyAndExport(req.body, application, validationErrors);
+      } else {
+        saveResponse = await mapAndSave.policyAndExport(req.body, application);
       }
 
-      return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+      if (!saveResponse) {
+        return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+      }
     }
 
-    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`);
+    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`);
   } catch (err) {
     console.error('Error updating application', { err });
 

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/save-and-back/index.ts
@@ -1,10 +1,8 @@
 import { ROUTES } from '../../../../../constants';
 import { Request, Response } from '../../../../../../types';
 import hasFormData from '../../../../../helpers/has-form-data';
-import mapSubmittedData from '../../map-submitted-data';
 import generateValidationErrors from '../validation';
-import save from '../../save-data';
-
+import mapAndSave from '../../map-and-save';
 const {
   INSURANCE: { INSURANCE_ROOT },
 } = ROUTES;
@@ -29,19 +27,13 @@ export const post = async (req: Request, res: Response) => {
     if (hasFormData(req.body)) {
       const validationErrors = generateValidationErrors(req.body);
 
-      const populatedData = mapSubmittedData(req.body);
+      const saved = await mapAndSave.policyAndExport(req.body, application, validationErrors);
 
-      let saveResponse;
-
-      if (validationErrors) {
-        saveResponse = await save.policyAndExport(application, populatedData, validationErrors.errorList);
-      } else {
-        saveResponse = await save.policyAndExport(application, populatedData);
+      if (saved) {
+        return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`);
       }
 
-      if (!saveResponse) {
-        return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
-      }
+      return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
     }
 
     return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`);

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/index.ts
@@ -2,6 +2,6 @@ import validationRules from './rules';
 import combineValidationRules from '../../../../../helpers/combine-validation-rules';
 import { RequestBody, ValidationErrors } from '../../../../../../types';
 
-const validation = (formBody: RequestBody): ValidationErrors => combineValidationRules(validationRules, formBody);
+const validation = (formBody: RequestBody): ValidationErrors => combineValidationRules(validationRules, formBody) as ValidationErrors;
 
 export default validation;

--- a/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.ts
@@ -5,7 +5,7 @@ import { Request, Response } from '../../../../../types';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import generateValidationErrors from './validation';
 import { isMultiPolicyType, isSinglePolicyType } from '../../../../helpers/policy-type';
-import save from '../save-data';
+import mapAndSave from '../map-and-save';
 
 const { INSURANCE_ROOT } = ROUTES.INSURANCE;
 const { POLICY_AND_EXPORTS } = FIELD_IDS.INSURANCE;
@@ -80,7 +80,7 @@ export const post = async (req: Request, res: Response) => {
 
   try {
     // save the application
-    const saveResponse = await save.policyAndExport(application, req.body);
+    const saveResponse = await mapAndSave.policyAndExport(req.body, application);
 
     if (!saveResponse) {
       return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/save-and-back/index.test.ts
@@ -108,7 +108,7 @@ describe('controllers/insurance/policy-and-export/type-of-policy/save-and-back',
   });
 
   describe('api error handling', () => {
-    describe('when save application policyAndExport call does not retun anything', () => {
+    describe('when save application policyAndExport call does not return anything', () => {
       beforeEach(() => {
         req.body = mockValidFormBody;
 

--- a/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/save-and-back/index.ts
@@ -2,10 +2,10 @@ import { ROUTES } from '../../../../../constants';
 import { Request, Response } from '../../../../../../types';
 import hasFormData from '../../../../../helpers/has-form-data';
 import generateValidationErrors from '../validation';
-import save from '../../save-data';
+import mapAndSave from '../../map-and-save';
 
 const {
-  INSURANCE: { INSURANCE_ROOT },
+  INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS },
 } = ROUTES;
 
 /**
@@ -31,9 +31,9 @@ export const post = async (req: Request, res: Response) => {
       let saveResponse;
 
       if (validationErrors) {
-        saveResponse = await save.policyAndExport(application, req.body, validationErrors.errorList);
+        saveResponse = await mapAndSave.policyAndExport(req.body, application, validationErrors);
       } else {
-        saveResponse = await save.policyAndExport(application, req.body);
+        saveResponse = await mapAndSave.policyAndExport(req.body, application);
       }
 
       if (!saveResponse) {
@@ -41,7 +41,7 @@ export const post = async (req: Request, res: Response) => {
       }
     }
 
-    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`);
+    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`);
   } catch (err) {
     console.error('Error updating application', { err });
 

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -7,6 +7,7 @@ import { post as typeOfPolicySaveAndBackPost } from '../../controllers/insurance
 import { get as singleContractPolicyGet, post as singleContractPolicyPost } from '../../controllers/insurance/policy-and-export/single-contract-policy';
 import { post as singleContractPolicySaveAndBackPost } from '../../controllers/insurance/policy-and-export/single-contract-policy/save-and-back';
 import { get as multipleContractPolicyGet, post as multipleContractPolicyPost } from '../../controllers/insurance/policy-and-export/multiple-contract-policy';
+import { post as multipleContractPolicySaveAndBackPost } from '../../controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back';
 import { get as aboutGoodsOrServicesGet } from '../../controllers/insurance/policy-and-export/about-goods-or-services';
 import { get as pageNotFoundGet } from '../../controllers/insurance/page-not-found';
 
@@ -21,7 +22,7 @@ describe('routes/insurance', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(25);
-    expect(post).toHaveBeenCalledTimes(20);
+    expect(post).toHaveBeenCalledTimes(21);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);
@@ -55,6 +56,10 @@ describe('routes/insurance', () => {
     expect(post).toHaveBeenCalledWith(
       `${INSURANCE_ROOT}/:referenceNumber${INSURANCE_ROUTES.POLICY_AND_EXPORTS.MULTIPLE_CONTRACT_POLICY}`,
       multipleContractPolicyPost,
+    );
+    expect(post).toHaveBeenCalledWith(
+      `${INSURANCE_ROOT}/:referenceNumber${INSURANCE_ROUTES.POLICY_AND_EXPORTS.MULTIPLE_CONTRACT_POLICY_SAVE_AND_BACK}`,
+      multipleContractPolicySaveAndBackPost,
     );
 
     expect(get).toHaveBeenCalledWith(

--- a/src/ui/server/routes/insurance/index.ts
+++ b/src/ui/server/routes/insurance/index.ts
@@ -9,6 +9,7 @@ import { post as typeOfPolicySaveAndBackPost } from '../../controllers/insurance
 import { get as singleContractPolicyGet, post as singleContractPolicyPost } from '../../controllers/insurance/policy-and-export/single-contract-policy';
 import { post as singleContractPolicySaveAndBackPost } from '../../controllers/insurance/policy-and-export/single-contract-policy/save-and-back';
 import { get as multipleContractPolicyGet, post as multipleContractPolicyPost } from '../../controllers/insurance/policy-and-export/multiple-contract-policy';
+import { post as multipleContractPolicySaveAndBackPost } from '../../controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back';
 import { get as aboutGoodsOrServicesGet } from '../../controllers/insurance/policy-and-export/about-goods-or-services';
 import { get as pageNotFoundGet } from '../../controllers/insurance/page-not-found';
 import insuranceEligibilityRoutes from './eligibility';
@@ -42,6 +43,10 @@ insuranceRouter.post(
 
 insuranceRouter.get(`${INSURANCE_ROOT}/:referenceNumber${INSURANCE_ROUTES.POLICY_AND_EXPORTS.MULTIPLE_CONTRACT_POLICY}`, multipleContractPolicyGet);
 insuranceRouter.post(`${INSURANCE_ROOT}/:referenceNumber${INSURANCE_ROUTES.POLICY_AND_EXPORTS.MULTIPLE_CONTRACT_POLICY}`, multipleContractPolicyPost);
+insuranceRouter.post(
+  `${INSURANCE_ROOT}/:referenceNumber${INSURANCE_ROUTES.POLICY_AND_EXPORTS.MULTIPLE_CONTRACT_POLICY_SAVE_AND_BACK}`,
+  multipleContractPolicySaveAndBackPost,
+);
 
 insuranceRouter.get(`${INSURANCE_ROOT}/:referenceNumber${INSURANCE_ROUTES.POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES}`, aboutGoodsOrServicesGet);
 


### PR DESCRIPTION
This PR adds "save and go back" functionality to the "multiple contract policy" page.

## Summary of changes

- Add "save and go back" route and POST controller.
- Add E2E test.
- Add documentation RE submit button requirements, update "what happens when a form is submitted" section. Here is the markdown generated section: https://github.com/UK-Export-Finance/exip/blob/e0b3c3552c0a1f9926b38ad6ffcc0a3385a97d9c/README.md#requirements-for-submitting-a-form

## Technical improvements

- Create a `mapAndSave.policyAndExport` function. This can be used in all POST methods for any page in the policy and export section. This function:
  - Maps any form data (if required). E.g, transform day/month/year fields into a timestamp.
  - Calls `save.policyAndExport` with the mapped data and any passed validation errors.  This save function then sanitises the data and calls the API.
- Update all POST controllers in policy and export to call `mapAndSave.policyAndExport` instead of mapping and passing the mapping to `save.policyAndExport`. DRY
- Update all policy and export E2E tests to have a single declaration of the relevant task.