### PR TITLE
feat(EMS-856): Policy and exports - strip commas from monetary fields

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -143,9 +143,7 @@ export const ERROR_MESSAGES = {
             CANNOT_BE_BEFORE: 'Your contract completion date must be after your policy start date',
           },
           [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.SINGLE.TOTAL_CONTRACT_VALUE]: {
-            IS_EMPTY: 'Enter your contract value as a whole number - do not enter decimals',
-            NOT_A_NUMBER: 'Enter your contract value as a whole number - do not enter decimals',
-            NOT_A_WHOLE_NUMBER: 'Enter your contract value as a whole number - do not enter decimals',
+            INCORRECT_FORMAT: 'Enter your contract value as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your contract value must be 1 or more',
             ABOVE_MAXIMUM: 'The maximum the buyer will owe cannot be more than £499.999',
           },
@@ -155,15 +153,11 @@ export const ERROR_MESSAGES = {
             IS_EMPTY: 'Select how many months you want to be insured for',
           },
           [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.MULTIPLE.TOTAL_SALES_TO_BUYER]: {
-            IS_EMPTY: 'Enter your estimated sales as a whole number - do not enter decimals',
-            NOT_A_NUMBER: 'Enter your estimated sales as a whole number - do not enter decimals',
-            NOT_A_WHOLE_NUMBER: 'Enter your estimated sales as a whole number - do not enter decimals',
+            INCORRECT_FORMAT: 'Enter your estimated sales as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your estimated sales must be 1 or more',
           },
           [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.MULTIPLE.MAXIMUM_BUYER_WILL_OWE]: {
-            IS_EMPTY: 'Enter the maximum the buyer will owe as a whole number - do not enter decimals',
-            NOT_A_NUMBER: 'Enter the maximum the buyer will owe as a whole number - do not enter decimals',
-            NOT_A_WHOLE_NUMBER: 'Enter the maximum the buyer will owe as a whole number - do not enter decimals',
+            INCORRECT_FORMAT: 'Enter the maximum the buyer will owe as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'The maximum the buyer will owe must be 1 or more',
             ABOVE_MAXIMUM: 'The maximum the buyer will owe cannot be more than £499.999',
           },

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-maximum-buyer-will-owe.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-maximum-buyer-will-owe.spec.js
@@ -76,12 +76,12 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
       cy.checkText(
         partials.errorSummaryListItems().eq(3),
-        CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].IS_EMPTY,
+        CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].IS_EMPTY}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].INCORRECT_FORMAT}`,
       );
     });
   });
@@ -93,12 +93,12 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
       cy.checkText(
         partials.errorSummaryListItems().eq(3),
-        CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].NOT_A_NUMBER,
+        CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].NOT_A_NUMBER}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].INCORRECT_FORMAT}`,
       );
     });
   });
@@ -110,12 +110,12 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
       cy.checkText(
         partials.errorSummaryListItems().eq(3),
-        CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].NOT_A_WHOLE_NUMBER,
+        CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].NOT_A_WHOLE_NUMBER}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].INCORRECT_FORMAT}`,
       );
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-maximum-buyer-will-owe.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-maximum-buyer-will-owe.spec.js
@@ -12,7 +12,16 @@ import getReferenceNumber from '../../../../../helpers/get-reference-number';
 
 const { taskList } = partials.insurancePartials;
 
-const { INSURANCE } = ROUTES;
+const {
+  INSURANCE: {
+    ROOT: INSURANCE_ROOT,
+    START,
+    POLICY_AND_EXPORTS: {
+      MULTIPLE_CONTRACT_POLICY,
+      ABOUT_GOODS_OR_SERVICES,
+    },
+  },
+} = ROUTES;
 
 const {
   INSURANCE: {
@@ -38,7 +47,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
   let referenceNumber;
 
   before(() => {
-    cy.navigateToUrl(INSURANCE.START);
+    cy.navigateToUrl(START);
 
     cy.submitInsuranceEligibilityAndStartApplication();
 
@@ -48,7 +57,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
     getReferenceNumber().then((id) => {
       referenceNumber = id;
-      const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE.ROOT}/${referenceNumber}${INSURANCE.POLICY_AND_EXPORTS.MULTIPLE_CONTRACT_POLICY}`;
+      const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
 
       cy.url().should('eq', expectedUrl);
     });
@@ -61,7 +70,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
   const field = multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE];
 
