### PR TITLE
fix(EMS-913): Policy and exports - fix date issue when changing contract from multiple to single

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/change-your-answers/change-your-answers-change-policy-type-multiple-to-single.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/change-your-answers/change-your-answers-change-policy-type-multiple-to-single.spec.js
@@ -20,7 +20,7 @@ const {
     POLICY_AND_EXPORTS: {
       TYPE_OF_POLICY: { POLICY_TYPE },
       CONTRACT_POLICY: {
-        SINGLE: { TOTAL_CONTRACT_VALUE },
+        SINGLE: { CONTRACT_COMPLETION_DATE, TOTAL_CONTRACT_VALUE },
       },
     },
   },
@@ -94,6 +94,13 @@ context('Insurance - Policy and exports - Change your answers - Policy type - mu
 
     describe('`Add` links', () => {
       it('should have empty summary list row values and links for the empty single policy specific fields', () => {
+        cy.assertSummaryListRowValue(summaryList, CONTRACT_COMPLETION_DATE, DEFAULT.EMPTY);
+
+        cy.checkText(
+          summaryList[CONTRACT_COMPLETION_DATE].changeLink(),
+          `${LINKS.ADD} ${SINGLE_FIELD_STRINGS[CONTRACT_COMPLETION_DATE].SUMMARY.TITLE}`,
+        );
+
         cy.assertSummaryListRowValue(summaryList, TOTAL_CONTRACT_VALUE, DEFAULT.EMPTY);
 
         cy.checkText(

--- a/src/ui/server/helpers/summary-lists/policy-and-export/multiple-contract-policy-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/policy-and-export/multiple-contract-policy-fields/index.test.ts
@@ -25,39 +25,47 @@ describe('server/helpers/summary-lists/policy-and-export/multiple-contract-polic
   const mockAnswers = mockMultiplePolicyAndExport;
   const { referenceNumber } = mockApplication;
 
+  const expectedBase = {
+    [TOTAL_MONTHS_OF_COVER]: {
+      field: getFieldById(FIELDS.CONTRACT_POLICY.MULTIPLE, TOTAL_MONTHS_OF_COVER),
+      renderChangeLink: true,
+      href: `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_CHANGE}#${TOTAL_MONTHS_OF_COVER}-label`,
+    },
+    [TOTAL_SALES_TO_BUYER]: {
+      field: getFieldById(FIELDS.CONTRACT_POLICY.MULTIPLE, TOTAL_SALES_TO_BUYER),
+      renderChangeLink: true,
+      href: `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_CHANGE}#${TOTAL_SALES_TO_BUYER}-label`,
+    },
+    [MAXIMUM_BUYER_WILL_OWE]: {
+      field: getFieldById(FIELDS.CONTRACT_POLICY.MULTIPLE, MAXIMUM_BUYER_WILL_OWE),
+      renderChangeLink: true,
+      href: `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_CHANGE}#${MAXIMUM_BUYER_WILL_OWE}-label`,
+    },
+  };
+
   it('should return fields and values from the submitted data/answers', () => {
     const result = generateMultipleContractPolicyFields(mockAnswers, referenceNumber);
 
     const expected = [
-      fieldGroupItem(
-        {
-          field: getFieldById(FIELDS.CONTRACT_POLICY.MULTIPLE, TOTAL_MONTHS_OF_COVER),
-          data: mockAnswers,
-          renderChangeLink: true,
-          href: `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_CHANGE}#${TOTAL_MONTHS_OF_COVER}-label`,
-        },
-        mapMonthString(mockAnswers[TOTAL_MONTHS_OF_COVER]),
-      ),
-      fieldGroupItem(
-        {
-          field: getFieldById(FIELDS.CONTRACT_POLICY.MULTIPLE, TOTAL_SALES_TO_BUYER),
-          data: mockAnswers,
-          renderChangeLink: true,
-          href: `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_CHANGE}#${TOTAL_SALES_TO_BUYER}-label`,
-        },
-        formatCurrency(mockAnswers[TOTAL_SALES_TO_BUYER], GBP_CURRENCY_CODE),
-      ),
-      fieldGroupItem(
-        {
-          field: getFieldById(FIELDS.CONTRACT_POLICY.MULTIPLE, MAXIMUM_BUYER_WILL_OWE),
-          data: mockAnswers,
-          renderChangeLink: true,
-          href: `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_CHANGE}#${MAXIMUM_BUYER_WILL_OWE}-label`,
-        },
-        formatCurrency(mockAnswers[MAXIMUM_BUYER_WILL_OWE], GBP_CURRENCY_CODE),
-      ),
+      fieldGroupItem(expectedBase[TOTAL_MONTHS_OF_COVER], mapMonthString(mockAnswers[TOTAL_MONTHS_OF_COVER])),
+      fieldGroupItem(expectedBase[TOTAL_SALES_TO_BUYER], formatCurrency(mockAnswers[TOTAL_SALES_TO_BUYER], GBP_CURRENCY_CODE)),
+      fieldGroupItem(expectedBase[MAXIMUM_BUYER_WILL_OWE], formatCurrency(mockAnswers[MAXIMUM_BUYER_WILL_OWE], GBP_CURRENCY_CODE)),
     ];
 
     expect(result).toEqual(expected);
+  });
+
+  describe('when there are no submitted data/answers', () => {
+    it('should return fields without values', () => {
+      const result = generateMultipleContractPolicyFields({ id: mockApplication.id }, referenceNumber);
+
+      const expected = [
+        fieldGroupItem(expectedBase[TOTAL_MONTHS_OF_COVER]),
+        fieldGroupItem(expectedBase[TOTAL_SALES_TO_BUYER]),
+        fieldGroupItem(expectedBase[MAXIMUM_BUYER_WILL_OWE]),
+      ];
+
+      expect(result).toEqual(expected);
+    });
   });
 });

--- a/src/ui/server/helpers/summary-lists/policy-and-export/single-contract-policy-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/policy-and-export/single-contract-policy-fields/index.test.ts
@@ -25,28 +25,37 @@ describe('server/helpers/summary-lists/policy-and-export/single-contract-policy-
   const mockAnswers = mockSinglePolicyAndExport;
   const { referenceNumber } = mockApplication;
 
+  const expectedBase = {
+    [CONTRACT_COMPLETION_DATE]: {
+      field: getFieldById(FIELDS.CONTRACT_POLICY.SINGLE, CONTRACT_COMPLETION_DATE),
+      renderChangeLink: true,
+      href: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_CHANGE}#${CONTRACT_COMPLETION_DATE}-label`,
+    },
+    [TOTAL_CONTRACT_VALUE]: {
+      field: getFieldById(FIELDS.CONTRACT_POLICY.SINGLE, TOTAL_CONTRACT_VALUE),
+      renderChangeLink: true,
+      href: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_CHANGE}#${TOTAL_CONTRACT_VALUE}-label`,
+    },
+  };
+
   it('should return fields and values from the submitted data/answes', () => {
     const result = generateSingleContractPolicyFields(mockAnswers, referenceNumber);
 
     const expected = [
-      fieldGroupItem(
-        {
-          field: getFieldById(FIELDS.CONTRACT_POLICY.SINGLE, CONTRACT_COMPLETION_DATE),
-          renderChangeLink: true,
-          href: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_CHANGE}#${CONTRACT_COMPLETION_DATE}-label`,
-        },
-        formatDate(mockAnswers[CONTRACT_COMPLETION_DATE]),
-      ),
-      fieldGroupItem(
-        {
-          field: getFieldById(FIELDS.CONTRACT_POLICY.SINGLE, TOTAL_CONTRACT_VALUE),
-          renderChangeLink: true,
-          href: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_CHANGE}#${TOTAL_CONTRACT_VALUE}-label`,
-        },
-        formatCurrency(mockAnswers[TOTAL_CONTRACT_VALUE], GBP_CURRENCY_CODE),
-      ),
+      fieldGroupItem(expectedBase[CONTRACT_COMPLETION_DATE], formatDate(mockAnswers[CONTRACT_COMPLETION_DATE])),
+      fieldGroupItem(expectedBase[TOTAL_CONTRACT_VALUE], formatCurrency(mockAnswers[TOTAL_CONTRACT_VALUE], GBP_CURRENCY_CODE)),
     ];
 
     expect(result).toEqual(expected);
+  });
+
+  describe('when there are no submitted data/answers', () => {
+    it('should return fields without values', () => {
+      const result = generateSingleContractPolicyFields({ id: mockApplication.id }, referenceNumber);
+
+      const expected = [fieldGroupItem(expectedBase[CONTRACT_COMPLETION_DATE]), fieldGroupItem(expectedBase[TOTAL_CONTRACT_VALUE])];
+
+      expect(result).toEqual(expected);
+    });
   });
 });

--- a/src/ui/server/helpers/summary-lists/policy-and-export/single-contract-policy-fields/index.ts
+++ b/src/ui/server/helpers/summary-lists/policy-and-export/single-contract-policy-fields/index.ts
@@ -34,7 +34,7 @@ const generateSingleContractPolicyFields = (answers: ApplicationPolicyAndExport,
         renderChangeLink: true,
         href: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_CHANGE}#${CONTRACT_COMPLETION_DATE}-label`,
       },
-      formatDate(answers[CONTRACT_COMPLETION_DATE]),
+      answers[CONTRACT_COMPLETION_DATE] && formatDate(answers[CONTRACT_COMPLETION_DATE]),
     ),
     fieldGroupItem(
       {


### PR DESCRIPTION
The policy and exports summary list was rendering a default date (with year 1970) for the "contract completion date" field if a date is not passed.

## Changes

- Add a condition to the summary list row value param.
- Improve test coverage for summary list row value conditions.
- Add E2E test to ensure we don't regress in the future.