### PR TITLE
feat(EMS-781): Account creation - password validation 

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -192,6 +192,9 @@ export const ERROR_MESSAGES = {
           [FIELD_IDS.INSURANCE.ACCOUNT.EMAIL]: {
             INCORRECT_FORMAT: 'Enter your email address in the correct format - for example name@example.com',
           },
+          [FIELD_IDS.INSURANCE.ACCOUNT.PASSWORD]: {
+            INCORRECT_FORMAT: 'Enter a password in the correct format - for example, 14 characters long with an uppercase letter, lower case letter, number and special character',
+          },
         },
       },
     },

--- a/e2e-tests/content-strings/fields/insurance/account/index.js
+++ b/e2e-tests/content-strings/fields/insurance/account/index.js
@@ -19,6 +19,15 @@ export const ACCOUNT_FIELDS = {
       },
       [PASSWORD]: {
         LABEL: 'Create a password',
+        HINT: {
+          INTRO: 'Your password must contain at least 14 characters and have:',
+          RULES: [
+            'an uppercase letter',
+            'a lowercase letter',
+            'a number',
+            'a special character',
+          ],
+        },
       },
     },
   },

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details-validation-password.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details-validation-password.spec.js
@@ -1,0 +1,96 @@
+import { submitButton } from '../../../../../pages/shared';
+import partials from '../../../../../partials';
+import { yourDetailsPage } from '../../../../../pages/insurance/account/create';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
+import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const {
+  START,
+  ACCOUNT: { CREATE: { YOUR_DETAILS } },
+} = ROUTES;
+
+const {
+  ACCOUNT: { PASSWORD },
+} = INSURANCE_FIELD_IDS;
+
+const {
+  INSURANCE: {
+    ACCOUNT: {
+      CREATE: { YOUR_DETAILS: YOUR_DETAILS_ERROR_MESSAGES },
+    },
+  },
+} = ERROR_MESSAGES;
+
+const expectedMessage = YOUR_DETAILS_ERROR_MESSAGES[PASSWORD].INCORRECT_FORMAT;
+
+const submitAndAssertErrors = (fieldValue) => {
+  const field = yourDetailsPage[PASSWORD];
+
+  field.input().clear().type(fieldValue, { delay: 0 });
+  submitButton().click();
+
+  cy.checkText(
+    partials.errorSummaryListItems().eq(3),
+    expectedMessage,
+  );
+
+  cy.checkText(field.errorMessage(), `Error: ${expectedMessage}`);
+};
+
+context('Insurance - Account - Create - Your details page - form validation - password', () => {
+  before(() => {
+    cy.navigateToUrl(START);
+
+    cy.submitEligibilityAndStartAccountCreation();
+
+    const expected = `${Cypress.config('baseUrl')}${YOUR_DETAILS}`;
+
+    cy.url().should('eq', expected);
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('connect.sid');
+  });
+
+  describe('when password does not have the minimum amount of characters', () => {
+    it('should render a validation error', () => {
+      const invalidPassword = 'Mock1!';
+
+      submitAndAssertErrors(invalidPassword);
+    });
+  });
+
+  describe('when password does not contain an uppercase letter', () => {
+    it('should render a validation error', () => {
+      const invalidPassword = 'mockpassword1!';
+
+      submitAndAssertErrors(invalidPassword);
+    });
+  });
+
+  describe('when password does not contain a lowercase letter', () => {
+    it('should render a validation error', () => {
+      const invalidPassword = 'MOCKPASSWORD1!';
+
+      submitAndAssertErrors(invalidPassword);
+    });
+  });
+
+  describe('when password does not contain a number', () => {
+    it('should render a validation error', () => {
+      const invalidPassword = 'Mockpassword!';
+
+      submitAndAssertErrors(invalidPassword);
+    });
+  });
+
+  describe('when password does not contain a special character', () => {
+    it('should render a validation error', () => {
+      const invalidPassword = 'Mockpassword1';
+
+      submitAndAssertErrors(invalidPassword);
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details-validation.spec.js
@@ -48,7 +48,7 @@ context('Insurance - Account - Create - Your details page - form validation', ()
     });
 
     it('sHould render validation errors for all required fields', () => {
-      const TOTAL_REQUIRED_FIELDS = 3;
+      const TOTAL_REQUIRED_FIELDS = 4;
 
       partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
@@ -135,7 +135,7 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
     cy.checkText(field.label(), FIELD_STRINGS[fieldId].LABEL);
 
     field.input().should('exist');
-    
+
     cy.checkText(field.hint.intro(), FIELD_STRINGS[fieldId].HINT.INTRO);
     cy.checkText(field.hint.listItem1(), FIELD_STRINGS[fieldId].HINT.RULES[0]);
     cy.checkText(field.hint.listItem2(), FIELD_STRINGS[fieldId].HINT.RULES[1]);

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
@@ -171,6 +171,7 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
       yourDetailsPage[FIRST_NAME].input().type(account[FIRST_NAME], { delay: 0 });
       yourDetailsPage[LAST_NAME].input().type(account[LAST_NAME], { delay: 0 });
       yourDetailsPage[EMAIL].input().type(account[EMAIL], { delay: 0 });
+      yourDetailsPage[PASSWORD].input().type(account[PASSWORD], { delay: 0 });
 
       submitButton().click();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
@@ -127,7 +127,7 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
     field.input().should('exist');
   });
 
-  it('renders `password` label and input', () => {
+  it('renders `password` label, hint and input', () => {
     const fieldId = PASSWORD;
     const field = yourDetailsPage[fieldId];
 
@@ -135,6 +135,12 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
     cy.checkText(field.label(), FIELD_STRINGS[fieldId].LABEL);
 
     field.input().should('exist');
+    
+    cy.checkText(field.hint.intro(), FIELD_STRINGS[fieldId].HINT.INTRO);
+    cy.checkText(field.hint.listItem1(), FIELD_STRINGS[fieldId].HINT.RULES[0]);
+    cy.checkText(field.hint.listItem2(), FIELD_STRINGS[fieldId].HINT.RULES[1]);
+    cy.checkText(field.hint.listItem3(), FIELD_STRINGS[fieldId].HINT.RULES[2]);
+    cy.checkText(field.hint.listItem4(), FIELD_STRINGS[fieldId].HINT.RULES[3]);
   });
 
   it('renders a submit button', () => {

--- a/e2e-tests/cypress/e2e/pages/insurance/account/create/yourDetails.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/account/create/yourDetails.js
@@ -33,6 +33,13 @@ const yourDetailsPage = {
     label: () => cy.get(`[data-cy="${PASSWORD}-label"]`),
     input: () => cy.get(`[data-cy="${PASSWORD}-input"]`),
     errorMessage: () => cy.get(`[data-cy="${PASSWORD}-error-message"]`),
+    hint: {
+      intro: () => cy.get(`[data-cy="${PASSWORD}-hint-intro"]`),
+      listItem1: () => cy.get(`[data-cy="${PASSWORD}-hint-list-item-1"]`),
+      listItem2: () => cy.get(`[data-cy="${PASSWORD}-hint-list-item-2"]`),
+      listItem3: () => cy.get(`[data-cy="${PASSWORD}-hint-list-item-3"]`),
+      listItem4: () => cy.get(`[data-cy="${PASSWORD}-hint-list-item-4"]`),
+    },
   },
 };
 

--- a/e2e-tests/cypress/fixtures/account.js
+++ b/e2e-tests/cypress/fixtures/account.js
@@ -2,7 +2,9 @@ import { FIELD_IDS } from '../../constants';
 
 const {
   INSURANCE: {
-    ACCOUNT: { FIRST_NAME, LAST_NAME, EMAIL },
+    ACCOUNT: {
+      FIRST_NAME, LAST_NAME, EMAIL, PASSWORD,
+    },
   },
 } = FIELD_IDS;
 
@@ -10,6 +12,7 @@ const account = {
   [FIRST_NAME]: 'Joe',
   [LAST_NAME]: 'Bloggs',
   [EMAIL]: 'mock@email.com',
+  [PASSWORD]: 'Mockpassword1!',
 };
 
 export default account;

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -41,6 +41,7 @@
         "graphql-tag": "^2.12.6",
         "is-url": "^1.2.4",
         "joi": "^17.7.0",
+        "joi-password": "^4.0.0",
         "morgan": "1.10.0",
         "node-notifier": "^10.0.1",
         "nodemon": "2.0.20",
@@ -12158,6 +12159,14 @@
         "@sideway/address": "^4.1.3",
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/joi-password": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/joi-password/-/joi-password-4.0.0.tgz",
+      "integrity": "sha512-wLomwS7O1T2jbUN4pzMH1H4GNNfbywNzRv+H/S4shUxuTzNF0yk+HiXMXODssSJeshzCy6eU+TV+l6p8Zg5zsA==",
+      "dependencies": {
+        "joi": "^17.6.0"
       }
     },
     "node_modules/js-sdsl": {
@@ -24924,6 +24933,14 @@
         "@sideway/address": "^4.1.3",
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "joi-password": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/joi-password/-/joi-password-4.0.0.tgz",
+      "integrity": "sha512-wLomwS7O1T2jbUN4pzMH1H4GNNfbywNzRv+H/S4shUxuTzNF0yk+HiXMXODssSJeshzCy6eU+TV+l6p8Zg5zsA==",
+      "requires": {
+        "joi": "^17.6.0"
       }
     },
     "js-sdsl": {

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -59,6 +59,7 @@
     "graphql-tag": "^2.12.6",
     "is-url": "^1.2.4",
     "joi": "^17.7.0",
+    "joi-password": "^4.0.0",
     "morgan": "1.10.0",
     "node-notifier": "^10.0.1",
     "nodemon": "2.0.20",

--- a/src/ui/server/constants/account.ts
+++ b/src/ui/server/constants/account.ts
@@ -1,0 +1,9 @@
+export const ACCOUNT = {
+  PASSWORD: {
+    MIN_LENGTH: 14,
+    MIN_LOWERCASE: 1,
+    MIN_UPPERCASE: 1,
+    MIN_NUMERIC: 1,
+    MIN_SPECIAL_CHARACTERS: 1,
+  },
+};

--- a/src/ui/server/constants/index.ts
+++ b/src/ui/server/constants/index.ts
@@ -1,4 +1,5 @@
 export * from './api';
+export * from './account';
 export * from './application';
 export * from './currencies';
 export * from './field-ids';

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -196,6 +196,10 @@ export const ERROR_MESSAGES = {
           [FIELD_IDS.INSURANCE.ACCOUNT.EMAIL]: {
             INCORRECT_FORMAT: 'Enter your email address in the correct format - for example name@example.com',
           },
+          [FIELD_IDS.INSURANCE.ACCOUNT.PASSWORD]: {
+            INCORRECT_FORMAT:
+              'Enter a password in the correct format - for example, 14 characters long with an uppercase letter, lower case letter, number and special character',
+          },
         },
       },
     },

--- a/src/ui/server/content-strings/fields/insurance/account/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/account/index.ts
@@ -17,6 +17,10 @@ export const ACCOUNT_FIELDS = {
       },
       [PASSWORD]: {
         LABEL: 'Create a password',
+        HINT: {
+          INTRO: 'Your password must contain at least 14 characters and have:',
+          RULES: ['an uppercase letter', 'a lowercase letter', 'a number', 'a special character'],
+        },
       },
     },
   },

--- a/src/ui/server/content-strings/fields/insurance/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/index.ts
@@ -1,2 +1,4 @@
+export * from './account';
 export * from './policy-and-exports';
+export * from './your-business';
 export * from './your-buyer';

--- a/src/ui/server/controllers/insurance/account/create/your-details/validation/rules/email.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/validation/rules/email.ts
@@ -15,7 +15,7 @@ const {
 
 /**
  * emailRules
- * Check submitted form data for errors with the first name field
+ * Check submitted form data for errors with the email field
  * Returns generateValidationErrors if there are any errors.
  * @param {Express.Response.body} Express response body
  * @param {Object} Errors object from previous validation errors

--- a/src/ui/server/controllers/insurance/account/create/your-details/validation/rules/index.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/validation/rules/index.ts
@@ -1,9 +1,10 @@
 import firstNameRules from './first-name';
 import lastNameRules from './last-name';
 import emailRules from './email';
+import passwordRules from './password';
 import { ValidationErrors } from '../../../../../../../../types';
 
-const rules = [firstNameRules, lastNameRules, emailRules];
+const rules = [firstNameRules, lastNameRules, emailRules, passwordRules];
 
 const validationRules = rules as Array<() => ValidationErrors>;
 

--- a/src/ui/server/controllers/insurance/account/create/your-details/validation/rules/password.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/validation/rules/password.test.ts
@@ -1,0 +1,30 @@
+import passwordRules from './password';
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/account';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import passwordValidation from '../../../../../../../shared-validation/password';
+
+const { PASSWORD: FIELD_ID } = FIELD_IDS;
+
+const {
+  ACCOUNT: {
+    CREATE: {
+      YOUR_DETAILS: { [FIELD_ID]: ERROR_MESSAGE },
+    },
+  },
+} = ERROR_MESSAGES.INSURANCE;
+
+describe('controllers/insurance/account/create/your-details/validation/rules/password', () => {
+  const mockErrors = {
+    summary: [],
+    errorList: {},
+  };
+
+  it('should return the result of passwordValidation', () => {
+    const mockFormBody = {};
+    const result = passwordRules(mockFormBody, mockErrors);
+
+    const expected = passwordValidation(FIELD_ID, mockFormBody[FIELD_ID], ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/ui/server/controllers/insurance/account/create/your-details/validation/rules/password.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/validation/rules/password.ts
@@ -1,0 +1,30 @@
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/account';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import passwordValidation from '../../../../../../../shared-validation/password';
+import { RequestBody } from '../../../../../../../../types';
+
+const { PASSWORD: FIELD_ID } = FIELD_IDS;
+
+const {
+  ACCOUNT: {
+    CREATE: {
+      YOUR_DETAILS: { [FIELD_ID]: ERROR_MESSAGE },
+    },
+  },
+} = ERROR_MESSAGES.INSURANCE;
+
+/**
+ * passwordRules
+ * Check submitted form data for errors with the password field
+ * Returns generateValidationErrors if there are any errors.
+ * @param {Express.Response.body} Express response body
+ * @param {Object} Errors object from previous validation errors
+ * @returns {Object} Validation errors
+ */
+const passwordRules = (formBody: RequestBody, errors: object) => {
+  const fieldValue = formBody[FIELD_ID];
+
+  return passwordValidation(FIELD_ID, fieldValue, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
+};
+
+export default passwordRules;

--- a/src/ui/server/shared-validation/password/index.test.ts
+++ b/src/ui/server/shared-validation/password/index.test.ts
@@ -1,0 +1,89 @@
+import passwordValidation from '.';
+import generateValidationErrors from '../../helpers/validation';
+import { ValidationErrors } from '../../../types';
+
+describe('shared-validation/password', () => {
+  const mockErrors = {
+    summary: [],
+    errorList: {},
+  };
+
+  const mockFieldId = 'password';
+  const mockErrorMessage = 'Incorrect format';
+
+  const assertResult = (result: ValidationErrors) => {
+    const expected = generateValidationErrors(mockFieldId, mockErrorMessage, mockErrors);
+
+    expect(result).toEqual(expected);
+  };
+
+  describe('when the email is empty', () => {
+    it('should return validation error', () => {
+      const mockValue = '';
+
+      const result = passwordValidation(mockFieldId, mockValue, mockErrorMessage, mockErrors);
+
+      assertResult(result);
+    });
+  });
+
+  describe('when password does not have the minimum amount of characters', () => {
+    it('should return validation error', () => {
+      const mockValue = 'Mock1!';
+
+      const result = passwordValidation(mockFieldId, mockValue, mockErrorMessage, mockErrors);
+
+      assertResult(result);
+    });
+  });
+
+  describe('when password does not contain an uppercase letter', () => {
+    it('should return validation error', () => {
+      const mockValue = 'mockpassword1!';
+
+      const result = passwordValidation(mockFieldId, mockValue, mockErrorMessage, mockErrors);
+
+      assertResult(result);
+    });
+  });
+
+  describe('when password does not contain a lowercase letter', () => {
+    it('should return validation error', () => {
+      const mockValue = 'MOCKPASSWORD1!';
+
+      const result = passwordValidation(mockFieldId, mockValue, mockErrorMessage, mockErrors);
+
+      assertResult(result);
+    });
+  });
+
+  describe('when password does not contain a number', () => {
+    it('should return validation error', () => {
+      const mockValue = 'Mockpassword!';
+
+      const result = passwordValidation(mockFieldId, mockValue, mockErrorMessage, mockErrors);
+
+      assertResult(result);
+    });
+  });
+
+  describe('when password does not contain a special character', () => {
+    it('should return validation error', () => {
+      const mockValue = 'Mockpassword1';
+
+      const result = passwordValidation(mockFieldId, mockValue, mockErrorMessage, mockErrors);
+
+      assertResult(result);
+    });
+  });
+
+  describe('when there are no validation errors', () => {
+    it('should return the provided errors object', () => {
+      const mockValue = 'Mockpassword1!';
+
+      const result = passwordValidation(mockFieldId, mockValue, mockErrorMessage, mockErrors);
+
+      expect(result).toEqual(mockErrors);
+    });
+  });
+});

--- a/src/ui/server/shared-validation/password/index.ts
+++ b/src/ui/server/shared-validation/password/index.ts
@@ -1,0 +1,51 @@
+import Joi from 'joi';
+import { joiPasswordExtendCore } from 'joi-password';
+import { ACCOUNT } from '../../constants';
+import generateValidationErrors from '../../helpers/validation';
+
+const JoiPassword = Joi.extend(joiPasswordExtendCore);
+
+const { MIN_LENGTH, MIN_LOWERCASE, MIN_UPPERCASE, MIN_NUMERIC, MIN_SPECIAL_CHARACTERS } = ACCOUNT.PASSWORD;
+
+/**
+ * passwordValidation
+ * Check if an password is valid
+ * Returns generateValidationErrors if there are any errors.
+ * @param {String} Field ID
+ * @param {String} Password
+ * @param {String} Error message
+ * @param {Object} Errors object from previous validation errors
+ * @returns {Object} Validation errors
+ */
+const passwordValidation = (fieldId: string, password: string, errorMessage: string, errors: object) => {
+  try {
+    if (password.length < MIN_LENGTH) {
+      return generateValidationErrors(fieldId, errorMessage, errors);
+    }
+
+    const schema = Joi.object({
+      username: Joi.string().min(5).max(200).required(),
+      password: JoiPassword.string()
+        .minOfSpecialCharacters(MIN_SPECIAL_CHARACTERS)
+        .minOfLowercase(MIN_LOWERCASE)
+        .minOfUppercase(MIN_UPPERCASE)
+        .minOfNumeric(MIN_NUMERIC)
+        .noWhiteSpaces()
+        .required(),
+    });
+
+    // joi-password requires username to be passed.
+    // We do not have usernames so we pass a mock value instead.
+    const validation = schema.validate({ username: 'username', password });
+
+    if (validation.error) {
+      return generateValidationErrors(fieldId, errorMessage, errors);
+    }
+  } catch (err) {
+    return errors;
+  }
+
+  return errors;
+};
+
+export default passwordValidation;

--- a/src/ui/templates/insurance/account/create/your-details.njk
+++ b/src/ui/templates/insurance/account/create/your-details.njk
@@ -108,17 +108,17 @@
       </div>
     </div>
 
-    {% set passwordFieldId = FIELDS.PASSWORD.ID %}
+    {% set PASSWORD_FIELD_ID = FIELDS.PASSWORD.ID %}
 
     {% set passwordHintHtml %}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters-from-desktop">
 
-          <p class="govuk-hint" data-cy="{{ passwordFieldId }}-hint-intro">{{ FIELDS.PASSWORD.HINT.INTRO }}</p>
+          <p class="govuk-hint" data-cy="{{ PASSWORD_FIELD_ID }}-hint-intro">{{ FIELDS.PASSWORD.HINT.INTRO }}</p>
 
           <ul>
             {% for rule in FIELDS.PASSWORD.HINT.RULES %}
-              <li data-cy="{{ passwordFieldId }}-hint-list-item-{{ loop.index }}">{{ rule }}</li>
+              <li data-cy="{{ PASSWORD_FIELD_ID }}-hint-list-item-{{ loop.index }}">{{ rule }}</li>
             {% endfor %}
           </ul>
 
@@ -131,24 +131,24 @@
         text: FIELDS.PASSWORD.LABEL,
         classes: "govuk-!-font-weight-bold govuk-!-font-size-24",
         attributes: {
-          id: passwordFieldId + '-label',
-          'data-cy': passwordFieldId + '-label'
+          id: PASSWORD_FIELD_ID + '-label',
+          'data-cy': PASSWORD_FIELD_ID + '-label'
         }
       },
       attributes: {
-        'data-cy': passwordFieldId + '-input'
+        'data-cy': PASSWORD_FIELD_ID + '-input'
       },
-      id: passwordFieldId,
-      name: passwordFieldId,
+      id: PASSWORD_FIELD_ID,
+      name: PASSWORD_FIELD_ID,
       hint: {
         html: passwordHintHtml
       },
       classes: "govuk-!-width-one-half",
-      value: submittedValues[passwordFieldId],
-      errorMessage: validationErrors.errorList[passwordFieldId] and {
-        text: validationErrors.errorList[passwordFieldId].text,
+      value: submittedValues[PASSWORD_FIELD_ID],
+      errorMessage: validationErrors.errorList[PASSWORD_FIELD_ID] and {
+        text: validationErrors.errorList[PASSWORD_FIELD_ID].text,
         attributes: {
-          "data-cy": passwordFieldId + "-error-message"
+          "data-cy": PASSWORD_FIELD_ID + "-error-message"
         }
       }
     }) }}

--- a/src/ui/templates/insurance/account/create/your-details.njk
+++ b/src/ui/templates/insurance/account/create/your-details.njk
@@ -105,31 +105,53 @@
           }
         }) }}
 