-  describe('when total sales to buyer is not provided', () => {
+  describe('when maximum buyer will owe is not provided', () => {
     it('should render a validation error', () => {
       submitButton().click();
 
@@ -77,7 +86,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
     });
   });
 
-  describe('when total sales to buyer is not a number', () => {
+  describe('when maximum buyer will owe is not a number', () => {
     it('should render a validation error', () => {
       multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().clear().type('ten!');
       submitButton().click();
@@ -94,7 +103,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
     });
   });
 
-  describe('when total sales to buyer contains a decimal', () => {
+  describe('when maximum buyer will owe contains a decimal', () => {
     it('should render a validation error', () => {
       multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().clear().type('1.2');
       submitButton().click();
@@ -111,7 +120,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
     });
   });
 
-  describe('when total sales to buyer is below the minimum', () => {
+  describe('when maximum buyer will owe is below the minimum', () => {
     it('should render a validation error', () => {
       multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().clear().type('0');
       submitButton().click();
@@ -128,7 +137,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
     });
   });
 
-  describe('when total sales to buyer is above the maximum', () => {
+  describe('when maximum buyer will owe is above the maximum', () => {
     it('should render a validation error', () => {
       const MAXIMUM = APPLICATION.POLICY_AND_EXPORT.MAXIMUM_BUYER_CAN_OWE;
 
@@ -144,6 +153,19 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
         field.errorMessage(),
         `Error: ${CONTRACT_ERROR_MESSAGES[MAXIMUM_BUYER_WILL_OWE].ABOVE_MAXIMUM}`,
       );
+    });
+  });
+
+  describe('when maximum buyer will owe is valid and contains a comma', () => {
+    it('should redirect to the next page as all fields are valid', () => {
+      cy.completeAndSubmitMultipleContractPolicyForm();
+      partials.backLink().click();
+
+      multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().clear().type('1,234');
+      submitButton().click();
+
+      const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`;
+      cy.url().should('eq', expectedUrl);
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-total-sales-to-buyer.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-total-sales-to-buyer.spec.js
@@ -71,12 +71,12 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
       cy.checkText(
         partials.errorSummaryListItems().eq(2),
-        CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].IS_EMPTY,
+        CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].IS_EMPTY}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].INCORRECT_FORMAT}`,
       );
     });
   });
@@ -88,12 +88,12 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
       cy.checkText(
         partials.errorSummaryListItems().eq(2),
-        CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].NOT_A_NUMBER,
+        CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].NOT_A_NUMBER}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].INCORRECT_FORMAT}`,
       );
     });
   });
@@ -105,12 +105,12 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
       cy.checkText(
         partials.errorSummaryListItems().eq(2),
-        CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].NOT_A_WHOLE_NUMBER,
+        CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].NOT_A_WHOLE_NUMBER}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].INCORRECT_FORMAT}`,
       );
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-total-sales-to-buyer.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-total-sales-to-buyer.spec.js
@@ -7,7 +7,16 @@ import getReferenceNumber from '../../../../../helpers/get-reference-number';
 
 const { taskList } = partials.insurancePartials;
 
-const { INSURANCE } = ROUTES;
+const {
+  INSURANCE: {
+    ROOT: INSURANCE_ROOT,
+    START,
+    POLICY_AND_EXPORTS: {
+      MULTIPLE_CONTRACT_POLICY,
+      ABOUT_GOODS_OR_SERVICES,
+    },
+  },
+} = ROUTES;
 
 const {
   INSURANCE: {
@@ -33,7 +42,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
   let referenceNumber;
 
   before(() => {
-    cy.navigateToUrl(INSURANCE.START);
+    cy.navigateToUrl(START);
 
     cy.submitInsuranceEligibilityAndStartApplication();
 
@@ -43,7 +52,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
     getReferenceNumber().then((id) => {
       referenceNumber = id;
-      const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE.ROOT}/${referenceNumber}${INSURANCE.POLICY_AND_EXPORTS.MULTIPLE_CONTRACT_POLICY}`;
+      const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
 
       cy.url().should('eq', expectedUrl);
     });
@@ -120,6 +129,19 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
         field.errorMessage(),
         `Error: ${CONTRACT_ERROR_MESSAGES[TOTAL_SALES_TO_BUYER].BELOW_MINIMUM}`,
       );
+    });
+  });
+
+  describe('when total sales to buyer is valid and contains a comma', () => {
+    it('should redirect to the next page as all fields are valid', () => {
+      cy.completeAndSubmitMultipleContractPolicyForm();
+      partials.backLink().click();
+
+      multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().clear().type('1,234');
+      submitButton().click();
+
+      const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`;
+      cy.url().should('eq', expectedUrl);
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
@@ -79,12 +79,12 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
 
     cy.checkText(
       partials.errorSummaryListItems().eq(2),
-      CONTRACT_ERROR_MESSAGES.MULTIPLE[TOTAL_SALES_TO_BUYER].IS_EMPTY,
+      CONTRACT_ERROR_MESSAGES.MULTIPLE[TOTAL_SALES_TO_BUYER].INCORRECT_FORMAT,
     );
 
     cy.checkText(
       partials.errorSummaryListItems().eq(3),
-      CONTRACT_ERROR_MESSAGES.MULTIPLE[MAXIMUM_BUYER_WILL_OWE].IS_EMPTY,
+      CONTRACT_ERROR_MESSAGES.MULTIPLE[MAXIMUM_BUYER_WILL_OWE].INCORRECT_FORMAT,
     );
 
     cy.checkText(

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-total-contract-value.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-total-contract-value.spec.js
@@ -71,12 +71,12 @@ context('Insurance - Policy and exports - Single contract policy page - form val
 
       cy.checkText(
         partials.errorSummaryListItems().eq(2),
-        CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].IS_EMPTY,
+        CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].IS_EMPTY}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].INCORRECT_FORMAT}`,
       );
     });
   });
@@ -88,12 +88,12 @@ context('Insurance - Policy and exports - Single contract policy page - form val
 
       cy.checkText(
         partials.errorSummaryListItems().eq(2),
-        CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].NOT_A_NUMBER,
+        CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].NOT_A_NUMBER}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].INCORRECT_FORMAT}`,
       );
     });
   });
@@ -105,12 +105,12 @@ context('Insurance - Policy and exports - Single contract policy page - form val
 
       cy.checkText(
         partials.errorSummaryListItems().eq(2),
-        CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].NOT_A_WHOLE_NUMBER,
+        CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].INCORRECT_FORMAT,
       );
 
       cy.checkText(
         field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].NOT_A_WHOLE_NUMBER}`,
+        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].INCORRECT_FORMAT}`,
       );
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-total-contract-value.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-total-contract-value.spec.js
@@ -7,7 +7,16 @@ import getReferenceNumber from '../../../../../helpers/get-reference-number';
 
 const { taskList } = partials.insurancePartials;
 
