### PR TITLE
fix(EMS-867-EMS-877): Policy and exports - add invalid date format validation, fix typos in Your buyer address field

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -112,7 +112,7 @@ export const ERROR_MESSAGES = {
           ABOVE_MAXIMUM: 'The credit period you have with your buyer cannot be more than 1000 characters.',
         },
         [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.REQUESTED_START_DATE]: {
-          IS_EMPTY: 'Enter a policy start date in the correct format - for example, 06 11 2023',
+          INCORRECT_FORMAT: 'Enter a policy start date in the correct format - for example, 06 11 2023',
           NOT_A_NUMBER: 'Enter a policy start date in the correct format - for example, 06 11 2023',
           BEFORE_EARLIEST: 'You cannot enter a policy start date in the past - enter a future date',
         },
@@ -121,7 +121,7 @@ export const ERROR_MESSAGES = {
         },
         SINGLE: {
           [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.SINGLE.CONTRACT_COMPLETION_DATE]: {
-            IS_EMPTY: 'Enter a contract completion date in the correct format - for example, 06 11 2023',
+            INCORRECT_FORMAT: 'Enter a contract completion date in the correct format - for example, 06 11 2023',
             NOT_A_NUMBER: 'Enter a contract completion date in the correct format - for example, 06 11 2023',
             BEFORE_EARLIEST: 'You cannot enter a contract completion date in the past - enter a future date',
             AFTER_LATEST:

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -173,7 +173,7 @@ export const ERROR_MESSAGES = {
         },
         [FIELD_IDS.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION.ADDRESS]: {
           IS_EMPTY: "Enter the buyer's address",
-          ABOVE_MAXIMUM: 'Buyer address cannot be more than 330 characters',
+          ABOVE_MAXIMUM: 'Buyer address cannot be more than 300 characters',
         },
       },
     },

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-requested-start-date.spec.js
@@ -76,6 +76,12 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
     });
   });
 
+  describe('when the date has an invalid format', () => {
+    it('should render a validation error', () => {
+      checkValidation.notInTheFuture();
+    });
+  });
+
   describe('when the date is today', () => {
     it('should NOT render a validation error', () => {
       checkValidation.isToday();

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
@@ -69,7 +69,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
     cy.checkText(
       partials.errorSummaryListItems().eq(0),
-      CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].IS_EMPTY,
+      CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INCORRECT_FORMAT,
     );
 
     cy.checkText(

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
@@ -75,12 +75,12 @@ context('Insurance - Policy and exports - Single contract policy page - form val
 
       cy.checkText(
         partials.errorSummaryListItems().eq(1),
-        CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].IS_EMPTY,
+        CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].IS_EMPTY}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT}`,
       );
     });
   });
@@ -94,12 +94,12 @@ context('Insurance - Policy and exports - Single contract policy page - form val
 
       cy.checkText(
         partials.errorSummaryListItems().eq(1),
-        CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].IS_EMPTY,
+        CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].IS_EMPTY}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT}`,
       );
     });
   });
@@ -113,12 +113,12 @@ context('Insurance - Policy and exports - Single contract policy page - form val
 
       cy.checkText(
         partials.errorSummaryListItems().eq(1),
-        CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].IS_EMPTY,
+        CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].IS_EMPTY}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT}`,
       );
     });
   });
@@ -195,6 +195,28 @@ context('Insurance - Policy and exports - Single contract policy page - form val
       cy.checkText(
         field.errorMessage(),
         `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].BEFORE_EARLIEST}`,
+      );
+    });
+  });
+
+  describe('when the date has an invalid format', () => {
+    it('should render a validation error', () => {
+      const date = new Date();
+      const futureDate = add(date, { days: 1 });
+
+      field.dayInput().clear().type(getDate(futureDate));
+      field.monthInput().clear().type('24');
+      field.yearInput().clear().type(getYear(futureDate));
+      submitButton().click();
+
+      cy.checkText(
+        partials.errorSummaryListItems().eq(1),
+        CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT,
+      );
+
+      cy.checkText(
+        field.errorMessage(),
+        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT}`,
       );
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
@@ -76,6 +76,12 @@ context('Insurance - Policy and exports - Single contract policy page - form val
     });
   });
 
