### PR TITLE
fix(EMS-851): Explicit list of string number fields to allow submission/saving if submitted as a pure number

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/about-goods-or-services.spec.js
@@ -46,10 +46,6 @@ const {
 
 const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
-const goToPageDirectly = (referenceNumber) => {
-  cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`);
-};
-
 context('Insurance - Policy and exports - About goods or services page - As an exporter, I want to enter the details of the export contract', () => {
   let referenceNumber;
 
@@ -96,7 +92,7 @@ context('Insurance - Policy and exports - About goods or services page - As an e
 
     cy.url().should('eq', expectedUrl);
 
-    goToPageDirectly(referenceNumber);
+    cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`);
   });
 
   it('renders an analytics cookies consent banner that can be accepted', () => {
@@ -181,12 +177,28 @@ context('Insurance - Policy and exports - About goods or services page - As an e
 
     describe('when going back to the page', () => {
       it('should have the submitted values', () => {
-        goToPageDirectly(referenceNumber);
+        cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`);
 
         aboutGoodsOrServicesPage[DESCRIPTION].input().should('have.value', application.POLICY_AND_EXPORTS[DESCRIPTION]);
 
         const country = countries.find((c) => c.isoCode === application.POLICY_AND_EXPORTS[FINAL_DESTINATION]);
         cy.checkText(aboutGoodsOrServicesPage[FINAL_DESTINATION].inputOptionSelected(), country.name);
+      });
+    });
+
+    describe('when the description field is a pure number and there are no other validation errors', () => {
+      const descriptionField = aboutGoodsOrServicesPage[DESCRIPTION];
+      const submittedValue = '1234';
+
+      before(() => {
+        descriptionField.input().clear().type(submittedValue, { delay: 0 });
+        submitButton().click();
+      });
+
+      it('should retain the submitted value when going back to the page', () => {
+        partials.backLink().click();
+
+        descriptionField.input().should('have.value', submittedValue);
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -62,10 +62,6 @@ const {
 
 const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
-const goToPageDirectly = (referenceNumber) => {
-  cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`);
-};
-
 context('Insurance - Policy and exports - Multiple contract policy page - As an exporter, I want to enter the type of policy I need for my export contract', () => {
   let referenceNumber;
 
@@ -110,7 +106,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
 
     cy.url().should('eq', expectedUrl);
 
-    goToPageDirectly(referenceNumber);
+    cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`);
   });
 
   it('renders an analytics cookies consent banner that can be accepted', () => {
@@ -255,7 +251,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
 
     describe('when going back to the page', () => {
       it('should have the submitted values', () => {
-        goToPageDirectly(referenceNumber);
+        cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`);
 
         multipleContractPolicyPage[REQUESTED_START_DATE].dayInput().should('have.value', application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].day);
         multipleContractPolicyPage[REQUESTED_START_DATE].monthInput().should('have.value', application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].month);
@@ -267,6 +263,22 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
         multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().should('have.value', application.POLICY_AND_EXPORTS[MAXIMUM_BUYER_WILL_OWE]);
         multipleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().should('have.value', application.POLICY_AND_EXPORTS[CREDIT_PERIOD_WITH_BUYER]);
         policyCurrencyCodeFormField.inputOptionSelected().contains(application.POLICY_AND_EXPORTS[POLICY_CURRENCY_CODE]);
+      });
+    });
+
+    describe('when the credit period with buyer field is a pure number and there are no other validation errors', () => {
+      const creditPeriodField = multipleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER];
+      const submittedValue = '1234';
+
+      before(() => {
+        creditPeriodField.input().clear().type(submittedValue, { delay: 0 });
+        submitButton().click();
+      });
+
+      it('should retain the submitted value when going back to the page', () => {
+        partials.backLink().click();
+
+        creditPeriodField.input().should('have.value', submittedValue);
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
@@ -56,10 +56,6 @@ const {
   },
 } = FIELD_IDS;
 
-const goToPageDirectly = (referenceNumber) => {
-  cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`);
-};
-
 const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
 context('Insurance - Policy and exports - Single contract policy page - As an exporter, I want to enter the type of policy I need for my export contract', () => {
@@ -106,7 +102,7 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
 
     cy.url().should('eq', expectedUrl);
 
-    goToPageDirectly(referenceNumber);
+    cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`);
   });
 
   it('renders an analytics cookies consent banner that can be accepted', () => {
@@ -221,7 +217,7 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
 
     describe('when going back to the page', () => {
       it('should have the submitted values', () => {
-        goToPageDirectly(referenceNumber);
+        cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`);
 
         singleContractPolicyPage[REQUESTED_START_DATE].dayInput().should('have.value', application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].day);
         singleContractPolicyPage[REQUESTED_START_DATE].monthInput().should('have.value', application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].month);
@@ -234,6 +230,22 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
         singleContractPolicyPage[TOTAL_CONTRACT_VALUE].input().should('have.value', application.POLICY_AND_EXPORTS[TOTAL_CONTRACT_VALUE]);
         singleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().should('have.value', application.POLICY_AND_EXPORTS[CREDIT_PERIOD_WITH_BUYER]);
         policyCurrencyCodeFormField.inputOptionSelected().contains(application.POLICY_AND_EXPORTS[POLICY_CURRENCY_CODE]);
+      });
+    });
+
+    describe('when the credit period with buyer field is a pure number and there are no other validation errors', () => {
+      const creditPeriodField = singleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER];
+      const submittedValue = '1234';
+
+      before(() => {
+        creditPeriodField.input().clear().type(submittedValue, { delay: 0 });
+        submitButton().click();
+      });
+
+      it('should retain the submitted value when going back to the page', () => {
+        partials.backLink().click();
+
+        creditPeriodField.input().should('have.value', submittedValue);
       });
     });
   });

--- a/src/ui/server/helpers/sanitise-data/index.test.ts
+++ b/src/ui/server/helpers/sanitise-data/index.test.ts
@@ -1,4 +1,4 @@
-import { shouldChangeToNumber, sanitiseValue, isDayMonthYearField, NUMBER_FIELDS, shouldIncludeAndSanitiseField, sanitiseData } from '.';
+import { NUMBER_FIELDS, STRING_NUMBER_FIELDS, shouldChangeToNumber, sanitiseValue, isDayMonthYearField, shouldIncludeAndSanitiseField, sanitiseData } from '.';
 import { FIELD_IDS } from '../../constants';
 import { mockPhoneNumbers } from '../../test-mocks';
 
@@ -6,17 +6,36 @@ const {
   EXPORTER_BUSINESS: {
     COMPANY_HOUSE: { COMPANY_NUMBER },
     YOUR_COMPANY: { PHONE_NUMBER },
+    NATURE_OF_YOUR_BUSINESS: { GOODS_OR_SERVICES },
   },
   POLICY_AND_EXPORTS: {
     CONTRACT_POLICY: {
+      CREDIT_PERIOD_WITH_BUYER,
       SINGLE: { TOTAL_CONTRACT_VALUE },
       MULTIPLE: { TOTAL_MONTHS_OF_COVER, TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE },
     },
+    ABOUT_GOODS_OR_SERVICES: { DESCRIPTION },
   },
 } = FIELD_IDS.INSURANCE;
 
 describe('server/helpers/sanitise-data', () => {
   const mockFieldKey = 'fieldA';
+
+  describe('NUMBER_FIELDS', () => {
+    it('should return an explicit array of field IDs that are number fields that could have a value of 0', () => {
+      const expected = [TOTAL_CONTRACT_VALUE, TOTAL_MONTHS_OF_COVER, TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE];
+
+      expect(NUMBER_FIELDS).toEqual(expected);
+    });
+  });
+
+  describe('STRING_NUMBER_FIELDS', () => {
+    it('should return an explicit array of field IDs that are string fields that could have a pure number value', () => {
+      const expected = [CREDIT_PERIOD_WITH_BUYER, DESCRIPTION, COMPANY_NUMBER, PHONE_NUMBER, GOODS_OR_SERVICES];
+
+      expect(STRING_NUMBER_FIELDS).toEqual(expected);
+    });
+  });
 
   describe('shouldChangeToNumber', () => {
     describe('when the value is a string number', () => {
@@ -165,14 +184,6 @@ describe('server/helpers/sanitise-data', () => {
 
         expect(result).toEqual(false);
       });
-    });
-  });
-
-  describe('NUMBER_FIELDS', () => {
-    it('should return an Explicit array of field IDs', () => {
-      const expected = [TOTAL_CONTRACT_VALUE, TOTAL_MONTHS_OF_COVER, TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE];
-
-      expect(NUMBER_FIELDS).toEqual(expected);
     });
   });
 

--- a/src/ui/server/helpers/sanitise-data/index.ts
+++ b/src/ui/server/helpers/sanitise-data/index.ts
@@ -7,14 +7,36 @@ const {
   EXPORTER_BUSINESS: {
     COMPANY_HOUSE: { COMPANY_NUMBER },
     YOUR_COMPANY: { PHONE_NUMBER },
+    NATURE_OF_YOUR_BUSINESS: { GOODS_OR_SERVICES },
   },
   POLICY_AND_EXPORTS: {
     CONTRACT_POLICY: {
+      CREDIT_PERIOD_WITH_BUYER,
       SINGLE: { TOTAL_CONTRACT_VALUE },
       MULTIPLE: { TOTAL_MONTHS_OF_COVER, TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE },
     },
+    ABOUT_GOODS_OR_SERVICES: { DESCRIPTION },
   },
 } = FIELD_IDS.INSURANCE;
+
+/**
+ * NUMBER_FIELDS
+ * Explicit list of field IDs in the insurance forms that are number fields.
+ * @returns {Array} Field IDs
+ */
+const NUMBER_FIELDS = [TOTAL_CONTRACT_VALUE, TOTAL_MONTHS_OF_COVER, TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE];
+
+/**
+ * STRING_NUMBER_FIELDS
+ * Explicit exemptions list of field IDs in the insurance forms that are string fields that could be submitted as a pure number.
+ * If one of these fields is pure numbers, our default "sanitise data" behaviour is to transform a string number into a number type.
+ * However, we do not want this to happen with these fields. This means that:
+ * - The data is saved correctly
+ * - We avoid adding additional error handling in the UI.
+ * - We avoid a "problem with service" page scenario where the data save fails, because it tries to save a number type as a text string type.
+ * @returns {Array} Field IDs
+ */
+const STRING_NUMBER_FIELDS = [CREDIT_PERIOD_WITH_BUYER, DESCRIPTION, COMPANY_NUMBER, PHONE_NUMBER, GOODS_OR_SERVICES];
 
 /**
  * shouldChangeToNumber
@@ -23,7 +45,7 @@ const {
  * @returns {Boolean}
  */
 const shouldChangeToNumber = (key: string, value: string | number) => {
-  if (key === COMPANY_NUMBER || key === PHONE_NUMBER || isEmptyString(String(value))) {
+  if (STRING_NUMBER_FIELDS.includes(key) || isEmptyString(String(value))) {
     return false;
   }
 
@@ -77,13 +99,6 @@ const isDayMonthYearField = (fieldName: string): boolean => {
 };
 
 /**
- * NUMBER_FIELDS
- * Explicit list of field IDs in the insurance forms that are number fields.
- * @returns {Array} Field IDs
- */
-const NUMBER_FIELDS = [TOTAL_CONTRACT_VALUE, TOTAL_MONTHS_OF_COVER, TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE];
-
-/**
  * shouldIncludeAndSanitiseField
  * Check if we should include and sanitise a form field.
  * @param {String} Form field key/ID
@@ -133,4 +148,4 @@ const sanitiseData = (formBody: RequestBody) => {
   return sanitised;
 };
 
-export { shouldChangeToNumber, sanitiseValue, isDayMonthYearField, NUMBER_FIELDS, shouldIncludeAndSanitiseField, sanitiseData };
+export { NUMBER_FIELDS, STRING_NUMBER_FIELDS, shouldChangeToNumber, sanitiseValue, isDayMonthYearField, shouldIncludeAndSanitiseField, sanitiseData };


### PR DESCRIPTION
This PR adds a an explicit list of string number fields, `STRING_NUMBER_FIELDS` - string fields that could be numbers.

When sanitising form data before sending to the API, we have a check - `shouldChangeToNumber`. This is great - ensuring that a pure number in a string, is converted to an actual number type.

However, there are scenarios where a user could enter a pure number, e.g "1234" into a free text field. The default sanitise data behaviour is to transform this into a number type, but we do not want this to happen on specific fields.

Without introducing an explicit "string number fields that we don't want to transform if they have pure numbers", the data save will fail and the user will be taken to a "problem with service" page. 

An alternative approach is to add additional validation handling in the UI, however this is more work in the long run and not an elegant design for users.

This scenario is edge case, but it could happen so we are introducing this approach.

## Summary of changes

- Add `STRING_NUMBER_FIELDS` to sanitise data file.
- Update `shouldChangeToNumber` to check the list of number fields.
- Add E2E test coverage for all scenarios in the policy and export pages.


@Zainzzkk We should add an E2E test like in this PR for the `GOODS_OR_SERVICES` field in the company section.