### PR TITLE
fix(EMS-958): Account creation - conditionally render 'we sent a link to...' text

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email-refresh-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email-refresh-page.spec.js
@@ -1,0 +1,26 @@
+import { confirmEmailPage } from '../../../../../pages/insurance/account/create';
+import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const {
+  START,
+  ACCOUNT: { CREATE: { CONFIRM_EMAIL } },
+} = ROUTES;
+
+context('Insurance - Account - Create - Confirm email page - refreshing the page', () => {
+  before(() => {
+    cy.navigateToUrl(START);
+
+    cy.submitEligibilityAndStartAccountCreation();
+    cy.completeAndSubmitCreateAccountForm();
+
+    const expected = `${Cypress.config('baseUrl')}${CONFIRM_EMAIL}`;
+
+    cy.url().should('eq', expected);
+
+    cy.reload();
+  });
+
+  it('should NOT render `sent a link to` with the submitted email, because it is no longer in the session', () => {
+    confirmEmailPage.weSentLinkTo().should('not.exist');
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email-renders-submitted-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email-renders-submitted-email.spec.js
@@ -1,4 +1,5 @@
 import { confirmEmailPage } from '../../../../../pages/insurance/account/create';
+import partials from '../../../../../partials';
 import { PAGES } from '../../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -36,5 +37,15 @@ context('Insurance - Account - Create - Confirm email page should render the sub
     const expected = `${CONTENT_STRINGS.WE_SENT_LINK_TO} ${expectedEmail}`;
 
     cy.checkText(confirmEmailPage.weSentLinkTo(), expected);
+  });
+
+  describe('when submitting the cookie consent form', () => {
+    before(() => {
+      partials.cookieBanner.question.acceptButton().click();
+    });
+
+    it('should NOT render `sent a link to` with the submitted email, because it is no longer in the session', () => {
+      confirmEmailPage.weSentLinkTo().should('not.exist');
+    });
   });
 });

--- a/src/ui/templates/insurance/account/create/confirm-email.njk
+++ b/src/ui/templates/insurance/account/create/confirm-email.njk
@@ -17,7 +17,9 @@
 
   <h1 class="govuk-heading-xl" data-cy="heading">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 
-  <p data-cy="we-sent-link-to">{{ CONTENT_STRINGS.WE_SENT_LINK_TO }} {{ email }}</p>
+  {% if email %}
+    <p data-cy="we-sent-link-to">{{ CONTENT_STRINGS.WE_SENT_LINK_TO }} {{ email }}</p>
+  {% endif %}
   
   <p class="govuk-!-margin-bottom-9" data-cy="check-your-email">{{ CONTENT_STRINGS.CHECK_YOUR_EMAIL }}</p>
 


### PR DESCRIPTION
This PR adds a condition to the "confirm email" page to conditionally render the "we sent a link to ..." text. The email that is rendered in this page/sentence is only available for one request - it's (rightly) deleted in GET request.

## Changes
- Conditionally render the text on the page.
- Add test coverage for scenarios where the text would not appear:
  - When a user refreshes the page.
  - When a user submits the cookie consent banner form.