+  describe('when the date has an invalid format', () => {
+    it('should render a validation error', () => {
+      checkValidation.notInTheFuture();
+    });
+  });
+
   describe('when the date is today', () => {
     it('should NOT render a validation error', () => {
       checkValidation.isToday();

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation.spec.js
@@ -68,12 +68,12 @@ context('Insurance - Policy and exports - Single contract policy page - form val
 
     cy.checkText(
       partials.errorSummaryListItems().eq(0),
-      CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].IS_EMPTY,
+      CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INCORRECT_FORMAT,
     );
 
     cy.checkText(
       partials.errorSummaryListItems().eq(1),
-      CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].IS_EMPTY,
+      CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT,
     );
 
     cy.checkText(

--- a/e2e-tests/cypress/support/insurance/requested-start-date-field.js
+++ b/e2e-tests/cypress/support/insurance/requested-start-date-field.js
@@ -1,4 +1,5 @@
 import {
+  add,
   getDate,
   getMonth,
   getYear,
@@ -39,12 +40,12 @@ const checkValidation = {
 
       cy.checkText(
         partials.errorSummaryListItems().eq(0),
-        CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].IS_EMPTY,
+        CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].IS_EMPTY}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INCORRECT_FORMAT}`,
       );
     },
     notANumber: () => {
@@ -71,12 +72,12 @@ const checkValidation = {
 
       cy.checkText(
         partials.errorSummaryListItems().eq(0),
-        CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].IS_EMPTY,
+        CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].IS_EMPTY}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INCORRECT_FORMAT}`,
       );
     },
     notANumber: () => {
@@ -104,12 +105,12 @@ const checkValidation = {
 
       cy.checkText(
         partials.errorSummaryListItems().eq(0),
-        CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].IS_EMPTY,
+        CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].IS_EMPTY}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INCORRECT_FORMAT}`,
       );
     },
     notANumber: () => {
@@ -146,6 +147,25 @@ const checkValidation = {
     cy.checkText(
       field.errorMessage(),
       `Error: ${CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].BEFORE_EARLIEST}`,
+    );
+  },
+  invalidFormat: () => {
+    const date = new Date();
+    const futureDate = add(date, { days: 1 });
+
+    field.dayInput().clear().type(getDate(futureDate));
+    field.monthInput().clear().type('24');
+    field.yearInput().clear().type(getYear(futureDate));
+    submitButton().click();
+
+    cy.checkText(
+      partials.errorSummaryListItems().eq(0),
+      CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INCORRECT_FORMAT,
+    );
+
+    cy.checkText(
+      field.errorMessage(),
+      `Error: ${CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INCORRECT_FORMAT}`,
     );
   },
   isToday: () => {

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -116,7 +116,7 @@ export const ERROR_MESSAGES = {
           ABOVE_MAXIMUM: 'The credit period you have with your buyer cannot be more than 1000 characters.',
         },
         [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.REQUESTED_START_DATE]: {
-          IS_EMPTY: 'Enter a policy start date in the correct format - for example, 06 11 2023',
+          INCORRECT_FORMAT: 'Enter a policy start date in the correct format - for example, 06 11 2023',
           NOT_A_NUMBER: 'Enter a policy start date in the correct format - for example, 06 11 2023',
           BEFORE_EARLIEST: 'You cannot enter a policy start date in the past - enter a future date',
         },
@@ -125,7 +125,7 @@ export const ERROR_MESSAGES = {
         },
         SINGLE: {
           [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.SINGLE.CONTRACT_COMPLETION_DATE]: {
-            IS_EMPTY: 'Enter a contract completion date in the correct format - for example, 06 11 2023',
+            INCORRECT_FORMAT: 'Enter a contract completion date in the correct format - for example, 06 11 2023',
             NOT_A_NUMBER: 'Enter a contract completion date in the correct format - for example, 06 11 2023',
             BEFORE_EARLIEST: 'You cannot enter a contract completion date in the past - enter a future date',
             AFTER_LATEST:
@@ -134,7 +134,7 @@ export const ERROR_MESSAGES = {
             CANNOT_BE_BEFORE: 'Your contract completion date must be after your policy start date',
           },
           [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.SINGLE.TOTAL_CONTRACT_VALUE]: {
-            IS_EMPTY: 'Enter your contract value as a whole number - do not enter decimals',
+            INCORRECT_FORMAT: 'Enter your contract value as a whole number - do not enter decimals',
             NOT_A_NUMBER: 'Enter your contract value as a whole number - do not enter decimals',
             NOT_A_WHOLE_NUMBER: 'Enter your contract value as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your contract value must be 1 or more',

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -177,7 +177,7 @@ export const ERROR_MESSAGES = {
         },
         [FIELD_IDS.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION.ADDRESS]: {
           IS_EMPTY: "Enter the buyer's address",
-          ABOVE_MAXIMUM: 'Buyer address cannot be more than 330 characters',
+          ABOVE_MAXIMUM: 'Buyer address cannot be more than 300 characters',
         },
       },
     },

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -134,7 +134,7 @@ export const ERROR_MESSAGES = {
             CANNOT_BE_BEFORE: 'Your contract completion date must be after your policy start date',
           },
           [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.SINGLE.TOTAL_CONTRACT_VALUE]: {
-            INCORRECT_FORMAT: 'Enter your contract value as a whole number - do not enter decimals',
+            IS_EMPTY: 'Enter your contract value as a whole number - do not enter decimals',
             NOT_A_NUMBER: 'Enter your contract value as a whole number - do not enter decimals',
             NOT_A_WHOLE_NUMBER: 'Enter your contract value as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your contract value must be 1 or more',

--- a/src/ui/server/content-strings/fields/insurance/your-buyer/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/your-buyer/index.ts
@@ -11,7 +11,7 @@ export const YOUR_BUYER_FIELDS = {
     },
     [COMPANY_OR_ORGANISATION.ADDRESS]: {
       LABEL: 'Address',
-      MAXIMUM: 330,
+      MAXIMUM: 300,
     },
     [COMPANY_OR_ORGANISATION.COUNTRY]: {
       LABEL: 'Country',

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/contract-completion-date.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/contract-completion-date.test.ts
@@ -40,7 +40,7 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/validat
 
       const result = contractCompletionDateRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.IS_EMPTY, mockErrors);
+      const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });
@@ -55,7 +55,7 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/validat
 
       const result = contractCompletionDateRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.IS_EMPTY, mockErrors);
+      const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });
@@ -70,7 +70,7 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/validat
 
       const result = contractCompletionDateRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.IS_EMPTY, mockErrors);
+      const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });
@@ -87,6 +87,25 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/validat
       const result = contractCompletionDateRules(mockSubmittedData, mockErrors);
 
       const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.NOT_A_NUMBER, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when the date is invalid', () => {
+    it('should return validation error', () => {
+      const date = new Date();
+      const futureDate = add(date, { days: 1, months: 1 });
+
+      const mockSubmittedData = {
+        [`${CONTRACT_COMPLETION_DATE}-day`]: getDate(futureDate),
+        [`${CONTRACT_COMPLETION_DATE}-month`]: '24',
+        [`${CONTRACT_COMPLETION_DATE}-year`]: getYear(futureDate),
+      };
+
+      const result = contractCompletionDateRules(mockSubmittedData, mockErrors);
+
+      const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });
@@ -113,7 +132,7 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/validat
 
   describe(`when ${REQUESTED_START_DATE} is also provided`, () => {
     const date = new Date();
-    const futureDate = sub(date, { months: 3 });
+    const futureDate = add(date, { months: 3 });
 
     const requestedStartDateFields = {
       [`${REQUESTED_START_DATE}-day`]: getDate(futureDate),

--- a/src/ui/server/shared-validation/requested-start-date/index.test.ts
+++ b/src/ui/server/shared-validation/requested-start-date/index.test.ts
@@ -35,7 +35,7 @@ describe('shared-validation/requested-start-date', () => {
 
       const result = requestedStartDateRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors);
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });
@@ -50,7 +50,7 @@ describe('shared-validation/requested-start-date', () => {
 
       const result = requestedStartDateRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors);
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });
@@ -65,7 +65,7 @@ describe('shared-validation/requested-start-date', () => {
 
       const result = requestedStartDateRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors);
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });
@@ -82,6 +82,25 @@ describe('shared-validation/requested-start-date', () => {
       const result = requestedStartDateRules(mockSubmittedData, mockErrors);
 
       const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when the date is invalid', () => {
+    it('should return validation error', () => {
+      const date = new Date();
+      const futureDate = add(date, { days: 1, months: 1 });
+
+      const mockSubmittedData = {
+        [`${FIELD_ID}-day`]: getDate(futureDate),
+        [`${FIELD_ID}-month`]: '24',
+        [`${FIELD_ID}-year`]: getYear(futureDate),
+      };
+
+      const result = requestedStartDateRules(mockSubmittedData, mockErrors);
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });

--- a/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
+++ b/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
@@ -65,21 +65,21 @@
           maxlength: FIELDS.ADDRESS.MAXIMUM,
           classes: "govuk-!-width-two-thirds",
           attributes: {
-              'data-cy': FIELDS.ADDRESS.ID + '-input'
+            'data-cy': FIELDS.ADDRESS.ID + '-input'
           },
           value: submittedValues[FIELDS.ADDRESS.ID],
           errorMessage: validationErrors.errorList[FIELDS.ADDRESS.ID] and {
-              text: validationErrors.errorList[FIELDS.ADDRESS.ID].text,
-              attributes: {
-                "data-cy": FIELDS.ADDRESS.ID + "-error-message"
-              }
-            },
+            text: validationErrors.errorList[FIELDS.ADDRESS.ID].text,
+            attributes: {
+              "data-cy": FIELDS.ADDRESS.ID + "-error-message"
+            }
+          },
           label: {
             text: FIELDS.ADDRESS.LABEL,
             classes: "govuk-!-font-weight-bold govuk-!-font-size-19",
             attributes: {
-                id: FIELDS.ADDRESS.ID + '-label',
-                'data-cy': FIELDS.ADDRESS.ID + '-label'
+              id: FIELDS.ADDRESS.ID + '-label',
+              'data-cy': FIELDS.ADDRESS.ID + '-label'
             }
           }
         }) }}


### PR DESCRIPTION
This PR adds "is valid"  checks to the "cover start" and "contract completion" date fields in the policy and exports section. We now present an error to the user if they e.g enter an incorrect month of e.g "24", or in US style. Also fixed a small typo bug in the your buyer page.


## Summary of changes

- Use `isValid` date-fns function to check the date for invalid formatting in both date validation functions.
- Rename `IS_EMPTY` error message to `INCORRECT_FORMAT`.
- Add E2E tests for all instances (single and multiple pages).
- Align requested start date and contract completion date validation patterns (returning errors in each condition instead of assigning variable and simplify the default return param).
- EMS-877: Fix some typos for maximum characters allowed in the "address" field of Your buyer.