### PR TITLE
fix(EMS-852): Order countries alphabetically

### DIFF
--- a/src/ui/server/helpers/mappings/map-countries.test.ts
+++ b/src/ui/server/helpers/mappings/map-countries.test.ts
@@ -1,12 +1,13 @@
 import mapCountries from './map-countries';
 import mapSelectOption from './map-select-option';
+import sortArrayAlphabetically from '../sort-array-alphabetically';
 import { mockCountries } from '../../test-mocks';
 
 describe('server/helpers/mappings/map-countries', () => {
   it('should return an array of mapped objects from mapSelectOption and with a default option', () => {
     const result = mapCountries(mockCountries);
 
-    const expectedMapped = mockCountries.map(({ name, isoCode }) => mapSelectOption(name, isoCode, false));
+    const mapped = mockCountries.map(({ name, isoCode }) => mapSelectOption(name, isoCode, false));
 
     const expected = [
       {
@@ -14,7 +15,7 @@ describe('server/helpers/mappings/map-countries', () => {
         selected: true,
         value: '',
       },
-      ...expectedMapped,
+      ...sortArrayAlphabetically(mapped, 'text'),
     ];
 
     expect(result).toEqual(expected);
@@ -26,7 +27,9 @@ describe('server/helpers/mappings/map-countries', () => {
 
       const result = mapCountries(mockCountries, mockSelectedValue);
 
-      const expected = mockCountries.map(({ name, isoCode }) => mapSelectOption(name, isoCode, false, mockSelectedValue));
+      const mapped = mockCountries.map(({ name, isoCode }) => mapSelectOption(name, isoCode, false, mockSelectedValue));
+
+      const expected = sortArrayAlphabetically(mapped, 'text');
 
       expect(result).toEqual(expected);
     });

--- a/src/ui/server/helpers/mappings/map-countries.ts
+++ b/src/ui/server/helpers/mappings/map-countries.ts
@@ -1,4 +1,5 @@
 import mapSelectOption from './map-select-option';
+import sortArrayAlphabetically from '../sort-array-alphabetically';
 import { Country } from '../../../types';
 
 /**
@@ -6,10 +7,12 @@ import { Country } from '../../../types';
  * Map all countries into the required structure for GOV select component.
  * @param {Array} Array of currency objects
  * @returns {String} Selected credit period value
- * @returns {Array} Array of mapped currencies
+ * @returns {Array} Array of mapped countries, ordered alphabetically
  */
 const mapCountries = (countries: Array<Country>, selectedValue?: string) => {
   const mapped = countries.map(({ name, isoCode }) => mapSelectOption(name, isoCode, false, selectedValue));
+
+  const sortedCountries = sortArrayAlphabetically(mapped, 'text');
 
   if (!selectedValue) {
     const defaultOption = {
@@ -18,14 +21,12 @@ const mapCountries = (countries: Array<Country>, selectedValue?: string) => {
       value: '',
     };
 
-    const result = [defaultOption, ...mapped];
+    const result = [defaultOption, ...sortedCountries];
 
     return result;
   }
 
-  const result = mapped;
-
-  return result;
+  return sortedCountries;
 };
 
 export default mapCountries;


### PR DESCRIPTION
Update `mapCountries` funciton to order the countries alphabetically.

This mapping function is consumed only in the full application i.e not in eligibility - eligibility uses countries from the CSI API and has a  a different mapping function (due to different data structure).

