### PR TITLE
feat(EMS-808): API/DB structure for exporter company

### DIFF
--- a/database/exip.sql
+++ b/database/exip.sql
@@ -52,17 +52,6 @@ CREATE TABLE IF NOT EXISTS `Application` (
 
 
 
-# Dump of table CompanySicCode
-# ------------------------------------------------------------
-
-CREATE TABLE IF NOT EXISTS `CompanySicCode` (
-  `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `code` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-
-
 # Dump of table Country
 # ------------------------------------------------------------
 
@@ -399,6 +388,17 @@ CREATE TABLE IF NOT EXISTS `ExporterCompanyAddress` (
   KEY `ExporterCompanyAddress_application_idx` (`application`),
   CONSTRAINT `ExporterCompanyAddress_application_fkey` FOREIGN KEY (`application`) REFERENCES `Application` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `ExporterCompanyAddress_exporterCompany_fkey` FOREIGN KEY (`exporterCompany`) REFERENCES `ExporterCompany` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+
+# Dump of table ExporterCompanySicCode
+# ------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS `ExporterCompanySicCode` (
+  `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `code` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 

--- a/database/exip.sql
+++ b/database/exip.sql
@@ -55,85 +55,10 @@ CREATE TABLE IF NOT EXISTS `Application` (
 # Dump of table CompanySicCode
 # ------------------------------------------------------------
 
-DROP TABLE IF EXISTS `CompanySicCode`;
-
-CREATE TABLE `CompanySicCode` (
+CREATE TABLE IF NOT EXISTS `CompanySicCode` (
   `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `code` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-
-
-# Dump of table ExporterBusiness
-# ------------------------------------------------------------
-
-DROP TABLE IF NOT EXISTS `ExporterBusiness`;
-
-CREATE TABLE `ExporterBusiness` (
-  `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `company` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `ExporterBusiness_company_idx` (`company`),
-  CONSTRAINT `ExporterBusiness_company_fkey` FOREIGN KEY (`company`) REFERENCES `ExporterCompany` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-
-
-# Dump of table ExporterCompany
-# ------------------------------------------------------------
-
-DROP TABLE IF EXISTS `ExporterCompany`;
-
-CREATE TABLE `ExporterCompany` (
-  `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `application` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `exporterCompanyAddress` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `business` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `sicCodes` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `companyName` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `companyNumber` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `dateOfCreation` datetime(3) DEFAULT NULL,
-  `hasTradingAddress` tinyint(1) NOT NULL DEFAULT '0',
-  `hasTradingName` tinyint(1) NOT NULL DEFAULT '0',
-  `companyWebsite` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `phoneNumber` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  PRIMARY KEY (`id`),
-  KEY `ExporterCompany_application_idx` (`application`),
-  KEY `ExporterCompany_exporterCompanyAddress_idx` (`exporterCompanyAddress`),
-  KEY `ExporterCompany_business_idx` (`business`),
-  KEY `ExporterCompany_sicCodes_idx` (`sicCodes`),
-  CONSTRAINT `ExporterCompany_application_fkey` FOREIGN KEY (`application`) REFERENCES `Application` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
-  CONSTRAINT `ExporterCompany_business_fkey` FOREIGN KEY (`business`) REFERENCES `ExporterBusiness` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
-  CONSTRAINT `ExporterCompany_exporterCompanyAddress_fkey` FOREIGN KEY (`exporterCompanyAddress`) REFERENCES `ExporterCompanyAddress` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
-  CONSTRAINT `ExporterCompany_sicCodes_fkey` FOREIGN KEY (`sicCodes`) REFERENCES `CompanySicCode` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-
-
-
-# Dump of table ExporterCompanyAddress
-# ------------------------------------------------------------
-
-DROP TABLE IF EXISTS `ExporterCompanyAddress`;
-
-CREATE TABLE `ExporterCompanyAddress` (
-  `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `exporterCompany` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `application` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `addressLine1` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `addressLine2` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `careOf` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `locality` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `region` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `postalCode` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `country` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `premises` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  PRIMARY KEY (`id`),
-  KEY `ExporterCompanyAddress_exporterCompany_idx` (`exporterCompany`),
-  KEY `ExporterCompanyAddress_application_idx` (`application`),
-  CONSTRAINT `ExporterCompanyAddress_application_fkey` FOREIGN KEY (`application`) REFERENCES `Application` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
-  CONSTRAINT `ExporterCompanyAddress_exporterCompany_fkey` FOREIGN KEY (`exporterCompany`) REFERENCES `ExporterCompany` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 
@@ -409,6 +334,71 @@ CREATE TABLE IF NOT EXISTS `Eligibility` (
   KEY `Eligibility_buyerCountry_idx` (`buyerCountry`),
   CONSTRAINT `Eligibility_application_fkey` FOREIGN KEY (`application`) REFERENCES `Application` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `Eligibility_buyerCountry_fkey` FOREIGN KEY (`buyerCountry`) REFERENCES `Country` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+# Dump of table ExporterBusiness
+# ------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS `ExporterBusiness` (
+  `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `company` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `ExporterBusiness_company_idx` (`company`),
+  CONSTRAINT `ExporterBusiness_company_fkey` FOREIGN KEY (`company`) REFERENCES `ExporterCompany` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+
+# Dump of table ExporterCompany
+# ------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS `ExporterCompany` (
+  `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `application` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `exporterCompanyAddress` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `business` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `sicCodes` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `companyName` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `companyNumber` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `dateOfCreation` datetime(3) DEFAULT NULL,
+  `hasTradingAddress` tinyint(1) NOT NULL DEFAULT '0',
+  `hasTradingName` tinyint(1) NOT NULL DEFAULT '0',
+  `companyWebsite` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `phoneNumber` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  KEY `ExporterCompany_application_idx` (`application`),
+  KEY `ExporterCompany_exporterCompanyAddress_idx` (`exporterCompanyAddress`),
+  KEY `ExporterCompany_business_idx` (`business`),
+  KEY `ExporterCompany_sicCodes_idx` (`sicCodes`),
+  CONSTRAINT `ExporterCompany_application_fkey` FOREIGN KEY (`application`) REFERENCES `Application` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `ExporterCompany_business_fkey` FOREIGN KEY (`business`) REFERENCES `ExporterBusiness` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `ExporterCompany_exporterCompanyAddress_fkey` FOREIGN KEY (`exporterCompanyAddress`) REFERENCES `ExporterCompanyAddress` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `ExporterCompany_sicCodes_fkey` FOREIGN KEY (`sicCodes`) REFERENCES `CompanySicCode` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+
+# Dump of table ExporterCompanyAddress
+# ------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS `ExporterCompanyAddress` (
+  `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `exporterCompany` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `application` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `addressLine1` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `addressLine2` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `careOf` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `locality` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `region` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `postalCode` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `country` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `premises` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  KEY `ExporterCompanyAddress_exporterCompany_idx` (`exporterCompany`),
+  KEY `ExporterCompanyAddress_application_idx` (`application`),
+  CONSTRAINT `ExporterCompanyAddress_application_fkey` FOREIGN KEY (`application`) REFERENCES `Application` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `ExporterCompanyAddress_exporterCompany_fkey` FOREIGN KEY (`exporterCompany`) REFERENCES `ExporterCompany` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 

--- a/database/exip.sql
+++ b/database/exip.sql
@@ -36,12 +36,104 @@ CREATE TABLE IF NOT EXISTS `Application` (
   `submissionType` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT 'Manual Inclusion Application',
   `eligibility` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `policyAndExport` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `exporterCompany` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `exporterCompanyAddress` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `Application_referenceNumber_idx` (`referenceNumber`),
   KEY `Application_eligibility_idx` (`eligibility`),
   KEY `Application_policyAndExport_idx` (`policyAndExport`),
+  KEY `Application_exporterCompany_idx` (`exporterCompany`),
+  KEY `Application_exporterCompanyAddress_idx` (`exporterCompanyAddress`),
   CONSTRAINT `Application_eligibility_fkey` FOREIGN KEY (`eligibility`) REFERENCES `Eligibility` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `Application_exporterCompany_fkey` FOREIGN KEY (`exporterCompany`) REFERENCES `ExporterCompany` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `Application_exporterCompanyAddress_fkey` FOREIGN KEY (`exporterCompanyAddress`) REFERENCES `ExporterCompanyAddress` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `Application_policyAndExport_fkey` FOREIGN KEY (`policyAndExport`) REFERENCES `PolicyAndExport` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+
+# Dump of table CompanySicCode
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `CompanySicCode`;
+
+CREATE TABLE `CompanySicCode` (
+  `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `code` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+
+# Dump of table ExporterBusiness
+# ------------------------------------------------------------
+
+DROP TABLE IF NOT EXISTS `ExporterBusiness`;
+
+CREATE TABLE `ExporterBusiness` (
+  `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `company` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `ExporterBusiness_company_idx` (`company`),
+  CONSTRAINT `ExporterBusiness_company_fkey` FOREIGN KEY (`company`) REFERENCES `ExporterCompany` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+
+# Dump of table ExporterCompany
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `ExporterCompany`;
+
+CREATE TABLE `ExporterCompany` (
+  `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `application` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `exporterCompanyAddress` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `business` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `sicCodes` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `companyName` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `companyNumber` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `dateOfCreation` datetime(3) DEFAULT NULL,
+  `hasTradingAddress` tinyint(1) NOT NULL DEFAULT '0',
+  `hasTradingName` tinyint(1) NOT NULL DEFAULT '0',
+  `companyWebsite` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `phoneNumber` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  KEY `ExporterCompany_application_idx` (`application`),
+  KEY `ExporterCompany_exporterCompanyAddress_idx` (`exporterCompanyAddress`),
+  KEY `ExporterCompany_business_idx` (`business`),
+  KEY `ExporterCompany_sicCodes_idx` (`sicCodes`),
+  CONSTRAINT `ExporterCompany_application_fkey` FOREIGN KEY (`application`) REFERENCES `Application` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `ExporterCompany_business_fkey` FOREIGN KEY (`business`) REFERENCES `ExporterBusiness` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `ExporterCompany_exporterCompanyAddress_fkey` FOREIGN KEY (`exporterCompanyAddress`) REFERENCES `ExporterCompanyAddress` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `ExporterCompany_sicCodes_fkey` FOREIGN KEY (`sicCodes`) REFERENCES `CompanySicCode` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+
+
+# Dump of table ExporterCompanyAddress
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `ExporterCompanyAddress`;
+
+CREATE TABLE `ExporterCompanyAddress` (
+  `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `exporterCompany` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `application` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `addressLine1` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `addressLine2` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `careOf` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `locality` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `region` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `postalCode` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `country` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `premises` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  KEY `ExporterCompanyAddress_exporterCompany_idx` (`exporterCompany`),
+  KEY `ExporterCompanyAddress_application_idx` (`application`),
+  CONSTRAINT `ExporterCompanyAddress_application_fkey` FOREIGN KEY (`application`) REFERENCES `Application` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `ExporterCompanyAddress_exporterCompany_fkey` FOREIGN KEY (`exporterCompany`) REFERENCES `ExporterCompany` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 
@@ -294,6 +386,7 @@ VALUES
 
 /*!40000 ALTER TABLE `Country` ENABLE KEYS */;
 UNLOCK TABLES;
+
 
 
 # Dump of table Eligibility

--- a/e2e-tests/constants/field-ids/insurance/exporter-business/index.js
+++ b/e2e-tests/constants/field-ids/insurance/exporter-business/index.js
@@ -11,8 +11,8 @@ export const EXPORTER_BUSINESS = {
   },
   YOUR_COMPANY: {
     YOUR_BUSINESS: 'yourBusiness',
-    TRADING_NAME: 'tradingName',
-    TRADING_ADDRESS: 'tradingAddress',
+    TRADING_NAME: 'hasTradingName',
+    TRADING_ADDRESS: 'hasTradingAddress',
     WEBSITE: 'companyWebsite',
     PHONE_NUMBER: 'phoneNumber',
   },

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -81,7 +81,9 @@ var lists = {
         options: [{ label: APPLICATION.SUBMISSION_TYPE.MIA, value: APPLICATION.SUBMISSION_TYPE.MIA }],
         defaultValue: APPLICATION.SUBMISSION_TYPE.MIA
       }),
-      policyAndExport: (0, import_fields.relationship)({ ref: "PolicyAndExport" })
+      policyAndExport: (0, import_fields.relationship)({ ref: "PolicyAndExport" }),
+      exporterCompany: (0, import_fields.relationship)({ ref: "Company" }),
+      exporterCompanyAddress: (0, import_fields.relationship)({ ref: "CompanyAddress" })
     },
     hooks: {
       resolveInput: async ({ operation, resolvedData, context }) => {
@@ -109,6 +111,28 @@ var lists = {
                 id: policyAndExportId
               }
             };
+            const { id: exporterCompanyId } = await context.db.Company.createOne({
+              data: {}
+            });
+            modifiedData.exporterCompany = {
+              connect: {
+                id: exporterCompanyId
+              }
+            };
+            const { id: exporterCompanyAddressId } = await context.db.CompanyAddress.createOne({
+              data: {
+                company: {
+                  connect: {
+                    id: exporterCompanyId
+                  }
+                }
+              }
+            });
+            modifiedData.exporterCompanyAddress = {
+              connect: {
+                id: exporterCompanyAddressId
+              }
+            };
             const now = new Date();
             modifiedData.createdAt = now;
             modifiedData.updatedAt = now;
@@ -125,9 +149,9 @@ var lists = {
       afterOperation: async ({ operation, item, context }) => {
         if (operation === "create") {
           try {
-            console.info("Adding application ID to reference number entry");
+            console.info("Adding application ID to relationships");
             const applicationId = item.id;
-            const { referenceNumber, eligibilityId, policyAndExportId } = item;
+            const { referenceNumber, eligibilityId, policyAndExportId, exporterCompanyId, exporterCompanyAddressId } = item;
             await context.db.ReferenceNumber.updateOne({
               where: { id: String(referenceNumber) },
               data: {
@@ -150,6 +174,26 @@ var lists = {
             });
             await context.db.PolicyAndExport.updateOne({
               where: { id: policyAndExportId },
+              data: {
+                application: {
+                  connect: {
+                    id: applicationId
+                  }
+                }
+              }
+            });
+            await context.db.Company.updateOne({
+              where: { id: exporterCompanyId },
+              data: {
+                application: {
+                  connect: {
+                    id: applicationId
+                  }
+                }
+              }
+            });
+            await context.db.CompanyAddress.updateOne({
+              where: { id: exporterCompanyAddressId },
               data: {
                 application: {
                   connect: {
@@ -192,6 +236,50 @@ var lists = {
     },
     access: import_access.allowAll
   },
+  CompanyAddress: (0, import_core.list)({
+    fields: {
+      company: (0, import_fields.relationship)({ ref: "Company" }),
+      application: (0, import_fields.relationship)({ ref: "Application" }),
+      addressLine1: (0, import_fields.text)(),
+      addressLine2: (0, import_fields.text)(),
+      careOf: (0, import_fields.text)(),
+      locality: (0, import_fields.text)(),
+      region: (0, import_fields.text)(),
+      postalCode: (0, import_fields.text)(),
+      country: (0, import_fields.text)(),
+      premises: (0, import_fields.text)()
+    },
+    access: import_access.allowAll
+  }),
+  CompanySicCode: {
+    fields: {
+      code: (0, import_fields.text)(),
+      company: (0, import_fields.relationship)({ ref: "Company" })
+    },
+    access: import_access.allowAll
+  },
+  Company: (0, import_core.list)({
+    fields: {
+      application: (0, import_fields.relationship)({ ref: "Application" }),
+      companyAddress: (0, import_fields.relationship)({ ref: "CompanyAddress" }),
+      business: (0, import_fields.relationship)({ ref: "Business" }),
+      sicCodes: (0, import_fields.relationship)({ ref: "CompanySicCode" }),
+      companyName: (0, import_fields.text)(),
+      companyNumber: (0, import_fields.text)(),
+      dateOfCreation: (0, import_fields.timestamp)(),
+      hasTradingAddress: (0, import_fields.checkbox)(),
+      hasTradingName: (0, import_fields.checkbox)(),
+      companyWebsite: (0, import_fields.text)(),
+      phoneNumber: (0, import_fields.text)()
+    },
+    access: import_access.allowAll
+  }),
+  Business: (0, import_core.list)({
+    fields: {
+      company: (0, import_fields.relationship)({ ref: "Company" })
+    },
+    access: import_access.allowAll
+  }),
   Country: (0, import_core.list)({
     fields: {
       isoCode: (0, import_fields.text)({
@@ -343,7 +431,59 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
         apiError: Boolean
       }
 
+      type ApplicationCompanyAddress {
+        addressLine1: String
+        addressLine2: String
+        careOf: String
+        locality: String
+        region: String
+        postalCode: String
+        country: String
+        premises: String
+      }
+
+      input ApplicationCompanyAddressInput {
+        addressLine1: String
+        addressLine2: String
+        careOf: String
+        locality: String
+        region: String
+        postalCode: String
+        country: String
+        premises: String
+      }
+
+      type ApplicationCompanyAndCompanyAddress {
+        id: ID!
+        exporterCompanyAddress: ApplicationCompanyAddress
+        companyName: String
+        companyNumber: String
+        dateOfCreation: DateTime
+        hasTradingAddress: Boolean
+        hasTradingName: Boolean
+        companyWebsite: String
+        phoneNumber: String
+      }
+
+      input ApplicationCompanyAndCompanyAddressInput {
+        exporterCompanyAddress: ApplicationCompanyAddressInput
+        companyName: String
+        companyNumber: String
+        dateOfCreation: DateTime
+        hasTradingAddress: Boolean
+        hasTradingName: Boolean
+        companyWebsite: String
+        phoneNumber: String
+      }
+
       type Mutation {
+        """ update application company and company address """
+        updateApplicationCompanyAndCompanyAddress(
+          companyId: ID!
+          companyAddressId: ID!
+          data: ApplicationCompanyAndCompanyAddressInput!
+        ): ApplicationCompanyAndCompanyAddress
+
         """ send an email """
         sendEmail(
           templateId: String!
@@ -360,6 +500,26 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
     `,
   resolvers: {
     Mutation: {
+      updateApplicationCompanyAndCompanyAddress: async (root, variables, context) => {
+        try {
+          console.info("Updating application company and company address for ", variables.companyId);
+          const { exporterCompanyAddress, ...exporterCompany } = variables.data;
+          await context.db.Company.updateOne({
+            where: { id: variables.id },
+            data: exporterCompany
+          });
+          await context.db.CompanyAddress.updateOne({
+            where: { id: variables.companyAddressId },
+            data: exporterCompanyAddress
+          });
+          return {
+            id: variables.id
+          };
+        } catch (err) {
+          console.error("Error updating application company and company address", { err });
+          throw new Error(`Updating application company and company address ${err}`);
+        }
+      },
       sendEmail: async (root, variables) => {
         try {
           console.info("Calling Notify API. templateId: ", variables.templateId);

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -82,8 +82,8 @@ var lists = {
         defaultValue: APPLICATION.SUBMISSION_TYPE.MIA
       }),
       policyAndExport: (0, import_fields.relationship)({ ref: "PolicyAndExport" }),
-      exporterCompany: (0, import_fields.relationship)({ ref: "Company" }),
-      exporterCompanyAddress: (0, import_fields.relationship)({ ref: "CompanyAddress" })
+      exporterCompany: (0, import_fields.relationship)({ ref: "ExporterCompany" }),
+      exporterCompanyAddress: (0, import_fields.relationship)({ ref: "ExporterCompanyAddress" })
     },
     hooks: {
       resolveInput: async ({ operation, resolvedData, context }) => {
@@ -111,7 +111,7 @@ var lists = {
                 id: policyAndExportId
               }
             };
-            const { id: exporterCompanyId } = await context.db.Company.createOne({
+            const { id: exporterCompanyId } = await context.db.ExporterCompany.createOne({
               data: {}
             });
             modifiedData.exporterCompany = {
@@ -119,9 +119,9 @@ var lists = {
                 id: exporterCompanyId
               }
             };
-            const { id: exporterCompanyAddressId } = await context.db.CompanyAddress.createOne({
+            const { id: exporterCompanyAddressId } = await context.db.ExporterCompanyAddress.createOne({
               data: {
-                company: {
+                exporterCompany: {
                   connect: {
                     id: exporterCompanyId
                   }
@@ -182,7 +182,7 @@ var lists = {
                 }
               }
             });
-            await context.db.Company.updateOne({
+            await context.db.ExporterCompany.updateOne({
               where: { id: exporterCompanyId },
               data: {
                 application: {
@@ -192,7 +192,7 @@ var lists = {
                 }
               }
             });
-            await context.db.CompanyAddress.updateOne({
+            await context.db.ExporterCompanyAddress.updateOne({
               where: { id: exporterCompanyAddressId },
               data: {
                 application: {
@@ -203,7 +203,7 @@ var lists = {
               }
             });
           } catch (err) {
-            console.error("Error adding an application ID to reference number entry ", { err });
+            console.error("Error adding an application ID to relationships ", { err });
             return err;
           }
         }
@@ -236,9 +236,21 @@ var lists = {
     },
     access: import_access.allowAll
   },
-  CompanyAddress: (0, import_core.list)({
+  CompanySicCode: {
     fields: {
-      company: (0, import_fields.relationship)({ ref: "Company" }),
+      code: (0, import_fields.text)()
+    },
+    access: import_access.allowAll
+  },
+  ExporterBusiness: (0, import_core.list)({
+    fields: {
+      company: (0, import_fields.relationship)({ ref: "ExporterCompany" })
+    },
+    access: import_access.allowAll
+  }),
+  ExporterCompanyAddress: (0, import_core.list)({
+    fields: {
+      exporterCompany: (0, import_fields.relationship)({ ref: "ExporterCompany" }),
       application: (0, import_fields.relationship)({ ref: "Application" }),
       addressLine1: (0, import_fields.text)(),
       addressLine2: (0, import_fields.text)(),
@@ -251,18 +263,11 @@ var lists = {
     },
     access: import_access.allowAll
   }),
-  CompanySicCode: {
-    fields: {
-      code: (0, import_fields.text)(),
-      company: (0, import_fields.relationship)({ ref: "Company" })
-    },
-    access: import_access.allowAll
-  },
-  Company: (0, import_core.list)({
+  ExporterCompany: (0, import_core.list)({
     fields: {
       application: (0, import_fields.relationship)({ ref: "Application" }),
-      companyAddress: (0, import_fields.relationship)({ ref: "CompanyAddress" }),
-      business: (0, import_fields.relationship)({ ref: "Business" }),
+      exporterCompanyAddress: (0, import_fields.relationship)({ ref: "ExporterCompanyAddress" }),
+      business: (0, import_fields.relationship)({ ref: "ExporterBusiness" }),
       sicCodes: (0, import_fields.relationship)({ ref: "CompanySicCode" }),
       companyName: (0, import_fields.text)(),
       companyNumber: (0, import_fields.text)(),
@@ -271,12 +276,6 @@ var lists = {
       hasTradingName: (0, import_fields.checkbox)(),
       companyWebsite: (0, import_fields.text)(),
       phoneNumber: (0, import_fields.text)()
-    },
-    access: import_access.allowAll
-  }),
-  Business: (0, import_core.list)({
-    fields: {
-      company: (0, import_fields.relationship)({ ref: "Company" })
     },
     access: import_access.allowAll
   }),
@@ -410,7 +409,7 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
       }
 
       # fields from registered_office_address object
-      type CompanyAddress {
+      type CompaniesHouseCompanyAddress {
         addressLine1: String
         addressLine2: String
         careOf: String
@@ -423,7 +422,7 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
 
       type CompaniesHouseResponse {
         companyName: String
-        registeredOfficeAddress: CompanyAddress
+        registeredOfficeAddress: ExporterCompanyAddress
         companyNumber: String
         dateOfCreation: String
         sicCodes: [String]
@@ -431,7 +430,7 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
         apiError: Boolean
       }
 
-      type ApplicationCompanyAddress {
+      type ExporterCompanyAddress {
         addressLine1: String
         addressLine2: String
         careOf: String
@@ -442,7 +441,7 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
         premises: String
       }
 
-      input ApplicationCompanyAddressInput {
+      input ExporterCompanyAddressInput {
         addressLine1: String
         addressLine2: String
         careOf: String
@@ -453,9 +452,9 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
         premises: String
       }
 
-      type ApplicationCompanyAndCompanyAddress {
+      type ExporterCompanyAndCompanyAddress {
         id: ID!
-        exporterCompanyAddress: ApplicationCompanyAddress
+        exporterCompanyAddress: ExporterCompanyAddress
         companyName: String
         companyNumber: String
         dateOfCreation: DateTime
@@ -465,8 +464,8 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
         phoneNumber: String
       }
 
-      input ApplicationCompanyAndCompanyAddressInput {
-        exporterCompanyAddress: ApplicationCompanyAddressInput
+      input ExporterCompanyAndCompanyAddressInput {
+        exporterCompanyAddress: ExporterCompanyAddressInput
         companyName: String
         companyNumber: String
         dateOfCreation: DateTime
@@ -478,11 +477,11 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
 
       type Mutation {
         """ update application company and company address """
-        updateApplicationCompanyAndCompanyAddress(
+        updateExporterCompanyAndCompanyAddress(
           companyId: ID!
           companyAddressId: ID!
-          data: ApplicationCompanyAndCompanyAddressInput!
-        ): ApplicationCompanyAndCompanyAddress
+          data: ExporterCompanyAndCompanyAddressInput!
+        ): ExporterCompanyAndCompanyAddress
 
         """ send an email """
         sendEmail(
@@ -500,15 +499,15 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
     `,
   resolvers: {
     Mutation: {
-      updateApplicationCompanyAndCompanyAddress: async (root, variables, context) => {
+      updateExporterCompanyAndCompanyAddress: async (root, variables, context) => {
         try {
-          console.info("Updating application company and company address for ", variables.companyId);
+          console.info("Updating application exporter company and exporter company address for ", variables.companyId);
           const { exporterCompanyAddress, ...exporterCompany } = variables.data;
-          await context.db.Company.updateOne({
+          await context.db.ExporterCompany.updateOne({
             where: { id: variables.id },
             data: exporterCompany
           });
-          await context.db.CompanyAddress.updateOne({
+          await context.db.ExporterCompanyAddress.updateOne({
             where: { id: variables.companyAddressId },
             data: exporterCompanyAddress
           });
@@ -516,8 +515,8 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
             id: variables.id
           };
         } catch (err) {
-          console.error("Error updating application company and company address", { err });
-          throw new Error(`Updating application company and company address ${err}`);
+          console.error("Error updating application exporter company and exporter company address", { err });
+          throw new Error(`Updating application exporter company and exporter company address ${err}`);
         }
       },
       sendEmail: async (root, variables) => {

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -236,12 +236,6 @@ var lists = {
     },
     access: import_access.allowAll
   },
-  CompanySicCode: {
-    fields: {
-      code: (0, import_fields.text)()
-    },
-    access: import_access.allowAll
-  },
   ExporterBusiness: (0, import_core.list)({
     fields: {
       company: (0, import_fields.relationship)({ ref: "ExporterCompany" })
@@ -268,7 +262,7 @@ var lists = {
       application: (0, import_fields.relationship)({ ref: "Application" }),
       exporterCompanyAddress: (0, import_fields.relationship)({ ref: "ExporterCompanyAddress" }),
       business: (0, import_fields.relationship)({ ref: "ExporterBusiness" }),
-      sicCodes: (0, import_fields.relationship)({ ref: "CompanySicCode" }),
+      sicCodes: (0, import_fields.relationship)({ ref: "ExporterCompanySicCode" }),
       companyName: (0, import_fields.text)(),
       companyNumber: (0, import_fields.text)(),
       dateOfCreation: (0, import_fields.timestamp)(),
@@ -279,6 +273,12 @@ var lists = {
     },
     access: import_access.allowAll
   }),
+  ExporterCompanySicCode: {
+    fields: {
+      code: (0, import_fields.text)()
+    },
+    access: import_access.allowAll
+  },
   Country: (0, import_core.list)({
     fields: {
       isoCode: (0, import_fields.text)({
@@ -476,7 +476,7 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
       }
 
       type Mutation {
-        """ update application company and company address """
+        """ update exporter company and company address """
         updateExporterCompanyAndCompanyAddress(
           companyId: ID!
           companyAddressId: ID!

--- a/src/api/custom-schema.ts
+++ b/src/api/custom-schema.ts
@@ -22,7 +22,7 @@ export const extendGraphqlSchema = (schema: GraphQLSchema) =>
       }
 
       # fields from registered_office_address object
-      type CompanyAddress {
+      type CompaniesHouseCompanyAddress {
         addressLine1: String
         addressLine2: String
         careOf: String
@@ -35,7 +35,7 @@ export const extendGraphqlSchema = (schema: GraphQLSchema) =>
 
       type CompaniesHouseResponse {
         companyName: String
-        registeredOfficeAddress: CompanyAddress
+        registeredOfficeAddress: ExporterCompanyAddress
         companyNumber: String
         dateOfCreation: String
         sicCodes: [String]
@@ -43,7 +43,7 @@ export const extendGraphqlSchema = (schema: GraphQLSchema) =>
         apiError: Boolean
       }
 
-      type ApplicationCompanyAddress {
+      type ExporterCompanyAddress {
         addressLine1: String
         addressLine2: String
         careOf: String
@@ -54,7 +54,7 @@ export const extendGraphqlSchema = (schema: GraphQLSchema) =>
         premises: String
       }
 
-      input ApplicationCompanyAddressInput {
+      input ExporterCompanyAddressInput {
         addressLine1: String
         addressLine2: String
         careOf: String
@@ -65,9 +65,9 @@ export const extendGraphqlSchema = (schema: GraphQLSchema) =>
         premises: String
       }
 
-      type ApplicationCompanyAndCompanyAddress {
+      type ExporterCompanyAndCompanyAddress {
         id: ID!
-        exporterCompanyAddress: ApplicationCompanyAddress
+        exporterCompanyAddress: ExporterCompanyAddress
         companyName: String
         companyNumber: String
         dateOfCreation: DateTime
@@ -77,8 +77,8 @@ export const extendGraphqlSchema = (schema: GraphQLSchema) =>
         phoneNumber: String
       }
 
-      input ApplicationCompanyAndCompanyAddressInput {
-        exporterCompanyAddress: ApplicationCompanyAddressInput
+      input ExporterCompanyAndCompanyAddressInput {
+        exporterCompanyAddress: ExporterCompanyAddressInput
         companyName: String
         companyNumber: String
         dateOfCreation: DateTime
@@ -90,11 +90,11 @@ export const extendGraphqlSchema = (schema: GraphQLSchema) =>
 
       type Mutation {
         """ update application company and company address """
-        updateApplicationCompanyAndCompanyAddress(
+        updateExporterCompanyAndCompanyAddress(
           companyId: ID!
           companyAddressId: ID!
-          data: ApplicationCompanyAndCompanyAddressInput!
-        ): ApplicationCompanyAndCompanyAddress
+          data: ExporterCompanyAndCompanyAddressInput!
+        ): ExporterCompanyAndCompanyAddress
 
         """ send an email """
         sendEmail(
@@ -112,18 +112,18 @@ export const extendGraphqlSchema = (schema: GraphQLSchema) =>
     `,
     resolvers: {
       Mutation: {
-        updateApplicationCompanyAndCompanyAddress: async (root, variables, context) => {
+        updateExporterCompanyAndCompanyAddress: async (root, variables, context) => {
           try {
-            console.info('Updating application company and company address for ', variables.companyId);
+            console.info('Updating application exporter company and exporter company address for ', variables.companyId);
 
             const { exporterCompanyAddress, ...exporterCompany } = variables.data;
 
-            await context.db.Company.updateOne({
+            await context.db.ExporterCompany.updateOne({
               where: { id: variables.id },
               data: exporterCompany,
             });
 
-            await context.db.CompanyAddress.updateOne({
+            await context.db.ExporterCompanyAddress.updateOne({
               where: { id: variables.companyAddressId },
               data: exporterCompanyAddress,
             });
@@ -132,9 +132,9 @@ export const extendGraphqlSchema = (schema: GraphQLSchema) =>
               id: variables.id,
             };
           } catch (err) {
-            console.error('Error updating application company and company address', { err });
+            console.error('Error updating application exporter company and exporter company address', { err });
 
-            throw new Error(`Updating application company and company address ${err}`);
+            throw new Error(`Updating application exporter company and exporter company address ${err}`);
           }
         },
         sendEmail: async (root, variables) => {

--- a/src/api/custom-schema.ts
+++ b/src/api/custom-schema.ts
@@ -89,7 +89,7 @@ export const extendGraphqlSchema = (schema: GraphQLSchema) =>
       }
 
       type Mutation {
-        """ update application company and company address """
+        """ update exporter company and company address """
         updateExporterCompanyAndCompanyAddress(
           companyId: ID!
           companyAddressId: ID!

--- a/src/api/keystone.test.ts
+++ b/src/api/keystone.test.ts
@@ -16,7 +16,8 @@ describe('Create an Application', () => {
   beforeAll(async () => {
     application = (await context.query.Application.createOne({
       data: {},
-      query: 'id createdAt updatedAt referenceNumber submissionDeadline submissionType eligibility { id } policyAndExport { id }',
+      query:
+        'id createdAt updatedAt referenceNumber submissionDeadline submissionType eligibility { id } policyAndExport { id } exporterCompany { id } exporterCompanyAddress { id }',
     })) as Application;
   });
 
@@ -75,6 +76,16 @@ describe('Create an Application', () => {
     expect(typeof application.policyAndExport.id).toEqual('string');
   });
 
+  test('it should have an exporter company id', () => {
+    expect(application.exporterCompany).toBeDefined();
+    expect(typeof application.exporterCompany.id).toEqual('string');
+  });
+
+  test('it should have an exporter company address id', () => {
+    expect(application.exporterCompanyAddress).toBeDefined();
+    expect(typeof application.exporterCompanyAddress.id).toEqual('string');
+  });
+
   test('it should have a default submission type', () => {
     expect(application.submissionType).toEqual(APPLICATION.SUBMISSION_TYPE.MIA);
   });
@@ -108,5 +119,27 @@ describe('Create an Application', () => {
     });
 
     expect(policyAndExport.application.id).toEqual(application.id);
+  });
+
+  test('it should add the application ID to the exporter company entry', async () => {
+    const exporterCompany = await context.query.ExporterCompany.findOne({
+      where: {
+        id: application.exporterCompany.id,
+      },
+      query: 'id application { id }',
+    });
+
+    expect(exporterCompany.application.id).toEqual(application.id);
+  });
+
+  test('it should add the application ID to the exporter company address entry', async () => {
+    const exporterCompanyAddress = await context.query.ExporterCompanyAddress.findOne({
+      where: {
+        id: application.exporterCompanyAddress.id,
+      },
+      query: 'id application { id }',
+    });
+
+    expect(exporterCompanyAddress.application.id).toEqual(application.id);
   });
 });

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -71,8 +71,8 @@ type Application {
   submissionDeadline: DateTime
   submissionType: String
   policyAndExport: PolicyAndExport
-  exporterCompany: Company
-  exporterCompanyAddress: CompanyAddress
+  exporterCompany: ExporterCompany
+  exporterCompanyAddress: ExporterCompanyAddress
 }
 
 scalar DateTime @specifiedBy(url: "https://datatracker.ietf.org/doc/html/rfc3339#section-5.6")
@@ -93,8 +93,8 @@ input ApplicationWhereInput {
   submissionDeadline: DateTimeNullableFilter
   submissionType: StringNullableFilter
   policyAndExport: PolicyAndExportWhereInput
-  exporterCompany: CompanyWhereInput
-  exporterCompanyAddress: CompanyAddressWhereInput
+  exporterCompany: ExporterCompanyWhereInput
+  exporterCompanyAddress: ExporterCompanyAddressWhereInput
 }
 
 input DateTimeNullableFilter {
@@ -164,8 +164,8 @@ input ApplicationUpdateInput {
   submissionDeadline: DateTime
   submissionType: String
   policyAndExport: PolicyAndExportRelateToOneForUpdateInput
-  exporterCompany: CompanyRelateToOneForUpdateInput
-  exporterCompanyAddress: CompanyAddressRelateToOneForUpdateInput
+  exporterCompany: ExporterCompanyRelateToOneForUpdateInput
+  exporterCompanyAddress: ExporterCompanyAddressRelateToOneForUpdateInput
 }
 
 input EligibilityRelateToOneForUpdateInput {
@@ -180,15 +180,15 @@ input PolicyAndExportRelateToOneForUpdateInput {
   disconnect: Boolean
 }
 
-input CompanyRelateToOneForUpdateInput {
-  create: CompanyCreateInput
-  connect: CompanyWhereUniqueInput
+input ExporterCompanyRelateToOneForUpdateInput {
+  create: ExporterCompanyCreateInput
+  connect: ExporterCompanyWhereUniqueInput
   disconnect: Boolean
 }
 
-input CompanyAddressRelateToOneForUpdateInput {
-  create: CompanyAddressCreateInput
-  connect: CompanyAddressWhereUniqueInput
+input ExporterCompanyAddressRelateToOneForUpdateInput {
+  create: ExporterCompanyAddressCreateInput
+  connect: ExporterCompanyAddressWhereUniqueInput
   disconnect: Boolean
 }
 
@@ -205,8 +205,8 @@ input ApplicationCreateInput {
   submissionDeadline: DateTime
   submissionType: String
   policyAndExport: PolicyAndExportRelateToOneForCreateInput
-  exporterCompany: CompanyRelateToOneForCreateInput
-  exporterCompanyAddress: CompanyAddressRelateToOneForCreateInput
+  exporterCompany: ExporterCompanyRelateToOneForCreateInput
+  exporterCompanyAddress: ExporterCompanyAddressRelateToOneForCreateInput
 }
 
 input EligibilityRelateToOneForCreateInput {
@@ -219,14 +219,14 @@ input PolicyAndExportRelateToOneForCreateInput {
   connect: PolicyAndExportWhereUniqueInput
 }
 
-input CompanyRelateToOneForCreateInput {
-  create: CompanyCreateInput
-  connect: CompanyWhereUniqueInput
+input ExporterCompanyRelateToOneForCreateInput {
+  create: ExporterCompanyCreateInput
+  connect: ExporterCompanyWhereUniqueInput
 }
 
-input CompanyAddressRelateToOneForCreateInput {
-  create: CompanyAddressCreateInput
-  connect: CompanyAddressWhereUniqueInput
+input ExporterCompanyAddressRelateToOneForCreateInput {
+  create: ExporterCompanyAddressCreateInput
+  connect: ExporterCompanyAddressWhereUniqueInput
 }
 
 type PolicyAndExport {
@@ -336,88 +336,9 @@ input PolicyAndExportCreateInput {
   maximumBuyerWillOwe: Int
 }
 
-type CompanyAddress {
-  id: ID!
-  company: Company
-  application: Application
-  addressLine1: String
-  addressLine2: String
-  careOf: String
-  locality: String
-  region: String
-  postalCode: String
-  country: String
-  premises: String
-}
-
-input CompanyAddressWhereUniqueInput {
-  id: ID
-}
-
-input CompanyAddressWhereInput {
-  AND: [CompanyAddressWhereInput!]
-  OR: [CompanyAddressWhereInput!]
-  NOT: [CompanyAddressWhereInput!]
-  id: IDFilter
-  company: CompanyWhereInput
-  application: ApplicationWhereInput
-  addressLine1: StringFilter
-  addressLine2: StringFilter
-  careOf: StringFilter
-  locality: StringFilter
-  region: StringFilter
-  postalCode: StringFilter
-  country: StringFilter
-  premises: StringFilter
-}
-
-input CompanyAddressOrderByInput {
-  id: OrderDirection
-  addressLine1: OrderDirection
-  addressLine2: OrderDirection
-  careOf: OrderDirection
-  locality: OrderDirection
-  region: OrderDirection
-  postalCode: OrderDirection
-  country: OrderDirection
-  premises: OrderDirection
-}
-
-input CompanyAddressUpdateInput {
-  company: CompanyRelateToOneForUpdateInput
-  application: ApplicationRelateToOneForUpdateInput
-  addressLine1: String
-  addressLine2: String
-  careOf: String
-  locality: String
-  region: String
-  postalCode: String
-  country: String
-  premises: String
-}
-
-input CompanyAddressUpdateArgs {
-  where: CompanyAddressWhereUniqueInput!
-  data: CompanyAddressUpdateInput!
-}
-
-input CompanyAddressCreateInput {
-  company: CompanyRelateToOneForCreateInput
-  application: ApplicationRelateToOneForCreateInput
-  addressLine1: String
-  addressLine2: String
-  careOf: String
-  locality: String
-  region: String
-  postalCode: String
-  country: String
-  premises: String
-}
-
 type CompanySicCode {
   id: ID!
   code: String
-  company: Company
 }
 
 input CompanySicCodeWhereUniqueInput {
@@ -430,7 +351,6 @@ input CompanySicCodeWhereInput {
   NOT: [CompanySicCodeWhereInput!]
   id: IDFilter
   code: StringFilter
-  company: CompanyWhereInput
 }
 
 input CompanySicCodeOrderByInput {
@@ -440,7 +360,6 @@ input CompanySicCodeOrderByInput {
 
 input CompanySicCodeUpdateInput {
   code: String
-  company: CompanyRelateToOneForUpdateInput
 }
 
 input CompanySicCodeUpdateArgs {
@@ -450,14 +369,125 @@ input CompanySicCodeUpdateArgs {
 
 input CompanySicCodeCreateInput {
   code: String
-  company: CompanyRelateToOneForCreateInput
 }
 
-type Company {
+type ExporterBusiness {
+  id: ID!
+  company: ExporterCompany
+}
+
+input ExporterBusinessWhereUniqueInput {
+  id: ID
+}
+
+input ExporterBusinessWhereInput {
+  AND: [ExporterBusinessWhereInput!]
+  OR: [ExporterBusinessWhereInput!]
+  NOT: [ExporterBusinessWhereInput!]
+  id: IDFilter
+  company: ExporterCompanyWhereInput
+}
+
+input ExporterBusinessOrderByInput {
+  id: OrderDirection
+}
+
+input ExporterBusinessUpdateInput {
+  company: ExporterCompanyRelateToOneForUpdateInput
+}
+
+input ExporterBusinessUpdateArgs {
+  where: ExporterBusinessWhereUniqueInput!
+  data: ExporterBusinessUpdateInput!
+}
+
+input ExporterBusinessCreateInput {
+  company: ExporterCompanyRelateToOneForCreateInput
+}
+
+type ExporterCompanyAddress {
+  id: ID!
+  exporterCompany: ExporterCompany
+  application: Application
+  addressLine1: String
+  addressLine2: String
+  careOf: String
+  locality: String
+  region: String
+  postalCode: String
+  country: String
+  premises: String
+}
+
+input ExporterCompanyAddressWhereUniqueInput {
+  id: ID
+}
+
+input ExporterCompanyAddressWhereInput {
+  AND: [ExporterCompanyAddressWhereInput!]
+  OR: [ExporterCompanyAddressWhereInput!]
+  NOT: [ExporterCompanyAddressWhereInput!]
+  id: IDFilter
+  exporterCompany: ExporterCompanyWhereInput
+  application: ApplicationWhereInput
+  addressLine1: StringFilter
+  addressLine2: StringFilter
+  careOf: StringFilter
+  locality: StringFilter
+  region: StringFilter
+  postalCode: StringFilter
+  country: StringFilter
+  premises: StringFilter
+}
+
+input ExporterCompanyAddressOrderByInput {
+  id: OrderDirection
+  addressLine1: OrderDirection
+  addressLine2: OrderDirection
+  careOf: OrderDirection
+  locality: OrderDirection
+  region: OrderDirection
+  postalCode: OrderDirection
+  country: OrderDirection
+  premises: OrderDirection
+}
+
+input ExporterCompanyAddressUpdateInput {
+  exporterCompany: ExporterCompanyRelateToOneForUpdateInput
+  application: ApplicationRelateToOneForUpdateInput
+  addressLine1: String
+  addressLine2: String
+  careOf: String
+  locality: String
+  region: String
+  postalCode: String
+  country: String
+  premises: String
+}
+
+input ExporterCompanyAddressUpdateArgs {
+  where: ExporterCompanyAddressWhereUniqueInput!
+  data: ExporterCompanyAddressUpdateInput!
+}
+
+input ExporterCompanyAddressCreateInput {
+  exporterCompany: ExporterCompanyRelateToOneForCreateInput
+  application: ApplicationRelateToOneForCreateInput
+  addressLine1: String
+  addressLine2: String
+  careOf: String
+  locality: String
+  region: String
+  postalCode: String
+  country: String
+  premises: String
+}
+
+type ExporterCompany {
   id: ID!
   application: Application
-  companyAddress: CompanyAddress
-  business: Business
+  exporterCompanyAddress: ExporterCompanyAddress
+  business: ExporterBusiness
   sicCodes: CompanySicCode
   companyName: String
   companyNumber: String
@@ -468,18 +498,18 @@ type Company {
   phoneNumber: String
 }
 
-input CompanyWhereUniqueInput {
+input ExporterCompanyWhereUniqueInput {
   id: ID
 }
 
-input CompanyWhereInput {
-  AND: [CompanyWhereInput!]
-  OR: [CompanyWhereInput!]
-  NOT: [CompanyWhereInput!]
+input ExporterCompanyWhereInput {
+  AND: [ExporterCompanyWhereInput!]
+  OR: [ExporterCompanyWhereInput!]
+  NOT: [ExporterCompanyWhereInput!]
   id: IDFilter
   application: ApplicationWhereInput
-  companyAddress: CompanyAddressWhereInput
-  business: BusinessWhereInput
+  exporterCompanyAddress: ExporterCompanyAddressWhereInput
+  business: ExporterBusinessWhereInput
   sicCodes: CompanySicCodeWhereInput
   companyName: StringFilter
   companyNumber: StringFilter
@@ -495,7 +525,7 @@ input BooleanFilter {
   not: BooleanFilter
 }
 
-input CompanyOrderByInput {
+input ExporterCompanyOrderByInput {
   id: OrderDirection
   companyName: OrderDirection
   companyNumber: OrderDirection
@@ -506,10 +536,10 @@ input CompanyOrderByInput {
   phoneNumber: OrderDirection
 }
 
-input CompanyUpdateInput {
+input ExporterCompanyUpdateInput {
   application: ApplicationRelateToOneForUpdateInput
-  companyAddress: CompanyAddressRelateToOneForUpdateInput
-  business: BusinessRelateToOneForUpdateInput
+  exporterCompanyAddress: ExporterCompanyAddressRelateToOneForUpdateInput
+  business: ExporterBusinessRelateToOneForUpdateInput
   sicCodes: CompanySicCodeRelateToOneForUpdateInput
   companyName: String
   companyNumber: String
@@ -520,9 +550,9 @@ input CompanyUpdateInput {
   phoneNumber: String
 }
 
-input BusinessRelateToOneForUpdateInput {
-  create: BusinessCreateInput
-  connect: BusinessWhereUniqueInput
+input ExporterBusinessRelateToOneForUpdateInput {
+  create: ExporterBusinessCreateInput
+  connect: ExporterBusinessWhereUniqueInput
   disconnect: Boolean
 }
 
@@ -532,15 +562,15 @@ input CompanySicCodeRelateToOneForUpdateInput {
   disconnect: Boolean
 }
 
-input CompanyUpdateArgs {
-  where: CompanyWhereUniqueInput!
-  data: CompanyUpdateInput!
+input ExporterCompanyUpdateArgs {
+  where: ExporterCompanyWhereUniqueInput!
+  data: ExporterCompanyUpdateInput!
 }
 
-input CompanyCreateInput {
+input ExporterCompanyCreateInput {
   application: ApplicationRelateToOneForCreateInput
-  companyAddress: CompanyAddressRelateToOneForCreateInput
-  business: BusinessRelateToOneForCreateInput
+  exporterCompanyAddress: ExporterCompanyAddressRelateToOneForCreateInput
+  business: ExporterBusinessRelateToOneForCreateInput
   sicCodes: CompanySicCodeRelateToOneForCreateInput
   companyName: String
   companyNumber: String
@@ -551,48 +581,14 @@ input CompanyCreateInput {
   phoneNumber: String
 }
 
-input BusinessRelateToOneForCreateInput {
-  create: BusinessCreateInput
-  connect: BusinessWhereUniqueInput
+input ExporterBusinessRelateToOneForCreateInput {
+  create: ExporterBusinessCreateInput
+  connect: ExporterBusinessWhereUniqueInput
 }
 
 input CompanySicCodeRelateToOneForCreateInput {
   create: CompanySicCodeCreateInput
   connect: CompanySicCodeWhereUniqueInput
-}
-
-type Business {
-  id: ID!
-  company: Company
-}
-
-input BusinessWhereUniqueInput {
-  id: ID
-}
-
-input BusinessWhereInput {
-  AND: [BusinessWhereInput!]
-  OR: [BusinessWhereInput!]
-  NOT: [BusinessWhereInput!]
-  id: IDFilter
-  company: CompanyWhereInput
-}
-
-input BusinessOrderByInput {
-  id: OrderDirection
-}
-
-input BusinessUpdateInput {
-  company: CompanyRelateToOneForUpdateInput
-}
-
-input BusinessUpdateArgs {
-  where: BusinessWhereUniqueInput!
-  data: BusinessUpdateInput!
-}
-
-input BusinessCreateInput {
-  company: CompanyRelateToOneForCreateInput
 }
 
 type Country {
@@ -843,30 +839,30 @@ type Mutation {
   updatePolicyAndExports(data: [PolicyAndExportUpdateArgs!]!): [PolicyAndExport]
   deletePolicyAndExport(where: PolicyAndExportWhereUniqueInput!): PolicyAndExport
   deletePolicyAndExports(where: [PolicyAndExportWhereUniqueInput!]!): [PolicyAndExport]
-  createCompanyAddress(data: CompanyAddressCreateInput!): CompanyAddress
-  createCompanyAddresses(data: [CompanyAddressCreateInput!]!): [CompanyAddress]
-  updateCompanyAddress(where: CompanyAddressWhereUniqueInput!, data: CompanyAddressUpdateInput!): CompanyAddress
-  updateCompanyAddresses(data: [CompanyAddressUpdateArgs!]!): [CompanyAddress]
-  deleteCompanyAddress(where: CompanyAddressWhereUniqueInput!): CompanyAddress
-  deleteCompanyAddresses(where: [CompanyAddressWhereUniqueInput!]!): [CompanyAddress]
   createCompanySicCode(data: CompanySicCodeCreateInput!): CompanySicCode
   createCompanySicCodes(data: [CompanySicCodeCreateInput!]!): [CompanySicCode]
   updateCompanySicCode(where: CompanySicCodeWhereUniqueInput!, data: CompanySicCodeUpdateInput!): CompanySicCode
   updateCompanySicCodes(data: [CompanySicCodeUpdateArgs!]!): [CompanySicCode]
   deleteCompanySicCode(where: CompanySicCodeWhereUniqueInput!): CompanySicCode
   deleteCompanySicCodes(where: [CompanySicCodeWhereUniqueInput!]!): [CompanySicCode]
-  createCompany(data: CompanyCreateInput!): Company
-  createCompanies(data: [CompanyCreateInput!]!): [Company]
-  updateCompany(where: CompanyWhereUniqueInput!, data: CompanyUpdateInput!): Company
-  updateCompanies(data: [CompanyUpdateArgs!]!): [Company]
-  deleteCompany(where: CompanyWhereUniqueInput!): Company
-  deleteCompanies(where: [CompanyWhereUniqueInput!]!): [Company]
-  createBusiness(data: BusinessCreateInput!): Business
-  createBusinesses(data: [BusinessCreateInput!]!): [Business]
-  updateBusiness(where: BusinessWhereUniqueInput!, data: BusinessUpdateInput!): Business
-  updateBusinesses(data: [BusinessUpdateArgs!]!): [Business]
-  deleteBusiness(where: BusinessWhereUniqueInput!): Business
-  deleteBusinesses(where: [BusinessWhereUniqueInput!]!): [Business]
+  createExporterBusiness(data: ExporterBusinessCreateInput!): ExporterBusiness
+  createExporterBusinesses(data: [ExporterBusinessCreateInput!]!): [ExporterBusiness]
+  updateExporterBusiness(where: ExporterBusinessWhereUniqueInput!, data: ExporterBusinessUpdateInput!): ExporterBusiness
+  updateExporterBusinesses(data: [ExporterBusinessUpdateArgs!]!): [ExporterBusiness]
+  deleteExporterBusiness(where: ExporterBusinessWhereUniqueInput!): ExporterBusiness
+  deleteExporterBusinesses(where: [ExporterBusinessWhereUniqueInput!]!): [ExporterBusiness]
+  createExporterCompanyAddress(data: ExporterCompanyAddressCreateInput!): ExporterCompanyAddress
+  createExporterCompanyAddresses(data: [ExporterCompanyAddressCreateInput!]!): [ExporterCompanyAddress]
+  updateExporterCompanyAddress(where: ExporterCompanyAddressWhereUniqueInput!, data: ExporterCompanyAddressUpdateInput!): ExporterCompanyAddress
+  updateExporterCompanyAddresses(data: [ExporterCompanyAddressUpdateArgs!]!): [ExporterCompanyAddress]
+  deleteExporterCompanyAddress(where: ExporterCompanyAddressWhereUniqueInput!): ExporterCompanyAddress
+  deleteExporterCompanyAddresses(where: [ExporterCompanyAddressWhereUniqueInput!]!): [ExporterCompanyAddress]
+  createExporterCompany(data: ExporterCompanyCreateInput!): ExporterCompany
+  createExporterCompanies(data: [ExporterCompanyCreateInput!]!): [ExporterCompany]
+  updateExporterCompany(where: ExporterCompanyWhereUniqueInput!, data: ExporterCompanyUpdateInput!): ExporterCompany
+  updateExporterCompanies(data: [ExporterCompanyUpdateArgs!]!): [ExporterCompany]
+  deleteExporterCompany(where: ExporterCompanyWhereUniqueInput!): ExporterCompany
+  deleteExporterCompanies(where: [ExporterCompanyWhereUniqueInput!]!): [ExporterCompany]
   createCountry(data: CountryCreateInput!): Country
   createCountries(data: [CountryCreateInput!]!): [Country]
   updateCountry(where: CountryWhereUniqueInput!, data: CountryUpdateInput!): Country
@@ -896,7 +892,7 @@ type Mutation {
   createInitialUser(data: CreateInitialUserInput!): UserAuthenticationWithPasswordSuccess!
 
   """ update application company and company address """
-  updateApplicationCompanyAndCompanyAddress(companyId: ID!, companyAddressId: ID!, data: ApplicationCompanyAndCompanyAddressInput!): ApplicationCompanyAndCompanyAddress
+  updateExporterCompanyAndCompanyAddress(companyId: ID!, companyAddressId: ID!, data: ExporterCompanyAndCompanyAddressInput!): ExporterCompanyAndCompanyAddress
 
   """ send an email """
   sendEmail(templateId: String!, sendToEmailAddress: String!): EmailResponse
@@ -929,18 +925,18 @@ type Query {
   policyAndExports(where: PolicyAndExportWhereInput! = {}, orderBy: [PolicyAndExportOrderByInput!]! = [], take: Int, skip: Int! = 0): [PolicyAndExport!]
   policyAndExport(where: PolicyAndExportWhereUniqueInput!): PolicyAndExport
   policyAndExportsCount(where: PolicyAndExportWhereInput! = {}): Int
-  companyAddresses(where: CompanyAddressWhereInput! = {}, orderBy: [CompanyAddressOrderByInput!]! = [], take: Int, skip: Int! = 0): [CompanyAddress!]
-  companyAddress(where: CompanyAddressWhereUniqueInput!): CompanyAddress
-  companyAddressesCount(where: CompanyAddressWhereInput! = {}): Int
   companySicCodes(where: CompanySicCodeWhereInput! = {}, orderBy: [CompanySicCodeOrderByInput!]! = [], take: Int, skip: Int! = 0): [CompanySicCode!]
   companySicCode(where: CompanySicCodeWhereUniqueInput!): CompanySicCode
   companySicCodesCount(where: CompanySicCodeWhereInput! = {}): Int
-  companies(where: CompanyWhereInput! = {}, orderBy: [CompanyOrderByInput!]! = [], take: Int, skip: Int! = 0): [Company!]
-  company(where: CompanyWhereUniqueInput!): Company
-  companiesCount(where: CompanyWhereInput! = {}): Int
-  businesses(where: BusinessWhereInput! = {}, orderBy: [BusinessOrderByInput!]! = [], take: Int, skip: Int! = 0): [Business!]
-  business(where: BusinessWhereUniqueInput!): Business
-  businessesCount(where: BusinessWhereInput! = {}): Int
+  exporterBusinesses(where: ExporterBusinessWhereInput! = {}, orderBy: [ExporterBusinessOrderByInput!]! = [], take: Int, skip: Int! = 0): [ExporterBusiness!]
+  exporterBusiness(where: ExporterBusinessWhereUniqueInput!): ExporterBusiness
+  exporterBusinessesCount(where: ExporterBusinessWhereInput! = {}): Int
+  exporterCompanyAddresses(where: ExporterCompanyAddressWhereInput! = {}, orderBy: [ExporterCompanyAddressOrderByInput!]! = [], take: Int, skip: Int! = 0): [ExporterCompanyAddress!]
+  exporterCompanyAddress(where: ExporterCompanyAddressWhereUniqueInput!): ExporterCompanyAddress
+  exporterCompanyAddressesCount(where: ExporterCompanyAddressWhereInput! = {}): Int
+  exporterCompanies(where: ExporterCompanyWhereInput! = {}, orderBy: [ExporterCompanyOrderByInput!]! = [], take: Int, skip: Int! = 0): [ExporterCompany!]
+  exporterCompany(where: ExporterCompanyWhereUniqueInput!): ExporterCompany
+  exporterCompaniesCount(where: ExporterCompanyWhereInput! = {}): Int
   countries(where: CountryWhereInput! = {}, orderBy: [CountryOrderByInput!]! = [], take: Int, skip: Int! = 0): [Country!]
   country(where: CountryWhereUniqueInput!): Country
   countriesCount(where: CountryWhereInput! = {}): Int
@@ -1066,9 +1062,20 @@ type EmailResponse {
   success: Boolean
 }
 
+type CompaniesHouseCompanyAddress {
+  addressLine1: String
+  addressLine2: String
+  careOf: String
+  locality: String
+  region: String
+  postalCode: String
+  country: String
+  premises: String
+}
+
 type CompaniesHouseResponse {
   companyName: String
-  registeredOfficeAddress: CompanyAddress
+  registeredOfficeAddress: ExporterCompanyAddress
   companyNumber: String
   dateOfCreation: String
   sicCodes: [String]
@@ -1076,7 +1083,7 @@ type CompaniesHouseResponse {
   apiError: Boolean
 }
 
-type ApplicationCompanyAddress {
+input ExporterCompanyAddressInput {
   addressLine1: String
   addressLine2: String
   careOf: String
@@ -1087,20 +1094,9 @@ type ApplicationCompanyAddress {
   premises: String
 }
 
-input ApplicationCompanyAddressInput {
-  addressLine1: String
-  addressLine2: String
-  careOf: String
-  locality: String
-  region: String
-  postalCode: String
-  country: String
-  premises: String
-}
-
-type ApplicationCompanyAndCompanyAddress {
+type ExporterCompanyAndCompanyAddress {
   id: ID!
-  exporterCompanyAddress: ApplicationCompanyAddress
+  exporterCompanyAddress: ExporterCompanyAddress
   companyName: String
   companyNumber: String
   dateOfCreation: DateTime
@@ -1110,8 +1106,8 @@ type ApplicationCompanyAndCompanyAddress {
   phoneNumber: String
 }
 
-input ApplicationCompanyAndCompanyAddressInput {
-  exporterCompanyAddress: ApplicationCompanyAddressInput
+input ExporterCompanyAndCompanyAddressInput {
+  exporterCompanyAddress: ExporterCompanyAddressInput
   companyName: String
   companyNumber: String
   dateOfCreation: DateTime

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -71,6 +71,8 @@ type Application {
   submissionDeadline: DateTime
   submissionType: String
   policyAndExport: PolicyAndExport
+  exporterCompany: Company
+  exporterCompanyAddress: CompanyAddress
 }
 
 scalar DateTime @specifiedBy(url: "https://datatracker.ietf.org/doc/html/rfc3339#section-5.6")
@@ -91,6 +93,8 @@ input ApplicationWhereInput {
   submissionDeadline: DateTimeNullableFilter
   submissionType: StringNullableFilter
   policyAndExport: PolicyAndExportWhereInput
+  exporterCompany: CompanyWhereInput
+  exporterCompanyAddress: CompanyAddressWhereInput
 }
 
 input DateTimeNullableFilter {
@@ -160,6 +164,8 @@ input ApplicationUpdateInput {
   submissionDeadline: DateTime
   submissionType: String
   policyAndExport: PolicyAndExportRelateToOneForUpdateInput
+  exporterCompany: CompanyRelateToOneForUpdateInput
+  exporterCompanyAddress: CompanyAddressRelateToOneForUpdateInput
 }
 
 input EligibilityRelateToOneForUpdateInput {
@@ -171,6 +177,18 @@ input EligibilityRelateToOneForUpdateInput {
 input PolicyAndExportRelateToOneForUpdateInput {
   create: PolicyAndExportCreateInput
   connect: PolicyAndExportWhereUniqueInput
+  disconnect: Boolean
+}
+
+input CompanyRelateToOneForUpdateInput {
+  create: CompanyCreateInput
+  connect: CompanyWhereUniqueInput
+  disconnect: Boolean
+}
+
+input CompanyAddressRelateToOneForUpdateInput {
+  create: CompanyAddressCreateInput
+  connect: CompanyAddressWhereUniqueInput
   disconnect: Boolean
 }
 
@@ -187,6 +205,8 @@ input ApplicationCreateInput {
   submissionDeadline: DateTime
   submissionType: String
   policyAndExport: PolicyAndExportRelateToOneForCreateInput
+  exporterCompany: CompanyRelateToOneForCreateInput
+  exporterCompanyAddress: CompanyAddressRelateToOneForCreateInput
 }
 
 input EligibilityRelateToOneForCreateInput {
@@ -197,6 +217,16 @@ input EligibilityRelateToOneForCreateInput {
 input PolicyAndExportRelateToOneForCreateInput {
   create: PolicyAndExportCreateInput
   connect: PolicyAndExportWhereUniqueInput
+}
+
+input CompanyRelateToOneForCreateInput {
+  create: CompanyCreateInput
+  connect: CompanyWhereUniqueInput
+}
+
+input CompanyAddressRelateToOneForCreateInput {
+  create: CompanyAddressCreateInput
+  connect: CompanyAddressWhereUniqueInput
 }
 
 type PolicyAndExport {
@@ -306,6 +336,265 @@ input PolicyAndExportCreateInput {
   maximumBuyerWillOwe: Int
 }
 
+type CompanyAddress {
+  id: ID!
+  company: Company
+  application: Application
+  addressLine1: String
+  addressLine2: String
+  careOf: String
+  locality: String
+  region: String
+  postalCode: String
+  country: String
+  premises: String
+}
+
+input CompanyAddressWhereUniqueInput {
+  id: ID
+}
+
+input CompanyAddressWhereInput {
+  AND: [CompanyAddressWhereInput!]
+  OR: [CompanyAddressWhereInput!]
+  NOT: [CompanyAddressWhereInput!]
+  id: IDFilter
+  company: CompanyWhereInput
+  application: ApplicationWhereInput
+  addressLine1: StringFilter
+  addressLine2: StringFilter
+  careOf: StringFilter
+  locality: StringFilter
+  region: StringFilter
+  postalCode: StringFilter
+  country: StringFilter
+  premises: StringFilter
+}
+
+input CompanyAddressOrderByInput {
+  id: OrderDirection
+  addressLine1: OrderDirection
+  addressLine2: OrderDirection
+  careOf: OrderDirection
+  locality: OrderDirection
+  region: OrderDirection
+  postalCode: OrderDirection
+  country: OrderDirection
+  premises: OrderDirection
+}
+
+input CompanyAddressUpdateInput {
+  company: CompanyRelateToOneForUpdateInput
+  application: ApplicationRelateToOneForUpdateInput
+  addressLine1: String
+  addressLine2: String
+  careOf: String
+  locality: String
+  region: String
+  postalCode: String
+  country: String
+  premises: String
+}
+
+input CompanyAddressUpdateArgs {
+  where: CompanyAddressWhereUniqueInput!
+  data: CompanyAddressUpdateInput!
+}
+
+input CompanyAddressCreateInput {
+  company: CompanyRelateToOneForCreateInput
+  application: ApplicationRelateToOneForCreateInput
+  addressLine1: String
+  addressLine2: String
+  careOf: String
+  locality: String
+  region: String
+  postalCode: String
+  country: String
+  premises: String
+}
+
+type CompanySicCode {
+  id: ID!
+  code: String
+  company: Company
+}
+
+input CompanySicCodeWhereUniqueInput {
+  id: ID
+}
+
+input CompanySicCodeWhereInput {
+  AND: [CompanySicCodeWhereInput!]
+  OR: [CompanySicCodeWhereInput!]
+  NOT: [CompanySicCodeWhereInput!]
+  id: IDFilter
+  code: StringFilter
+  company: CompanyWhereInput
+}
+
+input CompanySicCodeOrderByInput {
+  id: OrderDirection
+  code: OrderDirection
+}
+
+input CompanySicCodeUpdateInput {
+  code: String
+  company: CompanyRelateToOneForUpdateInput
+}
+
+input CompanySicCodeUpdateArgs {
+  where: CompanySicCodeWhereUniqueInput!
+  data: CompanySicCodeUpdateInput!
+}
+
+input CompanySicCodeCreateInput {
+  code: String
+  company: CompanyRelateToOneForCreateInput
+}
+
+type Company {
+  id: ID!
+  application: Application
+  companyAddress: CompanyAddress
+  business: Business
+  sicCodes: CompanySicCode
+  companyName: String
+  companyNumber: String
+  dateOfCreation: DateTime
+  hasTradingAddress: Boolean
+  hasTradingName: Boolean
+  companyWebsite: String
+  phoneNumber: String
+}
+
+input CompanyWhereUniqueInput {
+  id: ID
+}
+
+input CompanyWhereInput {
+  AND: [CompanyWhereInput!]
+  OR: [CompanyWhereInput!]
+  NOT: [CompanyWhereInput!]
+  id: IDFilter
+  application: ApplicationWhereInput
+  companyAddress: CompanyAddressWhereInput
+  business: BusinessWhereInput
+  sicCodes: CompanySicCodeWhereInput
+  companyName: StringFilter
+  companyNumber: StringFilter
+  dateOfCreation: DateTimeNullableFilter
+  hasTradingAddress: BooleanFilter
+  hasTradingName: BooleanFilter
+  companyWebsite: StringFilter
+  phoneNumber: StringFilter
+}
+
+input BooleanFilter {
+  equals: Boolean
+  not: BooleanFilter
+}
+
+input CompanyOrderByInput {
+  id: OrderDirection
+  companyName: OrderDirection
+  companyNumber: OrderDirection
+  dateOfCreation: OrderDirection
+  hasTradingAddress: OrderDirection
+  hasTradingName: OrderDirection
+  companyWebsite: OrderDirection
+  phoneNumber: OrderDirection
+}
+
+input CompanyUpdateInput {
+  application: ApplicationRelateToOneForUpdateInput
+  companyAddress: CompanyAddressRelateToOneForUpdateInput
+  business: BusinessRelateToOneForUpdateInput
+  sicCodes: CompanySicCodeRelateToOneForUpdateInput
+  companyName: String
+  companyNumber: String
+  dateOfCreation: DateTime
+  hasTradingAddress: Boolean
+  hasTradingName: Boolean
+  companyWebsite: String
+  phoneNumber: String
+}
+
+input BusinessRelateToOneForUpdateInput {
+  create: BusinessCreateInput
+  connect: BusinessWhereUniqueInput
+  disconnect: Boolean
+}
+
+input CompanySicCodeRelateToOneForUpdateInput {
+  create: CompanySicCodeCreateInput
+  connect: CompanySicCodeWhereUniqueInput
+  disconnect: Boolean
+}
+
+input CompanyUpdateArgs {
+  where: CompanyWhereUniqueInput!
+  data: CompanyUpdateInput!
+}
+
+input CompanyCreateInput {
+  application: ApplicationRelateToOneForCreateInput
+  companyAddress: CompanyAddressRelateToOneForCreateInput
+  business: BusinessRelateToOneForCreateInput
+  sicCodes: CompanySicCodeRelateToOneForCreateInput
+  companyName: String
+  companyNumber: String
+  dateOfCreation: DateTime
+  hasTradingAddress: Boolean
+  hasTradingName: Boolean
+  companyWebsite: String
+  phoneNumber: String
+}
+
+input BusinessRelateToOneForCreateInput {
+  create: BusinessCreateInput
+  connect: BusinessWhereUniqueInput
+}
+
+input CompanySicCodeRelateToOneForCreateInput {
+  create: CompanySicCodeCreateInput
+  connect: CompanySicCodeWhereUniqueInput
+}
+
+type Business {
+  id: ID!
+  company: Company
+}
+
+input BusinessWhereUniqueInput {
+  id: ID
+}
+
+input BusinessWhereInput {
+  AND: [BusinessWhereInput!]
+  OR: [BusinessWhereInput!]
+  NOT: [BusinessWhereInput!]
+  id: IDFilter
+  company: CompanyWhereInput
+}
+
+input BusinessOrderByInput {
+  id: OrderDirection
+}
+
+input BusinessUpdateInput {
+  company: CompanyRelateToOneForUpdateInput
+}
+
+input BusinessUpdateArgs {
+  where: BusinessWhereUniqueInput!
+  data: BusinessUpdateInput!
+}
+
+input BusinessCreateInput {
+  company: CompanyRelateToOneForCreateInput
+}
+
 type Country {
   id: ID!
   isoCode: String
@@ -379,11 +668,6 @@ input EligibilityWhereInput {
   needPreCreditPeriodCover: BooleanFilter
   wantCoverOverMaxAmount: BooleanFilter
   wantCoverOverMaxPeriod: BooleanFilter
-}
-
-input BooleanFilter {
-  equals: Boolean
-  not: BooleanFilter
 }
 
 input EligibilityOrderByInput {
@@ -559,6 +843,30 @@ type Mutation {
   updatePolicyAndExports(data: [PolicyAndExportUpdateArgs!]!): [PolicyAndExport]
   deletePolicyAndExport(where: PolicyAndExportWhereUniqueInput!): PolicyAndExport
   deletePolicyAndExports(where: [PolicyAndExportWhereUniqueInput!]!): [PolicyAndExport]
+  createCompanyAddress(data: CompanyAddressCreateInput!): CompanyAddress
+  createCompanyAddresses(data: [CompanyAddressCreateInput!]!): [CompanyAddress]
+  updateCompanyAddress(where: CompanyAddressWhereUniqueInput!, data: CompanyAddressUpdateInput!): CompanyAddress
+  updateCompanyAddresses(data: [CompanyAddressUpdateArgs!]!): [CompanyAddress]
+  deleteCompanyAddress(where: CompanyAddressWhereUniqueInput!): CompanyAddress
+  deleteCompanyAddresses(where: [CompanyAddressWhereUniqueInput!]!): [CompanyAddress]
+  createCompanySicCode(data: CompanySicCodeCreateInput!): CompanySicCode
+  createCompanySicCodes(data: [CompanySicCodeCreateInput!]!): [CompanySicCode]
+  updateCompanySicCode(where: CompanySicCodeWhereUniqueInput!, data: CompanySicCodeUpdateInput!): CompanySicCode
+  updateCompanySicCodes(data: [CompanySicCodeUpdateArgs!]!): [CompanySicCode]
+  deleteCompanySicCode(where: CompanySicCodeWhereUniqueInput!): CompanySicCode
+  deleteCompanySicCodes(where: [CompanySicCodeWhereUniqueInput!]!): [CompanySicCode]
+  createCompany(data: CompanyCreateInput!): Company
+  createCompanies(data: [CompanyCreateInput!]!): [Company]
+  updateCompany(where: CompanyWhereUniqueInput!, data: CompanyUpdateInput!): Company
+  updateCompanies(data: [CompanyUpdateArgs!]!): [Company]
+  deleteCompany(where: CompanyWhereUniqueInput!): Company
+  deleteCompanies(where: [CompanyWhereUniqueInput!]!): [Company]
+  createBusiness(data: BusinessCreateInput!): Business
+  createBusinesses(data: [BusinessCreateInput!]!): [Business]
+  updateBusiness(where: BusinessWhereUniqueInput!, data: BusinessUpdateInput!): Business
+  updateBusinesses(data: [BusinessUpdateArgs!]!): [Business]
+  deleteBusiness(where: BusinessWhereUniqueInput!): Business
+  deleteBusinesses(where: [BusinessWhereUniqueInput!]!): [Business]
   createCountry(data: CountryCreateInput!): Country
   createCountries(data: [CountryCreateInput!]!): [Country]
   updateCountry(where: CountryWhereUniqueInput!, data: CountryUpdateInput!): Country
@@ -586,6 +894,9 @@ type Mutation {
   endSession: Boolean!
   authenticateUserWithPassword(email: String!, password: String!): UserAuthenticationWithPasswordResult
   createInitialUser(data: CreateInitialUserInput!): UserAuthenticationWithPasswordSuccess!
+
+  """ update application company and company address """
+  updateApplicationCompanyAndCompanyAddress(companyId: ID!, companyAddressId: ID!, data: ApplicationCompanyAndCompanyAddressInput!): ApplicationCompanyAndCompanyAddress
 
   """ send an email """
   sendEmail(templateId: String!, sendToEmailAddress: String!): EmailResponse
@@ -618,6 +929,18 @@ type Query {
   policyAndExports(where: PolicyAndExportWhereInput! = {}, orderBy: [PolicyAndExportOrderByInput!]! = [], take: Int, skip: Int! = 0): [PolicyAndExport!]
   policyAndExport(where: PolicyAndExportWhereUniqueInput!): PolicyAndExport
   policyAndExportsCount(where: PolicyAndExportWhereInput! = {}): Int
+  companyAddresses(where: CompanyAddressWhereInput! = {}, orderBy: [CompanyAddressOrderByInput!]! = [], take: Int, skip: Int! = 0): [CompanyAddress!]
+  companyAddress(where: CompanyAddressWhereUniqueInput!): CompanyAddress
+  companyAddressesCount(where: CompanyAddressWhereInput! = {}): Int
+  companySicCodes(where: CompanySicCodeWhereInput! = {}, orderBy: [CompanySicCodeOrderByInput!]! = [], take: Int, skip: Int! = 0): [CompanySicCode!]
+  companySicCode(where: CompanySicCodeWhereUniqueInput!): CompanySicCode
+  companySicCodesCount(where: CompanySicCodeWhereInput! = {}): Int
+  companies(where: CompanyWhereInput! = {}, orderBy: [CompanyOrderByInput!]! = [], take: Int, skip: Int! = 0): [Company!]
+  company(where: CompanyWhereUniqueInput!): Company
+  companiesCount(where: CompanyWhereInput! = {}): Int
+  businesses(where: BusinessWhereInput! = {}, orderBy: [BusinessOrderByInput!]! = [], take: Int, skip: Int! = 0): [Business!]
+  business(where: BusinessWhereUniqueInput!): Business
+  businessesCount(where: BusinessWhereInput! = {}): Int
   countries(where: CountryWhereInput! = {}, orderBy: [CountryOrderByInput!]! = [], take: Int, skip: Int! = 0): [Country!]
   country(where: CountryWhereUniqueInput!): Country
   countriesCount(where: CountryWhereInput! = {}): Int
@@ -743,7 +1066,17 @@ type EmailResponse {
   success: Boolean
 }
 
-type CompanyAddress {
+type CompaniesHouseResponse {
+  companyName: String
+  registeredOfficeAddress: CompanyAddress
+  companyNumber: String
+  dateOfCreation: String
+  sicCodes: [String]
+  success: Boolean
+  apiError: Boolean
+}
+
+type ApplicationCompanyAddress {
   addressLine1: String
   addressLine2: String
   careOf: String
@@ -754,12 +1087,36 @@ type CompanyAddress {
   premises: String
 }
 
-type CompaniesHouseResponse {
+input ApplicationCompanyAddressInput {
+  addressLine1: String
+  addressLine2: String
+  careOf: String
+  locality: String
+  region: String
+  postalCode: String
+  country: String
+  premises: String
+}
+
+type ApplicationCompanyAndCompanyAddress {
+  id: ID!
+  exporterCompanyAddress: ApplicationCompanyAddress
   companyName: String
-  registeredOfficeAddress: CompanyAddress
   companyNumber: String
-  dateOfCreation: String
-  sicCodes: [String]
-  success: Boolean
-  apiError: Boolean
+  dateOfCreation: DateTime
+  hasTradingAddress: Boolean
+  hasTradingName: Boolean
+  companyWebsite: String
+  phoneNumber: String
+}
+
+input ApplicationCompanyAndCompanyAddressInput {
+  exporterCompanyAddress: ApplicationCompanyAddressInput
+  companyName: String
+  companyNumber: String
+  dateOfCreation: DateTime
+  hasTradingAddress: Boolean
+  hasTradingName: Boolean
+  companyWebsite: String
+  phoneNumber: String
 }

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -336,41 +336,6 @@ input PolicyAndExportCreateInput {
   maximumBuyerWillOwe: Int
 }
 
-type CompanySicCode {
-  id: ID!
-  code: String
-}
-
-input CompanySicCodeWhereUniqueInput {
-  id: ID
-}
-
-input CompanySicCodeWhereInput {
-  AND: [CompanySicCodeWhereInput!]
-  OR: [CompanySicCodeWhereInput!]
-  NOT: [CompanySicCodeWhereInput!]
-  id: IDFilter
-  code: StringFilter
-}
-
-input CompanySicCodeOrderByInput {
-  id: OrderDirection
-  code: OrderDirection
-}
-
-input CompanySicCodeUpdateInput {
-  code: String
-}
-
-input CompanySicCodeUpdateArgs {
-  where: CompanySicCodeWhereUniqueInput!
-  data: CompanySicCodeUpdateInput!
-}
-
-input CompanySicCodeCreateInput {
-  code: String
-}
-
 type ExporterBusiness {
   id: ID!
   company: ExporterCompany
@@ -488,7 +453,7 @@ type ExporterCompany {
   application: Application
   exporterCompanyAddress: ExporterCompanyAddress
   business: ExporterBusiness
-  sicCodes: CompanySicCode
+  sicCodes: ExporterCompanySicCode
   companyName: String
   companyNumber: String
   dateOfCreation: DateTime
@@ -510,7 +475,7 @@ input ExporterCompanyWhereInput {
   application: ApplicationWhereInput
   exporterCompanyAddress: ExporterCompanyAddressWhereInput
   business: ExporterBusinessWhereInput
-  sicCodes: CompanySicCodeWhereInput
+  sicCodes: ExporterCompanySicCodeWhereInput
   companyName: StringFilter
   companyNumber: StringFilter
   dateOfCreation: DateTimeNullableFilter
@@ -540,7 +505,7 @@ input ExporterCompanyUpdateInput {
   application: ApplicationRelateToOneForUpdateInput
   exporterCompanyAddress: ExporterCompanyAddressRelateToOneForUpdateInput
   business: ExporterBusinessRelateToOneForUpdateInput
-  sicCodes: CompanySicCodeRelateToOneForUpdateInput
+  sicCodes: ExporterCompanySicCodeRelateToOneForUpdateInput
   companyName: String
   companyNumber: String
   dateOfCreation: DateTime
@@ -556,9 +521,9 @@ input ExporterBusinessRelateToOneForUpdateInput {
   disconnect: Boolean
 }
 
-input CompanySicCodeRelateToOneForUpdateInput {
-  create: CompanySicCodeCreateInput
-  connect: CompanySicCodeWhereUniqueInput
+input ExporterCompanySicCodeRelateToOneForUpdateInput {
+  create: ExporterCompanySicCodeCreateInput
+  connect: ExporterCompanySicCodeWhereUniqueInput
   disconnect: Boolean
 }
 
@@ -571,7 +536,7 @@ input ExporterCompanyCreateInput {
   application: ApplicationRelateToOneForCreateInput
   exporterCompanyAddress: ExporterCompanyAddressRelateToOneForCreateInput
   business: ExporterBusinessRelateToOneForCreateInput
-  sicCodes: CompanySicCodeRelateToOneForCreateInput
+  sicCodes: ExporterCompanySicCodeRelateToOneForCreateInput
   companyName: String
   companyNumber: String
   dateOfCreation: DateTime
@@ -586,9 +551,44 @@ input ExporterBusinessRelateToOneForCreateInput {
   connect: ExporterBusinessWhereUniqueInput
 }
 
-input CompanySicCodeRelateToOneForCreateInput {
-  create: CompanySicCodeCreateInput
-  connect: CompanySicCodeWhereUniqueInput
+input ExporterCompanySicCodeRelateToOneForCreateInput {
+  create: ExporterCompanySicCodeCreateInput
+  connect: ExporterCompanySicCodeWhereUniqueInput
+}
+
+type ExporterCompanySicCode {
+  id: ID!
+  code: String
+}
+
+input ExporterCompanySicCodeWhereUniqueInput {
+  id: ID
+}
+
+input ExporterCompanySicCodeWhereInput {
+  AND: [ExporterCompanySicCodeWhereInput!]
+  OR: [ExporterCompanySicCodeWhereInput!]
+  NOT: [ExporterCompanySicCodeWhereInput!]
+  id: IDFilter
+  code: StringFilter
+}
+
+input ExporterCompanySicCodeOrderByInput {
+  id: OrderDirection
+  code: OrderDirection
+}
+
+input ExporterCompanySicCodeUpdateInput {
+  code: String
+}
+
+input ExporterCompanySicCodeUpdateArgs {
+  where: ExporterCompanySicCodeWhereUniqueInput!
+  data: ExporterCompanySicCodeUpdateInput!
+}
+
+input ExporterCompanySicCodeCreateInput {
+  code: String
 }
 
 type Country {
@@ -839,12 +839,6 @@ type Mutation {
   updatePolicyAndExports(data: [PolicyAndExportUpdateArgs!]!): [PolicyAndExport]
   deletePolicyAndExport(where: PolicyAndExportWhereUniqueInput!): PolicyAndExport
   deletePolicyAndExports(where: [PolicyAndExportWhereUniqueInput!]!): [PolicyAndExport]
-  createCompanySicCode(data: CompanySicCodeCreateInput!): CompanySicCode
-  createCompanySicCodes(data: [CompanySicCodeCreateInput!]!): [CompanySicCode]
-  updateCompanySicCode(where: CompanySicCodeWhereUniqueInput!, data: CompanySicCodeUpdateInput!): CompanySicCode
-  updateCompanySicCodes(data: [CompanySicCodeUpdateArgs!]!): [CompanySicCode]
-  deleteCompanySicCode(where: CompanySicCodeWhereUniqueInput!): CompanySicCode
-  deleteCompanySicCodes(where: [CompanySicCodeWhereUniqueInput!]!): [CompanySicCode]
   createExporterBusiness(data: ExporterBusinessCreateInput!): ExporterBusiness
   createExporterBusinesses(data: [ExporterBusinessCreateInput!]!): [ExporterBusiness]
   updateExporterBusiness(where: ExporterBusinessWhereUniqueInput!, data: ExporterBusinessUpdateInput!): ExporterBusiness
@@ -863,6 +857,12 @@ type Mutation {
   updateExporterCompanies(data: [ExporterCompanyUpdateArgs!]!): [ExporterCompany]
   deleteExporterCompany(where: ExporterCompanyWhereUniqueInput!): ExporterCompany
   deleteExporterCompanies(where: [ExporterCompanyWhereUniqueInput!]!): [ExporterCompany]
+  createExporterCompanySicCode(data: ExporterCompanySicCodeCreateInput!): ExporterCompanySicCode
+  createExporterCompanySicCodes(data: [ExporterCompanySicCodeCreateInput!]!): [ExporterCompanySicCode]
+  updateExporterCompanySicCode(where: ExporterCompanySicCodeWhereUniqueInput!, data: ExporterCompanySicCodeUpdateInput!): ExporterCompanySicCode
+  updateExporterCompanySicCodes(data: [ExporterCompanySicCodeUpdateArgs!]!): [ExporterCompanySicCode]
+  deleteExporterCompanySicCode(where: ExporterCompanySicCodeWhereUniqueInput!): ExporterCompanySicCode
+  deleteExporterCompanySicCodes(where: [ExporterCompanySicCodeWhereUniqueInput!]!): [ExporterCompanySicCode]
   createCountry(data: CountryCreateInput!): Country
   createCountries(data: [CountryCreateInput!]!): [Country]
   updateCountry(where: CountryWhereUniqueInput!, data: CountryUpdateInput!): Country
@@ -891,7 +891,7 @@ type Mutation {
   authenticateUserWithPassword(email: String!, password: String!): UserAuthenticationWithPasswordResult
   createInitialUser(data: CreateInitialUserInput!): UserAuthenticationWithPasswordSuccess!
 
-  """ update application company and company address """
+  """ update exporter company and company address """
   updateExporterCompanyAndCompanyAddress(companyId: ID!, companyAddressId: ID!, data: ExporterCompanyAndCompanyAddressInput!): ExporterCompanyAndCompanyAddress
 
   """ send an email """
@@ -925,9 +925,6 @@ type Query {
   policyAndExports(where: PolicyAndExportWhereInput! = {}, orderBy: [PolicyAndExportOrderByInput!]! = [], take: Int, skip: Int! = 0): [PolicyAndExport!]
   policyAndExport(where: PolicyAndExportWhereUniqueInput!): PolicyAndExport
   policyAndExportsCount(where: PolicyAndExportWhereInput! = {}): Int
-  companySicCodes(where: CompanySicCodeWhereInput! = {}, orderBy: [CompanySicCodeOrderByInput!]! = [], take: Int, skip: Int! = 0): [CompanySicCode!]
-  companySicCode(where: CompanySicCodeWhereUniqueInput!): CompanySicCode
-  companySicCodesCount(where: CompanySicCodeWhereInput! = {}): Int
   exporterBusinesses(where: ExporterBusinessWhereInput! = {}, orderBy: [ExporterBusinessOrderByInput!]! = [], take: Int, skip: Int! = 0): [ExporterBusiness!]
   exporterBusiness(where: ExporterBusinessWhereUniqueInput!): ExporterBusiness
   exporterBusinessesCount(where: ExporterBusinessWhereInput! = {}): Int
@@ -937,6 +934,9 @@ type Query {
   exporterCompanies(where: ExporterCompanyWhereInput! = {}, orderBy: [ExporterCompanyOrderByInput!]! = [], take: Int, skip: Int! = 0): [ExporterCompany!]
   exporterCompany(where: ExporterCompanyWhereUniqueInput!): ExporterCompany
   exporterCompaniesCount(where: ExporterCompanyWhereInput! = {}): Int
+  exporterCompanySicCodes(where: ExporterCompanySicCodeWhereInput! = {}, orderBy: [ExporterCompanySicCodeOrderByInput!]! = [], take: Int, skip: Int! = 0): [ExporterCompanySicCode!]
+  exporterCompanySicCode(where: ExporterCompanySicCodeWhereUniqueInput!): ExporterCompanySicCode
+  exporterCompanySicCodesCount(where: ExporterCompanySicCodeWhereInput! = {}): Int
   countries(where: CountryWhereInput! = {}, orderBy: [CountryOrderByInput!]! = [], take: Int, skip: Int! = 0): [Country!]
   country(where: CountryWhereUniqueInput!): Country
   countriesCount(where: CountryWhereInput! = {}): Int

--- a/src/api/schema.prisma
+++ b/src/api/schema.prisma
@@ -31,13 +31,21 @@ model Application {
   submissionType                   String?           @default("Manual Inclusion Application")
   policyAndExport                  PolicyAndExport?  @relation("Application_policyAndExport", fields: [policyAndExportId], references: [id])
   policyAndExportId                String?           @map("policyAndExport")
+  exporterCompany                  Company?          @relation("Application_exporterCompany", fields: [exporterCompanyId], references: [id])
+  exporterCompanyId                String?           @map("exporterCompany")
+  exporterCompanyAddress           CompanyAddress?   @relation("Application_exporterCompanyAddress", fields: [exporterCompanyAddressId], references: [id])
+  exporterCompanyAddressId         String?           @map("exporterCompanyAddress")
   from_ReferenceNumber_application ReferenceNumber[] @relation("ReferenceNumber_application")
   from_PolicyAndExport_application PolicyAndExport[] @relation("PolicyAndExport_application")
+  from_CompanyAddress_application  CompanyAddress[]  @relation("CompanyAddress_application")
+  from_Company_application         Company[]         @relation("Company_application")
   from_Eligibility_application     Eligibility[]     @relation("Eligibility_application")
 
   @@index([eligibilityId])
   @@index([referenceNumber])
   @@index([policyAndExportId])
+  @@index([exporterCompanyId])
+  @@index([exporterCompanyAddressId])
 }
 
 model PolicyAndExport {
@@ -56,6 +64,74 @@ model PolicyAndExport {
   from_Application_policyAndExport Application[] @relation("Application_policyAndExport")
 
   @@index([applicationId])
+}
+
+model CompanyAddress {
+  id                                      String        @id @default(cuid())
+  company                                 Company?      @relation("CompanyAddress_company", fields: [companyId], references: [id])
+  companyId                               String?       @map("company")
+  application                             Application?  @relation("CompanyAddress_application", fields: [applicationId], references: [id])
+  applicationId                           String?       @map("application")
+  addressLine1                            String        @default("")
+  addressLine2                            String        @default("")
+  careOf                                  String        @default("")
+  locality                                String        @default("")
+  region                                  String        @default("")
+  postalCode                              String        @default("")
+  country                                 String        @default("")
+  premises                                String        @default("")
+  from_Application_exporterCompanyAddress Application[] @relation("Application_exporterCompanyAddress")
+  from_Company_companyAddress             Company[]     @relation("Company_companyAddress")
+
+  @@index([companyId])
+  @@index([applicationId])
+}
+
+model CompanySicCode {
+  id                    String    @id @default(cuid())
+  code                  String    @default("")
+  company               Company?  @relation("CompanySicCode_company", fields: [companyId], references: [id])
+  companyId             String?   @map("company")
+  from_Company_sicCodes Company[] @relation("Company_sicCodes")
+
+  @@index([companyId])
+}
+
+model Company {
+  id                               String           @id @default(cuid())
+  application                      Application?     @relation("Company_application", fields: [applicationId], references: [id])
+  applicationId                    String?          @map("application")
+  companyAddress                   CompanyAddress?  @relation("Company_companyAddress", fields: [companyAddressId], references: [id])
+  companyAddressId                 String?          @map("companyAddress")
+  business                         Business?        @relation("Company_business", fields: [businessId], references: [id])
+  businessId                       String?          @map("business")
+  sicCodes                         CompanySicCode?  @relation("Company_sicCodes", fields: [sicCodesId], references: [id])
+  sicCodesId                       String?          @map("sicCodes")
+  companyName                      String           @default("")
+  companyNumber                    String           @default("")
+  dateOfCreation                   DateTime?
+  hasTradingAddress                Boolean          @default(false)
+  hasTradingName                   Boolean          @default(false)
+  companyWebsite                   String           @default("")
+  phoneNumber                      String           @default("")
+  from_Application_exporterCompany Application[]    @relation("Application_exporterCompany")
+  from_CompanyAddress_company      CompanyAddress[] @relation("CompanyAddress_company")
+  from_CompanySicCode_company      CompanySicCode[] @relation("CompanySicCode_company")
+  from_Business_company            Business[]       @relation("Business_company")
+
+  @@index([applicationId])
+  @@index([companyAddressId])
+  @@index([businessId])
+  @@index([sicCodesId])
+}
+
+model Business {
+  id                    String    @id @default(cuid())
+  company               Company?  @relation("Business_company", fields: [companyId], references: [id])
+  companyId             String?   @map("company")
+  from_Company_business Company[] @relation("Company_business")
+
+  @@index([companyId])
 }
 
 model Country {

--- a/src/api/schema.prisma
+++ b/src/api/schema.prisma
@@ -21,25 +21,25 @@ model ReferenceNumber {
 }
 
 model Application {
-  id                               String            @id @default(cuid())
-  createdAt                        DateTime?
-  updatedAt                        DateTime?
-  eligibility                      Eligibility?      @relation("Application_eligibility", fields: [eligibilityId], references: [id])
-  eligibilityId                    String?           @map("eligibility")
-  referenceNumber                  Int?
-  submissionDeadline               DateTime?
-  submissionType                   String?           @default("Manual Inclusion Application")
-  policyAndExport                  PolicyAndExport?  @relation("Application_policyAndExport", fields: [policyAndExportId], references: [id])
-  policyAndExportId                String?           @map("policyAndExport")
-  exporterCompany                  Company?          @relation("Application_exporterCompany", fields: [exporterCompanyId], references: [id])
-  exporterCompanyId                String?           @map("exporterCompany")
-  exporterCompanyAddress           CompanyAddress?   @relation("Application_exporterCompanyAddress", fields: [exporterCompanyAddressId], references: [id])
-  exporterCompanyAddressId         String?           @map("exporterCompanyAddress")
-  from_ReferenceNumber_application ReferenceNumber[] @relation("ReferenceNumber_application")
-  from_PolicyAndExport_application PolicyAndExport[] @relation("PolicyAndExport_application")
-  from_CompanyAddress_application  CompanyAddress[]  @relation("CompanyAddress_application")
-  from_Company_application         Company[]         @relation("Company_application")
-  from_Eligibility_application     Eligibility[]     @relation("Eligibility_application")
+  id                                      String                   @id @default(cuid())
+  createdAt                               DateTime?
+  updatedAt                               DateTime?
+  eligibility                             Eligibility?             @relation("Application_eligibility", fields: [eligibilityId], references: [id])
+  eligibilityId                           String?                  @map("eligibility")
+  referenceNumber                         Int?
+  submissionDeadline                      DateTime?
+  submissionType                          String?                  @default("Manual Inclusion Application")
+  policyAndExport                         PolicyAndExport?         @relation("Application_policyAndExport", fields: [policyAndExportId], references: [id])
+  policyAndExportId                       String?                  @map("policyAndExport")
+  exporterCompany                         ExporterCompany?         @relation("Application_exporterCompany", fields: [exporterCompanyId], references: [id])
+  exporterCompanyId                       String?                  @map("exporterCompany")
+  exporterCompanyAddress                  ExporterCompanyAddress?  @relation("Application_exporterCompanyAddress", fields: [exporterCompanyAddressId], references: [id])
+  exporterCompanyAddressId                String?                  @map("exporterCompanyAddress")
+  from_ReferenceNumber_application        ReferenceNumber[]        @relation("ReferenceNumber_application")
+  from_PolicyAndExport_application        PolicyAndExport[]        @relation("PolicyAndExport_application")
+  from_ExporterCompanyAddress_application ExporterCompanyAddress[] @relation("ExporterCompanyAddress_application")
+  from_ExporterCompany_application        ExporterCompany[]        @relation("ExporterCompany_application")
+  from_Eligibility_application            Eligibility[]            @relation("Eligibility_application")
 
   @@index([eligibilityId])
   @@index([referenceNumber])
@@ -66,72 +66,67 @@ model PolicyAndExport {
   @@index([applicationId])
 }
 
-model CompanyAddress {
-  id                                      String        @id @default(cuid())
-  company                                 Company?      @relation("CompanyAddress_company", fields: [companyId], references: [id])
-  companyId                               String?       @map("company")
-  application                             Application?  @relation("CompanyAddress_application", fields: [applicationId], references: [id])
-  applicationId                           String?       @map("application")
-  addressLine1                            String        @default("")
-  addressLine2                            String        @default("")
-  careOf                                  String        @default("")
-  locality                                String        @default("")
-  region                                  String        @default("")
-  postalCode                              String        @default("")
-  country                                 String        @default("")
-  premises                                String        @default("")
-  from_Application_exporterCompanyAddress Application[] @relation("Application_exporterCompanyAddress")
-  from_Company_companyAddress             Company[]     @relation("Company_companyAddress")
-
-  @@index([companyId])
-  @@index([applicationId])
-}
-
 model CompanySicCode {
-  id                    String    @id @default(cuid())
-  code                  String    @default("")
-  company               Company?  @relation("CompanySicCode_company", fields: [companyId], references: [id])
-  companyId             String?   @map("company")
-  from_Company_sicCodes Company[] @relation("Company_sicCodes")
+  id                            String            @id @default(cuid())
+  code                          String            @default("")
+  from_ExporterCompany_sicCodes ExporterCompany[] @relation("ExporterCompany_sicCodes")
+}
+
+model ExporterBusiness {
+  id                            String            @id @default(cuid())
+  company                       ExporterCompany?  @relation("ExporterBusiness_company", fields: [companyId], references: [id])
+  companyId                     String?           @map("company")
+  from_ExporterCompany_business ExporterCompany[] @relation("ExporterCompany_business")
 
   @@index([companyId])
 }
 
-model Company {
-  id                               String           @id @default(cuid())
-  application                      Application?     @relation("Company_application", fields: [applicationId], references: [id])
-  applicationId                    String?          @map("application")
-  companyAddress                   CompanyAddress?  @relation("Company_companyAddress", fields: [companyAddressId], references: [id])
-  companyAddressId                 String?          @map("companyAddress")
-  business                         Business?        @relation("Company_business", fields: [businessId], references: [id])
-  businessId                       String?          @map("business")
-  sicCodes                         CompanySicCode?  @relation("Company_sicCodes", fields: [sicCodesId], references: [id])
-  sicCodesId                       String?          @map("sicCodes")
-  companyName                      String           @default("")
-  companyNumber                    String           @default("")
-  dateOfCreation                   DateTime?
-  hasTradingAddress                Boolean          @default(false)
-  hasTradingName                   Boolean          @default(false)
-  companyWebsite                   String           @default("")
-  phoneNumber                      String           @default("")
-  from_Application_exporterCompany Application[]    @relation("Application_exporterCompany")
-  from_CompanyAddress_company      CompanyAddress[] @relation("CompanyAddress_company")
-  from_CompanySicCode_company      CompanySicCode[] @relation("CompanySicCode_company")
-  from_Business_company            Business[]       @relation("Business_company")
+model ExporterCompanyAddress {
+  id                                          String            @id @default(cuid())
+  exporterCompany                             ExporterCompany?  @relation("ExporterCompanyAddress_exporterCompany", fields: [exporterCompanyId], references: [id])
+  exporterCompanyId                           String?           @map("exporterCompany")
+  application                                 Application?      @relation("ExporterCompanyAddress_application", fields: [applicationId], references: [id])
+  applicationId                               String?           @map("application")
+  addressLine1                                String            @default("")
+  addressLine2                                String            @default("")
+  careOf                                      String            @default("")
+  locality                                    String            @default("")
+  region                                      String            @default("")
+  postalCode                                  String            @default("")
+  country                                     String            @default("")
+  premises                                    String            @default("")
+  from_Application_exporterCompanyAddress     Application[]     @relation("Application_exporterCompanyAddress")
+  from_ExporterCompany_exporterCompanyAddress ExporterCompany[] @relation("ExporterCompany_exporterCompanyAddress")
+
+  @@index([exporterCompanyId])
+  @@index([applicationId])
+}
+
+model ExporterCompany {
+  id                                          String                   @id @default(cuid())
+  application                                 Application?             @relation("ExporterCompany_application", fields: [applicationId], references: [id])
+  applicationId                               String?                  @map("application")
+  exporterCompanyAddress                      ExporterCompanyAddress?  @relation("ExporterCompany_exporterCompanyAddress", fields: [exporterCompanyAddressId], references: [id])
+  exporterCompanyAddressId                    String?                  @map("exporterCompanyAddress")
+  business                                    ExporterBusiness?        @relation("ExporterCompany_business", fields: [businessId], references: [id])
+  businessId                                  String?                  @map("business")
+  sicCodes                                    CompanySicCode?          @relation("ExporterCompany_sicCodes", fields: [sicCodesId], references: [id])
+  sicCodesId                                  String?                  @map("sicCodes")
+  companyName                                 String                   @default("")
+  companyNumber                               String                   @default("")
+  dateOfCreation                              DateTime?
+  hasTradingAddress                           Boolean                  @default(false)
+  hasTradingName                              Boolean                  @default(false)
+  companyWebsite                              String                   @default("")
+  phoneNumber                                 String                   @default("")
+  from_Application_exporterCompany            Application[]            @relation("Application_exporterCompany")
+  from_ExporterBusiness_company               ExporterBusiness[]       @relation("ExporterBusiness_company")
+  from_ExporterCompanyAddress_exporterCompany ExporterCompanyAddress[] @relation("ExporterCompanyAddress_exporterCompany")
 
   @@index([applicationId])
-  @@index([companyAddressId])
+  @@index([exporterCompanyAddressId])
   @@index([businessId])
   @@index([sicCodesId])
-}
-
-model Business {
-  id                    String    @id @default(cuid())
-  company               Company?  @relation("Business_company", fields: [companyId], references: [id])
-  companyId             String?   @map("company")
-  from_Company_business Company[] @relation("Company_business")
-
-  @@index([companyId])
 }
 
 model Country {

--- a/src/api/schema.prisma
+++ b/src/api/schema.prisma
@@ -66,12 +66,6 @@ model PolicyAndExport {
   @@index([applicationId])
 }
 
-model CompanySicCode {
-  id                            String            @id @default(cuid())
-  code                          String            @default("")
-  from_ExporterCompany_sicCodes ExporterCompany[] @relation("ExporterCompany_sicCodes")
-}
-
 model ExporterBusiness {
   id                            String            @id @default(cuid())
   company                       ExporterCompany?  @relation("ExporterBusiness_company", fields: [companyId], references: [id])
@@ -110,7 +104,7 @@ model ExporterCompany {
   exporterCompanyAddressId                    String?                  @map("exporterCompanyAddress")
   business                                    ExporterBusiness?        @relation("ExporterCompany_business", fields: [businessId], references: [id])
   businessId                                  String?                  @map("business")
-  sicCodes                                    CompanySicCode?          @relation("ExporterCompany_sicCodes", fields: [sicCodesId], references: [id])
+  sicCodes                                    ExporterCompanySicCode?  @relation("ExporterCompany_sicCodes", fields: [sicCodesId], references: [id])
   sicCodesId                                  String?                  @map("sicCodes")
   companyName                                 String                   @default("")
   companyNumber                               String                   @default("")
@@ -127,6 +121,12 @@ model ExporterCompany {
   @@index([exporterCompanyAddressId])
   @@index([businessId])
   @@index([sicCodesId])
+}
+
+model ExporterCompanySicCode {
+  id                            String            @id @default(cuid())
+  code                          String            @default("")
+  from_ExporterCompany_sicCodes ExporterCompany[] @relation("ExporterCompany_sicCodes")
 }
 
 model Country {

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -30,7 +30,10 @@ export const lists = {
         defaultValue: APPLICATION.SUBMISSION_TYPE.MIA,
       }),
       policyAndExport: relationship({ ref: 'PolicyAndExport' }),
+      exporterCompany: relationship({ ref: 'Company' }),
+      exporterCompanyAddress: relationship({ ref: 'CompanyAddress' }),
     },
+    // TODO: add logs to the hooks
     hooks: {
       resolveInput: async ({ operation, resolvedData, context }) => {
         if (operation === 'create') {
@@ -67,6 +70,34 @@ export const lists = {
               },
             };
 
+            // generate and attach a new `exporter company` relationship
+            const { id: exporterCompanyId } = await context.db.Company.createOne({
+              data: {},
+            });
+
+            modifiedData.exporterCompany = {
+              connect: {
+                id: exporterCompanyId,
+              },
+            };
+
+            // generate and attach a new `exporter company address` relationship
+            const { id: exporterCompanyAddressId } = await context.db.CompanyAddress.createOne({
+              data: {
+                company: {
+                  connect: {
+                    id: exporterCompanyId,
+                  },
+                },
+              },
+            });
+
+            modifiedData.exporterCompanyAddress = {
+              connect: {
+                id: exporterCompanyAddressId,
+              },
+            };
+
             // add dates
             const now = new Date();
             modifiedData.createdAt = now;
@@ -89,10 +120,11 @@ export const lists = {
       afterOperation: async ({ operation, item, context }) => {
         if (operation === 'create') {
           try {
-            console.info('Adding application ID to reference number entry');
+            console.info('Adding application ID to relationships');
 
             const applicationId = item.id;
-            const { referenceNumber, eligibilityId, policyAndExportId } = item;
+
+            const { referenceNumber, eligibilityId, policyAndExportId, exporterCompanyId, exporterCompanyAddressId } = item;
 
             // add the application ID to the reference number entry.
             await context.db.ReferenceNumber.updateOne({
@@ -106,7 +138,7 @@ export const lists = {
               },
             });
 
-            // add the application ID to the elgibility entry.
+            // add the application ID to the eligibility entry.
             await context.db.Eligibility.updateOne({
               where: { id: eligibilityId },
               data: {
@@ -129,8 +161,32 @@ export const lists = {
                 },
               },
             });
+
+            // add the application ID to the exporter company entry.
+            await context.db.Company.updateOne({
+              where: { id: exporterCompanyId },
+              data: {
+                application: {
+                  connect: {
+                    id: applicationId,
+                  },
+                },
+              },
+            });
+
+            // add the application ID to the exporter company address entry.
+            await context.db.CompanyAddress.updateOne({
+              where: { id: exporterCompanyAddressId },
+              data: {
+                application: {
+                  connect: {
+                    id: applicationId,
+                  },
+                },
+              },
+            });
           } catch (err) {
-            console.error('Error adding an application ID to reference number entry ', { err });
+            console.error('Error adding an application ID to relationships ', { err });
 
             return err;
           }
@@ -164,6 +220,50 @@ export const lists = {
     },
     access: allowAll,
   },
+  CompanyAddress: list({
+    fields: {
+      company: relationship({ ref: 'Company' }),
+      application: relationship({ ref: 'Application' }),
+      addressLine1: text(),
+      addressLine2: text(),
+      careOf: text(),
+      locality: text(),
+      region: text(),
+      postalCode: text(),
+      country: text(),
+      premises: text(),
+    },
+    access: allowAll,
+  }),
+  CompanySicCode: {
+    fields: {
+      code: text(),
+      company: relationship({ ref: 'Company' }),
+    },
+    access: allowAll,
+  },
+  Company: list({
+    fields: {
+      application: relationship({ ref: 'Application' }),
+      companyAddress: relationship({ ref: 'CompanyAddress' }),
+      business: relationship({ ref: 'Business' }),
+      sicCodes: relationship({ ref: 'CompanySicCode' }),
+      companyName: text(),
+      companyNumber: text(),
+      dateOfCreation: timestamp(),
+      hasTradingAddress: checkbox(),
+      hasTradingName: checkbox(),
+      companyWebsite: text(),
+      phoneNumber: text(),
+    },
+    access: allowAll,
+  }),
+  Business: list({
+    fields: {
+      company: relationship({ ref: 'Company' }),
+    },
+    access: allowAll,
+  }),
   Country: list({
     fields: {
       isoCode: text({

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -30,8 +30,8 @@ export const lists = {
         defaultValue: APPLICATION.SUBMISSION_TYPE.MIA,
       }),
       policyAndExport: relationship({ ref: 'PolicyAndExport' }),
-      exporterCompany: relationship({ ref: 'Company' }),
-      exporterCompanyAddress: relationship({ ref: 'CompanyAddress' }),
+      exporterCompany: relationship({ ref: 'ExporterCompany' }),
+      exporterCompanyAddress: relationship({ ref: 'ExporterCompanyAddress' }),
     },
     // TODO: add logs to the hooks
     hooks: {
@@ -71,7 +71,7 @@ export const lists = {
             };
 
             // generate and attach a new `exporter company` relationship
-            const { id: exporterCompanyId } = await context.db.Company.createOne({
+            const { id: exporterCompanyId } = await context.db.ExporterCompany.createOne({
               data: {},
             });
 
@@ -82,9 +82,9 @@ export const lists = {
             };
 
             // generate and attach a new `exporter company address` relationship
-            const { id: exporterCompanyAddressId } = await context.db.CompanyAddress.createOne({
+            const { id: exporterCompanyAddressId } = await context.db.ExporterCompanyAddress.createOne({
               data: {
-                company: {
+                exporterCompany: {
                   connect: {
                     id: exporterCompanyId,
                   },
@@ -163,7 +163,7 @@ export const lists = {
             });
 
             // add the application ID to the exporter company entry.
-            await context.db.Company.updateOne({
+            await context.db.ExporterCompany.updateOne({
               where: { id: exporterCompanyId },
               data: {
                 application: {
@@ -175,7 +175,7 @@ export const lists = {
             });
 
             // add the application ID to the exporter company address entry.
-            await context.db.CompanyAddress.updateOne({
+            await context.db.ExporterCompanyAddress.updateOne({
               where: { id: exporterCompanyAddressId },
               data: {
                 application: {
@@ -220,9 +220,21 @@ export const lists = {
     },
     access: allowAll,
   },
-  CompanyAddress: list({
+  CompanySicCode: {
     fields: {
-      company: relationship({ ref: 'Company' }),
+      code: text(),
+    },
+    access: allowAll,
+  },
+  ExporterBusiness: list({
+    fields: {
+      company: relationship({ ref: 'ExporterCompany' }),
+    },
+    access: allowAll,
+  }),
+  ExporterCompanyAddress: list({
+    fields: {
+      exporterCompany: relationship({ ref: 'ExporterCompany' }),
       application: relationship({ ref: 'Application' }),
       addressLine1: text(),
       addressLine2: text(),
@@ -235,18 +247,11 @@ export const lists = {
     },
     access: allowAll,
   }),
-  CompanySicCode: {
-    fields: {
-      code: text(),
-      company: relationship({ ref: 'Company' }),
-    },
-    access: allowAll,
-  },
-  Company: list({
+  ExporterCompany: list({
     fields: {
       application: relationship({ ref: 'Application' }),
-      companyAddress: relationship({ ref: 'CompanyAddress' }),
-      business: relationship({ ref: 'Business' }),
+      exporterCompanyAddress: relationship({ ref: 'ExporterCompanyAddress' }),
+      business: relationship({ ref: 'ExporterBusiness' }),
       sicCodes: relationship({ ref: 'CompanySicCode' }),
       companyName: text(),
       companyNumber: text(),
@@ -255,12 +260,6 @@ export const lists = {
       hasTradingName: checkbox(),
       companyWebsite: text(),
       phoneNumber: text(),
-    },
-    access: allowAll,
-  }),
-  Business: list({
-    fields: {
-      company: relationship({ ref: 'Company' }),
     },
     access: allowAll,
   }),

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -220,12 +220,6 @@ export const lists = {
     },
     access: allowAll,
   },
-  CompanySicCode: {
-    fields: {
-      code: text(),
-    },
-    access: allowAll,
-  },
   ExporterBusiness: list({
     fields: {
       company: relationship({ ref: 'ExporterCompany' }),
@@ -252,7 +246,7 @@ export const lists = {
       application: relationship({ ref: 'Application' }),
       exporterCompanyAddress: relationship({ ref: 'ExporterCompanyAddress' }),
       business: relationship({ ref: 'ExporterBusiness' }),
-      sicCodes: relationship({ ref: 'CompanySicCode' }),
+      sicCodes: relationship({ ref: 'ExporterCompanySicCode' }),
       companyName: text(),
       companyNumber: text(),
       dateOfCreation: timestamp(),
@@ -263,6 +257,12 @@ export const lists = {
     },
     access: allowAll,
   }),
+  ExporterCompanySicCode: {
+    fields: {
+      code: text(),
+    },
+    access: allowAll,
+  },
   Country: list({
     fields: {
       isoCode: text({

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -6,6 +6,14 @@ interface ApplicationPolicyAndExport {
   id: string;
 }
 
+interface ApplicationExporterCompany {
+  id: string;
+}
+
+interface ApplicationExporterCompanyAddress {
+  id: string;
+}
+
 interface Application {
   id: string;
   referenceNumber: number;
@@ -13,8 +21,10 @@ interface Application {
   updatedAt: string;
   submissionDeadline: string;
   submissionType: string;
-  policyAndExport: ApplicationPolicyAndExport;
   eligibility: ApplicationEligibility;
+  policyAndExport: ApplicationPolicyAndExport;
+  exporterCompany: ApplicationExporterCompany;
+  exporterCompanyAddress: ApplicationExporterCompanyAddress;
 }
 
 export { Application };

--- a/src/ui/server/api/keystone/application/index.ts
+++ b/src/ui/server/api/keystone/application/index.ts
@@ -120,7 +120,6 @@ const application = {
         throw new Error(`Updating application policy and export ${err}`);
       }
     },
-    // TODO: align error message
     exporterCompany: async (companyId: string, companyAddressId: string, update: object) => {
       try {
         console.info('Updating exporter company');

--- a/src/ui/server/api/keystone/application/index.ts
+++ b/src/ui/server/api/keystone/application/index.ts
@@ -6,6 +6,7 @@ import countries from '../countries';
 import createApplicationMutation from '../../../graphql/mutations/create-application';
 import getApplicationQuery from '../../../graphql/queries/application';
 import updateApplicationPolicyAndExportMutation from '../../../graphql/mutations/update-application/policy-and-export';
+import updateApplicationExporterCompanytMutation from '../../../graphql/mutations/update-application/exporter-company';
 
 const createEmptyApplication = async () => {
   try {
@@ -117,6 +118,38 @@ const application = {
         throw new Error('Updating application policy and export');
       } catch (err) {
         throw new Error(`Updating application policy and export ${err}`);
+      }
+    },
+    // TODO: align error message
+    exporterCompany: async (companyId: string, companyAddressId: string, update: object) => {
+      try {
+        console.info("Updating application's exporter company");
+
+        const variables = {
+          companyId,
+          companyAddressId,
+          data: update,
+        };
+
+        const response = (await apollo('POST', updateApplicationExporterCompanytMutation, variables)) as ApolloResponse;
+
+        if (response.errors) {
+          console.error("GraphQL error updating application's exporter company ", response.errors);
+        }
+
+        if (response?.networkError?.result?.errors) {
+          console.error("GraphQL network error updating application's exporter company ", response.networkError.result.errors);
+        }
+
+        if (response?.data?.updateApplicationCompanyAndCompanyAddress) {
+          const { data } = response;
+
+          return data.updateApplicationCompanyAndCompanyAddress;
+        }
+
+        throw new Error("Updating application's exporter company");
+      } catch (err) {
+        throw new Error(`Updating application's exporter company ${err}`);
       }
     },
   },

--- a/src/ui/server/api/keystone/application/index.ts
+++ b/src/ui/server/api/keystone/application/index.ts
@@ -6,7 +6,7 @@ import countries from '../countries';
 import createApplicationMutation from '../../../graphql/mutations/create-application';
 import getApplicationQuery from '../../../graphql/queries/application';
 import updateApplicationPolicyAndExportMutation from '../../../graphql/mutations/update-application/policy-and-export';
-import updateExporterCompanytMutation from '../../../graphql/mutations/update-application/exporter-company';
+import updateApplicationExporterCompanytMutation from '../../../graphql/mutations/update-application/exporter-company';
 
 const createEmptyApplication = async () => {
   try {
@@ -122,7 +122,7 @@ const application = {
     },
     exporterCompany: async (companyId: string, companyAddressId: string, update: object) => {
       try {
-        console.info('Updating exporter company');
+        console.info('Updating application exporter company');
 
         const variables = {
           companyId,
@@ -130,14 +130,14 @@ const application = {
           data: update,
         };
 
-        const response = (await apollo('POST', updateExporterCompanytMutation, variables)) as ApolloResponse;
+        const response = (await apollo('POST', updateApplicationExporterCompanytMutation, variables)) as ApolloResponse;
 
         if (response.errors) {
-          console.error('GraphQL error updating exporter company ', response.errors);
+          console.error('GraphQL error updating application exporter company ', response.errors);
         }
 
         if (response?.networkError?.result?.errors) {
-          console.error('GraphQL network error updating exporter company ', response.networkError.result.errors);
+          console.error('GraphQL network error updating application exporter company ', response.networkError.result.errors);
         }
 
         if (response?.data?.updateApplicationCompanyAndCompanyAddress) {
@@ -146,9 +146,9 @@ const application = {
           return data.updateApplicationCompanyAndCompanyAddress;
         }
 
-        throw new Error('Updating exporter company');
+        throw new Error('Updating application exporter company');
       } catch (err) {
-        throw new Error(`Updating exporter company ${err}`);
+        throw new Error(`Updating application exporter company ${err}`);
       }
     },
   },

--- a/src/ui/server/api/keystone/application/index.ts
+++ b/src/ui/server/api/keystone/application/index.ts
@@ -6,7 +6,7 @@ import countries from '../countries';
 import createApplicationMutation from '../../../graphql/mutations/create-application';
 import getApplicationQuery from '../../../graphql/queries/application';
 import updateApplicationPolicyAndExportMutation from '../../../graphql/mutations/update-application/policy-and-export';
-import updateApplicationExporterCompanytMutation from '../../../graphql/mutations/update-application/exporter-company';
+import updateExporterCompanytMutation from '../../../graphql/mutations/update-application/exporter-company';
 
 const createEmptyApplication = async () => {
   try {
@@ -123,7 +123,7 @@ const application = {
     // TODO: align error message
     exporterCompany: async (companyId: string, companyAddressId: string, update: object) => {
       try {
-        console.info("Updating application's exporter company");
+        console.info('Updating exporter company');
 
         const variables = {
           companyId,
@@ -131,14 +131,14 @@ const application = {
           data: update,
         };
 
-        const response = (await apollo('POST', updateApplicationExporterCompanytMutation, variables)) as ApolloResponse;
+        const response = (await apollo('POST', updateExporterCompanytMutation, variables)) as ApolloResponse;
 
         if (response.errors) {
-          console.error("GraphQL error updating application's exporter company ", response.errors);
+          console.error('GraphQL error updating exporter company ', response.errors);
         }
 
         if (response?.networkError?.result?.errors) {
-          console.error("GraphQL network error updating application's exporter company ", response.networkError.result.errors);
+          console.error('GraphQL network error updating exporter company ', response.networkError.result.errors);
         }
 
         if (response?.data?.updateApplicationCompanyAndCompanyAddress) {
@@ -147,9 +147,9 @@ const application = {
           return data.updateApplicationCompanyAndCompanyAddress;
         }
 
-        throw new Error("Updating application's exporter company");
+        throw new Error('Updating exporter company');
       } catch (err) {
-        throw new Error(`Updating application's exporter company ${err}`);
+        throw new Error(`Updating exporter company ${err}`);
       }
     },
   },

--- a/src/ui/server/constants/field-ids/insurance/exporter-business/index.ts
+++ b/src/ui/server/constants/field-ids/insurance/exporter-business/index.ts
@@ -10,8 +10,8 @@ const EXPORTER_BUSINESS = {
   },
   YOUR_COMPANY: {
     YOUR_BUSINESS: 'yourBusiness',
-    TRADING_ADDRESS: 'tradingAddress',
-    TRADING_NAME: 'tradingName',
+    TRADING_ADDRESS: 'hasTradingAddress',
+    TRADING_NAME: 'hasTradingName',
     WEBSITE: 'companyWebsite',
     PHONE_NUMBER: 'phoneNumber',
   },

--- a/src/ui/server/graphql/mutations/update-application/exporter-company.ts
+++ b/src/ui/server/graphql/mutations/update-application/exporter-company.ts
@@ -1,0 +1,11 @@
+import gql from 'graphql-tag';
+
+const updateCompanyAndCompanyAddressMutation = gql`
+  mutation ($companyId: ID!, $companyAddressId: ID! $data: ApplicationCompanyAndCompanyAddressInput!) {
+    updateApplicationCompanyAndCompanyAddress(companyId: $id, companyAddressId: $companyAddressId, data: $data) {
+      id
+    }
+  }
+`;
+
+export default updateCompanyAndCompanyAddressMutation;

--- a/src/ui/server/graphql/mutations/update-application/exporter-company.ts
+++ b/src/ui/server/graphql/mutations/update-application/exporter-company.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 const updateCompanyAndCompanyAddressMutation = gql`
-  mutation ($companyId: ID!, $companyAddressId: ID! $data: ApplicationCompanyAndCompanyAddressInput!) {
+  mutation ($companyId: ID!, $companyAddressId: ID!, $data: ApplicationCompanyAndCompanyAddressInput!) {
     updateApplicationCompanyAndCompanyAddress(companyId: $id, companyAddressId: $companyAddressId, data: $data) {
       id
     }

--- a/src/ui/server/graphql/queries/application.ts
+++ b/src/ui/server/graphql/queries/application.ts
@@ -37,6 +37,25 @@ const applicationQuery = gql`
           totalSalesToBuyer
           maximumBuyerWillOwe
         }
+        exporterCompany {
+          id
+          companyName
+          companyNumber
+          companyWebsite
+          hasTradingName
+          hasTradingAddress
+        }
+        exporterCompanyAddress {
+          id
+          addressLine1
+          addressLine2
+          careOf
+          locality
+          region
+          postalCode
+          country
+          premises
+        }
       }
     }
   }

--- a/src/ui/types/application.ts
+++ b/src/ui/types/application.ts
@@ -28,9 +28,19 @@ interface ApplicationPolicyAndExport {
   maximumBuyerWillOwe?: number;
 }
 
+interface ApplicationExporterCompany {
+  id: string;
+  companyName?: string;
+  companyNumber?: string;
+  companyWebsite?: string;
+  hasTradingName?: boolean;
+  hasTradingAddress?: boolean;
+}
+
 interface Application extends ApplicationCore {
   eligibility: ApplicationEligibility;
   policyAndExport: ApplicationPolicyAndExport;
+  exporterCompany: ApplicationExporterCompany;
 }
 
 interface ApplicationFlat extends ApplicationCore, InsuranceEligibilityCore, ApplicationPolicyAndExport {


### PR DESCRIPTION
This PR adds the ability to get and save exporter company details, for the "Company details" page.


## Summary of changes

- Add `exporterCompany` and `exporterCompanyAddress` to the keystone schema/DB/API. These are available to be queried from the top level of the application.
- Add placeholder `ExporterCompanySicCode` and `ExporterBusiness` to the schema, ready for further development.
- Create a new custom resolver in keystone schema to update an exporter company _and_ address.
  - The requirement we have is to update an exporter's company for an application, as well as the company address. We want to keep these pieces of data seperate to have a clean database structure.
  - For various reason, it is troublesome/not possible or results in poor code quality, to update 2 tables at the same time with one query. Alternative options are to either make 2 api calls from the UI (bad), or have a custom resolver that can handle the request and data saving as we need.
- Update application keystone schema so that when an application is created:
  - `exporterCompany` and `exporterCompanyAddress` rows are created and associated with the application. This avoids us having to create _and_ update further down the line.
- Add GQL mutation to the UI, for updating an exporter company.
- Update the "get application GQL query in the UI to return exporter company fields.

## Other improvements
- Rename trading name and trading address field IDs to reflect it being a boolean/yes/no question.
- Rename companies house naming in the custom schema to avoid confusion between `ExporterCompanyAddress`.