### PR TITLE
fix(EMS-793): Policy and exports - fix string fields/inputs not saving as empty with save & back functionality

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/save-and-back.spec.js
@@ -22,6 +22,7 @@ const {
   INSURANCE: {
     POLICY_AND_EXPORTS: {
       CONTRACT_POLICY: {
+        CREDIT_PERIOD_WITH_BUYER,
         MULTIPLE: { TOTAL_SALES_TO_BUYER },
       },
     },
@@ -149,6 +150,39 @@ context('Insurance - Policy and exports - Multiple contract policy page - Save a
 
       it('should have the submitted value', () => {
         multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().should('have.value', application.POLICY_AND_EXPORTS[TOTAL_SALES_TO_BUYER]);
+      });
+    });
+  });
+
+  describe('when removing a previously submitted `buyer credit period` value', () => {
+    const field = multipleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER];
+
+    before(() => {
+      // submit a value
+      field.input().type('Test');
+      submitButton().click();
+
+      // go back to the page
+      partials.backLink().click();
+
+      field.input().clear();
+      saveAndBackButton().click();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      cy.url().should('eq', expected);
+    });
+
+    describe('when going back to the page', () => {
+      before(() => {
+        task.link().click();
+        submitButton().click();
+      });
+
+      it('should have no value in `buyer credit period`', () => {
+        field.input().should('have.value', '');
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/save-and-back.spec.js
@@ -29,6 +29,7 @@ const {
     POLICY_AND_EXPORTS: {
       CONTRACT_POLICY: {
         REQUESTED_START_DATE,
+        CREDIT_PERIOD_WITH_BUYER,
       },
     },
   },
@@ -167,6 +168,39 @@ context('Insurance - Policy and exports - Single contract policy page - Save and
         field.dayInput().should('have.value', '1');
         field.monthInput().should('have.value', getMonth(futureDate));
         field.yearInput().should('have.value', getYear(futureDate));
+      });
+    });
+  });
+
+  describe('when removing a previously submitted `buyer credit period` value', () => {
+    const field = singleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER];
+
+    before(() => {
+      // submit a value
+      field.input().type('Test');
+      submitButton().click();
+
+      // go back to the page
+      partials.backLink().click();
+
+      field.input().clear();
+      saveAndBackButton().click();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      cy.url().should('eq', expected);
+    });
+
+    describe('when going back to the page', () => {
+      before(() => {
+        task.link().click();
+        submitButton().click();
+      });
+
+      it('should have no value in `buyer credit period`', () => {
+        field.input().should('have.value', '');
       });
     });
   });

--- a/src/ui/server/controllers/insurance/business/company-details/index.POST-continue.test.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.POST-continue.test.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from '../../../../../types';
 import { pageVariables, post } from '.';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
-import corePageVariables from '../../../../helpers/page-variables/core/insurance';
+import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import { PAGES } from '../../../../content-strings';
 import companiesHouseValidation from './validation/companies-house';
 import companyDetailsValidation from './validation/company-details';