-const { INSURANCE } = ROUTES;
+const {
+  INSURANCE: {
+    ROOT: INSURANCE_ROOT,
+    START,
+    POLICY_AND_EXPORTS: {
+      SINGLE_CONTRACT_POLICY,
+      ABOUT_GOODS_OR_SERVICES,
+    },
+  },
+} = ROUTES;
 
 const {
   INSURANCE: {
@@ -33,7 +42,7 @@ context('Insurance - Policy and exports - Single contract policy page - form val
   let referenceNumber;
 
   before(() => {
-    cy.navigateToUrl(INSURANCE.START);
+    cy.navigateToUrl(START);
 
     cy.submitInsuranceEligibilityAndStartApplication();
 
@@ -43,7 +52,7 @@ context('Insurance - Policy and exports - Single contract policy page - form val
 
     getReferenceNumber().then((id) => {
       referenceNumber = id;
-      const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE.ROOT}/${referenceNumber}${INSURANCE.POLICY_AND_EXPORTS.SINGLE_CONTRACT_POLICY}`;
+      const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
 
       cy.url().should('eq', expectedUrl);
     });
@@ -137,6 +146,19 @@ context('Insurance - Policy and exports - Single contract policy page - form val
         field.errorMessage(),
         `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].ABOVE_MAXIMUM}`,
       );
+    });
+  });
+
+  describe('when total contract value is valid and contains a comma', () => {
+    it('should redirect to the next page as all fields are valid', () => {
+      cy.completeAndSubmitSingleContractPolicyForm();
+      partials.backLink().click();
+
+      field.input().clear().type('1,234');
+      submitButton().click();
+
+      const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`;
+      cy.url().should('eq', expectedUrl);
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation.spec.js
@@ -78,7 +78,7 @@ context('Insurance - Policy and exports - Single contract policy page - form val
 
     cy.checkText(
       partials.errorSummaryListItems().eq(2),
-      CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].IS_EMPTY,
+      CONTRACT_ERROR_MESSAGES.SINGLE[TOTAL_CONTRACT_VALUE].INCORRECT_FORMAT,
     );
 
     cy.checkText(

--- a/e2e-tests/cypress/support/insurance/complete-and-submit-multiple-contract-policy-form.js
+++ b/e2e-tests/cypress/support/insurance/complete-and-submit-multiple-contract-policy-form.js
@@ -22,14 +22,14 @@ const {
 } = FIELD_IDS;
 
 export default () => {
-  multipleContractPolicyPage[REQUESTED_START_DATE].dayInput().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].day);
-  multipleContractPolicyPage[REQUESTED_START_DATE].monthInput().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].month);
-  multipleContractPolicyPage[REQUESTED_START_DATE].yearInput().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].year);
+  multipleContractPolicyPage[REQUESTED_START_DATE].dayInput().clear().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].day);
+  multipleContractPolicyPage[REQUESTED_START_DATE].monthInput().clear().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].month);
+  multipleContractPolicyPage[REQUESTED_START_DATE].yearInput().clear().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].year);
 
   multipleContractPolicyPage[TOTAL_MONTHS_OF_COVER].input().select(application.POLICY_AND_EXPORTS[TOTAL_MONTHS_OF_COVER]);
