### PR TITLE
fix(EMS-792-810): Policy end exports - pre-population issues

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-credit-period-with-buyer.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-credit-period-with-buyer.spec.js
@@ -81,10 +81,14 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
   });
 
   describe('when credit period with buyer is above the maximum', () => {
-    it('should render a validation error', () => {
-      field.input().type('a'.repeat(1001), { delay: 0 });
-      submitButton().click();
+    const submittedValue = 'a'.repeat(1001);
 
+    before(() => {
+      field.input().type(submittedValue, { delay: 0 });
+      submitButton().click();
+    });
+
+    it('should render a validation error', () => {
       checkText(
         partials.errorSummaryListItems().eq(4),
         CONTRACT_ERROR_MESSAGES[CREDIT_PERIOD_WITH_BUYER].ABOVE_MAXIMUM,
@@ -94,6 +98,10 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
         field.errorMessage(),
         `Error: ${CONTRACT_ERROR_MESSAGES[CREDIT_PERIOD_WITH_BUYER].ABOVE_MAXIMUM}`,
       );
+    });
+
+    it('should retain the submitted value', () => {
+      field.input().should('have.value', submittedValue);
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
@@ -1,9 +1,11 @@
 import { submitButton } from '../../../../../pages/shared';
+import { multipleContractPolicyPage } from '../../../../../pages/insurance/policy-and-export';
 import partials from '../../../../../partials';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { FIELD_IDS, FIELD_VALUES, ROUTES } from '../../../../../../../constants';
 import getReferenceNumber from '../../../../../helpers/get-reference-number';
 import checkText from '../../../../../helpers/check-text';
+import application from '../../../../../../fixtures/application';
 
 const { taskList } = partials.insurancePartials;
 
@@ -101,5 +103,15 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
       partials.errorSummaryListItems().eq(5),
       CONTRACT_ERROR_MESSAGES[POLICY_CURRENCY_CODE].IS_EMPTY,
     );
+  });
+
+  describe(`when ${POLICY_CURRENCY_CODE} is submitted but there are other validation errors`, () => {
+    it(`should retain the submitted ${POLICY_CURRENCY_CODE}`, () => {
+      const currencyCode = application.POLICY_AND_EXPORTS[POLICY_CURRENCY_CODE];
+
+      multipleContractPolicyPage[POLICY_CURRENCY_CODE].input().select(currencyCode);
+
+      multipleContractPolicyPage[POLICY_CURRENCY_CODE].inputOptionSelected().contains(currencyCode);
+    });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-credit-period-with-buyer.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-credit-period-with-buyer.spec.js
@@ -76,11 +76,15 @@ context('Insurance - Policy and exports - Single contract policy page - form val
     });
   });
 
-  describe('when total contract value is above the maximum', () => {
-    it('should render a validation error', () => {
-      field.input().type('a'.repeat(1001), { delay: 0 });
-      submitButton().click();
+  describe('when credit period with buyer is above the maximum', () => {
+    const submittedValue = 'a'.repeat(1001);
 
+    before(() => {
+      field.input().type(submittedValue, { delay: 0 });
+      submitButton().click();
+    });
+
+    it('should render a validation error', () => {
       checkText(
         partials.errorSummaryListItems().eq(3),
         CONTRACT_ERROR_MESSAGES[CREDIT_PERIOD_WITH_BUYER].ABOVE_MAXIMUM,
@@ -90,6 +94,10 @@ context('Insurance - Policy and exports - Single contract policy page - form val
         field.errorMessage(),
         `Error: ${CONTRACT_ERROR_MESSAGES[CREDIT_PERIOD_WITH_BUYER].ABOVE_MAXIMUM}`,
       );
+    });
+
+    it('should retain the submitted value', () => {
+      field.input().should('have.value', submittedValue);
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation.spec.js
@@ -1,9 +1,11 @@
 import { submitButton } from '../../../../../pages/shared';
+import { singleContractPolicyPage } from '../../../../../pages/insurance/policy-and-export';
 import partials from '../../../../../partials';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { FIELD_IDS, FIELD_VALUES, ROUTES } from '../../../../../../../constants';
 import getReferenceNumber from '../../../../../helpers/get-reference-number';
 import checkText from '../../../../../helpers/check-text';
+import application from '../../../../../../fixtures/application';
 
 const { taskList } = partials.insurancePartials;
 
@@ -95,5 +97,15 @@ context('Insurance - Policy and exports - Single contract policy page - form val
       partials.errorSummaryListItems().eq(4),
       CONTRACT_ERROR_MESSAGES[POLICY_CURRENCY_CODE].IS_EMPTY,
     );
+  });
+
+  describe(`when ${POLICY_CURRENCY_CODE} is submitted but there are other validation errors`, () => {
+    it(`should retain the submitted ${POLICY_CURRENCY_CODE}`, () => {
+      const currencyCode = application.POLICY_AND_EXPORTS[POLICY_CURRENCY_CODE];
+
+      singleContractPolicyPage[POLICY_CURRENCY_CODE].input().select(currencyCode);
+
+      singleContractPolicyPage[POLICY_CURRENCY_CODE].inputOptionSelected().contains(currencyCode);
+    });
   });
 });

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/index.test.ts
@@ -48,6 +48,8 @@ describe('controllers/insurance/policy-and-export/single-contract-policy', () =>
     },
   };
 
+  const currencyCode = mockCurrencies[0].isoCode;
+
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
@@ -282,6 +284,36 @@ describe('controllers/insurance/policy-and-export/single-contract-policy', () =>
         };
 
         expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
+      });
+
+      describe('when a policy currency code is submitted', () => {
+        const mockFormBody = {
+          [POLICY_CURRENCY_CODE]: currencyCode,
+        };
+
+        beforeEach(() => {
+          req.body = mockFormBody;
+        });
+
+        it('should render template with currencies mapped to submitted currency', async () => {
+          await post(req, res);
+
+          const expectedCurrencies = mapCurrencies(mockCurrencies, currencyCode);
+
+          const expectedVariables = {
+            ...insuranceCorePageVariables({
+              PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY_AND_EXPORTS.SINGLE_CONTRACT_POLICY,
+              BACK_LINK: req.headers.referer,
+            }),
+            ...pageVariables(refNumber),
+            application: mapApplicationToFormFields(mockApplicationWithoutCurrencyCode),
+            submittedValues: req.body,
+            currencies: expectedCurrencies,
+            validationErrors: generateValidationErrors(req.body),
+          };
+
+          expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
+        });
       });
     });
 

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/index.ts
@@ -137,7 +137,13 @@ export const post = async (req: Request, res: Response) => {
         return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
       }
 
-      const mappedCurrencies = mapCurrencies(currencies);
+      let mappedCurrencies;
+
+      if (objectHasProperty(req.body, POLICY_CURRENCY_CODE)) {
+        mappedCurrencies = mapCurrencies(currencies, req.body[POLICY_CURRENCY_CODE]);
+      } else {
+        mappedCurrencies = mapCurrencies(currencies);
+      }
 
       return res.render(TEMPLATE, {
         ...insuranceCorePageVariables({

--- a/src/ui/templates/insurance/policy-and-exports/multiple-contract-policy.njk
+++ b/src/ui/templates/insurance/policy-and-exports/multiple-contract-policy.njk
@@ -190,7 +190,7 @@
             'data-cy': FIELDS.CREDIT_PERIOD_WITH_BUYER.ID + '-input'
           },
           maxlength: FIELDS.CREDIT_PERIOD_WITH_BUYER.MAXIMUM,
-          value: submittedValues[FIELDS.TOTAL_CONTRACT_VALUE.ID] or application.policyAndExport[FIELDS.CREDIT_PERIOD_WITH_BUYER.ID],
+          value: submittedValues[FIELDS.CREDIT_PERIOD_WITH_BUYER.ID] or application.policyAndExport[FIELDS.CREDIT_PERIOD_WITH_BUYER.ID],
           errorMessage: validationErrors.errorList[FIELDS.CREDIT_PERIOD_WITH_BUYER.ID] and {
             text: validationErrors.errorList[FIELDS.CREDIT_PERIOD_WITH_BUYER.ID].text,
             attributes: {

--- a/src/ui/templates/insurance/policy-and-exports/single-contract-policy.njk
+++ b/src/ui/templates/insurance/policy-and-exports/single-contract-policy.njk
@@ -124,7 +124,7 @@
             'data-cy': FIELDS.CREDIT_PERIOD_WITH_BUYER.ID + '-input'
           },
           maxlength: FIELDS.CREDIT_PERIOD_WITH_BUYER.MAXIMUM,
-          value: submittedValues[FIELDS.TOTAL_CONTRACT_VALUE.ID] or application.policyAndExport[FIELDS.CREDIT_PERIOD_WITH_BUYER.ID],
+          value: submittedValues[FIELDS.CREDIT_PERIOD_WITH_BUYER.ID] or application.policyAndExport[FIELDS.CREDIT_PERIOD_WITH_BUYER.ID],
           errorMessage: validationErrors.errorList[FIELDS.CREDIT_PERIOD_WITH_BUYER.ID] and {
             text: validationErrors.errorList[FIELDS.CREDIT_PERIOD_WITH_BUYER.ID].text,
             attributes: {


### PR DESCRIPTION
This PR fixes two issues in the single/multiple policy type page where:

- After submitting the form and revisiting the page, the "credit period with buyer" field would render an incorrect value.
- When submitting the form with a currency selection, but there are other validation errors, previously selected currency would not be auto selected.

## Changes

- Add currency mapping to the single and multiple POST controllers.
- Fix a typo in the templates for single and multiple "credit period with buyer" field.