### PR TITLE
fix(EMS-795):  Company Details - Companies house search heading and date

### DIFF
--- a/e2e-tests/content-strings/fields/insurance/exporter-business/index.js
+++ b/e2e-tests/content-strings/fields/insurance/exporter-business/index.js
@@ -2,7 +2,7 @@ import { FIELD_IDS } from '../../../../constants';
 
 export const EXPORTER_BUSINESS_FIELDS = {
   [FIELD_IDS.INSURANCE.EXPORTER_BUSINESS.COMPANY_HOUSE.SUMMARY_LIST]: {
-    LABEL: 'Your business',
+    LABEL: 'Your company',
     COMPANY_NUMBER: {
       text: 'Companies House registration number',
     },

--- a/src/ui/server/content-strings/pages/insurance/your-business/exporter-business/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/your-business/exporter-business/index.ts
@@ -8,7 +8,7 @@ const COMPANY_DETAILS = {
   WEBSITE: 'Enter your company website, if you have one (optional)',
   TABLE_NAME: 'Your company',
   NO_COMPANY_HOUSE_NUMER: 'I do not have a UK Companies House registration number',
-  YOUR_BUSINESS_HEADING: 'Your business',
+  YOUR_BUSINESS_HEADING: 'Your company',
   PHONE_NUMBER: 'Your UK telephone number (optional)',
   PHONE_NUMBER_HINT: 'We may need to contact you about your application',
 };

--- a/src/ui/server/helpers/summary-lists/company-house-summary-list.test.ts
+++ b/src/ui/server/helpers/summary-lists/company-house-summary-list.test.ts
@@ -84,7 +84,7 @@ describe('server/helpers/summary-lists/company-house-summary-list', () => {
             id: COMPANY_INCORPORATED,
             ...FIELDS[COMPANY_INCORPORATED],
             value: {
-              text: format(new Date(mockCompany[COMPANY_INCORPORATED]), 'dd MMMM yyyy'),
+              text: format(new Date(mockCompany[COMPANY_INCORPORATED]), 'd MMMM yyyy'),
             },
           },
           {

--- a/src/ui/server/helpers/summary-lists/company-house-summary-list.ts
+++ b/src/ui/server/helpers/summary-lists/company-house-summary-list.ts
@@ -68,7 +68,7 @@ const generateFieldGroups = (companyDetails: CompanyHouseResponse) => {
       id: COMPANY_INCORPORATED,
       ...FIELDS[COMPANY_INCORPORATED],
       value: {
-        text: format(new Date(companyDetails[COMPANY_INCORPORATED]), 'dd MMMM yyyy'),
+        text: format(new Date(companyDetails[COMPANY_INCORPORATED]), 'd MMMM yyyy'),
       },
     },
     {


### PR DESCRIPTION
# Issue: 
* Companies house summary list had incorrect heading
* Companies house summary list date was in the wrong format

# Changes made:
* Changed title of summary list
* Changed date to be one digit for day if between 1-9
* Updated tests