-  multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().type(application.POLICY_AND_EXPORTS[TOTAL_SALES_TO_BUYER]);
-  multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().type(application.POLICY_AND_EXPORTS[MAXIMUM_BUYER_WILL_OWE]);
-  multipleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().type(application.POLICY_AND_EXPORTS[CREDIT_PERIOD_WITH_BUYER]);
+  multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input().clear().type(application.POLICY_AND_EXPORTS[TOTAL_SALES_TO_BUYER]);
+  multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input().clear().type(application.POLICY_AND_EXPORTS[MAXIMUM_BUYER_WILL_OWE]);
+  multipleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().clear().type(application.POLICY_AND_EXPORTS[CREDIT_PERIOD_WITH_BUYER]);
 
   insurancePartials.policyCurrencyCodeFormField.input().select(application.POLICY_AND_EXPORTS[POLICY_CURRENCY_CODE]);
 

--- a/e2e-tests/cypress/support/insurance/complete-and-submit-single-contract-policy-form.js
+++ b/e2e-tests/cypress/support/insurance/complete-and-submit-single-contract-policy-form.js
@@ -18,16 +18,16 @@ const {
 } = FIELD_IDS;
 
 export default () => {
-  singleContractPolicyPage[REQUESTED_START_DATE].dayInput().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].day);
-  singleContractPolicyPage[REQUESTED_START_DATE].monthInput().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].month);
-  singleContractPolicyPage[REQUESTED_START_DATE].yearInput().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].year);
+  singleContractPolicyPage[REQUESTED_START_DATE].dayInput().clear().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].day);
+  singleContractPolicyPage[REQUESTED_START_DATE].monthInput().clear().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].month);
+  singleContractPolicyPage[REQUESTED_START_DATE].yearInput().clear().type(application.POLICY_AND_EXPORTS[REQUESTED_START_DATE].year);
 
-  singleContractPolicyPage[CONTRACT_COMPLETION_DATE].dayInput().type(application.POLICY_AND_EXPORTS[CONTRACT_COMPLETION_DATE].day);
-  singleContractPolicyPage[CONTRACT_COMPLETION_DATE].monthInput().type(application.POLICY_AND_EXPORTS[CONTRACT_COMPLETION_DATE].month);
-  singleContractPolicyPage[CONTRACT_COMPLETION_DATE].yearInput().type(application.POLICY_AND_EXPORTS[CONTRACT_COMPLETION_DATE].year);
+  singleContractPolicyPage[CONTRACT_COMPLETION_DATE].dayInput().clear().type(application.POLICY_AND_EXPORTS[CONTRACT_COMPLETION_DATE].day);
+  singleContractPolicyPage[CONTRACT_COMPLETION_DATE].monthInput().clear().type(application.POLICY_AND_EXPORTS[CONTRACT_COMPLETION_DATE].month);
+  singleContractPolicyPage[CONTRACT_COMPLETION_DATE].yearInput().clear().type(application.POLICY_AND_EXPORTS[CONTRACT_COMPLETION_DATE].year);
 
-  singleContractPolicyPage[TOTAL_CONTRACT_VALUE].input().type(application.POLICY_AND_EXPORTS[TOTAL_CONTRACT_VALUE]);
-  singleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().type(application.POLICY_AND_EXPORTS[CREDIT_PERIOD_WITH_BUYER]);
+  singleContractPolicyPage[TOTAL_CONTRACT_VALUE].input().clear().type(application.POLICY_AND_EXPORTS[TOTAL_CONTRACT_VALUE]);
+  singleContractPolicyPage[CREDIT_PERIOD_WITH_BUYER].input().clear().type(application.POLICY_AND_EXPORTS[CREDIT_PERIOD_WITH_BUYER]);
   insurancePartials.policyCurrencyCodeFormField.input().select(application.POLICY_AND_EXPORTS[POLICY_CURRENCY_CODE]);
 
   submitButton().click();

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -147,9 +147,7 @@ export const ERROR_MESSAGES = {
             CANNOT_BE_BEFORE: 'Your contract completion date must be after your policy start date',
           },
           [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.SINGLE.TOTAL_CONTRACT_VALUE]: {
-            IS_EMPTY: 'Enter your contract value as a whole number - do not enter decimals',
-            NOT_A_NUMBER: 'Enter your contract value as a whole number - do not enter decimals',
-            NOT_A_WHOLE_NUMBER: 'Enter your contract value as a whole number - do not enter decimals',
+            INCORRECT_FORMAT: 'Enter your contract value as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your contract value must be 1 or more',
             ABOVE_MAXIMUM: 'The maximum the buyer will owe cannot be more than £499.999',
           },
