### PR TITLE
feat(EMS-607): Policy and exports - about goods or services - save and go back

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/save-and-back.spec.js
@@ -8,6 +8,18 @@ import application from '../../../../../fixtures/application';
 
 const {
   INSURANCE: {
+    ROOT: INSURANCE_ROOT,
+    START,
+    ALL_SECTIONS,
+    POLICY_AND_EXPORTS: {
+      SINGLE_CONTRACT_POLICY,
+      ABOUT_GOODS_OR_SERVICES,
+    },
+  },
+} = ROUTES;
+
+const {
+  INSURANCE: {
     POLICY_AND_EXPORTS: {
       ABOUT_GOODS_OR_SERVICES: { DESCRIPTION },
     },
@@ -40,7 +52,7 @@ context('Insurance - Policy and exports - About goods or services - Save and go 
     getReferenceNumber().then((id) => {
       referenceNumber = id;
 
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES}`;
+      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`;
       cy.url().should('eq', expected);
     });
   });
@@ -51,10 +63,10 @@ context('Insurance - Policy and exports - About goods or services - Save and go 
   });
 
   describe('when submitting an empty form via `save and go back` button', () => {
-    it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, () => {
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
       saveAndBackButton().click();
 
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`;
+      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       cy.url().should('eq', expected);
     });
@@ -76,11 +88,11 @@ context('Insurance - Policy and exports - About goods or services - Save and go 
       submitButton().click();
     });
 
-    it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, () => {
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
       aboutGoodsOrServicesPage[DESCRIPTION].input().type(application.POLICY_AND_EXPORTS[DESCRIPTION]);
       saveAndBackButton().click();
 
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`;
+      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       cy.url().should('eq', expected);
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/save-and-back.spec.js
@@ -1,0 +1,109 @@
+import { submitButton, saveAndBackButton } from '../../../../pages/shared';
+import { aboutGoodsOrServicesPage } from '../../../../pages/insurance/policy-and-export';
+import partials from '../../../../partials';
+import { TASKS } from '../../../../../../content-strings';
+import { ROUTES, FIELD_IDS, FIELD_VALUES } from '../../../../../../constants';
+import getReferenceNumber from '../../../../helpers/get-reference-number';
+import application from '../../../../../fixtures/application';
+
+const {
+  INSURANCE: {
+    POLICY_AND_EXPORTS: {
+      ABOUT_GOODS_OR_SERVICES: { DESCRIPTION },
+    },
+  },
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.prepareApplication.tasks.policyTypeAndExports;
+
+context('Insurance - Policy and exports - About goods or services - Save and go back', () => {
+  let referenceNumber;
+
+  before(() => {
+    cy.visit(ROUTES.INSURANCE.START, {
+      auth: {
+        username: Cypress.config('basicAuthKey'),
+        password: Cypress.config('basicAuthSecret'),
+      },
+    });
+
+    cy.submitInsuranceEligibilityAndStartApplication();
+
+    task.link().click();
+
+    cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+
+    cy.completeAndSubmitSingleContractPolicyForm();
+
+    getReferenceNumber().then((id) => {
+      referenceNumber = id;
+
+      const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES}`;
+      cy.url().should('eq', expected);
+    });
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
+  describe('when submitting an empty form via `save and go back` button', () => {
+    it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, () => {
+      saveAndBackButton().click();
+
+      const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`;
+
+      cy.url().should('eq', expected);
+    });
+
+    it('should retain the `type of policy and exports` task status as `in progress`', () => {
+      task.status().invoke('text').then((text) => {
+        const expected = TASKS.STATUS.IN_PROGRESS;
+
+        expect(text.trim()).equal(expected);
+      });
+    });
+  });
+
+  describe('when submitting an answer and submitting the form via `save and go back` button', () => {
+    before(() => {
+      // go back to the page via the task list
+      task.link().click();
+      submitButton().click();
+      submitButton().click();
+    });
+
+    it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, () => {
+      aboutGoodsOrServicesPage[DESCRIPTION].input().type(application.POLICY_AND_EXPORTS[DESCRIPTION]);
+      saveAndBackButton().click();
+
+      const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`;
+
+      cy.url().should('eq', expected);
+    });
+
+    it('should update the status of task `type of policy and exports`to `in progress`', () => {
+      task.status().invoke('text').then((text) => {
+        const expected = TASKS.STATUS.IN_PROGRESS;
+
+        expect(text.trim()).equal(expected);
+      });
+    });
+
+    describe('when going back to the page', () => {
+      before(() => {
+        // go back to the page via the task list
+        task.link().click();
+        submitButton().click();
+        submitButton().click();
+      });
+
+      it('should have the originally submitted answer selected', () => {
+        aboutGoodsOrServicesPage[DESCRIPTION].input().should('have.value', application.POLICY_AND_EXPORTS[DESCRIPTION]);
+      });
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/save-and-back.spec.js
@@ -11,10 +11,7 @@ const {
     ROOT: INSURANCE_ROOT,
     START,
     ALL_SECTIONS,
-    POLICY_AND_EXPORTS: {
-      SINGLE_CONTRACT_POLICY,
-      ABOUT_GOODS_OR_SERVICES,
-    },
+    POLICY_AND_EXPORTS: { ABOUT_GOODS_OR_SERVICES },
   },
 } = ROUTES;
 
@@ -30,11 +27,11 @@ const { taskList } = partials.insurancePartials;
 
 const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
-context('Insurance - Policy and exports - About goods or services - Save and go back', () => {
+context('Insurance - Policy and exports - About goods or services page - Save and go back', () => {
   let referenceNumber;
 
   before(() => {
-    cy.visit(ROUTES.INSURANCE.START, {
+    cy.visit(START, {
       auth: {
         username: Cypress.config('basicAuthKey'),
         password: Cypress.config('basicAuthSecret'),

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/validation/about-goods-or-services-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/validation/about-goods-or-services-validation.spec.js
@@ -25,7 +25,7 @@ const {
   },
 } = ERROR_MESSAGES;
 
-context('Insurance - Policy and exports - About goods or services - form validation', () => {
+context('Insurance - Policy and exports - About goods or services page - form validation', () => {
   let referenceNumber;
 
   before(() => {

--- a/src/ui/server/controllers/insurance/policy-and-export/about-goods-or-services/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/about-goods-or-services/save-and-back/index.test.ts
@@ -1,0 +1,108 @@
+import { post } from '.';
+import { ROUTES } from '../../../../../constants';
+import { Request, Response } from '../../../../../../types';
+import mapAndSave from '../../map-and-save';
+import generateValidationErrors from '../validation';
+import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
+
+const {
+  INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS },
+} = ROUTES;
+
+describe('controllers/insurance/policy-and-export/about-goods-or-services/save-and-back', () => {
+  let req: Request;
+  let res: Response;
+
+  jest.mock('../../map-and-save');
+
+  let mockMapAndSave = jest.fn(() => Promise.resolve(true));
+  mapAndSave.policyAndExport = mockMapAndSave;
+
+  const refNumber = Number(mockApplication.referenceNumber);
+
+  const mockFormBody = {
+    _csrf: '1234',
+    mock: true,
+  };
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+
+    res.locals.application = mockApplication;
+    req.params.referenceNumber = String(mockApplication.referenceNumber);
+
+    req.body = mockFormBody;
+  });
+
+  describe('when the form has data', () => {
+    it('should call mapAndSave.policyAndExport with req.body, application and validationErrors', async () => {
+      await post(req, res);
+
+      const validationErrors = generateValidationErrors(req.body);
+
+      expect(mapAndSave.policyAndExport).toHaveBeenCalledTimes(1);
+      expect(mapAndSave.policyAndExport).toHaveBeenCalledWith(mockFormBody, res.locals.application, validationErrors);
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
+      await post(req, res);
+
+      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+
+      expect(res.redirect).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('when the form does not have any data', () => {
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
+      req.body = { _csrf: '1234' };
+
+      await post(req, res);
+
+      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+
+      expect(res.redirect).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('when there is no application', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
+    });
+
+    it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+      await post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+    });
+  });
+
+  describe('api error handling', () => {
+    describe('when the mapAndSave call does not return anything', () => {
+      beforeEach(() => {
+        mockMapAndSave = jest.fn(() => Promise.resolve(false));
+        mapAndSave.policyAndExport = mockMapAndSave;
+      });
+
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+      });
+    });
+
+    describe('when the mapAndSave call fails', () => {
+      beforeEach(() => {
+        mockMapAndSave = jest.fn(() => Promise.reject(new Error('Mock error')));
+        mapAndSave.policyAndExport = mockMapAndSave;
+      });
+
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/policy-and-export/about-goods-or-services/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/about-goods-or-services/save-and-back/index.ts
@@ -1,0 +1,43 @@
+import { ROUTES } from '../../../../../constants';
+import { Request, Response } from '../../../../../../types';
+import hasFormData from '../../../../../helpers/has-form-data';
+import generateValidationErrors from '../validation';
+// import callMapAndSave from '../call-map-and-save';
+
+const {
+  INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS },
+} = ROUTES;
+
+/**
+ * post
+ * Save any valid About goods or services page fields and if successful, redirect to the all sections page
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.redirect} All sections page or error page
+ */
+export const post = async (req: Request, res: Response) => {
+  try {
+    const { application } = res.locals;
+
+    if (!application) {
+      return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+    }
+
+    const { referenceNumber } = req.params;
+
+    if (hasFormData(req.body)) {
+      // const saveResponse = await callMapAndSave(req.body, application, generateValidationErrors(req.body));
+      const saveResponse = true;
+
+      if (!saveResponse) {
+        return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+      }
+    }
+
+    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`);
+  } catch (err) {
+    console.error('Error updating application', { err });
+
+    return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+  }
+};

--- a/src/ui/server/controllers/insurance/policy-and-export/about-goods-or-services/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/about-goods-or-services/save-and-back/index.ts
@@ -2,7 +2,7 @@ import { ROUTES } from '../../../../../constants';
 import { Request, Response } from '../../../../../../types';
 import hasFormData from '../../../../../helpers/has-form-data';
 import generateValidationErrors from '../validation';
-// import callMapAndSave from '../call-map-and-save';
+import callMapAndSave from '../../call-map-and-save';
 
 const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS },
@@ -26,8 +26,7 @@ export const post = async (req: Request, res: Response) => {
     const { referenceNumber } = req.params;
 
     if (hasFormData(req.body)) {
-      // const saveResponse = await callMapAndSave(req.body, application, generateValidationErrors(req.body));
-      const saveResponse = true;
+      const saveResponse = await callMapAndSave(req.body, application, generateValidationErrors(req.body));
 
       if (!saveResponse) {
         return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -23,7 +23,7 @@ describe('routes/insurance', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(26);
-    expect(post).toHaveBeenCalledTimes(23);
+    expect(post).toHaveBeenCalledTimes(24);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -9,6 +9,7 @@ import { post as singleContractPolicySaveAndBackPost } from '../../controllers/i
 import { get as multipleContractPolicyGet, post as multipleContractPolicyPost } from '../../controllers/insurance/policy-and-export/multiple-contract-policy';
 import { post as multipleContractPolicySaveAndBackPost } from '../../controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back';
 import { get as aboutGoodsOrServicesGet, post as aboutGoodsOrServicesPost } from '../../controllers/insurance/policy-and-export/about-goods-or-services';
+import { post as aboutGoodsOrServicesSaveAndBackPost } from '../../controllers/insurance/policy-and-export/about-goods-or-services/save-and-back';
 import { get as pageNotFoundGet } from '../../controllers/insurance/page-not-found';
 
 describe('routes/insurance', () => {
@@ -69,6 +70,10 @@ describe('routes/insurance', () => {
     expect(post).toHaveBeenCalledWith(
       `${INSURANCE_ROOT}/:referenceNumber${INSURANCE_ROUTES.POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES}`,
       aboutGoodsOrServicesPost,
+    );
+    expect(post).toHaveBeenCalledWith(
+      `${INSURANCE_ROOT}/:referenceNumber${INSURANCE_ROUTES.POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES_SAVE_AND_BACK}`,
+      aboutGoodsOrServicesSaveAndBackPost,
     );
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.PAGE_NOT_FOUND, pageNotFoundGet);

--- a/src/ui/server/routes/insurance/index.ts
+++ b/src/ui/server/routes/insurance/index.ts
@@ -11,6 +11,7 @@ import { post as singleContractPolicySaveAndBackPost } from '../../controllers/i
 import { get as multipleContractPolicyGet, post as multipleContractPolicyPost } from '../../controllers/insurance/policy-and-export/multiple-contract-policy';
 import { post as multipleContractPolicySaveAndBackPost } from '../../controllers/insurance/policy-and-export/multiple-contract-policy/save-and-back';
 import { get as aboutGoodsOrServicesGet, post as aboutGoodsOrServicesPost } from '../../controllers/insurance/policy-and-export/about-goods-or-services';
+import { post as aboutGoodsOrServicesSaveAndBackPost } from '../../controllers/insurance/policy-and-export/about-goods-or-services/save-and-back';
 import { get as pageNotFoundGet } from '../../controllers/insurance/page-not-found';
 import insuranceEligibilityRoutes from './eligibility';
 import insuranceBusinessRouter from './business';
@@ -51,6 +52,10 @@ insuranceRouter.post(
 
 insuranceRouter.get(`${INSURANCE_ROOT}/:referenceNumber${INSURANCE_ROUTES.POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES}`, aboutGoodsOrServicesGet);
 insuranceRouter.post(`${INSURANCE_ROOT}/:referenceNumber${INSURANCE_ROUTES.POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES}`, aboutGoodsOrServicesPost);
+insuranceRouter.post(
+  `${INSURANCE_ROOT}/:referenceNumber${INSURANCE_ROUTES.POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES_SAVE_AND_BACK}`,
+  aboutGoodsOrServicesSaveAndBackPost,
+);
 
 insuranceRouter.get(INSURANCE_ROUTES.PAGE_NOT_FOUND, pageNotFoundGet);
 


### PR DESCRIPTION
This PR adds "save and go back" functionality to the "about goods or services" page.

## Summary of changes

- Add save and go back route and controller
- Add E2E test coverage