### PR TITLE
fix(EMS-911-919): Policy and exports - fix field hint link and error message

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -137,7 +137,7 @@ export const ERROR_MESSAGES = {
             NOT_A_NUMBER: 'Enter your contract value as a whole number - do not enter decimals',
             NOT_A_WHOLE_NUMBER: 'Enter your contract value as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your contract value must be 1 or more',
-            ABOVE_MAXIMUM: 'The maximum the buyer will owe cannot be more than £499.999. If you need cover for more than this, fill in this form instead.',
+            ABOVE_MAXIMUM: 'The maximum the buyer will owe cannot be more than £499.999',
           },
         },
         MULTIPLE: {

--- a/e2e-tests/content-strings/fields/insurance/policy-and-exports/index.js
+++ b/e2e-tests/content-strings/fields/insurance/policy-and-exports/index.js
@@ -110,7 +110,7 @@ export const POLICY_AND_EXPORT_FIELDS = {
           NEED_MORE_COVER: 'If you need cover for more than £499,999, ',
           FILL_IN_FORM: {
             TEXT: 'fill in this form instead.',
-            HREF: LINKS.EXTERNAL.FULL_APPLICATION,
+            HREF: LINKS.EXTERNAL.PROPOSAL_FORM,
           },
           NO_DECIMALS: 'Enter a whole number - do not enter decimals.',
         },

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -195,7 +195,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
 
     cy.checkText(field.hint.fillInFormLink(), HINT.FILL_IN_FORM.TEXT);
 
-    field.hint.fillInFormLink().should('have.attr', 'href', HINT.FILL_IN_FORM.HREF);
+    field.hint.fillInFormLink().should('have.attr', 'href', LINKS.EXTERNAL.PROPOSAL_FORM);
 
     cy.checkText(field.hint.noDecimals(), HINT.NO_DECIMALS);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
@@ -173,7 +173,7 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
       hintContent.FILL_IN_FORM.TEXT,
     );
 
-    field.hint.link().should('have.attr', 'href', hintContent.FILL_IN_FORM.HREF);
+    field.hint.link().should('have.attr', 'href', LINKS.EXTERNAL.PROPOSAL_FORM);
 
     cy.checkText(
       field.hint.noDecimals(),

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
@@ -168,9 +168,7 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
       const expectedHintText = `${HINT[0].text} ${HINT[1].text} ${HINT[2].text}`;
       cy.checkText(field.hint(), expectedHintText);
 
-      const expectedHintHref = HINT[1].href;
-
-      field.hintLink().should('have.attr', 'href', expectedHintHref);
+      field.hintLink().should('have.attr', 'href', LINKS.EXTERNAL.NBI_FORM);
 
       field.input().should('exist');
 

--- a/e2e-tests/cypress/support/insurance/check-policy-currency-code-input.js
+++ b/e2e-tests/cypress/support/insurance/check-policy-currency-code-input.js
@@ -1,4 +1,5 @@
 import insurancePartials from '../../e2e/partials/insurance';
+import { LINKS } from '../../../content-strings';
 import { POLICY_AND_EXPORT_FIELDS } from '../../../content-strings/fields/insurance/policy-and-exports';
 import { SUPPORTED_CURRENCIES } from '../../../constants';
 import { SHARED_CONTRACT_POLICY } from '../../../constants/field-ids/insurance/policy-and-exports';
@@ -33,7 +34,7 @@ const checkPolicyCurrencyCodeInput = () => {
     hintContent.APPLY_USING_FORM.TEXT,
   );
 
-  field.hint.link().should('have.attr', 'href', hintContent.APPLY_USING_FORM.HREF);
+  field.hint.link().should('have.attr', 'href', LINKS.EXTERNAL.PROPOSAL_FORM);
 
   field.input().should('exist');
 

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -141,7 +141,7 @@ export const ERROR_MESSAGES = {
             NOT_A_NUMBER: 'Enter your contract value as a whole number - do not enter decimals',
             NOT_A_WHOLE_NUMBER: 'Enter your contract value as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your contract value must be 1 or more',
-            ABOVE_MAXIMUM: 'The maximum the buyer will owe cannot be more than £499.999. If you need cover for more than this, fill in this form instead.',
+            ABOVE_MAXIMUM: 'The maximum the buyer will owe cannot be more than £499.999',
           },
         },
         MULTIPLE: {

--- a/src/ui/server/content-strings/fields/insurance/policy-and-exports/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy-and-exports/index.ts
@@ -110,7 +110,7 @@ export const POLICY_AND_EXPORTS_FIELDS = {
           NEED_MORE_COVER: 'If you need cover for more than £499,999, ',
           FILL_IN_FORM: {
             TEXT: 'fill in this form instead.',
-            HREF: LINKS.EXTERNAL.FULL_APPLICATION,
+            HREF: LINKS.EXTERNAL.PROPOSAL_FORM,
           },
           NO_DECIMALS: 'Enter a whole number - do not enter decimals.',
         },


### PR DESCRIPTION
This PR fixes 2 issues in the Policy and exports - single contract policy page.

- Incorrect link to external form in the "maximum buyer will owe" field hint.
- Incorrect/outdated error message for the "total contract value" field.
- Also updated the E2E tests for single/contract policy hint links to external form so that they assert from link content strings instead of field content strings.