-        {{ govukInput({
-          label: {
-            text: FIELDS.PASSWORD.LABEL,
-            classes: "govuk-!-font-weight-bold govuk-!-font-size-24",
-            attributes: {
-              id: FIELDS.PASSWORD.ID + '-label',
-              'data-cy': FIELDS.PASSWORD.ID + '-label'
-            }
-          },
-          attributes: {
-            'data-cy': FIELDS.PASSWORD.ID + '-input'
-          },
-          id: FIELDS.PASSWORD.ID,
-          name: FIELDS.PASSWORD.ID,
-          value: submittedValues[FIELDS.PASSWORD.ID],
-          errorMessage: validationErrors.errorList[FIELDS.PASSWORD.ID] and {
-            text: validationErrors.errorList[FIELDS.PASSWORD.ID].text,
-            attributes: {
-              "data-cy": FIELDS.PASSWORD.ID + "-error-message"
-            }
-          }
-        }) }}
-
       </div>
     </div>
+
+    {% set passwordFieldId = FIELDS.PASSWORD.ID %}
+
+    {% set passwordHintHtml %}
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters-from-desktop">
+
+          <p class="govuk-hint" data-cy="{{ passwordFieldId }}-hint-intro">{{ FIELDS.PASSWORD.HINT.INTRO }}</p>
+
+          <ul>
+            {% for rule in FIELDS.PASSWORD.HINT.RULES %}
+              <li data-cy="{{ passwordFieldId }}-hint-list-item-{{ loop.index }}">{{ rule }}</li>
+            {% endfor %}
+          </ul>
+
+        </div>
+      </div>
+    {% endset %}
+
+    {{ govukInput({
+      label: {
+        text: FIELDS.PASSWORD.LABEL,
+        classes: "govuk-!-font-weight-bold govuk-!-font-size-24",
+        attributes: {
+          id: passwordFieldId + '-label',
+          'data-cy': passwordFieldId + '-label'
+        }
+      },
+      attributes: {
+        'data-cy': passwordFieldId + '-input'
+      },
+      id: passwordFieldId,
+      name: passwordFieldId,
+      hint: {
+        html: passwordHintHtml
+      },
+      classes: "govuk-!-width-one-half",
+      value: submittedValues[passwordFieldId],
+      errorMessage: validationErrors.errorList[passwordFieldId] and {
+        text: validationErrors.errorList[passwordFieldId].text,
+        attributes: {
+          "data-cy": passwordFieldId + "-error-message"
+        }
+      }
+    }) }}
 
     <div class="govuk-button-group">
       {{ govukButton({


### PR DESCRIPTION
This PR adds password validation to the "your details" page of account creation.

## Changes

- Add `joi-password` package to easily read and maintain password rules; and validate without introducing regex.
- Create a shared, reusable validation function for checking a password with Joi and `joi-password`.
- Add password hints as per design.
- E2E test coverage.
- Also fixed a typo where "email" validation rule mentioned "first name".