@@ -159,15 +157,11 @@ export const ERROR_MESSAGES = {
             IS_EMPTY: 'Select how many months you want to be insured for',
           },
           [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.MULTIPLE.TOTAL_SALES_TO_BUYER]: {
-            IS_EMPTY: 'Enter your estimated sales as a whole number - do not enter decimals',
-            NOT_A_NUMBER: 'Enter your estimated sales as a whole number - do not enter decimals',
-            NOT_A_WHOLE_NUMBER: 'Enter your estimated sales as a whole number - do not enter decimals',
+            INCORRECT_FORMAT: 'Enter your estimated sales as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your estimated sales must be 1 or more',
           },
           [FIELD_IDS.INSURANCE.POLICY_AND_EXPORTS.CONTRACT_POLICY.MULTIPLE.MAXIMUM_BUYER_WILL_OWE]: {
-            IS_EMPTY: 'Enter the maximum the buyer will owe as a whole number - do not enter decimals',
-            NOT_A_NUMBER: 'Enter the maximum the buyer will owe as a whole number - do not enter decimals',
-            NOT_A_WHOLE_NUMBER: 'Enter the maximum the buyer will owe as a whole number - do not enter decimals',
+            INCORRECT_FORMAT: 'Enter the maximum the buyer will owe as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'The maximum the buyer will owe must be 1 or more',
             ABOVE_MAXIMUM: 'The maximum the buyer will owe cannot be more than £499.999',
           },

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.ts
@@ -36,7 +36,7 @@ const percentageTurnover = (responseBody: RequestBody, errors: object) => {
     return generateValidationErrors(FIELD_ID, errorMessage, errors);
   }
 
-  // removes any commas from number
+  // strip commas - commas are valid.
   const numberWithoutCommas = stripCommas(value);
 
   /**
@@ -51,6 +51,7 @@ const percentageTurnover = (responseBody: RequestBody, errors: object) => {
 
   // checks if number is below 0 and returns different error message
   if (isNumberBelowMinimum(Number(numberWithoutCommas), MINIMUM)) {
+    s
     const errorMessage = ERROR_MESSAGE.BELOW_MINIMUM;
 
     return generateValidationErrors(FIELD_ID, errorMessage, updatedErrors);

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe.test.ts
@@ -108,4 +108,16 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy/valid
       expect(result).toEqual(mockErrors);
     });
   });
+
+  describe('when there are no validation errors and the value contains a comma', () => {
+    it('should return the provided errors object', () => {
+      const mockSubmittedData = {
+        [FIELD_ID]: '10,000',
+      };
+
+      const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
+
+      expect(result).toEqual(mockErrors);
+    });
+  });
 });

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe.test.ts
@@ -35,7 +35,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy/valid
 
       const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors);
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });
@@ -49,7 +49,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy/valid
 
       const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, mockErrors);
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });
@@ -63,7 +63,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy/valid
 
       const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_WHOLE_NUMBER, mockErrors);
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe.ts
@@ -42,7 +42,7 @@ const maximumBuyerWillOweRules = (formBody: RequestBody, errors: object) => {
 
   // check if the field is empty.
   if (!objectHasProperty(formBody, FIELD_ID)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
   // strip commas - commas are valid.
@@ -50,12 +50,12 @@ const maximumBuyerWillOweRules = (formBody: RequestBody, errors: object) => {
 
   // check if the field is not a number
   if (!isNumber(numberWithoutCommas)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, errors);
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
   // check if the field is not a whole number
   if (numberHasDecimal(Number(numberWithoutCommas))) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_WHOLE_NUMBER, errors);
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
   // check if the field is below the minimum

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe.ts
@@ -2,8 +2,8 @@ import { APPLICATION, FIELD_IDS } from '../../../../../../constants';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import generateValidationErrors from '../../../../../../helpers/validation';
 import { objectHasProperty } from '../../../../../../helpers/object';
+import wholeNumberValidation from '../../../../../../helpers/whole-number-validation';
 import { stripCommas } from '../../../../../../helpers/string';
-import { isNumber, numberHasDecimal } from '../../../../../../helpers/number';
 import { RequestBody } from '../../../../../../../types';
 
 const {
@@ -38,34 +38,27 @@ const MAXIMUM = APPLICATION.POLICY_AND_EXPORT.MAXIMUM_BUYER_CAN_OWE;
  * @returns {Object} Validation errors
  */
 const maximumBuyerWillOweRules = (formBody: RequestBody, errors: object) => {
-  const updatedErrors = errors;
+  let updatedErrors = errors;
 
   // check if the field is empty.
   if (!objectHasProperty(formBody, FIELD_ID)) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
+  // check if the field is a whole number.
+  updatedErrors = wholeNumberValidation(formBody, updatedErrors, ERROR_MESSAGE.INCORRECT_FORMAT, FIELD_ID);
+
   // strip commas - commas are valid.
   const numberWithoutCommas = stripCommas(formBody[FIELD_ID]);
 
-  // check if the field is not a number
-  if (!isNumber(numberWithoutCommas)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
-  }
-
-  // check if the field is not a whole number
-  if (numberHasDecimal(Number(numberWithoutCommas))) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
-  }
-
   // check if the field is below the minimum
   if (Number(numberWithoutCommas) < MINIMUM) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, errors);
+    updatedErrors = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, errors);
   }
 
   // check if the field is above the maximum
   if (Number(numberWithoutCommas) > MAXIMUM) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.ABOVE_MAXIMUM, errors);
