### PR TITLE
fix(EMS-911): policy and exports - update links to external proposal form

### DIFF
--- a/e2e-tests/content-strings/fields/insurance/policy-and-exports/index.js
+++ b/e2e-tests/content-strings/fields/insurance/policy-and-exports/index.js
@@ -57,7 +57,7 @@ export const POLICY_AND_EXPORT_FIELDS = {
         NEED_DIFFERENT_CURRENCY: "If you need a different currency, you'll need to",
         APPLY_USING_FORM: {
           TEXT: 'apply using our form.',
-          HREF: LINKS.EXTERNAL.FULL_APPLICATION,
+          HREF: LINKS.EXTERNAL.PROPOSAL_FORM,
         },
       },
       SUMMARY: {
@@ -78,7 +78,7 @@ export const POLICY_AND_EXPORT_FIELDS = {
           NEED_MORE_COVER: 'If you need cover for more than £499,999,',
           FILL_IN_FORM: {
             TEXT: 'fill in this form instead',
-            HREF: LINKS.EXTERNAL.FULL_APPLICATION,
+            HREF: LINKS.EXTERNAL.PROPOSAL_FORM,
           },
           NO_DECIMALS: 'Enter a whole number - do not enter decimals.',
         },

--- a/src/ui/server/content-strings/fields/insurance/policy-and-exports/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy-and-exports/index.ts
@@ -57,7 +57,7 @@ export const POLICY_AND_EXPORTS_FIELDS = {
         NEED_DIFFERENT_CURRENCY: "If you need a different currency, you'll need to",
         APPLY_USING_FORM: {
           TEXT: 'apply using our form.',
-          HREF: LINKS.EXTERNAL.FULL_APPLICATION,
+          HREF: LINKS.EXTERNAL.PROPOSAL_FORM,
         },
       },
       SUMMARY: {
@@ -78,7 +78,7 @@ export const POLICY_AND_EXPORTS_FIELDS = {
           NEED_MORE_COVER: 'If you need cover for more than £499,999,',
           FILL_IN_FORM: {
             TEXT: 'fill in this form instead',
-            HREF: LINKS.EXTERNAL.FULL_APPLICATION,
+            HREF: LINKS.EXTERNAL.PROPOSAL_FORM,
           },
           NO_DECIMALS: 'Enter a whole number - do not enter decimals.',
         },


### PR DESCRIPTION
Update the link used in 3 policy and export fields so the link goes directly to an external form instead of a page that links to the PDF.