### PR TITLE
feat(EMS-607): Policy and exports - callMapAndSave function

### DIFF
--- a/src/ui/server/controllers/insurance/policy-and-export/call-map-and-save/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/call-map-and-save/index.test.ts
@@ -1,0 +1,90 @@
+import callMapAndSave from '.';
+import { FIELD_IDS, FIELD_VALUES } from '../../../../constants';
+import { Request, Response } from '../../../../../types';
+import generateValidationErrors from '../type-of-policy/validation';
+import mapAndSave from '../map-and-save';
+import { mockApplication, mockReq, mockRes } from '../../../../test-mocks';
+
+const { POLICY_TYPE } = FIELD_IDS;
+
+describe('controllers/insurance/policy-and-export/call-map-and-save', () => {
+  let req: Request;
+  let res: Response;
+
+  jest.mock('../map-and-save');
+
+  let mockMapAndSave = jest.fn(() => Promise.resolve(true));
+  mapAndSave.policyAndExport = mockMapAndSave;
+
+  const mockFormBody = {
+    _csrf: '1234',
+    mock: true,
+  };
+
+  const mockValidFormBody = {
+    _csrf: '1234',
+    [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.SINGLE,
+  };
+
+  const mockValidationErrors = generateValidationErrors(mockFormBody);
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+
+    res.locals.application = mockApplication;
+    req.params.referenceNumber = String(mockApplication.referenceNumber);
+
+    req.body = mockFormBody;
+  });
+
+  describe('when form data has validation errors ', () => {
+    it('should call mapAndSave.policyAndExport with application, form data and validationErrors', async () => {
+      await callMapAndSave(req.body, mockApplication, mockValidationErrors);
+
+      expect(mapAndSave.policyAndExport).toHaveBeenCalledTimes(1);
+      expect(mapAndSave.policyAndExport).toHaveBeenCalledWith(req.body, res.locals.application, mockValidationErrors);
+    });
+
+    describe('when the form does NOT have validation errors', () => {
+      beforeEach(() => {
+        req.body = mockValidFormBody;
+      });
+
+      it('should call mapAndSave.policyAndExport with application and form data', async () => {
+        await callMapAndSave(req.body, mockApplication);
+
+        expect(mapAndSave.policyAndExport).toHaveBeenCalledTimes(1);
+        expect(mapAndSave.policyAndExport).toHaveBeenCalledWith(req.body, res.locals.application);
+      });
+    });
+  });
+
+  describe('api error handling', () => {
+    describe('when the mapAndSave call does not return anything', () => {
+      beforeEach(() => {
+        mockMapAndSave = jest.fn(() => Promise.resolve(false));
+        mapAndSave.policyAndExport = mockMapAndSave;
+      });
+
+      it('should return false', async () => {
+        const result = await callMapAndSave(req.body, mockApplication, mockValidationErrors);
+
+        expect(result).toEqual(false);
+      });
+    });
+
+    describe('when the mapAndSave call fails', () => {
+      beforeEach(() => {
+        mockMapAndSave = jest.fn(() => Promise.reject(new Error('Mock error')));
+        mapAndSave.policyAndExport = mockMapAndSave;
+      });
+
+      it('should return false', async () => {
+        const result = await callMapAndSave(req.body, mockApplication, mockValidationErrors);
+
+        expect(result).toEqual(false);
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/policy-and-export/call-map-and-save/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/call-map-and-save/index.ts
@@ -1,0 +1,24 @@
+import mapAndSave from '../map-and-save';
+import { Application, RequestBody, ValidationErrors } from '../../../../../types';
+
+const callMapAndSave = async (formData: RequestBody, application: Application, validationErrors?: ValidationErrors) => {
+  try {
+    let saveResponse;
+
+    if (validationErrors) {
+      saveResponse = await mapAndSave.policyAndExport(formData, application, validationErrors);
+
+      return saveResponse;
+    }
+
+    saveResponse = await mapAndSave.policyAndExport(formData, application);
+
+    return saveResponse;
+  } catch (err) {
+    console.error('Error calling mapAndSave.policyAndExport', { err });
+
+    return false;
+  }
+};
+
+export default callMapAndSave;

--- a/src/ui/server/controllers/insurance/policy-and-export/call-map-and-save/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/call-map-and-save/index.ts
@@ -1,6 +1,14 @@
 import mapAndSave from '../map-and-save';
 import { Application, RequestBody, ValidationErrors } from '../../../../../types';
 
+/**
+ * callMapAndSave
+ * Call the "map and save" function with or without validation errors
+ * @param {RequestBody} Form body
+ * @param {Object} Application
+ * @param {Object} Form Validation errors
+ * @returns {Boolean}
+ */
 const callMapAndSave = async (formData: RequestBody, application: Application, validationErrors?: ValidationErrors) => {
   try {
     let saveResponse;

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back/index.ts
@@ -2,7 +2,7 @@ import { ROUTES } from '../../../../../constants';
 import { Request, Response } from '../../../../../../types';
 import hasFormData from '../../../../../helpers/has-form-data';
 import generateValidationErrors from '../validation';
-import mapAndSave from '../../map-and-save';
+import callMapAndSave from '../../call-map-and-save';
 
 const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS },
@@ -26,15 +26,7 @@ export const post = async (req: Request, res: Response) => {
     const { referenceNumber } = req.params;
 
     if (hasFormData(req.body)) {
-      const validationErrors = generateValidationErrors(req.body);
-
-      let saveResponse;
-
-      if (validationErrors) {
-        saveResponse = await mapAndSave.policyAndExport(req.body, application, validationErrors);
-      } else {
-        saveResponse = await mapAndSave.policyAndExport(req.body, application);
-      }
+      const saveResponse = await callMapAndSave(req.body, application, generateValidationErrors(req.body));
 
       if (!saveResponse) {
         return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/save-and-back/index.ts
@@ -2,7 +2,7 @@ import { ROUTES } from '../../../../../constants';
 import { Request, Response } from '../../../../../../types';
 import hasFormData from '../../../../../helpers/has-form-data';
 import generateValidationErrors from '../validation';
-import mapAndSave from '../../map-and-save';
+import callMapAndSave from '../../call-map-and-save';
 
 const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS },
@@ -26,15 +26,7 @@ export const post = async (req: Request, res: Response) => {
     const { referenceNumber } = req.params;
 
     if (hasFormData(req.body)) {
-      const validationErrors = generateValidationErrors(req.body);
-
-      let saveResponse;
-
-      if (validationErrors) {
-        saveResponse = await mapAndSave.policyAndExport(req.body, application, validationErrors);
-      } else {
-        saveResponse = await mapAndSave.policyAndExport(req.body, application);
-      }
+      const saveResponse = await callMapAndSave(req.body, application, generateValidationErrors(req.body));
 
       if (!saveResponse) {
         return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.ts
@@ -3,6 +3,7 @@ import { PAGES } from '../../../../content-strings';
 import { FIELDS } from '../../../../content-strings/fields/insurance';
 import { Request, Response } from '../../../../../types';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
+import { objectHasValues } from '../../../../helpers/object';
 import generateValidationErrors from './validation';
 import { isMultiPolicyType, isSinglePolicyType } from '../../../../helpers/policy-type';
 import mapAndSave from '../map-and-save';
@@ -67,7 +68,7 @@ export const post = async (req: Request, res: Response) => {
   // check for form errors.
   const validationErrors = generateValidationErrors(req.body);
 
-  if (validationErrors) {
+  if (objectHasValues(validationErrors)) {
     return res.render(TEMPLATE, {
       ...insuranceCorePageVariables({
         PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY_AND_EXPORTS.TYPE_OF_POLICY,

--- a/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/save-and-back/index.test.ts
@@ -1,11 +1,10 @@
 import { post } from '.';
-import { FIELD_IDS, FIELD_VALUES, ROUTES } from '../../../../../constants';
+import { ROUTES } from '../../../../../constants';
 import { Request, Response } from '../../../../../../types';
 import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save';
 import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
 
-const { POLICY_TYPE } = FIELD_IDS;
 const {
   INSURANCE: { INSURANCE_ROOT },
 } = ROUTES;
@@ -26,11 +25,6 @@ describe('controllers/insurance/policy-and-export/type-of-policy/save-and-back',
     mock: true,
   };
 
-  const mockValidFormBody = {
-    _csrf: '1234',
-    [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.SINGLE,
-  };
-
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
@@ -42,44 +36,21 @@ describe('controllers/insurance/policy-and-export/type-of-policy/save-and-back',
   });
 
   describe('when the form has data', () => {
-    describe('when the form has validation errors ', () => {
-      it('should call mapAndSave.policyAndExport with application reference number, form data and validationErrors.errorList', async () => {
-        await post(req, res);
+    it('should call mapAndSave.policyAndExport with application reference number, form data and validationErrors.errorList', async () => {
+      await post(req, res);
 
-        const validationErrors = generateValidationErrors(req.body);
+      const validationErrors = generateValidationErrors(req.body);
 
-        expect(mapAndSave.policyAndExport).toHaveBeenCalledTimes(1);
-        expect(mapAndSave.policyAndExport).toHaveBeenCalledWith(req.body, res.locals.application, validationErrors);
-      });
+      expect(mapAndSave.policyAndExport).toHaveBeenCalledTimes(1);
+      expect(mapAndSave.policyAndExport).toHaveBeenCalledWith(req.body, res.locals.application, validationErrors);
+    });
 
-      it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, async () => {
-        await post(req, res);
+    it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, async () => {
+      await post(req, res);
 
-        const expected = `${INSURANCE_ROOT}/${refNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`;
+      const expected = `${INSURANCE_ROOT}/${refNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`;
 
-        expect(res.redirect).toHaveBeenCalledWith(expected);
-      });
-
-      describe('when the form does NOT have validation errors', () => {
-        beforeEach(() => {
-          req.body = mockValidFormBody;
-        });
-
-        it('should call mapAndSave.policyAndExport with application reference number and form data', async () => {
-          await post(req, res);
-
-          expect(mapAndSave.policyAndExport).toHaveBeenCalledTimes(1);
-          expect(mapAndSave.policyAndExport).toHaveBeenCalledWith(req.body, res.locals.application);
-        });
-
-        it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, async () => {
-          await post(req, res);
-
-          const expected = `${INSURANCE_ROOT}/${refNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`;
-
-          expect(res.redirect).toHaveBeenCalledWith(expected);
-        });
-      });
+      expect(res.redirect).toHaveBeenCalledWith(expected);
     });
   });
 

--- a/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/save-and-back/index.ts
@@ -2,7 +2,7 @@ import { ROUTES } from '../../../../../constants';
 import { Request, Response } from '../../../../../../types';
 import hasFormData from '../../../../../helpers/has-form-data';
 import generateValidationErrors from '../validation';
-import mapAndSave from '../../map-and-save';
+import callMapAndSave from '../../call-map-and-save';
 
 const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS },
@@ -26,15 +26,7 @@ export const post = async (req: Request, res: Response) => {
     const { referenceNumber } = req.params;
 
     if (hasFormData(req.body)) {
-      const validationErrors = generateValidationErrors(req.body);
-
-      let saveResponse;
-
-      if (validationErrors) {
-        saveResponse = await mapAndSave.policyAndExport(req.body, application, validationErrors);
-      } else {
-        saveResponse = await mapAndSave.policyAndExport(req.body, application);
-      }
+      const saveResponse = await callMapAndSave(req.body, application, generateValidationErrors(req.body));
 
       if (!saveResponse) {
         return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/validation/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/validation/index.test.ts
@@ -1,5 +1,5 @@
 import validation from '.';
-import { FIELD_IDS } from '../../../../../constants';
+import { FIELD_IDS, FIELD_VALUES } from '../../../../../constants';
 import { ERROR_MESSAGES } from '../../../../../content-strings';
 import generateValidationErrors from '../../../../../helpers/validation';
 
@@ -22,14 +22,14 @@ describe('controllers/insurance/policy-and-export/type-of-policy/validation', ()
   });
 
   describe('when there are no validation errors', () => {
-    it('should return null', () => {
+    it('should return an empty object', () => {
       const mockBody = {
-        [FIELD_ID]: 'Single contract policy',
+        [FIELD_ID]: FIELD_VALUES.POLICY_TYPE.SINGLE,
       };
 
       const result = validation(mockBody);
 
-      expect(result).toEqual(null);
+      expect(result).toEqual({});
     });
   });
 });

--- a/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/validation/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/validation/index.ts
@@ -2,7 +2,7 @@ import generateValidationErrors from '../../../../../helpers/validation';
 import { objectHasValues, objectHasProperty } from '../../../../../helpers/object';
 import { FIELD_IDS } from '../../../../../constants';
 import { ERROR_MESSAGES } from '../../../../../content-strings';
-import { RequestBody } from '../../../../../../types';
+import { RequestBody, ValidationErrors } from '../../../../../../types';
 
 const { POLICY_AND_EXPORTS } = FIELD_IDS.INSURANCE;
 const FIELD_ID = POLICY_AND_EXPORTS.POLICY_TYPE;
@@ -13,12 +13,15 @@ const validation = (formBody: RequestBody) => {
   const hasErrors = !objectHasValues(formBody) || !objectHasProperty(formBody, FIELD_ID);
 
   if (hasErrors) {
-    errors = generateValidationErrors(POLICY_AND_EXPORTS.SINGLE_POLICY_TYPE, ERROR_MESSAGES.INSURANCE.POLICY_AND_EXPORTS[FIELD_ID].IS_EMPTY);
+    errors = generateValidationErrors(
+      POLICY_AND_EXPORTS.SINGLE_POLICY_TYPE,
+      ERROR_MESSAGES.INSURANCE.POLICY_AND_EXPORTS[FIELD_ID].IS_EMPTY,
+    ) as ValidationErrors;
 
     return errors;
   }
 
-  return null;
+  return {};
 };
 
 export default validation;

--- a/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/validation/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/validation/index.ts
@@ -2,7 +2,7 @@ import generateValidationErrors from '../../../../../helpers/validation';
 import { objectHasValues, objectHasProperty } from '../../../../../helpers/object';
 import { FIELD_IDS } from '../../../../../constants';
 import { ERROR_MESSAGES } from '../../../../../content-strings';
-import { RequestBody, ValidationErrors } from '../../../../../../types';
+import { RequestBody } from '../../../../../../types';
 
 const { POLICY_AND_EXPORTS } = FIELD_IDS.INSURANCE;
 const FIELD_ID = POLICY_AND_EXPORTS.POLICY_TYPE;
@@ -13,10 +13,7 @@ const validation = (formBody: RequestBody) => {
   const hasErrors = !objectHasValues(formBody) || !objectHasProperty(formBody, FIELD_ID);
 
   if (hasErrors) {
-    errors = generateValidationErrors(
-      POLICY_AND_EXPORTS.SINGLE_POLICY_TYPE,
-      ERROR_MESSAGES.INSURANCE.POLICY_AND_EXPORTS[FIELD_ID].IS_EMPTY,
-    ) as ValidationErrors;
+    errors = generateValidationErrors(POLICY_AND_EXPORTS.SINGLE_POLICY_TYPE, ERROR_MESSAGES.INSURANCE.POLICY_AND_EXPORTS[FIELD_ID].IS_EMPTY);
 
     return errors;
   }


### PR DESCRIPTION
This PR adds a new function to the policy and export controllers directory - `callMapAndSave`. This is to reduce repeated logic in the "save and back" controllers.


## Summary of changes
- Extract repeated logic and unit tests from "save and back" controllers and move into a single function.
- In the "type of policy" validation, return an empty object instead of null. This was causing issues with the improved codebase changes. Add a `objectHasValues` check to the controller so it works as before.