+    updatedErrors = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.ABOVE_MAXIMUM, errors);
   }
 
   return updatedErrors;

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/maximum-buyer-will-owe.ts
@@ -2,6 +2,7 @@ import { APPLICATION, FIELD_IDS } from '../../../../../../constants';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import generateValidationErrors from '../../../../../../helpers/validation';
 import { objectHasProperty } from '../../../../../../helpers/object';
+import { stripCommas } from '../../../../../../helpers/string';
 import { isNumber, numberHasDecimal } from '../../../../../../helpers/number';
 import { RequestBody } from '../../../../../../../types';
 
@@ -44,23 +45,26 @@ const maximumBuyerWillOweRules = (formBody: RequestBody, errors: object) => {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
   }
 
+  // strip commas - commas are valid.
+  const numberWithoutCommas = stripCommas(formBody[FIELD_ID]);
+
   // check if the field is not a number
-  if (!isNumber(formBody[FIELD_ID])) {
+  if (!isNumber(numberWithoutCommas)) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, errors);
   }
 
   // check if the field is not a whole number
-  if (numberHasDecimal(formBody[FIELD_ID])) {
+  if (numberHasDecimal(Number(numberWithoutCommas))) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_WHOLE_NUMBER, errors);
   }
 
   // check if the field is below the minimum
-  if (Number(formBody[FIELD_ID]) < MINIMUM) {
+  if (Number(numberWithoutCommas) < MINIMUM) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, errors);
   }
 
   // check if the field is above the maximum
-  if (Number(formBody[FIELD_ID]) > MAXIMUM) {
+  if (Number(numberWithoutCommas) > MAXIMUM) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.ABOVE_MAXIMUM, errors);
   }
 

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer.test.ts
@@ -35,7 +35,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy/valid
 
       const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors);
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });
@@ -49,7 +49,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy/valid
 
       const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, mockErrors);
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });
@@ -63,7 +63,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy/valid
 
       const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_WHOLE_NUMBER, mockErrors);
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer.test.ts
@@ -1,4 +1,4 @@
-import totalContractValueRules from './total-sales-to-buyer';
+import totalSalesToBuyerRules from './total-sales-to-buyer';
 import { FIELD_IDS } from '../../../../../../constants';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import generateValidationErrors from '../../../../../../helpers/validation';
@@ -33,7 +33,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy/valid
     it('should return validation error', () => {
       const mockSubmittedData = {};
 
-      const result = totalContractValueRules(mockSubmittedData, mockErrors);
+      const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
 
       const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors);
 
@@ -47,7 +47,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy/valid
         [FIELD_ID]: 'One hundred!',
       };
 
-      const result = totalContractValueRules(mockSubmittedData, mockErrors);
+      const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
 
       const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, mockErrors);
 
@@ -61,7 +61,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy/valid
         [FIELD_ID]: '123.456',
       };
 
-      const result = totalContractValueRules(mockSubmittedData, mockErrors);
+      const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
 
       const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_WHOLE_NUMBER, mockErrors);
 
@@ -75,7 +75,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy/valid
         [FIELD_ID]: '0',
       };
 
-      const result = totalContractValueRules(mockSubmittedData, mockErrors);
+      const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
 
       const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, mockErrors);
 
