### PR TITLE
fix(EMS-834-911): Policy and exports - update total contract value hint, update external links

### DIFF
--- a/e2e-tests/content-strings/fields/insurance/policy-and-exports/index.js
+++ b/e2e-tests/content-strings/fields/insurance/policy-and-exports/index.js
@@ -74,7 +74,14 @@ export const POLICY_AND_EXPORT_FIELDS = {
       },
       [CONTRACT_POLICY.SINGLE.TOTAL_CONTRACT_VALUE]: {
         LABEL: "What's the total value of the contract you want to insure?",
-        HINT: 'Enter a whole number - do not enter decimals.',
+        HINT: {
+          NEED_MORE_COVER: 'If you need cover for more than £499,999,',
+          FILL_IN_FORM: {
+            TEXT: 'fill in this form instead',
+            HREF: LINKS.EXTERNAL.FULL_APPLICATION,
+          },
+          NO_DECIMALS: 'Enter a whole number - do not enter decimals.',
+        },
         SUMMARY: {
           TITLE: 'Contract value',
         },

--- a/e2e-tests/content-strings/fields/insurance/policy-and-exports/index.js
+++ b/e2e-tests/content-strings/fields/insurance/policy-and-exports/index.js
@@ -57,7 +57,7 @@ export const POLICY_AND_EXPORT_FIELDS = {
         NEED_DIFFERENT_CURRENCY: "If you need a different currency, you'll need to",
         APPLY_USING_FORM: {
           TEXT: 'apply using our form.',
-          HREF: LINKS.EXTERNAL.NBI_FORM,
+          HREF: LINKS.EXTERNAL.FULL_APPLICATION,
         },
       },
       SUMMARY: {
@@ -110,7 +110,7 @@ export const POLICY_AND_EXPORT_FIELDS = {
           NEED_MORE_COVER: 'If you need cover for more than £499,999, ',
           FILL_IN_FORM: {
             TEXT: 'fill in this form instead.',
-            HREF: LINKS.EXTERNAL.NBI_FORM,
+            HREF: LINKS.EXTERNAL.FULL_APPLICATION,
           },
           NO_DECIMALS: 'Enter a whole number - do not enter decimals.',
         },

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
@@ -161,7 +161,24 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
     field.label().should('exist');
     cy.checkText(field.label(), FIELDS.CONTRACT_POLICY.SINGLE[fieldId].LABEL);
 
-    cy.checkText(field.hint(), FIELDS.CONTRACT_POLICY.SINGLE[fieldId].HINT);
+    const hintContent = FIELDS.CONTRACT_POLICY.SINGLE[fieldId].HINT;
+
+    cy.checkText(
+      field.hint.needMoreCover(),
+      hintContent.NEED_MORE_COVER,
+    );
+
+    cy.checkText(
+      field.hint.link(),
+      hintContent.FILL_IN_FORM.TEXT,
+    );
+
+    field.hint.link().should('have.attr', 'href', hintContent.FILL_IN_FORM.HREF);
+
+    cy.checkText(
+      field.hint.noDecimals(),
+      hintContent.NO_DECIMALS,
+    );
 
     cy.checkText(field.prefix(), '£');
 

--- a/e2e-tests/cypress/e2e/pages/insurance/policy-and-export/singleContractPolicy.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/policy-and-export/singleContractPolicy.js
@@ -34,7 +34,11 @@ const singleContractPolicy = {
   },
   [TOTAL_CONTRACT_VALUE]: {
     label: () => cy.get(`[data-cy="${TOTAL_CONTRACT_VALUE}-label"]`),
-    hint: () => cy.get(`[data-cy="${TOTAL_CONTRACT_VALUE}-hint"]`),
+    hint: {
+      needMoreCover: () => cy.get(`[data-cy="${TOTAL_CONTRACT_VALUE}-hint-need-more-cover"]`),
+      link: () => cy.get(`[data-cy="${TOTAL_CONTRACT_VALUE}-hint-link"]`),
+      noDecimals: () => cy.get(`[data-cy="${TOTAL_CONTRACT_VALUE}-hint-no-decimals"]`),
+    },
     prefix: () => cy.get(`[data-cy="${TOTAL_CONTRACT_VALUE}-prefix"]`),
     input: () => cy.get(`[data-cy="${TOTAL_CONTRACT_VALUE}-input"]`),
     errorMessage: () => cy.get(`[data-cy="${TOTAL_CONTRACT_VALUE}-error-message"]`),

--- a/src/ui/server/content-strings/fields/insurance/policy-and-exports/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy-and-exports/index.ts
@@ -74,7 +74,14 @@ export const POLICY_AND_EXPORTS_FIELDS = {
       },
       [CONTRACT_POLICY.SINGLE.TOTAL_CONTRACT_VALUE]: {
         LABEL: "What's the total value of the contract you want to insure?",
-        HINT: 'Enter a whole number - do not enter decimals.',
+        HINT: {
+          NEED_MORE_COVER: 'If you need cover for more than £499,999,',
+          FILL_IN_FORM: {
+            TEXT: 'fill in this form instead',
+            HREF: LINKS.EXTERNAL.FULL_APPLICATION,
+          },
+          NO_DECIMALS: 'Enter a whole number - do not enter decimals.',
+        },
         SUMMARY: {
           TITLE: 'Contract value',
         },

--- a/src/ui/server/content-strings/fields/insurance/policy-and-exports/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy-and-exports/index.ts
@@ -57,7 +57,7 @@ export const POLICY_AND_EXPORTS_FIELDS = {
         NEED_DIFFERENT_CURRENCY: "If you need a different currency, you'll need to",
         APPLY_USING_FORM: {
           TEXT: 'apply using our form.',
-          HREF: LINKS.EXTERNAL.NBI_FORM,
+          HREF: LINKS.EXTERNAL.FULL_APPLICATION,
         },
       },
       SUMMARY: {
@@ -110,7 +110,7 @@ export const POLICY_AND_EXPORTS_FIELDS = {
           NEED_MORE_COVER: 'If you need cover for more than £499,999, ',
           FILL_IN_FORM: {
             TEXT: 'fill in this form instead.',
-            HREF: LINKS.EXTERNAL.NBI_FORM,
+            HREF: LINKS.EXTERNAL.FULL_APPLICATION,
           },
           NO_DECIMALS: 'Enter a whole number - do not enter decimals.',
         },

--- a/src/ui/templates/insurance/policy-and-exports/single-contract-policy.njk
+++ b/src/ui/templates/insurance/policy-and-exports/single-contract-policy.njk
@@ -66,6 +66,18 @@
           submittedAnswers: submittedValues or application.policyAndExport
         }) }}
 
+        {% set totalContractValueHintHtml %}
+          <p class="govuk-!-margin-bottom-0">
+            <span data-cy="{{ FIELDS.TOTAL_CONTRACT_VALUE.ID }}-hint-need-more-cover">{{ FIELDS.TOTAL_CONTRACT_VALUE.HINT.NEED_MORE_COVER }}</span>
+            <a
+              class="govuk-link govuk-link"
+              href="{{ FIELDS.TOTAL_CONTRACT_VALUE.HINT.FILL_IN_FORM.HREF }}"
+              data-cy="{{ FIELDS.TOTAL_CONTRACT_VALUE.ID }}-hint-link"
+            >{{ FIELDS.TOTAL_CONTRACT_VALUE.HINT.FILL_IN_FORM.TEXT }}</a>
+          </p>
+          <p class="govuk-!-margin-top-0" data-cy="{{ FIELDS.TOTAL_CONTRACT_VALUE.ID }}-hint-no-decimals">{{ FIELDS.TOTAL_CONTRACT_VALUE.HINT.NO_DECIMALS }}</p>
+        {% endset %}
+
         {{ govukInput({
           label: {
             text: FIELDS.TOTAL_CONTRACT_VALUE.LABEL,
@@ -76,10 +88,7 @@
             }
           },
           hint: {
-            text: FIELDS.TOTAL_CONTRACT_VALUE.HINT,
-            attributes: {
-              'data-cy': FIELDS.TOTAL_CONTRACT_VALUE.ID + '-hint'
-            }
+            html: totalContractValueHintHtml
           },
           classes: "govuk-input--width-10 govuk-!-margin-bottom-4",
           attributes: {


### PR DESCRIPTION
This PR updates the hint for "total contract value" in the single contract policy page. Also fixes some incorrect external links.