@@ -56,8 +56,8 @@ describe('controllers/insurance/business/companies-details', () => {
 
         const submittedValues = {
           [INPUT]: req.body[INPUT],
-          [TRADING_NAME]: sanitiseValue(req.body[TRADING_NAME]),
-          [TRADING_ADDRESS]: sanitiseValue(req.body[TRADING_ADDRESS]),
+          [TRADING_NAME]: sanitiseValue(TRADING_NAME, req.body[TRADING_NAME]),
+          [TRADING_ADDRESS]: sanitiseValue(TRADING_ADDRESS, req.body[TRADING_ADDRESS]),
           [WEBSITE]: req.body[WEBSITE],
         };
 
@@ -67,7 +67,7 @@ describe('controllers/insurance/business/companies-details', () => {
         validationErrors = companyDetailsValidation(req.body, validationErrors);
 
         expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
-          ...corePageVariables({
+          ...insuranceCorePageVariables({
             PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
             BACK_LINK: req.headers.referer,
           }),

--- a/src/ui/server/controllers/insurance/business/company-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.test.ts
@@ -1,7 +1,8 @@
 import { Request, Response, Application } from '../../../../../types';
 import { pageVariables, get, redirectToExitPage, postCompaniesHouseSearch, TEMPLATE } from '.';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
-import corePageVariables from '../../../../helpers/page-variables/core/insurance';
+import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
+import { sanitiseValue } from '../../../../helpers/sanitise-data';
 import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import generateValidationErrors from '../../../../helpers/validation';
 import api from '../../../../api';
@@ -73,14 +74,14 @@ describe('controllers/insurance/business/companies-details', () => {
 
         const submittedValues = {
           [COMPANY_HOUSE.INPUT]: exporterCompany?.[COMPANY_HOUSE.COMPANY_NUMBER],
-          [TRADING_NAME]: exporterCompany?.[TRADING_NAME],
-          [TRADING_ADDRESS]: exporterCompany?.[TRADING_ADDRESS],
+          [TRADING_NAME]: sanitiseValue(TRADING_NAME, exporterCompany?.[TRADING_NAME]),
+          [TRADING_ADDRESS]: sanitiseValue(TRADING_ADDRESS, exporterCompany?.[TRADING_ADDRESS]),
           [WEBSITE]: exporterCompany?.[WEBSITE],
           [PHONE_NUMBER]: exporterCompany?.[PHONE_NUMBER],
         };
 
         expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
-          ...corePageVariables({
+          ...insuranceCorePageVariables({
             PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
             BACK_LINK: req.headers.referer,
           }),
@@ -108,14 +109,14 @@ describe('controllers/insurance/business/companies-details', () => {
 
         const submittedValues = {
           [COMPANY_HOUSE.INPUT]: exporterCompany?.[COMPANY_HOUSE.COMPANY_NUMBER],
-          [TRADING_NAME]: exporterCompany?.[TRADING_NAME],
-          [TRADING_ADDRESS]: exporterCompany?.[TRADING_ADDRESS],
+          [TRADING_NAME]: sanitiseValue(TRADING_NAME, exporterCompany?.[TRADING_NAME]),
+          [TRADING_ADDRESS]: sanitiseValue(TRADING_ADDRESS, exporterCompany?.[TRADING_ADDRESS]),
           [WEBSITE]: exporterCompany?.[WEBSITE],
           [PHONE_NUMBER]: exporterCompany?.[PHONE_NUMBER],
         };
 
         expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
-          ...corePageVariables({
+          ...insuranceCorePageVariables({
             PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
             BACK_LINK: req.headers.referer,
           }),
@@ -167,7 +168,7 @@ describe('controllers/insurance/business/companies-details', () => {
 
         const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].INCORRECT_FORMAT;
         expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
-          ...corePageVariables({
+          ...insuranceCorePageVariables({
             PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
             BACK_LINK: req.headers.referer,
           }),
@@ -190,7 +191,7 @@ describe('controllers/insurance/business/companies-details', () => {
 
         const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].INCORRECT_FORMAT;
         expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
-          ...corePageVariables({
+          ...insuranceCorePageVariables({
             PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
             BACK_LINK: req.headers.referer,
           }),
@@ -213,7 +214,7 @@ describe('controllers/insurance/business/companies-details', () => {
 
         const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].INCORRECT_FORMAT;
         expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
-          ...corePageVariables({
+          ...insuranceCorePageVariables({
             PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
             BACK_LINK: req.headers.referer,
           }),
@@ -239,7 +240,7 @@ describe('controllers/insurance/business/companies-details', () => {
 
         const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].NOT_FOUND;
         expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
-          ...corePageVariables({
+          ...insuranceCorePageVariables({
             PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
             BACK_LINK: req.headers.referer,
           }),
@@ -265,7 +266,7 @@ describe('controllers/insurance/business/companies-details', () => {
 
         const errorMessage = EXPORTER_BUSINESS_ERROR[COMPANY_HOUSE.INPUT].TECHNICAL_ISSUES;
         expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
-          ...corePageVariables({
+          ...insuranceCorePageVariables({
             PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
             BACK_LINK: req.headers.referer,
           }),
@@ -292,7 +293,7 @@ describe('controllers/insurance/business/companies-details', () => {
         await postCompaniesHouseSearch(req, res);
 
         expect(res.render).toHaveBeenCalledWith(companyDetailsTemplate, {
-          ...corePageVariables({
+          ...insuranceCorePageVariables({
             PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
             BACK_LINK: req.headers.referer,
           }),

--- a/src/ui/server/controllers/insurance/business/company-details/index.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.ts
@@ -123,8 +123,8 @@ const postCompaniesHouseSearch = async (req: Request, res: Response) => {
     const { companiesHouseNumber } = body;
     const submittedValues = {
       [COMPANY_HOUSE.INPUT]: companiesHouseNumber,
-      [TRADING_NAME]: sanitiseValue(body[TRADING_NAME]),
-      [TRADING_ADDRESS]: sanitiseValue(body[TRADING_ADDRESS]),
+      [TRADING_NAME]: sanitiseValue(TRADING_NAME, body[TRADING_NAME]),
+      [TRADING_ADDRESS]: sanitiseValue(TRADING_ADDRESS, body[TRADING_ADDRESS]),
       [WEBSITE]: body[WEBSITE],
       [PHONE_NUMBER]: body[PHONE_NUMBER],
     };
@@ -206,8 +206,8 @@ const post = async (req: Request, res: Response) => {
     const submittedValues = {
       [COMPANY_HOUSE.INPUT]: companiesHouseNumber,
       // if trading name is string true, then convert to boolean true
-      [TRADING_NAME]: sanitiseValue(body[TRADING_NAME]),
-      [TRADING_ADDRESS]: sanitiseValue(body[TRADING_ADDRESS]),
+      [TRADING_NAME]: sanitiseValue(TRADING_NAME, body[TRADING_NAME]),
+      [TRADING_ADDRESS]: sanitiseValue(TRADING_ADDRESS, body[TRADING_ADDRESS]),
       [WEBSITE]: body[WEBSITE],
       [PHONE_NUMBER]: body[PHONE_NUMBER],
     };

--- a/src/ui/server/controllers/insurance/policy-and-export/map-submitted-data/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/map-submitted-data/index.test.ts
@@ -107,13 +107,4 @@ describe('controllers/insurance/policy-and-export/map-submitted-data', () => {
       expect(result).toEqual(mockBody);
     });
   });
-
-  describe('when form body is not provided', () => {
-    it('should return an empty object', () => {
-      // @ts-ignore
-      const result = mapSubmittedData();
-
-      expect(result).toEqual({});
-    });
-  });
 });

--- a/src/ui/server/controllers/insurance/policy-and-export/map-submitted-data/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/map-submitted-data/index.ts
@@ -18,10 +18,6 @@ const {
  * @returns {Object} Page variables
  */
 const mapSubmittedData = (formBody: RequestBody): object => {
-  if (!formBody) {
-    return {};
-  }
-
   const populatedData = formBody;
 
   const dateFieldIds = {

--- a/src/ui/server/helpers/get-valid-fields/index.test.ts
+++ b/src/ui/server/helpers/get-valid-fields/index.test.ts
@@ -4,7 +4,7 @@ describe('helpers/get-valid-fields', () => {
   const mockFormData = {
     fieldA: true,
     fieldB: 'Mock',
-    fieldC: 'MOCK value',
+    fieldC: 'Mock value',
   };
 
   const mockErrorList = {

--- a/src/ui/server/helpers/get-valid-fields/index.test.ts
+++ b/src/ui/server/helpers/get-valid-fields/index.test.ts
@@ -1,13 +1,13 @@
 import getValidFields from '.';
 
 describe('helpers/get-valid-fields', () => {
-  let mockFormData = {
+  const mockFormData = {
     fieldA: true,
     fieldB: 'Mock',
-    fieldC: 'MOCK value'
+    fieldC: 'MOCK value',
   };
 
-  let mockErrorList = {
+  const mockErrorList = {
     fieldA: {
       text: 'Field A is incorrect',
       order: 1,
@@ -30,7 +30,7 @@ describe('helpers/get-valid-fields', () => {
   describe('when there are fields that do NOT have validation errors but have empty values', () => {
     it('should only return fields that do NOT have empty values', () => {
       mockFormData.fieldB = '';
-      
+
       const result = getValidFields(mockFormData, {});
 
       const expected = {

--- a/src/ui/server/helpers/get-valid-fields/index.test.ts
+++ b/src/ui/server/helpers/get-valid-fields/index.test.ts
@@ -1,14 +1,15 @@
 import getValidFields from '.';
 
 describe('helpers/get-valid-fields', () => {
-  const mockFormData = {
-    fieldA: '',
-    fieldB: true,
+  let mockFormData = {
+    fieldA: true,
+    fieldB: 'Mock',
+    fieldC: 'MOCK value'
   };
 
-  const mockErrorList = {
+  let mockErrorList = {
     fieldA: {
-      text: 'Enter field A',
+      text: 'Field A is incorrect',
       order: 1,
     },
   };
@@ -18,28 +19,26 @@ describe('helpers/get-valid-fields', () => {
       const result = getValidFields(mockFormData, mockErrorList);
 
       const expected = {
-        fieldB: true,
+        fieldB: mockFormData.fieldB,
+        fieldC: mockFormData.fieldC,
       };
 
       expect(result).toEqual(expected);
     });
   });
 
-  describe('when formData is not provided', () => {
-    it('should return an empty object', () => {
-      // @ts-ignore
-      const result = getValidFields(undefined, mockErrorList);
+  describe('when there are fields that do NOT have validation errors but have empty values', () => {
+    it('should only return fields that do NOT have empty values', () => {
+      mockFormData.fieldB = '';
+      
+      const result = getValidFields(mockFormData, {});
 
-      expect(result).toEqual({});
-    });
-  });
+      const expected = {
+        fieldA: mockFormData.fieldA,
+        fieldC: mockFormData.fieldC,
+      };
 
-  describe('when formData is provided and errorList is not', () => {
-    it('should return formData as iss', () => {
-      // @ts-ignore
-      const result = getValidFields(mockFormData, undefined);
-
-      expect(result).toEqual(mockFormData);
+      expect(result).toEqual(expected);
     });
   });
 });

--- a/src/ui/server/helpers/get-valid-fields/index.ts
+++ b/src/ui/server/helpers/get-valid-fields/index.ts
@@ -6,25 +6,19 @@
  * @returns {Object} Form data with invalid fields removed
  */
 const getValidFields = (formData: object, errorList: object) => {
-  if (formData) {
-    if (errorList) {
-      const fieldsWithErrors = Object.keys(errorList);
+  const fieldsWithErrors = Object.keys(errorList);
 
-      const validFields = {};
+  const validFields = {};
 
-      Object.keys(formData).forEach((fieldName) => {
-        if (!fieldsWithErrors.includes(fieldName)) {
-          validFields[fieldName] = formData[fieldName];
-        }
-      });
+  Object.keys(formData).forEach((fieldName) => {
+    const fieldValue = formData[fieldName];
 
-      return validFields;
+    if (!fieldsWithErrors.includes(fieldName) && fieldValue !== '') {
+      validFields[fieldName] = fieldValue;
     }
+  });
 
-    return formData;
-  }
-
-  return {};
+  return validFields;
 };
 
 export default getValidFields;

--- a/src/ui/server/helpers/get-valid-fields/index.ts
+++ b/src/ui/server/helpers/get-valid-fields/index.ts
@@ -1,3 +1,5 @@
+import { isEmptyString } from '../string';
+
 /**
  * getValidFields
  * Strip invalid fields from submitted form data
@@ -13,7 +15,8 @@ const getValidFields = (formData: object, errorList: object) => {
   Object.keys(formData).forEach((fieldName) => {
     const fieldValue = formData[fieldName];
 
-    if (!fieldsWithErrors.includes(fieldName) && fieldValue !== '') {
+    // do not return fields that are in the errors list or are empty
+    if (!fieldsWithErrors.includes(fieldName) && !isEmptyString(fieldValue)) {
       validFields[fieldName] = fieldValue;
     }
   });

--- a/src/ui/server/helpers/has-form-data/index.test.ts
+++ b/src/ui/server/helpers/has-form-data/index.test.ts
@@ -14,20 +14,24 @@ describe('helpers/has-form-data', () => {
     });
   });
 
+  describe('when a form has a field that is not _csrf', () => {
+    it('should return true', () => {
+      const mockFormData = {
+        _csrf: '1234',
+        mockField: true,
+      };
+
+      const result = hasFormData(mockFormData);
+
+      expect(result).toEqual(true);
+    });
+  });
+
   describe('when a form does NOT have a field other than _csrf', () => {
     it('should return false', () => {
       const mockFormData = { _csrf: '1234' };
 
       const result = hasFormData(mockFormData);
-
-      expect(result).toEqual(false);
-    });
-  });
-
-  describe('when no form data is provided', () => {
-    it('should return false', () => {
-      // @ts-ignore
-      const result = hasFormData();
 
       expect(result).toEqual(false);
     });

--- a/src/ui/server/helpers/has-form-data/index.ts
+++ b/src/ui/server/helpers/has-form-data/index.ts
@@ -1,5 +1,4 @@
 import { RequestBody } from '../../../types';
-import stripEmptyFormFields from '../strip-empty-form-fields';
 
 /**
  * hasFormData
@@ -8,18 +7,10 @@ import stripEmptyFormFields from '../strip-empty-form-fields';
  * @returns {Boolean}
  */
 const hasFormData = (formBody: RequestBody) => {
-  if (!formBody) {
-    return false;
-  }
-
   const { _csrf, ...formData } = formBody;
 
   if (formData && Object.keys(formData).length) {
-    const fieldsWithValues = stripEmptyFormFields(formData);
-
-    if (Object.keys(fieldsWithValues).length) {
-      return true;
-    }
+    return true;
   }
 
   return false;

--- a/src/ui/server/helpers/sanitise-data/index.test.ts
+++ b/src/ui/server/helpers/sanitise-data/index.test.ts
@@ -10,11 +10,7 @@ const {
   POLICY_AND_EXPORTS: {
     CONTRACT_POLICY: {
       SINGLE: { TOTAL_CONTRACT_VALUE },
-      MULTIPLE: {
-        TOTAL_MONTHS_OF_COVER,
-        TOTAL_SALES_TO_BUYER,
-        MAXIMUM_BUYER_WILL_OWE,
-      },
+      MULTIPLE: { TOTAL_MONTHS_OF_COVER, TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE },
     },
   },
 } = FIELD_IDS.INSURANCE;
@@ -174,12 +170,7 @@ describe('server/helpers/sanitise-data', () => {
 
   describe('NUMBER_FIELDS', () => {
     it('should return an Explicit array of field IDs', () => {
-      const expected = [
-        TOTAL_CONTRACT_VALUE,
-        TOTAL_MONTHS_OF_COVER,
-        TOTAL_SALES_TO_BUYER,
-        MAXIMUM_BUYER_WILL_OWE,
-      ];
+      const expected = [TOTAL_CONTRACT_VALUE, TOTAL_MONTHS_OF_COVER, TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE];
 
       expect(NUMBER_FIELDS).toEqual(expected);
     });

--- a/src/ui/server/helpers/sanitise-data/index.ts
+++ b/src/ui/server/helpers/sanitise-data/index.ts
@@ -1,5 +1,5 @@
 import { isNumber } from '../number';
-import { stripCommas } from '../string';
+import { isEmptyString, stripCommas } from '../string';
 import { RequestBody } from '../../../types';
 import { FIELD_IDS } from '../../constants';
 
@@ -23,7 +23,7 @@ const {
  * @returns {Boolean}
  */
 const shouldChangeToNumber = (key: string, value: string | number) => {
-  if (key === COMPANY_NUMBER || key === PHONE_NUMBER || value === '') {
+  if (key === COMPANY_NUMBER || key === PHONE_NUMBER || isEmptyString(String(value))) {
     return false;
   }
 
@@ -98,7 +98,7 @@ const shouldIncludeAndSanitiseField = (key: string, value: string) => {
 
   // EMS-793: do not include number fields that are empty.
   // empty number fields cannot be sent and saved via the API beacuse it is not a number.
-  if (NUMBER_FIELDS.includes(key) && value === '') {
+  if (NUMBER_FIELDS.includes(key) && isEmptyString(value)) {
     return false;
   }
 

--- a/src/ui/server/helpers/sanitise-data/index.ts
+++ b/src/ui/server/helpers/sanitise-data/index.ts
@@ -11,11 +11,7 @@ const {
   POLICY_AND_EXPORTS: {
     CONTRACT_POLICY: {
       SINGLE: { TOTAL_CONTRACT_VALUE },
-      MULTIPLE: {
-        TOTAL_MONTHS_OF_COVER,
-        TOTAL_SALES_TO_BUYER,
-        MAXIMUM_BUYER_WILL_OWE,
-      },
+      MULTIPLE: { TOTAL_MONTHS_OF_COVER, TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE },
     },
   },
 } = FIELD_IDS.INSURANCE;
@@ -85,12 +81,7 @@ const isDayMonthYearField = (fieldName: string): boolean => {
  * Explicit list of field IDs in the insurance forms that are number fields.
  * @returns {Array} Field IDs
  */
-const NUMBER_FIELDS = [
-  TOTAL_CONTRACT_VALUE,
-  TOTAL_MONTHS_OF_COVER,
-  TOTAL_SALES_TO_BUYER,
-  MAXIMUM_BUYER_WILL_OWE,
-];
+const NUMBER_FIELDS = [TOTAL_CONTRACT_VALUE, TOTAL_MONTHS_OF_COVER, TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE];
 
 /**
  * shouldIncludeAndSanitiseField

--- a/src/ui/server/helpers/sanitise-data/index.ts
+++ b/src/ui/server/helpers/sanitise-data/index.ts
@@ -1,13 +1,22 @@
 import { isNumber } from '../number';
 import { stripCommas } from '../string';
 import { RequestBody } from '../../../types';
-import stripEmptyFormFields from '../strip-empty-form-fields';
 import { FIELD_IDS } from '../../constants';
 
 const {
   EXPORTER_BUSINESS: {
     COMPANY_HOUSE: { COMPANY_NUMBER },
     YOUR_COMPANY: { PHONE_NUMBER },
+  },
+  POLICY_AND_EXPORTS: {
+    CONTRACT_POLICY: {
+      SINGLE: { TOTAL_CONTRACT_VALUE },
+      MULTIPLE: {
+        TOTAL_MONTHS_OF_COVER,
+        TOTAL_SALES_TO_BUYER,
+        MAXIMUM_BUYER_WILL_OWE,
+      },
+    },
   },
 } = FIELD_IDS.INSURANCE;
 
@@ -17,9 +26,9 @@ const {
  * @param {String | Number} Field value
  * @returns {Boolean}
  */
-const shouldChangeToNumber = (value: string | number) => {
-  if (typeof value === 'string' && isNumber(value)) {
-    return true;
+const shouldChangeToNumber = (key: string, value: string | number) => {
+  if (key === COMPANY_NUMBER || key === PHONE_NUMBER || value === '') {
+    return false;
   }
 
   if (typeof value === 'string') {
@@ -39,7 +48,7 @@ const shouldChangeToNumber = (value: string | number) => {
  * @param {String | Number} Field value
  * @returns {Boolean}
  */
-const sanitiseValue = (value: string | number | boolean, key?: string) => {
+const sanitiseValue = (key: string, value: string | number | boolean) => {
   if (value === 'true' || value === true) {
     return true;
   }
@@ -48,8 +57,7 @@ const sanitiseValue = (value: string | number | boolean, key?: string) => {
     return false;
   }
 
-  // should not change number if COMPANY_NUMBER or PHONE_NUMBER
-  if (shouldChangeToNumber(value) && key !== COMPANY_NUMBER && key !== PHONE_NUMBER) {
+  if (shouldChangeToNumber(key, value)) {
     const stripped = stripCommas(String(value));
 
     return Number(stripped);
@@ -73,6 +81,40 @@ const isDayMonthYearField = (fieldName: string): boolean => {
 };
 
 /**
+ * NUMBER_FIELDS
+ * Explicit list of field IDs in the insurance forms that are number fields.
+ * @returns {Array} Field IDs
+ */
+const NUMBER_FIELDS = [
+  TOTAL_CONTRACT_VALUE,
+  TOTAL_MONTHS_OF_COVER,
+  TOTAL_SALES_TO_BUYER,
+  MAXIMUM_BUYER_WILL_OWE,
+];
+
+/**
+ * shouldIncludeAndSanitiseField
+ * Check if we should include and sanitise a form field.
+ * @param {String} Form field key/ID
+ * @param {String} Form field value
+ * @returns {Boolean}
+ */
+const shouldIncludeAndSanitiseField = (key: string, value: string) => {
+  // do not include day/month/year fields, these should be captured as timestamps.
+  if (isDayMonthYearField(key)) {
+    return false;
+  }
+
+  // EMS-793: do not include number fields that are empty.
+  // empty number fields cannot be sent and saved via the API beacuse it is not a number.
+  if (NUMBER_FIELDS.includes(key) && value === '') {
+    return false;
+  }
+
+  return true;
+};
+
+/**
  * sanitiseData
  * Sanitise form data
  * @param {Express.Request.body} Form body
@@ -87,19 +129,17 @@ const sanitiseData = (formBody: RequestBody) => {
 
   const sanitised = {};
 
-  // strip any empty form fields
-  const keys = Object.keys(stripEmptyFormFields(formData));
+  const keys = Object.keys(formData);
 
   keys.forEach((key) => {
     const value = formData[key];
 
-    // do not include day/month/year fields, these should be captured as timestamps.
-    if (!isDayMonthYearField(key)) {
-      sanitised[key] = sanitiseValue(value, key);
+    if (shouldIncludeAndSanitiseField(key, value)) {
+      sanitised[key] = sanitiseValue(key, value);
     }
   });
 
   return sanitised;
 };
 
-export { shouldChangeToNumber, sanitiseValue, isDayMonthYearField, sanitiseData };
+export { shouldChangeToNumber, sanitiseValue, isDayMonthYearField, NUMBER_FIELDS, shouldIncludeAndSanitiseField, sanitiseData };

--- a/src/ui/server/helpers/string/index.test.ts
+++ b/src/ui/server/helpers/string/index.test.ts
@@ -1,6 +1,24 @@
-import { stripCommas } from '.';
+import { isEmptyString, stripCommas } from '.';
 
 describe('server/helpers/string', () => {
+  describe('isEmptyString', () => {
+    describe('when a string is empty', () => {
+      it('should return true', () => {
+        const result = isEmptyString('');
+
+        expect(result).toEqual(true);
+      });
+    });
+
+    describe('when a string is not empty', () => {
+      it('should return false', () => {
+        const result = isEmptyString('Mock');
+
+        expect(result).toEqual(false);
+      });
+    });
+  });
+
   describe('stripCommas', () => {
     describe('when a string has a comma', () => {
       it('should return a string without commas', () => {

--- a/src/ui/server/helpers/string/index.ts
+++ b/src/ui/server/helpers/string/index.ts
@@ -1,4 +1,12 @@
 /**
+ * isEmptyString
+ * Check if a string is empty
+ * @param {String}
+ * @returns {Boolean}
+ */
+const isEmptyString = (str: string) => str === '';
+
+/**
  * stripCommas
  * Remove commas from a string
  * @param {String}
@@ -6,4 +14,4 @@
  */
 const stripCommas = (str: string) => str.replace(/[,]/g, '');
 
-export { stripCommas };
+export { isEmptyString, stripCommas };


### PR DESCRIPTION
This PR changes the "sanitise form data" functions and therefore fixing an issue where a text input would not be sent to the API/saved in the database, if the value has been removed after being submitted with a value. We previously stripped out empty form fields before sending to the API. Also includes some technical improvements.

## Summary of changes
- Update `sanitiseData` function so that it does not return a field that is in a set of specific number fields and has an empty value. Without this, trying to send number fields with an empty string or value of 0, results in API/DB error and the data is not saved. 
  - Created `NUMBER_FIELDS` array of specific number fields that are in the applicatino forms.
  - Created `shouldIncludeAndSanitiseField` check.
  - Improved `shouldChangeToNumber` checks so that all checks are in this function instead of being outside.
- Simplify `hasFormData` function - do not strip out empty form fields and remove unnecessary param checks (typescript handles this).
- Simplfiy `mapSubmittedData` function - remove unnecessary param checks.
- Simplfiy `getValidFields` function - remove unnecessary param checks and add an empty string check.
- Update company details controller tests to use `sanitiseValue, passing the key and value instead of just the value. Also renamed the page variables import/usage.
- Add E2E tests for wiping the "credit period with buyer" field via "save and go back", for both single and multiple contracts.