### PR TITLE
chore(EMS-787): use constants instead of hard coded currency codes

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -1,11 +1,7 @@
 import { FIELD_IDS, PRODUCT } from '../constants';
+import formatCurrency from '../cypress/e2e/helpers/format-currency';
 
-export const MAX_COVER_AMOUNT = PRODUCT.MAX_COVER_AMOUNT_IN_GBP.toLocaleString('en', {
-  style: 'currency',
-  currency: 'GBP',
-  minimumFractionDigits: 0,
-  maximumFractionDigits: 0,
-});
+export const MAX_COVER_AMOUNT = formatCurrency(PRODUCT.MAX_COVER_AMOUNT_IN_GBP);
 
 export const ERROR_MESSAGES = {
   [FIELD_IDS.BUYER_COUNTRY]: 'Select where your buyer is based',

--- a/e2e-tests/content-strings/pages/insurance/eligibility/index.js
+++ b/e2e-tests/content-strings/pages/insurance/eligibility/index.js
@@ -1,11 +1,7 @@
 import { PRODUCT } from '../../../../constants';
+import formatCurrency from '../../../../cypress/e2e/helpers/format-currency';
 
-export const MAX_COVER_AMOUNT = PRODUCT.MAX_COVER_AMOUNT_IN_GBP.toLocaleString('en', {
-  style: 'currency',
-  currency: 'GBP',
-  minimumFractionDigits: 0,
-  maximumFractionDigits: 0,
-});
+export const MAX_COVER_AMOUNT = formatCurrency(PRODUCT.MAX_COVER_AMOUNT_IN_GBP);
 
 export const CHECK_IF_ELIGIBLE = {
   PAGE_TITLE: 'Check you can apply for UKEF insurance for your export',

--- a/e2e-tests/content-strings/pages/insurance/index.js
+++ b/e2e-tests/content-strings/pages/insurance/index.js
@@ -3,13 +3,9 @@ import * as ELIGIBILITY_PAGES from './eligibility';
 import * as EXPORTER_BUSINESS from './exporter-business';
 import { LINKS } from '../../links';
 import { PRODUCT } from '../../../constants';
+import formatCurrency from '../../../cypress/e2e/helpers/format-currency';
 
-export const MAX_COVER_AMOUNT = PRODUCT.MAX_COVER_AMOUNT_IN_GBP.toLocaleString('en', {
-  style: 'currency',
-  currency: 'GBP',
-  minimumFractionDigits: 0,
-  maximumFractionDigits: 0,
-});
+export const MAX_COVER_AMOUNT = formatCurrency(PRODUCT.MAX_COVER_AMOUNT_IN_GBP);
 
 const ALL_SECTIONS = {
   PAGE_TITLE: 'Apply for UKEF export insurance',

--- a/e2e-tests/cypress/e2e/helpers/format-currency.js
+++ b/e2e-tests/cypress/e2e/helpers/format-currency.js
@@ -1,6 +1,8 @@
+import { GBP_CURRENCY_CODE } from '../../fixtures/currencies';
+
 const formatCurrency = (str) => Number(str).toLocaleString('en', {
   style: 'currency',
-  currency: 'GBP',
+  currency: GBP_CURRENCY_CODE,
   minimumFractionDigits: 0,
 });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy-validation.spec.js
@@ -11,6 +11,7 @@ import partials from '../../../partials';
 import { ERROR_MESSAGES } from '../../../../../content-strings';
 import { FIELD_IDS } from '../../../../../constants';
 import checkText from '../../../helpers/check-text';
+import { GBP_CURRENCY_CODE } from '../../../../fixtures/currencies';
 
 context('Tell us about the multi policy you need - form validation', () => {
   beforeEach(() => {
@@ -172,12 +173,12 @@ context('Tell us about the multi policy you need - form validation', () => {
 
   describe('with any validation error', () => {
     it('should render submitted values', () => {
-      tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].input().select('GBP');
+      tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].input().select(GBP_CURRENCY_CODE);
       tellUsAboutYourPolicyPage[FIELD_IDS.MAX_AMOUNT_OWED].input().clear().type('10');
 
       submitButton().click();
 
-      tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].inputOptionSelected().contains('GBP');
+      tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].inputOptionSelected().contains(GBP_CURRENCY_CODE);
 
       tellUsAboutYourPolicyPage[FIELD_IDS.MAX_AMOUNT_OWED].input()
         .should('have.attr', 'value', '10');

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
@@ -16,6 +16,7 @@ import {
   PAGES,
 } from '../../../../../content-strings';
 import { ROUTES, FIELD_IDS, SUPPORTED_CURRENCIES } from '../../../../../constants';
+import { GBP_CURRENCY_CODE } from '../../../../fixtures/currencies';
 
 const CONTENT_STRINGS = PAGES.QUOTE.TELL_US_ABOUT_YOUR_POLICY;
 
@@ -216,7 +217,7 @@ context('Tell us about your multi policy page - as an exporter, I want to provid
   describe('when form is valid', () => {
     it(`should redirect to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`, () => {
       tellUsAboutYourPolicyPage[FIELD_IDS.MAX_AMOUNT_OWED].input().type('100');
-      tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].input().select('GBP');
+      tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].input().select(GBP_CURRENCY_CODE);
       tellUsAboutYourPolicyPage[FIELD_IDS.PERCENTAGE_OF_COVER].input().select('90');
       tellUsAboutYourPolicyPage[FIELD_IDS.CREDIT_PERIOD].input().select('1');
 

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy-validation.spec.js
@@ -11,6 +11,7 @@ import partials from '../../../partials';
 import { ERROR_MESSAGES } from '../../../../../content-strings';
 import { FIELD_IDS } from '../../../../../constants';
 import checkText from '../../../helpers/check-text';
+import { GBP_CURRENCY_CODE } from '../../../../fixtures/currencies';
 
 context('Tell us about the policy you need page - form validation', () => {
   beforeEach(() => {
@@ -141,12 +142,12 @@ context('Tell us about the policy you need page - form validation', () => {
 
   describe('with any validation error', () => {
     it('should render submitted values', () => {
-      tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].input().select('GBP');
+      tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].input().select(GBP_CURRENCY_CODE);
       tellUsAboutYourPolicyPage[FIELD_IDS.CONTRACT_VALUE].input().clear().type('10');
 
       submitButton().click();
 
-      tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].inputOptionSelected().contains('GBP');
+      tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].inputOptionSelected().contains(GBP_CURRENCY_CODE);
 
       tellUsAboutYourPolicyPage[FIELD_IDS.CONTRACT_VALUE].input()
         .should('have.attr', 'value', '10');

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
@@ -16,6 +16,7 @@ import {
   PAGES,
 } from '../../../../../content-strings';
 import { ROUTES, FIELD_IDS, SUPPORTED_CURRENCIES } from '../../../../../constants';
+import { GBP_CURRENCY_CODE } from '../../../../fixtures/currencies';
 
 const CONTENT_STRINGS = PAGES.QUOTE.TELL_US_ABOUT_YOUR_POLICY;
 
@@ -183,7 +184,7 @@ context('Tell us about your single policy page - as an exporter, I want to provi
   describe('when form is valid', () => {
     it(`should redirect to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`, () => {
       tellUsAboutYourPolicyPage[FIELD_IDS.CONTRACT_VALUE].input().type('100');
-      tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].input().select('GBP');
+      tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].input().select(GBP_CURRENCY_CODE);
       tellUsAboutYourPolicyPage[FIELD_IDS.PERCENTAGE_OF_COVER].input().select('90');
 
       submitButton().click();

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-kenya-single-policy-USD.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-kenya-single-policy-USD.spec.js
@@ -11,6 +11,7 @@ import {
   yourQuotePage,
 } from '../../../pages/quote';
 import { ROUTES, FIELD_IDS } from '../../../../../constants';
+import { USD_CURRENCY_CODE } from '../../../../fixtures/currencies';
 
 const {
   CONTRACT_VALUE,
@@ -44,7 +45,7 @@ context('Get a quote/your quote page (single policy, Kenya, USD) - as an exporte
 
   it('should get a quote with a large contract value and render in the correct format', () => {
     tellUsAboutYourPolicyPage[FIELD_IDS.CONTRACT_VALUE].input().type('100,000');
-    tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].input().select('USD');
+    tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].input().select(USD_CURRENCY_CODE);
     tellUsAboutYourPolicyPage[FIELD_IDS.PERCENTAGE_OF_COVER].input().select('80');
 
     submitButton().click();

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-large-contract-value.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-large-contract-value.spec.js
@@ -12,6 +12,7 @@ import {
   checkYourAnswersPage,
 } from '../../../pages/quote';
 import { ROUTES, FIELD_IDS } from '../../../../../constants';
+import { GBP_CURRENCY_CODE } from '../../../../fixtures/currencies';
 
 const {
   CONTRACT_VALUE,
@@ -35,7 +36,7 @@ context('Get a quote/your quote page (large contract value) - as an exporter, I 
 
   it('should get a quote with a large contract value and render in the correct format', () => {
     tellUsAboutYourPolicyPage[FIELD_IDS.CONTRACT_VALUE].input().type('12,345,678');
-    tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].input().select('GBP');
+    tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].input().select(GBP_CURRENCY_CODE);
     tellUsAboutYourPolicyPage[FIELD_IDS.PERCENTAGE_OF_COVER].input().select('90');
 
     submitButton().click();

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-non-gbp-currency.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-non-gbp-currency.spec.js
@@ -6,6 +6,7 @@ import {
 } from '../../../pages/quote';
 import { QUOTE_TITLES } from '../../../../../content-strings';
 import { ROUTES, FIELD_IDS } from '../../../../../constants';
+import { EUR_CURRENCY_CODE } from '../../../../fixtures/currencies';
 
 const {
   CONTRACT_VALUE,
@@ -27,7 +28,7 @@ context('Get a quote/your quote page (non GBP currency) - as an exporter, I want
     // change currency to non-GBP
     checkYourAnswersPage.summaryLists.policy[CONTRACT_VALUE].changeLink().click();
 
-    tellUsAboutYourPolicyPage[CURRENCY].input().select('EUR');
+    tellUsAboutYourPolicyPage[CURRENCY].input().select(EUR_CURRENCY_CODE);
     submitButton().click();
 
     submitButton().click();

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
@@ -7,6 +7,7 @@ import {
   QUOTE_TITLES,
 } from '../../../../../content-strings';
 import { ROUTES, FIELD_IDS, FIELD_VALUES } from '../../../../../constants';
+import { GBP_CURRENCY_CODE } from '../../../../fixtures/currencies';
 
 const CONTENT_STRINGS = PAGES.QUOTE.YOUR_QUOTE;
 
@@ -34,7 +35,7 @@ const submissionData = {
   [BUYER_COUNTRY]: 'Algeria',
   [HAS_MINIMUM_UK_GOODS_OR_SERVICES]: true,
   [CONTRACT_VALUE]: '150000',
-  [CURRENCY]: 'GBP',
+  [CURRENCY]: GBP_CURRENCY_CODE,
   [SINGLE_POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.SINGLE,
   [SINGLE_POLICY_LENGTH]: '3',
   [CREDIT_PERIOD]: '1',

--- a/e2e-tests/cypress/fixtures/application.js
+++ b/e2e-tests/cypress/fixtures/application.js
@@ -4,7 +4,7 @@ import {
   getYear,
 } from 'date-fns';
 import { FIELD_IDS } from '../../constants';
-import { GBP_CURRENCY_CODE } from '../fixtures/currencies';
+import { GBP_CURRENCY_CODE } from './currencies';
 
 const {
   INSURANCE: {

--- a/e2e-tests/cypress/fixtures/application.js
+++ b/e2e-tests/cypress/fixtures/application.js
@@ -4,6 +4,7 @@ import {
   getYear,
 } from 'date-fns';
 import { FIELD_IDS } from '../../constants';
+import { GBP_CURRENCY_CODE } from '../fixtures/currencies';
 
 const {
   INSURANCE: {
@@ -41,7 +42,7 @@ const application = {
     },
     [TOTAL_CONTRACT_VALUE]: '10000',
     [CREDIT_PERIOD_WITH_BUYER]: 'mock free text',
-    [POLICY_CURRENCY_CODE]: 'GBP',
+    [POLICY_CURRENCY_CODE]: GBP_CURRENCY_CODE,
     [TOTAL_MONTHS_OF_COVER]: '2',
     [TOTAL_SALES_TO_BUYER]: '1000',
     [MAXIMUM_BUYER_WILL_OWE]: '500',

--- a/e2e-tests/cypress/fixtures/currencies.js
+++ b/e2e-tests/cypress/fixtures/currencies.js
@@ -1,19 +1,24 @@
+export const EUR_CURRENCY_CODE = 'EUR';
+export const GBP_CURRENCY_CODE = 'GBP';
+export const HKD_CURRENCY_CODE = 'HKD';
+export const USD_CURRENCY_CODE = 'USD';
+
 const mockCurrencies = [
   {
     name: 'Euros',
-    isoCode: 'EUR',
+    isoCode: EUR_CURRENCY_CODE,
   },
   {
     name: 'Hong Kong Dollars',
-    isoCode: 'HKD',
+    isoCode: HKD_CURRENCY_CODE,
   },
   {
     name: 'UK Sterling',
-    isoCode: 'GBP',
+    isoCode: GBP_CURRENCY_CODE,
   },
   {
     name: 'US Dollars',
-    isoCode: 'USD',
+    isoCode: USD_CURRENCY_CODE,
   },
 ];
 

--- a/e2e-tests/cypress/support/quote/forms.js
+++ b/e2e-tests/cypress/support/quote/forms.js
@@ -1,6 +1,7 @@
 import { yesRadio, noRadio, submitButton } from '../../e2e/pages/shared';
 import { policyTypePage, tellUsAboutYourPolicyPage } from '../../e2e/pages/quote';
 import { FIELD_IDS } from '../../../constants';
+import { GBP_CURRENCY_CODE } from '../../fixtures/currencies';
 
 const {
   CONTRACT_VALUE,
@@ -41,14 +42,14 @@ export const completeAndSubmitPolicyTypeMultiForm = () => {
 };
 
 export const completeAndSubmitTellUsAboutYourSinglePolicyForm = () => {
-  tellUsAboutYourPolicyPage[CURRENCY].input().select('GBP');
+  tellUsAboutYourPolicyPage[CURRENCY].input().select(GBP_CURRENCY_CODE);
   tellUsAboutYourPolicyPage[CONTRACT_VALUE].input().type('150000');
   tellUsAboutYourPolicyPage[PERCENTAGE_OF_COVER].input().select('90');
   submitButton().click();
 };
 
 export const completeAndSubmitTellUsAboutYourMultiPolicyForm = () => {
-  tellUsAboutYourPolicyPage[CURRENCY].input().select('GBP');
+  tellUsAboutYourPolicyPage[CURRENCY].input().select(GBP_CURRENCY_CODE);
   tellUsAboutYourPolicyPage[MAX_AMOUNT_OWED].input().type('150000');
   tellUsAboutYourPolicyPage[PERCENTAGE_OF_COVER].input().select('90');
   tellUsAboutYourPolicyPage[CREDIT_PERIOD].input().select('1');

--- a/src/ui/server/constants/currencies.ts
+++ b/src/ui/server/constants/currencies.ts
@@ -1,0 +1,1 @@
+export const GBP_CURRENCY_CODE = 'GBP';

--- a/src/ui/server/constants/index.ts
+++ b/src/ui/server/constants/index.ts
@@ -1,5 +1,6 @@
 export * from './api';
 export * from './application';
+export * from './currencies';
 export * from './field-ids';
 export * from './field-values';
 export * from './percentages-of-cover';

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -1,11 +1,11 @@
-import { FIELD_IDS, PRODUCT } from '../constants';
+import { FIELD_IDS, GBP_CURRENCY_CODE, PRODUCT } from '../constants';
 import formatCurrency from '../helpers/format-currency';
 
 type ErrorMessage = {
   [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 };
 
-const MAX_COVER_AMOUNT = formatCurrency(PRODUCT.MAX_COVER_AMOUNT_IN_GBP, 'GBP', 0);
+const MAX_COVER_AMOUNT = formatCurrency(PRODUCT.MAX_COVER_AMOUNT_IN_GBP, GBP_CURRENCY_CODE, 0);
 
 export const ERROR_MESSAGES = {
   [FIELD_IDS.BUYER_COUNTRY]: 'Select where your buyer is based',

--- a/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
@@ -1,7 +1,7 @@
-import { PRODUCT } from '../../../../constants';
+import { GBP_CURRENCY_CODE, PRODUCT } from '../../../../constants';
 import formatCurrency from '../../../../helpers/format-currency';
 
-const MAX_COVER_AMOUNT = formatCurrency(PRODUCT.MAX_COVER_AMOUNT_IN_GBP, 'GBP', 0);
+const MAX_COVER_AMOUNT = formatCurrency(PRODUCT.MAX_COVER_AMOUNT_IN_GBP, GBP_CURRENCY_CODE, 0);
 
 const CHECK_IF_ELIGIBLE = {
   PAGE_TITLE: 'Check you can apply for UKEF insurance for your export',

--- a/src/ui/server/content-strings/pages/insurance/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/index.ts
@@ -1,4 +1,4 @@
-import { PRODUCT } from '../../../constants';
+import { GBP_CURRENCY_CODE, PRODUCT } from '../../../constants';
 import { LINKS } from '../../links';
 import ELIGIBILITY from './eligibility';
 import POLICY_AND_EXPORTS from './policy-and-exports';
@@ -6,7 +6,7 @@ import EXPORTER_BUSINESS from './your-business';
 import YOUR_BUYER from './your-buyer';
 import formatCurrency from '../../../helpers/format-currency';
 
-const MAX_COVER_AMOUNT = formatCurrency(PRODUCT.MAX_COVER_AMOUNT_IN_GBP, 'GBP', 0);
+const MAX_COVER_AMOUNT = formatCurrency(PRODUCT.MAX_COVER_AMOUNT_IN_GBP, GBP_CURRENCY_CODE, 0);
 
 const ALL_SECTIONS = {
   PAGE_TITLE: 'Apply for UKEF export insurance',

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/index.test.ts
@@ -1,6 +1,6 @@
 import { add, getMonth, getYear } from 'date-fns';
 import { pageVariables, TEMPLATE, totalMonthsOfCoverOptions, get, post } from '.';
-import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
+import { FIELD_IDS, GBP_CURRENCY_CODE, ROUTES, TEMPLATES } from '../../../../constants';
 import { PAGES } from '../../../../content-strings';
 import { POLICY_AND_EXPORTS_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance';
 import { Request, Response } from '../../../../../types';
@@ -283,7 +283,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy', () 
       [TOTAL_SALES_TO_BUYER]: '1000',
       [MAXIMUM_BUYER_WILL_OWE]: '500',
       [CREDIT_PERIOD_WITH_BUYER]: 'Mock',
-      [POLICY_CURRENCY_CODE]: 'GBP',
+      [POLICY_CURRENCY_CODE]: GBP_CURRENCY_CODE,
     };
 
     describe('when there are no validation errors', () => {

--- a/src/ui/server/controllers/quote/check-your-answers/index.test.ts
+++ b/src/ui/server/controllers/quote/check-your-answers/index.test.ts
@@ -1,6 +1,6 @@
 import { TEMPLATE, get, post } from '.';
 import { PAGES } from '../../../content-strings';
-import { FIELD_IDS, FIELD_VALUES, ROUTES, TEMPLATES } from '../../../constants';
+import { FIELD_IDS, FIELD_VALUES, GBP_CURRENCY_CODE, ROUTES, TEMPLATES } from '../../../constants';
 import { mapAnswersToContent } from '../../../helpers/data-content-mappings/map-answers-to-content';
 import { answersSummaryList } from '../../../helpers/summary-lists/answers-summary-list';
 import corePageVariables from '../../../helpers/page-variables/core/quote';
@@ -22,7 +22,7 @@ describe('controllers/quote/check-your-answers', () => {
       [CREDIT_PERIOD]: 2,
       [CURRENCY]: {
         name: 'UK Sterling',
-        isoCode: 'GBP',
+        isoCode: GBP_CURRENCY_CODE,
       },
       [MAX_AMOUNT_OWED]: 1234,
       [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.MULTI,

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/validation/rules/currency.test.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/validation/rules/currency.test.ts
@@ -1,5 +1,5 @@
 import rule from './currency';
-import { FIELD_IDS } from '../../../../../constants';
+import { FIELD_IDS, GBP_CURRENCY_CODE } from '../../../../../constants';
 import { ERROR_MESSAGES } from '../../../../../content-strings';
 import generateValidationErrors from '../../../../../helpers/validation';
 
@@ -26,7 +26,7 @@ describe('controllers/quote/tell-us-about-your-policy/validation/rules/currency'
   describe('when there are no validation errors', () => {
     it('should return the already provided errors', () => {
       const mockSubmittedData = {
-        [FIELD_IDS.CURRENCY]: 'GBP',
+        [FIELD_IDS.CURRENCY]: GBP_CURRENCY_CODE,
       };
 
       const result = rule(mockSubmittedData, mockErrors);

--- a/src/ui/server/helpers/data-content-mappings/map-cost.test.ts
+++ b/src/ui/server/helpers/data-content-mappings/map-cost.test.ts
@@ -1,6 +1,6 @@
 import mapCost from './map-cost';
 import formatCurrency from '../format-currency';
-import { FIELD_IDS, FIELD_VALUES } from '../../constants';
+import { FIELD_IDS, FIELD_VALUES, GBP_CURRENCY_CODE } from '../../constants';
 import { SubmittedDataQuoteEligibility } from '../../../types';
 
 const { CONTRACT_VALUE, CURRENCY, MAX_AMOUNT_OWED, POLICY_TYPE } = FIELD_IDS;
@@ -11,7 +11,7 @@ describe('server/helpers/data-content-mappings/map-cost', () => {
       const mockDataSinglePolicyType = {
         [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.SINGLE,
         [CURRENCY]: {
-          isoCode: 'GBP',
+          isoCode: GBP_CURRENCY_CODE,
         },
         [CONTRACT_VALUE]: 10,
       } as SubmittedDataQuoteEligibility;
@@ -31,7 +31,7 @@ describe('server/helpers/data-content-mappings/map-cost', () => {
       const mockDataMultiPolicyType = {
         [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.MULTI,
         [CURRENCY]: {
-          isoCode: 'GBP',
+          isoCode: GBP_CURRENCY_CODE,
         },
         [MAX_AMOUNT_OWED]: 10,
       } as SubmittedDataQuoteEligibility;

--- a/src/ui/server/helpers/format-currency/index.test.ts
+++ b/src/ui/server/helpers/format-currency/index.test.ts
@@ -1,8 +1,9 @@
 import formatCurrency from '.';
+import { GBP_CURRENCY_CODE } from '../../constants';
 
 describe('server/helpers/format-currency', () => {
   const mock = 123456;
-  const currencyCode = 'GBP';
+  const currencyCode = GBP_CURRENCY_CODE;
 
   it('should return a formatted currency', () => {
     const result = formatCurrency(mock, currencyCode, 2);

--- a/src/ui/server/helpers/summary-lists/policy-and-export/multiple-contract-policy-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/policy-and-export/multiple-contract-policy-fields/index.test.ts
@@ -1,6 +1,6 @@
 import generateMultipleContractPolicyFields from '.';
 import { POLICY_AND_EXPORTS_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance';
-import { FIELD_IDS } from '../../../../constants';
+import { FIELD_IDS, GBP_CURRENCY_CODE } from '../../../../constants';
 import fieldGroupItem from '../../generate-field-group-item';
 import getFieldById from '../../../get-field-by-id';
 import formatCurrency from '../../../format-currency';
@@ -36,14 +36,14 @@ describe('server/helpers/summary-lists/policy-and-export/multiple-contract-polic
           field: getFieldById(FIELDS.CONTRACT_POLICY.MULTIPLE, TOTAL_SALES_TO_BUYER),
           data: mockAnswers,
         },
-        formatCurrency(mockAnswers[TOTAL_SALES_TO_BUYER], 'GBP'),
+        formatCurrency(mockAnswers[TOTAL_SALES_TO_BUYER], GBP_CURRENCY_CODE),
       ),
       fieldGroupItem(
         {
           field: getFieldById(FIELDS.CONTRACT_POLICY.MULTIPLE, MAXIMUM_BUYER_WILL_OWE),
           data: mockAnswers,
         },
-        formatCurrency(mockAnswers[MAXIMUM_BUYER_WILL_OWE], 'GBP'),
+        formatCurrency(mockAnswers[MAXIMUM_BUYER_WILL_OWE], GBP_CURRENCY_CODE),
       ),
     ];
 

--- a/src/ui/server/helpers/summary-lists/policy-and-export/multiple-contract-policy-fields/index.ts
+++ b/src/ui/server/helpers/summary-lists/policy-and-export/multiple-contract-policy-fields/index.ts
@@ -1,4 +1,5 @@
 import { POLICY_AND_EXPORTS_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance';
+import { GBP_CURRENCY_CODE } from '../../../../constants';
 import FIELD_IDS from '../../../../constants/field-ids/insurance/policy-and-exports';
 import fieldGroupItem from '../../generate-field-group-item';
 import getFieldById from '../../../get-field-by-id';
@@ -32,14 +33,14 @@ const generateMultipleContractPolicyFields = (answers: ApplicationPolicyAndExpor
         field: getFieldById(FIELDS.CONTRACT_POLICY.MULTIPLE, TOTAL_SALES_TO_BUYER),
         data: answers,
       },
-      formatCurrency(answers[TOTAL_SALES_TO_BUYER], 'GBP'),
+      formatCurrency(answers[TOTAL_SALES_TO_BUYER], GBP_CURRENCY_CODE),
     ),
     fieldGroupItem(
       {
         field: getFieldById(FIELDS.CONTRACT_POLICY.MULTIPLE, MAXIMUM_BUYER_WILL_OWE),
         data: answers,
       },
-      formatCurrency(answers[MAXIMUM_BUYER_WILL_OWE], 'GBP'),
+      formatCurrency(answers[MAXIMUM_BUYER_WILL_OWE], GBP_CURRENCY_CODE),
     ),
   ] as Array<SummaryListItemData>;
 

--- a/src/ui/server/helpers/summary-lists/policy-and-export/single-contract-policy-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/policy-and-export/single-contract-policy-fields/index.test.ts
@@ -1,6 +1,6 @@
 import generateSingleContractPolicyFields from '.';
 import { POLICY_AND_EXPORTS_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance';
-import { FIELD_IDS } from '../../../../constants';
+import { FIELD_IDS, GBP_CURRENCY_CODE } from '../../../../constants';
 import fieldGroupItem from '../../generate-field-group-item';
 import getFieldById from '../../../get-field-by-id';
 import formatDate from '../../../date/format-date';
@@ -24,8 +24,11 @@ describe('server/helpers/summary-lists/policy-and-export/single-contract-policy-
     const result = generateSingleContractPolicyFields(mockAnswers);
 
     const expected = [
+      fieldGroupItem(
+        { field: getFieldById(FIELDS.CONTRACT_POLICY.SINGLE, TOTAL_CONTRACT_VALUE) },
+        formatCurrency(mockAnswers[TOTAL_CONTRACT_VALUE], GBP_CURRENCY_CODE),
+      ),
       fieldGroupItem({ field: getFieldById(FIELDS.CONTRACT_POLICY.SINGLE, CONTRACT_COMPLETION_DATE) }, formatDate(mockAnswers[CONTRACT_COMPLETION_DATE])),
-      fieldGroupItem({ field: getFieldById(FIELDS.CONTRACT_POLICY.SINGLE, TOTAL_CONTRACT_VALUE) }, formatCurrency(mockAnswers[TOTAL_CONTRACT_VALUE], 'GBP')),
     ];
 
     expect(result).toEqual(expected);

--- a/src/ui/server/helpers/summary-lists/policy-and-export/single-contract-policy-fields/index.ts
+++ b/src/ui/server/helpers/summary-lists/policy-and-export/single-contract-policy-fields/index.ts
@@ -1,4 +1,5 @@
 import { POLICY_AND_EXPORTS_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance';
+import { GBP_CURRENCY_CODE } from '../../../../constants';
 import FIELD_IDS from '../../../../constants/field-ids/insurance/policy-and-exports';
 import fieldGroupItem from '../../generate-field-group-item';
 import getFieldById from '../../../get-field-by-id';
@@ -20,8 +21,11 @@ const {
  */
 const generateSingleContractPolicyFields = (answers: ApplicationPolicyAndExport) => {
   const fields = [
+    fieldGroupItem(
+      { field: getFieldById(FIELDS.CONTRACT_POLICY.SINGLE, TOTAL_CONTRACT_VALUE) },
+      formatCurrency(answers[TOTAL_CONTRACT_VALUE], GBP_CURRENCY_CODE),
+    ),
     fieldGroupItem({ field: getFieldById(FIELDS.CONTRACT_POLICY.SINGLE, CONTRACT_COMPLETION_DATE) }, formatDate(answers[CONTRACT_COMPLETION_DATE])),
-    fieldGroupItem({ field: getFieldById(FIELDS.CONTRACT_POLICY.SINGLE, TOTAL_CONTRACT_VALUE) }, formatCurrency(answers[TOTAL_CONTRACT_VALUE], 'GBP')),
   ] as Array<SummaryListItemData>;
 
   return fields;

--- a/src/ui/server/test-mocks/mock-answers.ts
+++ b/src/ui/server/test-mocks/mock-answers.ts
@@ -1,4 +1,4 @@
-import { FIELD_IDS, FIELD_VALUES } from '../constants';
+import { FIELD_IDS, FIELD_VALUES, GBP_CURRENCY_CODE } from '../constants';
 import { SubmittedDataQuoteEligibility } from '../../types';
 
 const {
@@ -19,7 +19,7 @@ const mockAnswers = {
   [VALID_EXPORTER_LOCATION]: true,
   [BUYER_COUNTRY]: 'Algeria',
   [HAS_MINIMUM_UK_GOODS_OR_SERVICES]: true,
-  [CURRENCY]: 'GBP',
+  [CURRENCY]: GBP_CURRENCY_CODE,
   [CONTRACT_VALUE]: '123456',
   [CREDIT_PERIOD]: 1,
   [POLICY_TYPE]: FIELD_VALUES.POLICY_TYPE.SINGLE,

--- a/src/ui/server/test-mocks/mock-session.ts
+++ b/src/ui/server/test-mocks/mock-session.ts
@@ -1,4 +1,4 @@
-import { API, FIELD_IDS } from '../constants';
+import { API, FIELD_IDS, GBP_CURRENCY_CODE } from '../constants';
 import mockAnswers from './mock-answers';
 import { RequestSession } from '../../types';
 
@@ -17,7 +17,7 @@ const mockSession = {
       [BUYER_COUNTRY]: mockCountry,
       [CURRENCY]: {
         name: 'UK Sterling',
-        isoCode: 'GBP',
+        isoCode: GBP_CURRENCY_CODE,
       },
     },
     insuranceEligibility: {


### PR DESCRIPTION
This PR replace all hard coded instance of currency codes

## Changes

- Add some `CURRENCY_CODE` fixtures to E2E and constants to UI (only the currencies that EXIP supports).
- Update all hard coded currency codes.
- Also updates some E2E instances with `toLocaleString` functions, to use `formatCurrency` helper function.