@@ -86,10 +86,22 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy/valid
   describe('when there are no validation errors', () => {
     it('should return the provided errors object', () => {
       const mockSubmittedData = {
-        [FIELD_ID]: '10000',
+        [FIELD_ID]: '10,000',
       };
 
-      const result = totalContractValueRules(mockSubmittedData, mockErrors);
+      const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
+
+      expect(result).toEqual(mockErrors);
+    });
+  });
+
+  describe('when there are no validation errors and the value contains a comma', () => {
+    it('should return the provided errors object', () => {
+      const mockSubmittedData = {
+        [FIELD_ID]: '10,000',
+      };
+
+      const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
 
       expect(result).toEqual(mockErrors);
     });

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer.ts
@@ -41,7 +41,7 @@ const totalSalesToBuyerRules = (formBody: RequestBody, errors: object) => {
 
   // check if the field is empty.
   if (!objectHasProperty(formBody, FIELD_ID)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
   // strip commas - commas are valid.
@@ -49,12 +49,12 @@ const totalSalesToBuyerRules = (formBody: RequestBody, errors: object) => {
 
   // check if the field is not a number
   if (!isNumber(numberWithoutCommas)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, errors);
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
   // check if the field is not a whole number
   if (numberHasDecimal(Number(numberWithoutCommas))) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_WHOLE_NUMBER, errors);
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
   // check if the field is below the minimum

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer.ts
@@ -2,6 +2,7 @@ import { FIELD_IDS } from '../../../../../../constants';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import generateValidationErrors from '../../../../../../helpers/validation';
 import { objectHasProperty } from '../../../../../../helpers/object';
+import { stripCommas } from '../../../../../../helpers/string';
 import { isNumber, numberHasDecimal } from '../../../../../../helpers/number';
 import { RequestBody } from '../../../../../../../types';
 
@@ -43,18 +44,21 @@ const totalSalesToBuyerRules = (formBody: RequestBody, errors: object) => {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
   }
 
+  // strip commas - commas are valid.
+  const numberWithoutCommas = stripCommas(formBody[FIELD_ID]);
+
   // check if the field is not a number
-  if (!isNumber(formBody[FIELD_ID])) {
+  if (!isNumber(numberWithoutCommas)) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, errors);
   }
 
   // check if the field is not a whole number
-  if (numberHasDecimal(formBody[FIELD_ID])) {
+  if (numberHasDecimal(Number(numberWithoutCommas))) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_WHOLE_NUMBER, errors);
   }
 
   // check if the field is below the minimum
-  if (Number(formBody[FIELD_ID]) < MINIMUM) {
+  if (Number(numberWithoutCommas) < MINIMUM) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, errors);
   }
 

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/validation/rules/total-sales-to-buyer.ts
@@ -2,8 +2,8 @@ import { FIELD_IDS } from '../../../../../../constants';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import generateValidationErrors from '../../../../../../helpers/validation';
 import { objectHasProperty } from '../../../../../../helpers/object';
+import wholeNumberValidation from '../../../../../../helpers/whole-number-validation';
 import { stripCommas } from '../../../../../../helpers/string';
-import { isNumber, numberHasDecimal } from '../../../../../../helpers/number';
 import { RequestBody } from '../../../../../../../types';
 
 const {
@@ -37,25 +37,18 @@ const MINIMUM = 1;
  * @returns {Object} Validation errors
  */
 const totalSalesToBuyerRules = (formBody: RequestBody, errors: object) => {
-  const updatedErrors = errors;
+  let updatedErrors = errors;
 
   // check if the field is empty.
   if (!objectHasProperty(formBody, FIELD_ID)) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
+  // check if the field is a whole number.
+  updatedErrors = wholeNumberValidation(formBody, updatedErrors, ERROR_MESSAGE.INCORRECT_FORMAT, FIELD_ID);
+
   // strip commas - commas are valid.
   const numberWithoutCommas = stripCommas(formBody[FIELD_ID]);
-
-  // check if the field is not a number
-  if (!isNumber(numberWithoutCommas)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
-  }
-
-  // check if the field is not a whole number
-  if (numberHasDecimal(Number(numberWithoutCommas))) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
-  }
 
   // check if the field is below the minimum
   if (Number(numberWithoutCommas) < MINIMUM) {

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/total-contract-value.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/total-contract-value.test.ts
@@ -100,7 +100,19 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/validat
   describe('when there are no validation errors', () => {
     it('should return the provided errors object', () => {
       const mockSubmittedData = {
-        [FIELD_ID]: '10000',
+        [FIELD_ID]: '40000',
+      };
+
+      const result = totalContractValueRules(mockSubmittedData, mockErrors);
+
+      expect(result).toEqual(mockErrors);
+    });
+  });
+
+  describe('when there are no validation errors and the value contains a comma', () => {
+    it('should return the provided errors object', () => {
+      const mockSubmittedData = {
+        [FIELD_ID]: '40,000',
       };
 
       const result = totalContractValueRules(mockSubmittedData, mockErrors);

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/total-contract-value.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/total-contract-value.test.ts
@@ -35,7 +35,7 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/validat
 
       const result = totalContractValueRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors);
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });
@@ -49,7 +49,7 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/validat
 
       const result = totalContractValueRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, mockErrors);
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });
@@ -63,7 +63,7 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/validat
 
       const result = totalContractValueRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_WHOLE_NUMBER, mockErrors);
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
 
       expect(result).toEqual(expected);
     });

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/total-contract-value.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/total-contract-value.ts
@@ -41,7 +41,7 @@ const totalContractValueRules = (formBody: RequestBody, errors: object) => {
 
   // check if the field is empty.
   if (!objectHasProperty(formBody, FIELD_ID)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
   // strip commas - commas are valid.
@@ -49,12 +49,12 @@ const totalContractValueRules = (formBody: RequestBody, errors: object) => {
 
   // check if the field is not a number
   if (!isNumber(numberWithoutCommas)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, errors);
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
   // check if the field is not a whole number
   if (numberHasDecimal(Number(numberWithoutCommas))) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_WHOLE_NUMBER, errors);
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
   // check if the field is below the minimum

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/total-contract-value.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/total-contract-value.ts
@@ -1,9 +1,12 @@
-import { FIELD_IDS } from '../../../../../../constants';
+import { FIELD_IDS, APPLICATION } from '../../../../../../constants';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import generateValidationErrors from '../../../../../../helpers/validation';
 import { objectHasProperty } from '../../../../../../helpers/object';
+import { stripCommas } from '../../../../../../helpers/string';
 import { isNumber, numberHasDecimal } from '../../../../../../helpers/number';
 import { RequestBody } from '../../../../../../../types';
+
+const { MINIMUM, MAXIMUM } = APPLICATION.POLICY_AND_EXPORT.TOTAL_VALUE_OF_CONTRACT;
 
 const {
   INSURANCE: {
@@ -25,9 +28,6 @@ const {
   },
 } = ERROR_MESSAGES;
 
-const MINIMUM = 1;
-const MAXIMUM = 499999;
-
 /**
  * totalContractValueRules
  * Check submitted form data for errors with the total contract value field
@@ -44,23 +44,26 @@ const totalContractValueRules = (formBody: RequestBody, errors: object) => {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
   }
 
+  // strip commas - commas are valid.
+  const numberWithoutCommas = stripCommas(formBody[FIELD_ID]);
+
   // check if the field is not a number
-  if (!isNumber(formBody[FIELD_ID])) {
+  if (!isNumber(numberWithoutCommas)) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, errors);
   }
 
   // check if the field is not a whole number
-  if (numberHasDecimal(formBody[FIELD_ID])) {
+  if (numberHasDecimal(Number(numberWithoutCommas))) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_WHOLE_NUMBER, errors);
   }
 
   // check if the field is below the minimum
-  if (Number(formBody[FIELD_ID]) < MINIMUM) {
+  if (Number(numberWithoutCommas) < MINIMUM) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, errors);
   }
 
   // check if the field is above the maximum
-  if (Number(formBody[FIELD_ID]) > MAXIMUM) {
+  if (Number(numberWithoutCommas) > MAXIMUM) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.ABOVE_MAXIMUM, errors);
   }
 

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/total-contract-value.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/total-contract-value.ts
@@ -2,8 +2,8 @@ import { FIELD_IDS, APPLICATION } from '../../../../../../constants';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import generateValidationErrors from '../../../../../../helpers/validation';
 import { objectHasProperty } from '../../../../../../helpers/object';
+import wholeNumberValidation from '../../../../../../helpers/whole-number-validation';
 import { stripCommas } from '../../../../../../helpers/string';
-import { isNumber, numberHasDecimal } from '../../../../../../helpers/number';
 import { RequestBody } from '../../../../../../../types';
 
 const { MINIMUM, MAXIMUM } = APPLICATION.POLICY_AND_EXPORT.TOTAL_VALUE_OF_CONTRACT;
@@ -37,25 +37,18 @@ const {
  * @returns {Object} Validation errors
  */
 const totalContractValueRules = (formBody: RequestBody, errors: object) => {
-  const updatedErrors = errors;
+  let updatedErrors = errors;
 
   // check if the field is empty.
   if (!objectHasProperty(formBody, FIELD_ID)) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
+  // check if the field is a whole number.
+  updatedErrors = wholeNumberValidation(formBody, updatedErrors, ERROR_MESSAGE.INCORRECT_FORMAT, FIELD_ID);
+
   // strip commas - commas are valid.
   const numberWithoutCommas = stripCommas(formBody[FIELD_ID]);
-
-  // check if the field is not a number
-  if (!isNumber(numberWithoutCommas)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
-  }
-
-  // check if the field is not a whole number
-  if (numberHasDecimal(Number(numberWithoutCommas))) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
-  }
 
   // check if the field is below the minimum
   if (Number(numberWithoutCommas) < MINIMUM) {

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/validation/rules/cost.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/validation/rules/cost.ts
@@ -50,6 +50,7 @@ const costRules = (formBody: RequestBody, errors: object) => {
     return updatedErrors;
   }
 
+  // strip commas - commas are valid.
   const cleanString = stripCommas(formBody[fieldId]);
 
   if (Number(cleanString) < MINIMUM) {

--- a/src/ui/server/helpers/whole-number-validation/index.ts
+++ b/src/ui/server/helpers/whole-number-validation/index.ts
@@ -13,8 +13,9 @@ import { stripCommas } from '../string';
  * @returns {object} errors
  */
 const wholeNumberValidation = (responseBody: RequestBody, errors: object, errorMessage: string, field: string) => {
-  // remove commas from validation test as commas are valid
+  // strip commas - commas are valid.
   const numberWithoutCommas = stripCommas(responseBody[field]);
+
   const isFieldANumber = isNumber(numberWithoutCommas);
   const hasDecimal = numberHasDecimal(Number(numberWithoutCommas));
   const isBelowMinimum = isNumberBelowMinimum(Number(numberWithoutCommas), 0);


### PR DESCRIPTION
This PR updates the validation rules for 3x monetary fields in the Policy and exports forms, to allow for numbers with commas.

## Changes
- Update the validation functions to consume `wholeNumberValidation` helper and then strip commas for any additional rules.
- Add E2E test coverage.

## Other improvements
- Simplify the error messages for these fields - use only `INVALID_FORMAT` instead of repeating the same message for different validation scenarios.
- Add more destructuring to th E2E tests for these validation rules.
- Fix some typos. 