### PR TITLE
feat(EMS-871): Account sign in - password reveal

### DIFF
--- a/e2e-tests/content-strings/fields/insurance/account/index.js
+++ b/e2e-tests/content-strings/fields/insurance/account/index.js
@@ -9,6 +9,12 @@ export const ACCOUNT_FIELDS = {
   [EMAIL]: {
     LABEL: 'Email address',
   },
+  [PASSWORD]: {
+    REVEAL: {
+      SHOW: 'Show',
+      HIDE: 'Hide',
+    },
+  },
   CREATE: {
     YOUR_DETAILS: {
       [FIRST_NAME]: {
@@ -27,10 +33,6 @@ export const ACCOUNT_FIELDS = {
             'a number',
             'a special character',
           ],
-        },
-        REVEAL: {
-          SHOW: 'Show',
-          HIDE: 'Hide',
         },
       },
     },

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
@@ -145,40 +145,8 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
     });
 
     describe('reveal button', () => {
-      const expectedShowText = `${FIELD_STRINGS[fieldId].REVEAL.SHOW} password`;
-      const expectedHideText = `${FIELD_STRINGS[fieldId].REVEAL.HIDE} password`;
-
-      it('should be rendered', () => {
-        field.revealButton().should('exist');
-
-        cy.checkText(field.revealButton(), expectedShowText);
-      });
-
-      describe('when clicking the reveal button', () => {
-        it('should change the input type from `password` to `text`', () => {
-          field.input().should('have.attr', 'type', 'password');
-          field.input().type('Mock', { delay: 0 });
-
-          field.revealButton().click();
-
-          field.input().should('have.attr', 'type', 'text');
-        });
-
-        it('should change the reveal button text', () => {
-          cy.checkText(field.revealButton(), expectedHideText);
-        });
-
-        describe('when clicking the reveal button for a second time', () => {
-          it('should change the input type from `password`', () => {
-            field.revealButton().click();
-
-            field.input().should('have.attr', 'type', 'password');
-          });
-
-          it('should change the reveal button text', () => {
-            cy.checkText(field.revealButton(), expectedShowText);
-          });
-        });
+      it('should be rendered and show/reveal the password input', () => {
+        cy.assertPasswordRevealButton();
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
@@ -144,10 +144,8 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
       field.input().should('exist');
     });
 
-    describe('reveal button', () => {
-      it('should be rendered and show/reveal the password input', () => {
-        cy.assertPasswordRevealButton();
-      });
+    it('should render a revreal button that shows/reveals the password input', () => {
+      cy.assertPasswordRevealButton();
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
@@ -111,6 +111,12 @@ context('Insurance - Account - Sign in - I want to sign in into my UKEF digital 
 
       field.input().should('exist');
     });
+
+    describe('reveal button', () => {
+      it('should be rendered and show/reveal the password input', () => {
+        cy.assertPasswordRevealButton();
+      });
+    });
   });
 
   it('renders a submit button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
@@ -112,10 +112,8 @@ context('Insurance - Account - Sign in - I want to sign in into my UKEF digital 
       field.input().should('exist');
     });
 
-    describe('reveal button', () => {
-      it('should be rendered and show/reveal the password input', () => {
-        cy.assertPasswordRevealButton();
-      });
+    it('should render a revreal button that shows/reveals the password input', () => {
+      cy.assertPasswordRevealButton();
     });
   });
 

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -57,6 +57,8 @@ Cypress.Commands.add('assertSummaryListRowValue', require('./assert-summary-list
 Cypress.Commands.add('submitAndAssertRadioErrors', require('./submit-and-assert-radio-errors'));
 Cypress.Commands.add('submitAndAssertFieldErrors', require('./submit-and-assert-field-errors'));
 
+Cypress.Commands.add('assertPasswordRevealButton', require('./insurance/account/assert-password-reveal-button'));
+
 Cypress.Commands.add('checkText', require('./check-text'));
 Cypress.Commands.add('checkAriaLabel', require('./check-aria-label'));
 Cypress.Commands.add('checkTaskStatus', require('./check-task-status'));

--- a/e2e-tests/cypress/support/insurance/account/assert-password-reveal-button.js
+++ b/e2e-tests/cypress/support/insurance/account/assert-password-reveal-button.js
@@ -1,0 +1,57 @@
+import { INSURANCE_FIELD_IDS } from '../../../../constants/field-ids/insurance';
+import { ACCOUNT_FIELDS } from '../../../../content-strings/fields/insurance/account';
+import accountFormFields from '../../../e2e/partials/insurance/accountFormFields';
+
+const {
+  ACCOUNT: { PASSWORD },
+} = INSURANCE_FIELD_IDS;
+
+const fieldId = PASSWORD;
+
+const FIELD_STRINGS = ACCOUNT_FIELDS[fieldId];
+
+const field = accountFormFields[fieldId];
+
+const expectedShowText = `${FIELD_STRINGS.REVEAL.SHOW} password`;
+const expectedHideText = `${FIELD_STRINGS.REVEAL.HIDE} password`;
+
+const shouldRender = () => {
+  field.revealButton().should('exist');
+
+  cy.checkText(field.revealButton(), expectedShowText);
+};
+
+const afterClick = {
+  changesInputType: () => {
+    field.input().should('have.attr', 'type', 'password');
+    field.input().type('Mock', { delay: 0 });
+
+    field.revealButton().click();
+
+    // field input shuld change from password to text
+    field.input().should('have.attr', 'type', 'text');
+
+    // reveal button text should change to 'hide'
+    cy.checkText(field.revealButton(), expectedHideText);
+  },
+};
+
+const afterSecondClick = {
+  changesInputType: () => {
+    field.revealButton().click();
+
+    // field input shuld change from text to password
+    field.input().should('have.attr', 'type', 'password');
+
+    // reveal button text should change to 'show'
+    cy.checkText(field.revealButton(), expectedShowText);
+  },
+};
+
+export default () => {
+  shouldRender();
+
+  afterClick.changesInputType();
+
+  afterSecondClick.changesInputType();
+};

--- a/src/ui/server/content-strings/fields/insurance/account/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/account/index.ts
@@ -7,6 +7,12 @@ export const ACCOUNT_FIELDS = {
   [EMAIL]: {
     LABEL: 'Email address',
   },
+  [PASSWORD]: {
+    REVEAL: {
+      SHOW: 'Show',
+      HIDE: 'Hide',
+    },
+  },
   CREATE: {
     YOUR_DETAILS: {
       [FIRST_NAME]: {
@@ -20,11 +26,7 @@ export const ACCOUNT_FIELDS = {
         HINT: {
           INTRO: 'Your password must contain at least 14 characters and have:',
           RULES: ['an uppercase letter', 'a lowercase letter', 'a number', 'a special character'],
-        },
-        REVEAL: {
-          SHOW: 'Show',
-          HIDE: 'Hide',
-        },
+        },,
       },
     },
   },

--- a/src/ui/server/content-strings/fields/insurance/account/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/account/index.ts
@@ -26,7 +26,7 @@ export const ACCOUNT_FIELDS = {
         HINT: {
           INTRO: 'Your password must contain at least 14 characters and have:',
           RULES: ['an uppercase letter', 'a lowercase letter', 'a number', 'a special character'],
-        },,
+        },
       },
     },
   },


### PR DESCRIPTION
This PR ensures that password reveal functionality is working for the Account sign in page.

## Changes
- Create a cypress command for checking password reveal functionality. This is now a feature used in 2 places and there will be more in the future.
- Call this new command in the "create account" and "sign in" E2E page tests.