### PR TITLE
chore(EMS-970): cypress command for checking core page elements and features

### DIFF
--- a/e2e-tests/content-strings/pages/insurance/index.js
+++ b/e2e-tests/content-strings/pages/insurance/index.js
@@ -2,6 +2,7 @@ import POLICY_AND_EXPORTS from './policy-and-exports';
 import * as ELIGIBILITY_PAGES from './eligibility';
 import * as ACCOUNT_PAGES from './account';
 import * as EXPORTER_BUSINESS from './exporter-business';
+import * as YOUR_BUYER from './your-buyer';
 import { LINKS } from '../../links';
 import { PRODUCT } from '../../../constants';
 import formatCurrency from '../../../cypress/e2e/helpers/format-currency';
@@ -94,6 +95,7 @@ const INSURANCE = {
   POLICY_AND_EXPORTS,
   SPEAK_TO_UKEF_EFM,
   START,
+  YOUR_BUYER,
 };
 
 export default INSURANCE;

--- a/e2e-tests/content-strings/pages/insurance/your-buyer/index.js
+++ b/e2e-tests/content-strings/pages/insurance/your-buyer/index.js
@@ -2,11 +2,8 @@ const SHARED = {
   HEADING_CAPTION: 'Your buyer',
 };
 
-const COMPANY_OR_ORGANISATION = {
+export const COMPANY_OR_ORGANISATION = {
   ...SHARED,
   PAGE_TITLE: "Buyer's company or organisation",
 };
 
-module.exports = {
-  COMPANY_OR_ORGANISATION,
-};

--- a/e2e-tests/content-strings/pages/insurance/your-buyer/index.js
+++ b/e2e-tests/content-strings/pages/insurance/your-buyer/index.js
@@ -6,4 +6,3 @@ export const COMPANY_OR_ORGANISATION = {
   ...SHARED,
   PAGE_TITLE: "Buyer's company or organisation",
 };
-

--- a/e2e-tests/cypress/e2e/journeys/cookies.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/cookies.spec.js
@@ -23,7 +23,7 @@ context('Cookies page', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.COOKIES,
-      expectedBackLink: ROUTES.QUOTE.BUYER_COUNTRY,
+      backLink: ROUTES.QUOTE.BUYER_COUNTRY,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/cookies.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/cookies.spec.js
@@ -20,7 +20,7 @@ context('Cookies page', () => {
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.COOKIES,
       expectedBackLink: ROUTES.QUOTE.BUYER_COUNTRY,

--- a/e2e-tests/cypress/e2e/journeys/cookies.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/cookies.spec.js
@@ -24,6 +24,7 @@ context('Cookies page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.COOKIES,
       backLink: ROUTES.QUOTE.BUYER_COUNTRY,
+      submitButtonCopy: BUTTONS.SAVE_CHANGES,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/cookies.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/cookies.spec.js
@@ -1,8 +1,8 @@
-import { heading, inlineErrorMessage, submitButton } from '../pages/shared';
+import { inlineErrorMessage, submitButton } from '../pages/shared';
 import { cookiesPage } from '../pages';
 import partials from '../partials';
 import {
-  BUTTONS, ERROR_MESSAGES, FIELDS, LINKS, PAGES,
+  BUTTONS, ERROR_MESSAGES, FIELDS, PAGES,
 } from '../../../content-strings';
 import { FIELD_IDS, ROUTES } from '../../../constants';
 
@@ -19,34 +19,12 @@ context('Cookies page', () => {
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 65,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.COOKIES,
+      expectedBackLink: ROUTES.QUOTE.BUYER_COUNTRY,
     });
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.BUYER_COUNTRY}`;
-
-    partials.backLink().should('have.attr', 'href', expected);
-  });
-
-  it('renders a heading', () => {
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders a intro/description', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email.spec.js
@@ -27,7 +27,7 @@ context('Insurance - Account - Create - Confirm email page - I want to create an
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: CONFIRM_EMAIL,
       expectedBackLink: YOUR_DETAILS,

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email.spec.js
@@ -1,7 +1,5 @@
-import { heading } from '../../../../../pages/shared';
-import partials from '../../../../../partials';
 import { confirmEmailPage } from '../../../../../pages/insurance/account/create';
-import { ORGANISATION, LINKS, PAGES } from '../../../../../../../content-strings';
+import { PAGES } from '../../../../../../../content-strings';
 import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ACCOUNT.CREATE.CONFIRM_EMAIL;
@@ -28,50 +26,12 @@ context('Insurance - Account - Create - Confirm email page - I want to create an
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: CONFIRM_EMAIL,
+      expectedBackLink: YOUR_DETAILS,
     });
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${YOUR_DETAILS}`;
-
-    cy.url().should('eq', expectedUrl);
-
-    // go back to page
-    cy.navigateToUrl(CONFIRM_EMAIL);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('should render a header with href to insurance start', () => {
-    partials.header.serviceName().should('have.attr', 'href', START);
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders `check your email`', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email.spec.js
@@ -31,6 +31,7 @@ context('Insurance - Account - Create - Confirm email page - I want to create an
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: CONFIRM_EMAIL,
       backLink: YOUR_DETAILS,
+      assertSubmitButton: false,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email.spec.js
@@ -30,7 +30,7 @@ context('Insurance - Account - Create - Confirm email page - I want to create an
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: CONFIRM_EMAIL,
-      expectedBackLink: YOUR_DETAILS,
+      backLink: YOUR_DETAILS,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
@@ -105,7 +105,7 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
       field.input().should('exist');
     });
 
-    it('should render a revreal button that shows/reveals the password input', () => {
+    it('should render a reveal button that shows/reveals the password input', () => {
       cy.assertPasswordRevealButton();
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
@@ -46,6 +46,9 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: YOUR_DETAILS,
       backLink: ACCOUNT_TO_APPLY_ONLINE,
+      lightHouseThresholds: {
+        performance: 70,
+      },
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
@@ -45,7 +45,7 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: YOUR_DETAILS,
-      expectedBackLink: ACCOUNT_TO_APPLY_ONLINE,
+      backLink: ACCOUNT_TO_APPLY_ONLINE,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
@@ -46,7 +46,6 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: YOUR_DETAILS,
       expectedBackLink: ACCOUNT_TO_APPLY_ONLINE,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
@@ -1,13 +1,7 @@
-import { heading, submitButton } from '../../../../../pages/shared';
 import partials from '../../../../../partials';
 import accountFormFields from '../../../../../partials/insurance/accountFormFields';
 import { yourDetailsPage } from '../../../../../pages/insurance/account/create';
-import {
-  BUTTONS,
-  ORGANISATION,
-  LINKS,
-  PAGES,
-} from '../../../../../../../content-strings';
+import { BUTTONS, PAGES } from '../../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { ACCOUNT_FIELDS } from '../../../../../../../content-strings/fields/insurance/account';
 import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -47,50 +41,17 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 70,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: YOUR_DETAILS,
+      expectedBackLink: ACCOUNT_TO_APPLY_ONLINE,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${ACCOUNT_TO_APPLY_ONLINE}`;
-
-    cy.url().should('eq', expectedUrl);
-
-    // go back to page
-    cy.navigateToUrl(YOUR_DETAILS);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', START);
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders intro text', () => {
@@ -181,12 +142,6 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
         });
       });
     });
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   it('renders a `already got an account` copy and button link', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
@@ -42,7 +42,7 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: YOUR_DETAILS,
       expectedBackLink: ACCOUNT_TO_APPLY_ONLINE,

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
@@ -40,7 +40,7 @@ context('Insurance - Account - Sign in - I want to sign in into my UKEF digital 
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: SIGN_IN_ROOT,
       expectedBackLink: ACCOUNT_TO_APPLY_ONLINE,

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Account - Sign in - I want to sign in into my UKEF digital 
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: SIGN_IN_ROOT,
-      expectedBackLink: ACCOUNT_TO_APPLY_ONLINE,
+      backLink: ACCOUNT_TO_APPLY_ONLINE,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
@@ -44,6 +44,9 @@ context('Insurance - Account - Sign in - I want to sign in into my UKEF digital 
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: SIGN_IN_ROOT,
       backLink: ACCOUNT_TO_APPLY_ONLINE,
+      lightHouseThresholds: {
+        performance: 70,
+      },
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
@@ -44,7 +44,6 @@ context('Insurance - Account - Sign in - I want to sign in into my UKEF digital 
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: SIGN_IN_ROOT,
       expectedBackLink: ACCOUNT_TO_APPLY_ONLINE,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
@@ -73,7 +73,7 @@ context('Insurance - Account - Sign in - I want to sign in into my UKEF digital 
       field.input().should('exist');
     });
 
-    it('should render a revreal button that shows/reveals the password input', () => {
+    it('should render a reveal button that shows/reveals the password input', () => {
       cy.assertPasswordRevealButton();
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
@@ -1,13 +1,7 @@
-import { heading, submitButton } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import { signInPage } from '../../../../pages/insurance/account/sign-in';
 import accountFormFields from '../../../../partials/insurance/accountFormFields';
-import {
-  BUTTONS,
-  ORGANISATION,
-  LINKS,
-  PAGES,
-} from '../../../../../../content-strings';
+import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { ACCOUNT_FIELDS } from '../../../../../../content-strings/fields/insurance/account';
 import { INSURANCE_ROUTES as ROUTES } from '../../../../../../constants/routes/insurance';
@@ -45,50 +39,17 @@ context('Insurance - Account - Sign in - I want to sign in into my UKEF digital 
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 70,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: SIGN_IN_ROOT,
+      expectedBackLink: ACCOUNT_TO_APPLY_ONLINE,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${ACCOUNT_TO_APPLY_ONLINE}`;
-
-    cy.url().should('eq', expectedUrl);
-
-    // go back to page
-    cy.navigateToUrl(SIGN_IN_ROOT);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', START);
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders `email` label and input', () => {
@@ -111,12 +72,6 @@ context('Insurance - Account - Sign in - I want to sign in into my UKEF digital 
 
       field.input().should('exist');
     });
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   it('renders a `reset password` link', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/all-sections.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/all-sections.spec.js
@@ -30,7 +30,7 @@ context('Insurance - All sections - new application', () => {
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE,

--- a/e2e-tests/cypress/e2e/journeys/insurance/all-sections.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/all-sections.spec.js
@@ -34,6 +34,7 @@ context('Insurance - All sections - new application', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
       backLink: ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE,
+      assertSubmitButton: false,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/all-sections.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/all-sections.spec.js
@@ -1,13 +1,7 @@
 import { addMonths, format } from 'date-fns';
-import { heading } from '../../pages/shared';
 import insurance from '../../pages/insurance';
 import partials from '../../partials';
-import {
-  ORGANISATION,
-  LINKS,
-  PAGES,
-  TASKS,
-} from '../../../../content-strings';
+import { PAGES, TASKS } from '../../../../content-strings';
 import { APPLICATION, ROUTES } from '../../../../constants';
 
 const { taskList } = partials.insurancePartials;
@@ -35,46 +29,12 @@ context('Insurance - All sections - new application', () => {
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: `${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
+      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE,
     });
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE}`;
-
-    cy.url().should('include', expectedUrl);
-
-    // go back to page
-    cy.navigateToUrl(`${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   describe('task list', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/all-sections.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/all-sections.spec.js
@@ -33,7 +33,7 @@ context('Insurance - All sections - new application', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
-      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE,
+      backLink: ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/apply-offline-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/apply-offline-page.spec.js
@@ -31,6 +31,7 @@ context('Insurance - apply offline exit page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.APPLY_OFFLINE,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
+      assertSubmitButton: false,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/apply-offline-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/apply-offline-page.spec.js
@@ -1,7 +1,6 @@
-import { buyerCountryPage, heading, submitButton } from '../../pages/shared';
+import { buyerCountryPage, submitButton } from '../../pages/shared';
 import { insurance } from '../../pages';
-import partials from '../../partials';
-import { LINKS, ORGANISATION, PAGES } from '../../../../content-strings';
+import { PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../support/insurance/eligibility/forms';
 
@@ -9,8 +8,6 @@ const CONTENT_STRINGS = PAGES.INSURANCE.APPLY_OFFLINE;
 const { ACTIONS } = CONTENT_STRINGS;
 
 const COUNTRY_NAME_APPLY_OFFLINE_ONLY = 'Angola';
-
-const insuranceStartRoute = ROUTES.INSURANCE.START;
 
 context('Insurance - apply offline exit page', () => {
   beforeEach(() => {
@@ -29,45 +26,12 @@ context('Insurance - apply offline exit page', () => {
     cy.url().should('include', ROUTES.INSURANCE.APPLY_OFFLINE);
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.INSURANCE.APPLY_OFFLINE,
+      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
     });
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('should render a header with href to insurance start', () => {
-    partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY}`;
-
-    partials.backLink().should('have.attr', 'href', expected);
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders `download form` copy with link', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/apply-offline-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/apply-offline-page.spec.js
@@ -30,7 +30,7 @@ context('Insurance - apply offline exit page', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.APPLY_OFFLINE,
-      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
+      backLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
       assertSubmitButton: false,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/apply-offline-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/apply-offline-page.spec.js
@@ -27,7 +27,7 @@ context('Insurance - apply offline exit page', () => {
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.APPLY_OFFLINE,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/account-to-apply-online/account-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/account-to-apply-online/account-to-apply-online.spec.js
@@ -41,7 +41,7 @@ context('Insurance - Eligibility - Account to apply online page - I want to conf
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ACCOUNT_TO_APPLY_ONLINE,
       expectedBackLink: ELIGIBLE_TO_APPLY_ONLINE,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/account-to-apply-online/account-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/account-to-apply-online/account-to-apply-online.spec.js
@@ -1,13 +1,10 @@
 import {
-  heading, submitButton, tempCreateAccountButton, inlineErrorMessage, yesRadioInput, yesRadio, yesNoRadioHint, noRadio,
+  submitButton, tempCreateAccountButton, inlineErrorMessage, yesRadioInput, yesRadio, yesNoRadioHint, noRadio,
 } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import {
-  BUTTONS,
   ERROR_MESSAGES,
   FIELDS,
-  ORGANISATION,
-  LINKS,
   PAGES,
 } from '../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS as FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
@@ -43,50 +40,17 @@ context('Insurance - Eligibility - Account to apply online page - I want to conf
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ACCOUNT_TO_APPLY_ONLINE,
+      expectedBackLink: ELIGIBLE_TO_APPLY_ONLINE,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${ELIGIBLE_TO_APPLY_ONLINE}`;
-
-    cy.url().should('eq', expectedUrl);
-
-    // go back to page
-    cy.navigateToUrl(ACCOUNT_TO_APPLY_ONLINE);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', START);
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders yes and no radio buttons with a hint', () => {
@@ -99,12 +63,6 @@ context('Insurance - Eligibility - Account to apply online page - I want to conf
     cy.checkText(noRadio(), 'No');
 
     cy.checkText(yesNoRadioHint(), FIELDS[FIELD_ID].HINT);
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/account-to-apply-online/account-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/account-to-apply-online/account-to-apply-online.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Eligibility - Account to apply online page - I want to conf
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ACCOUNT_TO_APPLY_ONLINE,
-      expectedBackLink: ELIGIBLE_TO_APPLY_ONLINE,
+      backLink: ELIGIBLE_TO_APPLY_ONLINE,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/account-to-apply-online/account-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/account-to-apply-online/account-to-apply-online.spec.js
@@ -45,7 +45,6 @@ context('Insurance - Eligibility - Account to apply online page - I want to conf
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ACCOUNT_TO_APPLY_ONLINE,
       expectedBackLink: ELIGIBLE_TO_APPLY_ONLINE,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
@@ -26,7 +26,7 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
-      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE,
+      backLink: ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
@@ -23,7 +23,7 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
@@ -27,7 +27,6 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
@@ -1,18 +1,16 @@
 import { buyerCountryPage, submitButton } from '../../../../pages/shared';
 import partials from '../../../../partials';
-import { LINKS } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
+import { PAGES } from '../../../../../../content-strings';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility/forms';
 import {
-  checkPageTitleAndHeading,
   checkInputHint,
   checkAutocompleteInput,
-  checkSubmitButton,
   checkValidationErrors,
   checkFocusOnInputWhenClickingSummaryErrorMessage,
 } from '../../../../../support/check-buyer-country-form';
 
-const insuranceStartRoute = ROUTES.INSURANCE.START;
+const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY;
 
 context('Insurance - Buyer location page - as an exporter, I want to check if UKEF offer export insurance policy for where my buyer is based', () => {
   beforeEach(() => {
@@ -24,34 +22,13 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY);
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 70,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
+      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('should render a header with href to insurance start', () => {
-    partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE}`;
-
-    partials.backLink().should('have.attr', 'href', expected);
-  });
-
-  it('renders a page title and heading', () => {
-    checkPageTitleAndHeading();
   });
 
   it('renders a hint', () => {
@@ -78,10 +55,6 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
     it('allows user to remove a selected country and search again', () => {
       checkAutocompleteInput.allowsUserToRemoveCountryAndSearchAgain();
     });
-  });
-
-  it('renders a submit button', () => {
-    checkSubmitButton();
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
@@ -27,6 +27,9 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
       backLink: ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE,
+      lightHouseThresholds: {
+        performance: 70,
+      },
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
@@ -10,7 +10,7 @@ import {
   checkFocusOnInputWhenClickingSummaryErrorMessage,
 } from '../../../../../support/check-buyer-country-form';
 
-const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY;
+const CONTENT_STRINGS = PAGES.BUYER_COUNTRY;
 
 context('Insurance - Buyer location page - as an exporter, I want to check if UKEF offer export insurance policy for where my buyer is based', () => {
   beforeEach(() => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
@@ -31,7 +31,7 @@ context('Insurance Eligibility - Cannot apply exit page', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY,
-      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
+      backLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
@@ -28,7 +28,7 @@ context('Insurance Eligibility - Cannot apply exit page', () => {
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
@@ -32,6 +32,7 @@ context('Insurance Eligibility - Cannot apply exit page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY,
       backLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
+      assertSubmitButton: false,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
@@ -1,23 +1,15 @@
 import {
   buyerCountryPage,
   cannotApplyPage,
-  heading,
   submitButton,
 } from '../../../pages/shared';
-import partials from '../../../partials';
-import {
-  ORGANISATION,
-  LINKS,
-  PAGES,
-} from '../../../../../content-strings';
+import { PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.CANNOT_APPLY;
 
 const COUNTRY_NAME_UNSUPPORTED = 'France';
-
-const insuranceStartRoute = ROUTES.INSURANCE.START;
 
 context('Insurance Eligibility - Cannot apply exit page', () => {
   beforeEach(() => {
@@ -35,45 +27,12 @@ context('Insurance Eligibility - Cannot apply exit page', () => {
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY);
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY,
+      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
     });
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('should render a header with href to insurance start', () => {
-    partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY);
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders a reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
@@ -27,7 +27,6 @@ context('Insurance Eligibility - check if eligible page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE,
       expectedBackLink: insuranceStartRoute,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
@@ -23,7 +23,7 @@ context('Insurance Eligibility - check if eligible page', () => {
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE,
       expectedBackLink: insuranceStartRoute,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
@@ -26,7 +26,7 @@ context('Insurance Eligibility - check if eligible page', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE,
-      expectedBackLink: insuranceStartRoute,
+      backLink: insuranceStartRoute,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/check-if-eligible.spec.js
@@ -1,9 +1,6 @@
-import { heading, submitButton } from '../../../pages/shared';
+import { submitButton } from '../../../pages/shared';
 import { insurance } from '../../../pages';
-import partials from '../../../partials';
-import {
-  BUTTONS, LINKS, ORGANISATION, PAGES,
-} from '../../../../../content-strings';
+import { PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import { completeStartForm } from '../../../../support/insurance/eligibility/forms';
 
@@ -25,47 +22,17 @@ context('Insurance Eligibility - check if eligible page', () => {
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 70,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE,
+      expectedBackLink: insuranceStartRoute,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('should render a header with href to insurance start', () => {
-    partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.START}`;
-
-    partials.backLink().should('have.attr', 'href', expected);
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders a body text', () => {
     cy.checkText(insurance.eligibility.checkIfEligiblePage.body(), CONTENT_STRINGS.BODY);
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   context('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
@@ -50,7 +50,7 @@ context('Insurance - Eligibility - Companies house number page - I want to check
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER,
-      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD,
+      backLink: ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
@@ -47,7 +47,7 @@ context('Insurance - Eligibility - Companies house number page - I want to check
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
@@ -51,7 +51,6 @@ context('Insurance - Eligibility - Companies house number page - I want to check
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
@@ -1,14 +1,8 @@
 import {
-  heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton,
+  yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton,
 } from '../../../../pages/shared';
 import partials from '../../../../partials';
-import {
-  ORGANISATION,
-  BUTTONS,
-  LINKS,
-  PAGES,
-  ERROR_MESSAGES,
-} from '../../../../../../content-strings';
+import { PAGES, ERROR_MESSAGES } from '../../../../../../content-strings';
 import { ROUTES, FIELD_IDS } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
 import {
@@ -29,7 +23,7 @@ const insuranceStartRoute = ROUTES.INSURANCE.START;
 
 context('Insurance - Eligibility - Companies house number page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction if I do not have UK Companies House Registration Number', () => {
   before(() => {
-    cy.navigateToUrl(ROUTES.INSURANCE.START);
+    cy.navigateToUrl(insuranceStartRoute);
 
     completeStartForm();
     completeCheckIfEligibleForm();
@@ -52,50 +46,17 @@ context('Insurance - Eligibility - Companies house number page - I want to check
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER,
+      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD}`;
-
-    cy.url().should('include', expectedUrl);
-
-    // go back to page
-    cy.navigateToUrl(ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders `yes` radio button', () => {
@@ -108,12 +69,6 @@ context('Insurance - Eligibility - Companies house number page - I want to check
     noRadio().should('exist');
 
     cy.checkText(noRadio(), 'No');
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online.spec.js
@@ -37,7 +37,6 @@ context('Insurance - Eligibility - You are eligible to apply online page - I wan
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ELIGIBLE_TO_APPLY_ONLINE,
       expectedBackLink: COMPANIES_HOUSE_NUMBER,
-      assertSubmitButton: true,
       submitButtonCopy: CONTENT_STRINGS.SUBMIT_BUTTON,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online.spec.js
@@ -1,13 +1,7 @@
-import {
-  heading, submitButton,
-} from '../../../pages/shared';
+import { submitButton } from '../../../pages/shared';
 import { insurance } from '../../../pages';
 import partials from '../../../partials';
-import {
-  ORGANISATION,
-  LINKS,
-  PAGES,
-} from '../../../../../content-strings';
+import { PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE;
@@ -38,50 +32,17 @@ context('Insurance - Eligibility - You are eligible to apply online page - I wan
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ELIGIBLE_TO_APPLY_ONLINE,
+      expectedBackLink: COMPANIES_HOUSE_NUMBER,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${COMPANIES_HOUSE_NUMBER}`;
-
-    cy.url().should('include', expectedUrl);
-
-    // go back to page
-    cy.navigateToUrl(ELIGIBLE_TO_APPLY_ONLINE);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', START);
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders inset text', () => {
@@ -94,12 +55,6 @@ context('Insurance - Eligibility - You are eligible to apply online page - I wan
     insurance.eligibility.eligibleToApplyOnlinePage.body().should('exist');
 
     cy.checkText(insurance.eligibility.eligibleToApplyOnlinePage.body(), CONTENT_STRINGS.BODY);
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), CONTENT_STRINGS.SUBMIT_BUTTON);
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online.spec.js
@@ -38,6 +38,7 @@ context('Insurance - Eligibility - You are eligible to apply online page - I wan
       currentHref: ELIGIBLE_TO_APPLY_ONLINE,
       expectedBackLink: COMPANIES_HOUSE_NUMBER,
       assertSubmitButton: true,
+      submitButtonCopy: CONTENT_STRINGS.SUBMIT_BUTTON,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online.spec.js
@@ -36,7 +36,7 @@ context('Insurance - Eligibility - You are eligible to apply online page - I wan
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ELIGIBLE_TO_APPLY_ONLINE,
-      expectedBackLink: COMPANIES_HOUSE_NUMBER,
+      backLink: COMPANIES_HOUSE_NUMBER,
       submitButtonCopy: CONTENT_STRINGS.SUBMIT_BUTTON,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online.spec.js
@@ -33,7 +33,7 @@ context('Insurance - Eligibility - You are eligible to apply online page - I wan
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ELIGIBLE_TO_APPLY_ONLINE,
       expectedBackLink: COMPANIES_HOUSE_NUMBER,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
@@ -1,14 +1,8 @@
 import {
-  heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton,
+  yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton,
 } from '../../../../pages/shared';
 import partials from '../../../../partials';
-import {
-  ORGANISATION,
-  BUTTONS,
-  LINKS,
-  PAGES,
-  ERROR_MESSAGES,
-} from '../../../../../../content-strings';
+import { PAGES, ERROR_MESSAGES } from '../../../../../../content-strings';
 import { ROUTES, FIELD_IDS } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility/forms';
@@ -28,45 +22,17 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION);
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION,
+      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY);
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders yes and no radio buttons', () => {
@@ -77,12 +43,6 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
     noRadio().should('exist');
 
     cy.checkText(noRadio(), 'No');
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
@@ -27,7 +27,6 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
@@ -23,7 +23,7 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
@@ -26,7 +26,7 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION,
-      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
+      backLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
@@ -1,14 +1,8 @@
 import {
-  heading, yesRadio, yesRadioInput, noRadio, noRadioInput, inlineErrorMessage, submitButton,
+  yesRadio, yesRadioInput, noRadio, noRadioInput, inlineErrorMessage, submitButton,
 } from '../../../../pages/shared';
 import partials from '../../../../partials';
-import {
-  ORGANISATION,
-  BUTTONS,
-  LINKS,
-  PAGES,
-  ERROR_MESSAGES,
-} from '../../../../../../content-strings';
+import { PAGES, ERROR_MESSAGES } from '../../../../../../content-strings';
 import { ROUTES, FIELD_IDS } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
 import {
@@ -42,48 +36,17 @@ context('Insurance - Insured amount page - I want to check if I can use online s
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT,
+      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES);
-
-    // go back to page
-    cy.navigateToUrl(ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders `yes` radio button', () => {
@@ -96,12 +59,6 @@ context('Insurance - Insured amount page - I want to check if I can use online s
     noRadio().should('exist');
 
     cy.checkText(noRadio(), 'No');
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
@@ -40,7 +40,7 @@ context('Insurance - Insured amount page - I want to check if I can use online s
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT,
-      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES,
+      backLink: ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Insured amount page - I want to check if I can use online s
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
@@ -41,7 +41,6 @@ context('Insurance - Insured amount page - I want to check if I can use online s
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
@@ -1,14 +1,8 @@
 import {
-  heading, yesRadio, yesRadioInput, noRadio, noRadioInput, inlineErrorMessage, submitButton,
+  yesRadio, yesRadioInput, noRadio, noRadioInput, inlineErrorMessage, submitButton,
 } from '../../../../pages/shared';
 import partials from '../../../../partials';
-import {
-  ORGANISATION,
-  BUTTONS,
-  LINKS,
-  PAGES,
-  ERROR_MESSAGES,
-} from '../../../../../../content-strings';
+import { PAGES, ERROR_MESSAGES } from '../../../../../../content-strings';
 import { ROUTES, FIELD_IDS } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
 import {
@@ -48,50 +42,17 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT,
+      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED}`;
-
-    cy.url().should('include', expectedUrl);
-
-    // go back to page
-    cy.navigateToUrl(ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders `yes` radio button', () => {
@@ -104,12 +65,6 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
     noRadio().should('exist');
 
     cy.checkText(noRadio(), 'No');
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
@@ -47,7 +47,6 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
@@ -46,7 +46,7 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT,
-      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED,
+      backLink: ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
@@ -31,7 +31,6 @@ context('Insurance Eligibility - Need to start again exit page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.NEED_TO_START_AGAIN,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
-      assertSubmitButton: true,
       assertBackLink: false,
       submitButtonCopy: LINKS.START_AGAIN.TEXT,
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
@@ -1,5 +1,5 @@
-import { heading, submitButton, needToStartAgainPage } from '../../../pages/shared';
-import { LINKS, ORGANISATION, PAGES } from '../../../../../content-strings';
+import { submitButton, needToStartAgainPage } from '../../../pages/shared';
+import { PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import partials from '../../../partials';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../support/insurance/eligibility/forms';
@@ -26,46 +26,21 @@ context('Insurance Eligibility - Need to start again exit page', () => {
     cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.NEED_TO_START_AGAIN);
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.INSURANCE.ELIGIBILITY.NEED_TO_START_AGAIN,
+      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
   });
 
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
-  });
-
   it('renders a reason', () => {
     needToStartAgainPage.reason().should('exist');
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), LINKS.START_AGAIN.TEXT);
   });
 
   describe('clicking the submit button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
@@ -27,7 +27,7 @@ context('Insurance Eligibility - Need to start again exit page', () => {
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.NEED_TO_START_AGAIN,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
@@ -1,5 +1,5 @@
 import { submitButton, needToStartAgainPage } from '../../../pages/shared';
-import { BUTTONS, LINKS, PAGES } from '../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import partials from '../../../partials';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../support/insurance/eligibility/forms';

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
@@ -30,7 +30,7 @@ context('Insurance Eligibility - Need to start again exit page', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.NEED_TO_START_AGAIN,
-      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
+      backLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
       assertBackLink: false,
       submitButtonCopy: LINKS.START_AGAIN.TEXT,
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
@@ -1,5 +1,5 @@
 import { submitButton, needToStartAgainPage } from '../../../pages/shared';
-import { PAGES } from '../../../../../content-strings';
+import { BUTTONS, LINKS, PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import partials from '../../../partials';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../support/insurance/eligibility/forms';
@@ -32,6 +32,8 @@ context('Insurance Eligibility - Need to start again exit page', () => {
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.NEED_TO_START_AGAIN,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
       assertSubmitButton: true,
+      assertBackLink: false,
+      submitButtonCopy: LINKS.START_AGAIN.TEXT,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
@@ -42,7 +42,7 @@ context('Insurance - Other parties page - I want to check if I can use online se
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
@@ -46,7 +46,6 @@ context('Insurance - Other parties page - I want to check if I can use online se
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
@@ -1,15 +1,9 @@
 import {
-  heading, yesRadio, yesRadioInput, noRadio, noRadioInput, inlineErrorMessage, submitButton,
+  yesRadio, yesRadioInput, noRadio, noRadioInput, inlineErrorMessage, submitButton,
 } from '../../../../pages/shared';
 import { insurance } from '../../../../pages';
 import partials from '../../../../partials';
-import {
-  ORGANISATION,
-  BUTTONS,
-  LINKS,
-  PAGES,
-  ERROR_MESSAGES,
-} from '../../../../../../content-strings';
+import { PAGES, ERROR_MESSAGES } from '../../../../../../content-strings';
 import { ROUTES, FIELD_IDS } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
 import {
@@ -47,50 +41,17 @@ context('Insurance - Other parties page - I want to check if I can use online se
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED,
+      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD}`;
-
-    cy.url().should('include', expectedUrl);
-
-    // go back to page
-    cy.navigateToUrl(ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders `yes` radio button', () => {
@@ -131,12 +92,6 @@ context('Insurance - Other parties page - I want to check if I can use online se
 
       cy.checkText(insurance.eligibility.otherPartiesPage.description.list.item5(), CONTENT_STRINGS.OTHER_PARTIES_DESCRIPTION.LIST[4].TEXT);
     });
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
@@ -45,7 +45,7 @@ context('Insurance - Other parties page - I want to check if I can use online se
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED,
-      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
+      backLink: ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -55,7 +55,6 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -1,13 +1,10 @@
 import {
-  heading, yesNoRadioHint, yesRadio, yesRadioInput, noRadio, noRadioInput, inlineErrorMessage, submitButton,
+  yesNoRadioHint, yesRadio, yesRadioInput, noRadio, noRadioInput, inlineErrorMessage, submitButton,
 } from '../../../../pages/shared';
 import { insurance } from '../../../../pages';
 import partials from '../../../../partials';
 import {
-  ORGANISATION,
-  BUTTONS,
   FIELDS,
-  LINKS,
   PAGES,
   ERROR_MESSAGES,
 } from '../../../../../../content-strings';
@@ -53,50 +50,17 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD,
+      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`;
-
-    cy.url().should('include', expectedUrl);
-
-    // go back to page
-    cy.navigateToUrl(ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders radio button hint', () => {
@@ -153,12 +117,6 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
 
       cy.checkText(insurance.eligibility.preCreditPeriodPage.description.body3(), CONTENT_STRINGS.PRE_CREDIT_PERIOD_DESCRIPTION.BODY_3);
     });
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -54,7 +54,7 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD,
-      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT,
+      backLink: ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -51,7 +51,7 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -1,12 +1,9 @@
 import {
-  heading, yesNoRadioHint, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton,
+  yesNoRadioHint, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton,
 } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import {
-  ORGANISATION,
-  BUTTONS,
   FIELDS,
-  LINKS,
   PAGES,
   ERROR_MESSAGES,
 } from '../../../../../../content-strings';
@@ -45,48 +42,17 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES,
+      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    cy.url().should('include', ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION);
-
-    // go back to page
-    cy.navigateToUrl(ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders radio button hint', () => {
@@ -105,12 +71,6 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
     noRadio().should('exist');
 
     cy.checkText(noRadio(), 'No');
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   describe('expandable details - how to calculate percentage', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -46,7 +46,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES,
-      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION,
+      backLink: ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -43,7 +43,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION,

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -47,7 +47,6 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/page-not-found.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/page-not-found.spec.js
@@ -20,6 +20,7 @@ context('Insurance - page not found', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: invalidUrl,
+      assertBackLink: false,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/page-not-found.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/page-not-found.spec.js
@@ -20,6 +20,7 @@ context('Insurance - page not found', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: invalidUrl,
+      assertSubmitButton: false,
       assertBackLink: false,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/page-not-found.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/page-not-found.spec.js
@@ -1,13 +1,14 @@
-import { heading } from '../../pages/shared';
 import { pageNotFoundPage } from '../../pages';
-import { ORGANISATION, PAGES } from '../../../../content-strings';
+import { PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 
 const CONTENT_STRINGS = PAGES.PAGE_NOT_FOUND_PAGE;
 
 context('Insurance - page not found', () => {
+  const invalidUrl = `${ROUTES.INSURANCE.ROOT}/invalid-ref-number${ROUTES.INSURANCE.ALL_SECTIONS}`;
+
   before(() => {
-    cy.navigateToUrl(`${ROUTES.INSURANCE.ROOT}/invalid-ref-number${ROUTES.INSURANCE.ALL_SECTIONS}`);
+    cy.navigateToUrl(invalidUrl);
   });
 
   beforeEach(() => {
@@ -15,32 +16,11 @@ context('Insurance - page not found', () => {
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: invalidUrl,
     });
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders `typed` and `pasted` text', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/page-not-found.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/page-not-found.spec.js
@@ -17,7 +17,7 @@ context('Insurance - page not found', () => {
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: invalidUrl,
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/about-goods-or-services.spec.js
@@ -74,7 +74,6 @@ context('Insurance - Policy and exports - About goods or services page - As an e
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`,
       expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/about-goods-or-services.spec.js
@@ -1,6 +1,5 @@
 import {
   headingCaption,
-  heading,
   submitButton,
   saveAndBackButton,
 } from '../../../../pages/shared';
@@ -8,8 +7,6 @@ import { aboutGoodsOrServicesPage } from '../../../../pages/insurance/policy-and
 import partials from '../../../../partials';
 import {
   BUTTONS,
-  LINKS,
-  ORGANISATION,
   PAGES,
   TASKS,
 } from '../../../../../../content-strings';
@@ -72,47 +69,17 @@ context('Insurance - Policy and exports - About goods or services page - As an e
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: `${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`,
+      expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`,
+      assertSubmitButton: true,
     });
   });
 
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
-
-    cy.url().should('eq', expectedUrl);
-
-    cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading with caption', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
+  it('renders a heading caption', () => {
     cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders `description` label, hint, prefix and input', () => {
@@ -143,12 +110,6 @@ context('Insurance - Policy and exports - About goods or services page - As an e
     field.input().should('exist');
 
     field.inputFirstOption().should('be.disabled');
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   it('renders a `save and back` button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/about-goods-or-services.spec.js
@@ -70,7 +70,7 @@ context('Insurance - Policy and exports - About goods or services page - As an e
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`,
       expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`,

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/about-goods-or-services.spec.js
@@ -73,7 +73,7 @@ context('Insurance - Policy and exports - About goods or services page - As an e
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`,
-      expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`,
+      backLink: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/check-your-answers/check-your-answers.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/check-your-answers/check-your-answers.spec.js
@@ -60,6 +60,7 @@ context('Insurance - Policy and exports - Check your answers - As an exporter, I
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.CHECK_YOUR_ANSWERS}`,
       expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES}`,
       assertSubmitButton: true,
+      submitButtonCopy: BUTTONS.CONTINUE_NEXT_SECTION,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/check-your-answers/check-your-answers.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/check-your-answers/check-your-answers.spec.js
@@ -59,7 +59,6 @@ context('Insurance - Policy and exports - Check your answers - As an exporter, I
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.CHECK_YOUR_ANSWERS}`,
       expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES}`,
-      assertSubmitButton: true,
       submitButtonCopy: BUTTONS.CONTINUE_NEXT_SECTION,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/check-your-answers/check-your-answers.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/check-your-answers/check-your-answers.spec.js
@@ -1,14 +1,11 @@
 import {
   headingCaption,
-  heading,
   submitButton,
   saveAndBackButton,
 } from '../../../../pages/shared';
 import partials from '../../../../partials';
 import {
   BUTTONS,
-  LINKS,
-  ORGANISATION,
   PAGES,
 } from '../../../../../../content-strings';
 import { FIELD_VALUES, ROUTES } from '../../../../../../constants';
@@ -27,10 +24,6 @@ const insuranceStartRoute = START;
 const CONTENT_STRINGS = PAGES.INSURANCE.POLICY_AND_EXPORTS.CHECK_YOUR_ANSWERS;
 
 const { taskList } = partials.insurancePartials;
-
-const goToPageDirectly = (referenceNumber) => {
-  cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.CHECK_YOUR_ANSWERS}`);
-};
 
 const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
@@ -61,12 +54,12 @@ context('Insurance - Policy and exports - Check your answers - As an exporter, I
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.CHECK_YOUR_ANSWERS}`,
+      expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES}`,
+      assertSubmitButton: true,
     });
   });
 
@@ -74,44 +67,8 @@ context('Insurance - Policy and exports - Check your answers - As an exporter, I
     partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
   });
 
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES}`;
-
-    cy.url().should('eq', expectedUrl);
-
-    goToPageDirectly(referenceNumber);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading with caption', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
+  it('renders a heading caption', () => {
     cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE_NEXT_SECTION);
   });
 
   it('renders a `save and back` button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/check-your-answers/check-your-answers.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/check-your-answers/check-your-answers.spec.js
@@ -55,7 +55,7 @@ context('Insurance - Policy and exports - Check your answers - As an exporter, I
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.CHECK_YOUR_ANSWERS}`,
       expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES}`,

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/check-your-answers/check-your-answers.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/check-your-answers/check-your-answers.spec.js
@@ -58,7 +58,7 @@ context('Insurance - Policy and exports - Check your answers - As an exporter, I
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.CHECK_YOUR_ANSWERS}`,
-      expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES}`,
+      backLink: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.ABOUT_GOODS_OR_SERVICES}`,
       submitButtonCopy: BUTTONS.CONTINUE_NEXT_SECTION,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -88,7 +88,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`,
-      expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`,
+      backLink: `${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -89,7 +89,6 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`,
       expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -85,7 +85,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`,
       expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`,

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -1,6 +1,5 @@
 import {
   headingCaption,
-  heading,
   submitButton,
   saveAndBackButton,
 } from '../../../../pages/shared';
@@ -9,7 +8,6 @@ import partials from '../../../../partials';
 import {
   BUTTONS,
   LINKS,
-  ORGANISATION,
   PAGES,
   TASKS,
 } from '../../../../../../content-strings';
@@ -86,47 +84,17 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`,
+      expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`,
+      assertSubmitButton: true,
     });
   });
 
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;
-
-    cy.url().should('eq', expectedUrl);
-
-    cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading with caption', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
+  it('renders a heading caption', () => {
     cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders `requested start date` label, hint and inputs', () => {
@@ -217,12 +185,6 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
     it('renders `currency` label, hint and input with supported currencies ordered alphabetically', () => {
       checkPolicyCurrencyCodeInput();
     });
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   it('renders a `save and back` button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
@@ -84,7 +84,7 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`,
-      expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`,
+      backLink: `${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
@@ -81,7 +81,7 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`,
       expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`,

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
@@ -85,7 +85,6 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`,
       expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
@@ -1,6 +1,5 @@
 import {
   headingCaption,
-  heading,
   submitButton,
   saveAndBackButton,
 } from '../../../../pages/shared';
@@ -9,7 +8,6 @@ import partials from '../../../../partials';
 import {
   BUTTONS,
   LINKS,
-  ORGANISATION,
   PAGES,
   TASKS,
 } from '../../../../../../content-strings';
@@ -82,47 +80,17 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`,
+      expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`,
+      assertSubmitButton: true,
     });
   });
 
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;
-
-    cy.url().should('eq', expectedUrl);
-
-    cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading with caption', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
+  it('renders a heading caption', () => {
     cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders `requested start date` label, hint and inputs', () => {
@@ -200,12 +168,6 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
     it('renders `currency` label, hint and input with supported currencies ordered alphabetically', () => {
       checkPolicyCurrencyCodeInput();
     });
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   it('renders a `save and back` button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/type-of-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/type-of-policy.spec.js
@@ -58,7 +58,7 @@ context('Insurance - Policy and exports - Type of policy page - As an exporter, 
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.TYPE_OF_POLICY}`,
       expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/type-of-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/type-of-policy.spec.js
@@ -1,6 +1,5 @@
 import {
   headingCaption,
-  heading,
   inlineErrorMessage,
   submitButton,
   saveAndBackButton,
@@ -10,8 +9,6 @@ import partials from '../../../../partials';
 import {
   BUTTONS,
   ERROR_MESSAGES,
-  LINKS,
-  ORGANISATION,
   PAGES,
   TASKS,
 } from '../../../../../../content-strings';
@@ -60,12 +57,12 @@ context('Insurance - Policy and exports - Type of policy page - As an exporter, 
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.TYPE_OF_POLICY}`,
+      expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
+      assertSubmitButton: true,
     });
   });
 
@@ -73,38 +70,8 @@ context('Insurance - Policy and exports - Type of policy page - As an exporter, 
     partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
   });
 
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`;
-
-    cy.url().should('eq', expectedUrl);
-
-    goToPageDirectly(referenceNumber);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading with caption', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
+  it('renders a heading caption', () => {
     cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders an intro paragraph', () => {
@@ -133,12 +100,6 @@ context('Insurance - Policy and exports - Type of policy page - As an exporter, 
     cy.checkText(multiplePolicyField.hintList.item2(), FIELDS[FIELD_ID].OPTIONS.MULTIPLE.HINT_LIST[1]);
 
     cy.checkText(multiplePolicyField.hintList.item3(), FIELDS[FIELD_ID].OPTIONS.MULTIPLE.HINT_LIST[2]);
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   it('renders a `save and back` button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/type-of-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/type-of-policy.spec.js
@@ -62,7 +62,6 @@ context('Insurance - Policy and exports - Type of policy page - As an exporter, 
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.TYPE_OF_POLICY}`,
       expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/type-of-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/type-of-policy.spec.js
@@ -61,7 +61,7 @@ context('Insurance - Policy and exports - Type of policy page - As an exporter, 
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.TYPE_OF_POLICY}`,
-      expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
+      backLink: `${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/speak-to-ukef-efm.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/speak-to-ukef-efm.spec.js
@@ -37,7 +37,7 @@ context('Insurance - speak to UKEF EFM exit page', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.SPEAK_TO_UKEF_EFM,
-      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
+      backLink: ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
       assertSubmitButton: false,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/speak-to-ukef-efm.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/speak-to-ukef-efm.spec.js
@@ -1,9 +1,6 @@
-import {
-  heading, yesRadio, submitButton,
-} from '../../pages/shared';
+import { yesRadio, submitButton } from '../../pages/shared';
 import { insurance } from '../../pages';
-import partials from '../../partials';
-import { LINKS, ORGANISATION, PAGES } from '../../../../content-strings';
+import { PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 import {
   completeStartForm,
@@ -16,8 +13,6 @@ import { completeAndSubmitBuyerCountryForm } from '../../../support/forms';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.SPEAK_TO_UKEF_EFM;
 const { ACTIONS } = CONTENT_STRINGS;
-
-const insuranceStartRoute = ROUTES.INSURANCE.START;
 
 context('Insurance - speak to UKEF EFM exit page', () => {
   beforeEach(() => {
@@ -38,46 +33,12 @@ context('Insurance - speak to UKEF EFM exit page', () => {
     cy.url().should('include', ROUTES.INSURANCE.SPEAK_TO_UKEF_EFM);
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.INSURANCE.SPEAK_TO_UKEF_EFM,
+      expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
     });
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('should render a header with href to insurance start', () => {
-    partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD}`;
-
-    partials.backLink().should('have.attr', 'href', expected);
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders `find your nearest EFM` copy with link', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/speak-to-ukef-efm.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/speak-to-ukef-efm.spec.js
@@ -38,6 +38,7 @@ context('Insurance - speak to UKEF EFM exit page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.SPEAK_TO_UKEF_EFM,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,
+      assertSubmitButton: false,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/speak-to-ukef-efm.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/speak-to-ukef-efm.spec.js
@@ -34,7 +34,7 @@ context('Insurance - speak to UKEF EFM exit page', () => {
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.SPEAK_TO_UKEF_EFM,
       expectedBackLink: ROUTES.INSURANCE.ELIGIBILITY.INSURED_PERIOD,

--- a/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
@@ -19,7 +19,7 @@ context('Insurance Eligibility - start page', () => {
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: insuranceStartRoute,
       expectedBackLink: '#',

--- a/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
@@ -1,7 +1,7 @@
 import { insurance } from '../../pages';
 import { submitButton } from '../../pages/shared';
 import partials from '../../partials';
-import { PAGES } from '../../../../content-strings';
+import { BUTTONS, PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.START;
@@ -22,8 +22,9 @@ context('Insurance Eligibility - start page', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: insuranceStartRoute,
-      expectedBackLink: '#',
+      expectedBackLink: `${insuranceStartRoute}#`,
       assertSubmitButton: true,
+      submitButtonCopy: BUTTONS.START_NOW,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
@@ -1,9 +1,7 @@
-import { heading, submitButton } from '../../pages/shared';
 import { insurance } from '../../pages';
+import { submitButton } from '../../pages/shared';
 import partials from '../../partials';
-import {
-  BUTTONS, LINKS, ORGANISATION, PAGES,
-} from '../../../../content-strings';
+import { PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.START;
@@ -12,7 +10,7 @@ const insuranceStartRoute = ROUTES.INSURANCE.START;
 
 context('Insurance Eligibility - start page', () => {
   before(() => {
-    cy.navigateToUrl(ROUTES.INSURANCE.START);
+    cy.navigateToUrl(insuranceStartRoute);
   });
 
   beforeEach(() => {
@@ -20,35 +18,17 @@ context('Insurance Eligibility - start page', () => {
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 70,
-      'best-practices': 100,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: insuranceStartRoute,
+      expectedBackLink: '#',
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().should('have.attr', 'href', '#');
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders an intro', () => {
@@ -79,12 +59,6 @@ context('Insurance Eligibility - start page', () => {
     cy.checkText(insurance.startPage.body3(), CONTENT_STRINGS.BODY_3);
 
     cy.checkText(insurance.startPage.body4(), CONTENT_STRINGS.BODY_4);
-  });
-
-  it('renders a start now button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.START_NOW);
   });
 
   context('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
@@ -22,7 +22,7 @@ context('Insurance Eligibility - start page', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: insuranceStartRoute,
-      expectedBackLink: `${insuranceStartRoute}#`,
+      backLink: `${insuranceStartRoute}#`,
       submitButtonCopy: BUTTONS.START_NOW,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
@@ -23,7 +23,6 @@ context('Insurance Eligibility - start page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: insuranceStartRoute,
       expectedBackLink: `${insuranceStartRoute}#`,
-      assertSubmitButton: true,
       submitButtonCopy: BUTTONS.START_NOW,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
@@ -74,7 +74,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${BROKER}`,
       expectedBackLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
@@ -1,8 +1,8 @@
 import { broker } from '../../../../pages/your-business';
 import partials from '../../../../partials';
-import { submitButton, saveAndBackButton } from '../../../../pages/shared';
+import { saveAndBackButton } from '../../../../pages/shared';
 import {
-  PAGES, BUTTONS, LINKS, ERROR_MESSAGES,
+  PAGES, BUTTONS, ERROR_MESSAGES,
 } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { EXPORTER_BUSINESS as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/exporter-business';
@@ -30,8 +30,6 @@ const {
     BROKER,
   },
 } = ROUTES.INSURANCE;
-
-const insuranceStart = ROUTES.INSURANCE.START;
 
 const { taskList } = partials.insurancePartials;
 
@@ -75,40 +73,22 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      // accessibility threshold is reduced here because
-      // the radio component from design system has an invalid aria attribute.
-      // this is out of our control
-      accessibility: 90,
-      performance: 75,
-      'best-practices': 93,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: `${ROOT}/${referenceNumber}${BROKER}`,
+      expectedBackLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
+      assertSubmitButton: true,
+      lightHouseThresholds: {
+        // accessibility threshold is reduced here because
+        // the radio component from design system has an invalid aria attribute.
+        // this is out of our control
+        accessibility: 90,
+      },
     });
   });
 
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('should render a header with href to insurance start', () => {
-    partials.header.serviceName().should('have.attr', 'href', insuranceStart);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-  });
-
-  it('should display the headings correctly', () => {
+  it('renders a heading caption', () => {
     cy.checkText(partials.headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
   });
 
@@ -151,9 +131,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
     broker[POSTCODE].input().should('exist');
   });
 
-  it('should display the continue and save and go back button', () => {
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
-
+  it('should display save and go back button', () => {
     cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
@@ -77,7 +77,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${BROKER}`,
-      expectedBackLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
+      backLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
       lightHouseThresholds: {
         // accessibility threshold is reduced here because
         // the radio component from design system has an invalid aria attribute.

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
@@ -28,6 +28,7 @@ const {
   START,
   EXPORTER_BUSINESS: {
     BROKER,
+    TURNOVER,
   },
 } = ROUTES.INSURANCE;
 
@@ -77,7 +78,8 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${BROKER}`,
-      backLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
+      backLink: `${ROOT}/${referenceNumber}${TURNOVER}`,
+      assertSubmitButton: true,
       lightHouseThresholds: {
         // accessibility threshold is reduced here because
         // the radio component from design system has an invalid aria attribute.
@@ -95,8 +97,6 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
     const fieldId = USING_BROKER;
     const field = broker[fieldId];
 
-    cy.checkText(field.heading(), CONTENT_STRINGS.PAGE_TITLE);
-
     field.yesRadioInput().should('exist');
     cy.checkAriaLabel(field.yesRadioInput(), `${CONTENT_STRINGS.PAGE_TITLE} yes radio`);
 
@@ -109,7 +109,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
     const field = broker[fieldId];
     field.yesRadioInput().click();
 
-    cy.checkText(broker[HEADING].heading(), FIELDS.BROKER[HEADING].HEADING);
+    cy.checkText(broker[HEADING](), FIELDS.BROKER[HEADING].HEADING);
 
     cy.checkText(broker[NAME].label(), FIELDS.BROKER[NAME].LABEL);
     broker[NAME].input().should('exist');

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
@@ -78,7 +78,6 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${BROKER}`,
       expectedBackLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
-      assertSubmitButton: true,
       lightHouseThresholds: {
         // accessibility threshold is reduced here because
         // the radio component from design system has an invalid aria attribute.

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
@@ -23,6 +23,10 @@ const {
 
 const insuranceStart = ROUTES.INSURANCE.START;
 
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.prepareApplication.tasks.exporterBusiness;
+
 context('Insurance - Your business - Company details page - As an Exporter I want to enter my business\'s CRN So that I can apply for UKEF Export Insurance policy', () => {
   let referenceNumber;
 
@@ -31,12 +35,12 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
 
     cy.submitInsuranceEligibilityAndStartApplication();
 
+    task.link().click();
+
     cy.getReferenceNumber().then((id) => {
       referenceNumber = id;
 
       const url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`;
-
-      cy.navigateToUrl(url);
 
       cy.url().should('eq', url);
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
@@ -55,7 +55,7 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`,
-      expectedBackLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
+      backLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
@@ -56,6 +56,9 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`,
       backLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
+      lightHouseThresholds: {
+        'best-practices': 93,
+      },
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
@@ -48,7 +48,7 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`,
       expectedBackLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
@@ -1,13 +1,11 @@
 import { companyDetails } from '../../../../pages/your-business';
 import partials from '../../../../partials';
-import {
-  heading, submitButton, saveAndBackButton,
-} from '../../../../pages/shared';
-import {
-  PAGES, BUTTONS, LINKS,
-} from '../../../../../../content-strings';
+import { saveAndBackButton } from '../../../../pages/shared';
+import { PAGES, BUTTONS } from '../../../../../../content-strings';
 import { EXPORTER_BUSINESS_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/exporter-business';
 import { ROUTES, FIELD_IDS } from '../../../../../../constants';
+
+const { ROOT } = ROUTES.INSURANCE;
 
 const CONTENT_STRINGS = PAGES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS;
 
@@ -36,7 +34,7 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
     cy.getReferenceNumber().then((id) => {
       referenceNumber = id;
 
-      const url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`;
+      const url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`;
 
       cy.navigateToUrl(url);
 
@@ -49,40 +47,21 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 93,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`,
+      expectedBackLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', insuranceStart);
   });
 
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-  });
-
-  it('should display the headings correctly', () => {
+  it('renders a heading caption', () => {
     cy.checkText(partials.headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('should display the companies house search box', () => {
@@ -141,9 +120,7 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
     cy.checkAriaLabel(companyDetails.phoneNumber(), FIELDS[PHONE_NUMBER].LABEL);
   });
 
-  it('should display the continue and save and go back button', () => {
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
-
+  it('should display save and go back button', () => {
     cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
@@ -56,7 +56,6 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`,
       expectedBackLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/nature-of-business-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/nature-of-business-page.spec.js
@@ -64,7 +64,7 @@ context('Insurance - Your business - Nature of your business page - As an Export
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS}`,
-      expectedBackLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`,
+      backLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/nature-of-business-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/nature-of-business-page.spec.js
@@ -65,7 +65,6 @@ context('Insurance - Your business - Nature of your business page - As an Export
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS}`,
       expectedBackLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/nature-of-business-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/nature-of-business-page.spec.js
@@ -61,7 +61,7 @@ context('Insurance - Your business - Nature of your business page - As an Export
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS}`,
       expectedBackLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`,

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/nature-of-business-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/nature-of-business-page.spec.js
@@ -1,7 +1,7 @@
 import { natureOfBusiness } from '../../../../pages/your-business';
 import partials from '../../../../partials';
-import { heading, submitButton, saveAndBackButton } from '../../../../pages/shared';
-import { PAGES, BUTTONS, LINKS } from '../../../../../../content-strings';
+import { submitButton, saveAndBackButton } from '../../../../pages/shared';
+import { PAGES, BUTTONS } from '../../../../../../content-strings';
 import { EXPORTER_BUSINESS_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/exporter-business';
 import { ROUTES, FIELD_IDS } from '../../../../../../constants';
 import application from '../../../../../fixtures/application';
@@ -60,40 +60,21 @@ context('Insurance - Your business - Nature of your business page - As an Export
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 93,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: `${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS}`,
+      expectedBackLink: `${ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', insuranceStart);
   });
 
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-  });
-
-  it('should display the headings correctly', () => {
+  it('renders a heading caption', () => {
     cy.checkText(partials.headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it(`should display ${GOODS_OR_SERVICES} input box`, () => {
@@ -117,9 +98,7 @@ context('Insurance - Your business - Nature of your business page - As an Export
     cy.checkText(field.suffix(), FIELDS.NATURE_OF_YOUR_BUSINESS[fieldId].SUFFIX);
   });
 
-  it('should display the continue and save and go back button', () => {
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
-
+  it('should display save and go back button', () => {
     cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-page.spec.js
@@ -1,7 +1,7 @@
 import { turnover } from '../../../../pages/your-business';
 import partials from '../../../../partials';
-import { heading, submitButton, saveAndBackButton } from '../../../../pages/shared';
-import { PAGES, BUTTONS, LINKS } from '../../../../../../content-strings';
+import { saveAndBackButton } from '../../../../pages/shared';
+import { PAGES, BUTTONS } from '../../../../../../content-strings';
 import { EXPORTER_BUSINESS_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/exporter-business';
 import { ROUTES } from '../../../../../../constants';
 import { EXPORTER_BUSINESS as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/exporter-business';
@@ -22,6 +22,7 @@ const {
   START,
   EXPORTER_BUSINESS: {
     TURNOVER,
+    NATURE_OF_BUSINESS,
     BROKER,
   },
 } = ROUTES.INSURANCE;
@@ -61,40 +62,21 @@ context('Insurance - Your business - Turnover page - As an Exporter I want to en
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 93,
-      seo: 70,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: `${ROOT}/${referenceNumber}${TURNOVER}`,
+      expectedBackLink: `${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS}`,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
   });
 
   it('should render a header with href to insurance start', () => {
     partials.header.serviceName().should('have.attr', 'href', insuranceStart);
   });
 
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-  });
-
-  it('should display the headings correctly', () => {
+  it('renders a heading caption', () => {
     cy.checkText(partials.headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it(`should display ${FINANCIAL_YEAR_END_DATE} section`, () => {
@@ -133,9 +115,7 @@ context('Insurance - Your business - Turnover page - As an Exporter I want to en
     cy.checkText(field.suffix(), FIELDS.TURNOVER[fieldId].SUFFIX);
   });
 
-  it('should display the continue and save and go back button', () => {
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
-
+  it('should display save and go back button', () => {
     cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-page.spec.js
@@ -66,7 +66,7 @@ context('Insurance - Your business - Turnover page - As an Exporter I want to en
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${TURNOVER}`,
-      expectedBackLink: `${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS}`,
+      backLink: `${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS}`,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-page.spec.js
@@ -67,7 +67,6 @@ context('Insurance - Your business - Turnover page - As an Exporter I want to en
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${TURNOVER}`,
       expectedBackLink: `${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS}`,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-page.spec.js
@@ -63,7 +63,7 @@ context('Insurance - Your business - Turnover page - As an Exporter I want to en
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${TURNOVER}`,
       expectedBackLink: `${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS}`,

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/company-or-organisation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/company-or-organisation.spec.js
@@ -48,7 +48,7 @@ context('Insurance - Your Buyer - Company or organisation page - As an exporter,
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`,
-      expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
+      backLink: `${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/company-or-organisation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/company-or-organisation.spec.js
@@ -45,7 +45,7 @@ context('Insurance - Your Buyer - Company or organisation page - As an exporter,
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`,
       expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/company-or-organisation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/company-or-organisation.spec.js
@@ -1,14 +1,13 @@
-import {
-  submitButton,
-  saveAndBackButton,
-} from '../../../pages/shared';
+import { saveAndBackButton } from '../../../pages/shared';
 import partials from '../../../partials';
 import { companyOrOrganisationPage } from '../../../pages/insurance/your-buyer';
-import { BUTTONS } from '../../../../../content-strings';
+import { BUTTONS, PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../constants/field-ids/insurance/your-buyer';
 import { INSURANCE_ROOT } from '../../../../../constants/routes/insurance';
 import { YOUR_BUYER_FIELDS as FIELDS } from '../../../../../content-strings/fields/insurance/your-buyer';
+
+const CONTENT_STRINGS = PAGES.INSURANCE.EXPORTER_BUSINESS.COMPANY_OR_ORGANISATION;
 
 const {
   COMPANY_OR_ORGANISATION: {
@@ -45,16 +44,13 @@ context('Insurance - Your Buyer - Company or organisation page - As an exporter,
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: `${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`,
+      expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
+      assertSubmitButton: true,
+    });
   });
 
   it('renders an `organisation or company name` label, and input', () => {
@@ -83,12 +79,6 @@ context('Insurance - Your Buyer - Company or organisation page - As an exporter,
     cy.checkText(field.label(), FIELDS.COMPANY_OR_ORGANISATION[fieldId].LABEL);
 
     field.input().should('exist');
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   it('renders a `save and back` button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/company-or-organisation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/company-or-organisation.spec.js
@@ -49,7 +49,6 @@ context('Insurance - Your Buyer - Company or organisation page - As an exporter,
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`,
       expectedBackLink: `${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/company-or-organisation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/company-or-organisation.spec.js
@@ -7,7 +7,7 @@ import { YOUR_BUYER as FIELD_IDS } from '../../../../../constants/field-ids/insu
 import { INSURANCE_ROOT } from '../../../../../constants/routes/insurance';
 import { YOUR_BUYER_FIELDS as FIELDS } from '../../../../../content-strings/fields/insurance/your-buyer';
 
-const CONTENT_STRINGS = PAGES.INSURANCE.EXPORTER_BUSINESS.COMPANY_OR_ORGANISATION;
+const CONTENT_STRINGS = PAGES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION;
 
 const {
   COMPANY_OR_ORGANISATION: {

--- a/e2e-tests/cypress/e2e/journeys/page-not-found.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/page-not-found.spec.js
@@ -1,4 +1,3 @@
-import { heading } from '../pages/shared';
 import { pageNotFoundPage } from '../pages';
 import partials from '../partials';
 import { PAGES, PRODUCT } from '../../../content-strings';
@@ -10,12 +9,11 @@ context('404 Page not found', () => {
     cy.navigateToUrl('/test');
   });
 
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: '/test',
+    });
   });
 
   describe('header', () => {
@@ -30,14 +28,6 @@ context('404 Page not found', () => {
 
       partials.header.serviceName().should('have.attr', 'href', '/');
     });
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a heading', () => {
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders `typed` and `pasted` text', () => {

--- a/e2e-tests/cypress/e2e/journeys/page-not-found.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/page-not-found.spec.js
@@ -10,7 +10,7 @@ context('404 Page not found', () => {
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: '/test',
     });

--- a/e2e-tests/cypress/e2e/journeys/page-not-found.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/page-not-found.spec.js
@@ -13,6 +13,7 @@ context('404 Page not found', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: '/test',
+      assertSubmitButton: false,
       assertBackLink: false,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/page-not-found.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/page-not-found.spec.js
@@ -13,6 +13,7 @@ context('404 Page not found', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: '/test',
+      assertBackLink: false,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
@@ -26,7 +26,7 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.BUYER_BODY,
-      expectedBackLink: ROUTES.QUOTE.BUYER_COUNTRY,
+      backLink: ROUTES.QUOTE.BUYER_COUNTRY,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
@@ -25,7 +25,7 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
   it('renders core page elements', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
-      currentHref: ROUTES.QUOTE.NEED_TO_START_AGAIN,
+      currentHref: ROUTES.QUOTE.BUYER_BODY,
       expectedBackLink: ROUTES.QUOTE.BUYER_COUNTRY,
       assertSubmitButton: true,
     });
@@ -33,14 +33,6 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
 
   it('should render a header with href to quote start', () => {
     partials.header.serviceName().should('have.attr', 'href', startRoute);
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.BUYER_COUNTRY}`;
-    partials.backLink().should('have.attr', 'href', expected);
   });
 
   it('renders yes and no radio buttons', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
@@ -1,12 +1,10 @@
 import {
-  heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton,
+  yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton,
 } from '../../../pages/shared';
 import partials from '../../../partials';
 import {
-  BUTTONS,
   ERROR_MESSAGES,
   LINKS,
-  ORGANISATION,
   PAGES,
 } from '../../../../../content-strings';
 import { ROUTES, FIELD_IDS } from '../../../../../constants';
@@ -24,25 +22,13 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
     cy.url().should('include', ROUTES.QUOTE.BUYER_BODY);
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.QUOTE.NEED_TO_START_AGAIN,
+      expectedBackLink: ROUTES.QUOTE.BUYER_COUNTRY,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
   });
 
   it('should render a header with href to quote start', () => {
@@ -57,13 +43,6 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
     partials.backLink().should('have.attr', 'href', expected);
   });
 
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
-  });
-
   it('renders yes and no radio buttons', () => {
     yesRadio().should('exist');
 
@@ -72,12 +51,6 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
     noRadio().should('exist');
 
     cy.checkText(noRadio(), 'No');
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
@@ -2,11 +2,7 @@ import {
   yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton,
 } from '../../../pages/shared';
 import partials from '../../../partials';
-import {
-  ERROR_MESSAGES,
-  LINKS,
-  PAGES,
-} from '../../../../../content-strings';
+import { ERROR_MESSAGES, PAGES } from '../../../../../content-strings';
 import { ROUTES, FIELD_IDS } from '../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
 

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
@@ -27,7 +27,6 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.BUYER_BODY,
       expectedBackLink: ROUTES.QUOTE.BUYER_COUNTRY,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
@@ -23,7 +23,7 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.NEED_TO_START_AGAIN,
       expectedBackLink: ROUTES.QUOTE.BUYER_COUNTRY,

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
@@ -1,6 +1,6 @@
 import { buyerCountryPage, submitButton } from '../../../pages/shared';
 import partials from '../../../partials';
-import { LINKS } from '../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import {
   checkInputHint,
@@ -9,7 +9,7 @@ import {
   checkFocusOnInputWhenClickingSummaryErrorMessage,
 } from '../../../../support/check-buyer-country-form';
 
-const CONTENT_STRINGS = PAGEES.BUYER_COUNTRY;
+const CONTENT_STRINGS = PAGES.BUYER_COUNTRY;
 
 context('Buyer country page - as an exporter, I want to check if UKEF issue export insurance cover for where my buyer is based', () => {
   beforeEach(() => {
@@ -19,7 +19,7 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.BUYER_COUNTRY,
       expectedBackLink: LINKS.EXTERNAL.BEFORE_YOU_START,

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
@@ -22,7 +22,7 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.BUYER_COUNTRY,
-      expectedBackLink: LINKS.EXTERNAL.BEFORE_YOU_START,
+      backLink: LINKS.EXTERNAL.BEFORE_YOU_START,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
@@ -3,15 +3,13 @@ import partials from '../../../partials';
 import { LINKS } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import {
-  checkPageTitleAndHeading,
   checkInputHint,
   checkAutocompleteInput,
-  checkSubmitButton,
   checkValidationErrors,
   checkFocusOnInputWhenClickingSummaryErrorMessage,
 } from '../../../../support/check-buyer-country-form';
 
-const startRoute = ROUTES.QUOTE.START;
+const CONTENT_STRINGS = PAGEES.BUYER_COUNTRY;
 
 context('Buyer country page - as an exporter, I want to check if UKEF issue export insurance cover for where my buyer is based', () => {
   beforeEach(() => {
@@ -20,32 +18,13 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
     cy.url().should('include', ROUTES.QUOTE.BUYER_COUNTRY);
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 70,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.QUOTE.BUYER_COUNTRY,
+      expectedBackLink: LINKS.EXTERNAL.BEFORE_YOU_START,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('should render a header with href to quote start', () => {
-    partials.header.serviceName().should('have.attr', 'href', startRoute);
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().should('have.attr', 'href', LINKS.EXTERNAL.BEFORE_YOU_START);
-  });
-
-  it('renders a page title and heading', () => {
-    checkPageTitleAndHeading();
   });
 
   it('renders a hint', () => {
@@ -72,10 +51,6 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
     it('allows user to remove a selected country and search again', () => {
       checkAutocompleteInput.allowsUserToRemoveCountryAndSearchAgain();
     });
-  });
-
-  it('renders a submit button', () => {
-    checkSubmitButton();
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
@@ -23,6 +23,9 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.BUYER_COUNTRY,
       backLink: LINKS.EXTERNAL.BEFORE_YOU_START,
+      lightHouseThresholds: {
+        performance: 70,
+      },
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
@@ -23,7 +23,6 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.BUYER_COUNTRY,
       expectedBackLink: LINKS.EXTERNAL.BEFORE_YOU_START,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
@@ -26,7 +26,7 @@ context('Cannot apply exit page', () => {
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.CANNOT_APPLY,
       expectedBackLink: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,

--- a/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
@@ -30,6 +30,7 @@ context('Cannot apply exit page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.CANNOT_APPLY,
       expectedBackLink: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,
+      assertSubmitButton: false,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
@@ -31,6 +31,9 @@ context('Cannot apply exit page', () => {
       currentHref: ROUTES.QUOTE.CANNOT_APPLY,
       backLink: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,
       assertSubmitButton: false,
+      lightHouseThresholds: {
+        seo: 60,
+      },
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
@@ -29,7 +29,7 @@ context('Cannot apply exit page', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.CANNOT_APPLY,
-      expectedBackLink: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,
+      backLink: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,
       assertSubmitButton: false,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
@@ -1,12 +1,8 @@
 import {
-  cannotApplyPage, heading, noRadio, submitButton,
+  cannotApplyPage, noRadio, submitButton,
 } from '../../pages/shared';
 import partials from '../../partials';
-import {
-  ORGANISATION,
-  LINKS,
-  PAGES,
-} from '../../../../content-strings';
+import { PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../support/forms';
 import { completeAndSubmitBuyerBodyForm, completeAndSubmitExporterLocationForm } from '../../../support/quote/forms';
@@ -29,45 +25,16 @@ context('Cannot apply exit page', () => {
     cy.url().should('include', ROUTES.QUOTE.CANNOT_APPLY);
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.QUOTE.CANNOT_APPLY,
+      expectedBackLink: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,
     });
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
   });
 
   it('should render a header with href to quote start', () => {
     partials.header.serviceName().should('have.attr', 'href', startRoute);
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    cy.url().should('include', ROUTES.QUOTE.UK_GOODS_OR_SERVICES);
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders a reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/check-your-answers/check-your-answers-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/check-your-answers/check-your-answers-single-policy.spec.js
@@ -52,6 +52,7 @@ context('Check your answers page (single policy) - as an exporter, I want to rev
       currentHref: ROUTES.QUOTE.CHECK_YOUR_ANSWERS,
       expectedBackLink: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
       assertSubmitButton: true,
+      submitButtonCopy: CONTENT_STRINGS.SUBMIT_BUTTON,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/check-your-answers/check-your-answers-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/check-your-answers/check-your-answers-single-policy.spec.js
@@ -51,7 +51,6 @@ context('Check your answers page (single policy) - as an exporter, I want to rev
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.CHECK_YOUR_ANSWERS,
       expectedBackLink: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
-      assertSubmitButton: true,
       submitButtonCopy: CONTENT_STRINGS.SUBMIT_BUTTON,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/quote/check-your-answers/check-your-answers-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/check-your-answers/check-your-answers-single-policy.spec.js
@@ -1,8 +1,7 @@
-import { heading, submitButton } from '../../../pages/shared';
+import { submitButton } from '../../../pages/shared';
 import { checkYourAnswersPage } from '../../../pages/quote';
 import partials from '../../../partials';
 import {
-  ORGANISATION,
   FIELDS,
   LINKS,
   PAGES,
@@ -47,50 +46,17 @@ context('Check your answers page (single policy) - as an exporter, I want to rev
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.QUOTE.CHECK_YOUR_ANSWERS,
+      expectedBackLink: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY}`;
-    partials.backLink().should('have.attr', 'href', expected);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), CONTENT_STRINGS.SUBMIT_BUTTON);
   });
 
   it('should render a header with href to quote start', () => {
     partials.header.serviceName().should('have.attr', 'href', startRoute);
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   context('export summary list', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/check-your-answers/check-your-answers-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/check-your-answers/check-your-answers-single-policy.spec.js
@@ -50,7 +50,7 @@ context('Check your answers page (single policy) - as an exporter, I want to rev
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.CHECK_YOUR_ANSWERS,
-      expectedBackLink: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
+      backLink: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
       submitButtonCopy: CONTENT_STRINGS.SUBMIT_BUTTON,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/quote/check-your-answers/check-your-answers-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/check-your-answers/check-your-answers-single-policy.spec.js
@@ -47,7 +47,7 @@ context('Check your answers page (single policy) - as an exporter, I want to rev
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.CHECK_YOUR_ANSWERS,
       expectedBackLink: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,

--- a/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
@@ -1,5 +1,4 @@
 import {
-  heading,
   yesRadio,
   yesRadioInput,
   noRadio,
@@ -7,20 +6,12 @@ import {
   submitButton,
 } from '../../../pages/shared';
 import partials from '../../../partials';
-import {
-  ORGANISATION,
-  BUTTONS,
-  LINKS,
-  PAGES,
-  ERROR_MESSAGES,
-} from '../../../../../content-strings';
+import { PAGES, ERROR_MESSAGES } from '../../../../../content-strings';
 import { ROUTES, FIELD_IDS } from '../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
 import { completeAndSubmitBuyerBodyForm } from '../../../../support/quote/forms';
 
 const CONTENT_STRINGS = PAGES.EXPORTER_LOCATION;
-
-const startRoute = ROUTES.QUOTE.START;
 
 context('Exporter location page - as an exporter, I want to check if my company can get UKEF issue export insurance cover', () => {
   beforeEach(() => {
@@ -31,45 +22,13 @@ context('Exporter location page - as an exporter, I want to check if my company 
     cy.url().should('include', ROUTES.QUOTE.EXPORTER_LOCATION);
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.QUOTE.EXPORTER_LOCATION,
+      expectedBackLink: ROUTES.QUOTE.BUYER_BODY,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('should render a header with href to quote start', () => {
-    partials.header.serviceName().should('have.attr', 'href', startRoute);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    cy.url().should('include', ROUTES.QUOTE.BUYER_BODY);
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders yes and no radio buttons', () => {
@@ -80,12 +39,6 @@ context('Exporter location page - as an exporter, I want to check if my company 
     noRadio().should('exist');
 
     cy.checkText(noRadio(), 'No');
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
@@ -27,7 +27,6 @@ context('Exporter location page - as an exporter, I want to check if my company 
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.EXPORTER_LOCATION,
       expectedBackLink: ROUTES.QUOTE.BUYER_BODY,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
@@ -26,7 +26,7 @@ context('Exporter location page - as an exporter, I want to check if my company 
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.EXPORTER_LOCATION,
-      expectedBackLink: ROUTES.QUOTE.BUYER_BODY,
+      backLink: ROUTES.QUOTE.BUYER_BODY,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
@@ -23,7 +23,7 @@ context('Exporter location page - as an exporter, I want to check if my company 
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.EXPORTER_LOCATION,
       expectedBackLink: ROUTES.QUOTE.BUYER_BODY,

--- a/e2e-tests/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
@@ -21,7 +21,7 @@ context('Get a quote via email exit page', () => {
 
     submitButton().click();
 
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CANNOT_APPLY}`;
+    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.GET_A_QUOTE_BY_EMAIL}`;
 
     cy.url().should('eq', expectedUrl);
   });

--- a/e2e-tests/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
@@ -31,6 +31,7 @@ context('Get a quote via email exit page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.GET_A_QUOTE_BY_EMAIL,
       expectedBackLink: ROUTES.QUOTE.BUYER_COUNTRY,
+      assertSubmitButton: false,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
@@ -1,11 +1,7 @@
-import { buyerCountryPage, heading, submitButton } from '../../pages/shared';
+import { buyerCountryPage, submitButton } from '../../pages/shared';
 import { getAQuoteByEmailPage } from '../../pages/quote';
 import partials from '../../partials';
-import {
-  ORGANISATION,
-  LINKS,
-  PAGES,
-} from '../../../../content-strings';
+import { PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 
 const CONTENT_STRINGS = PAGES.QUOTE.GET_A_QUOTE_BY_EMAIL;
@@ -24,47 +20,22 @@ context('Get a quote via email exit page', () => {
     results.first().click();
 
     submitButton().click();
+
+    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CANNOT_APPLY}`;
+
+    cy.url().should('eq', expectedUrl);
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.QUOTE.GET_A_QUOTE_BY_EMAIL,
+      expectedBackLink: ROUTES.QUOTE.BUYER_COUNTRY,
     });
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
   });
 
   it('should render a header with href to quote start', () => {
     partials.header.serviceName().should('have.attr', 'href', startRoute);
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    cy.url().should('include', ROUTES.QUOTE.BUYER_COUNTRY);
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders a reason and description ', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
@@ -27,7 +27,7 @@ context('Get a quote via email exit page', () => {
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.GET_A_QUOTE_BY_EMAIL,
       expectedBackLink: ROUTES.QUOTE.BUYER_COUNTRY,

--- a/e2e-tests/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
@@ -32,6 +32,9 @@ context('Get a quote via email exit page', () => {
       currentHref: ROUTES.QUOTE.GET_A_QUOTE_BY_EMAIL,
       backLink: ROUTES.QUOTE.BUYER_COUNTRY,
       assertSubmitButton: false,
+      lightHouseThresholds: {
+        seo: 60,
+      },
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
@@ -30,7 +30,7 @@ context('Get a quote via email exit page', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.GET_A_QUOTE_BY_EMAIL,
-      expectedBackLink: ROUTES.QUOTE.BUYER_COUNTRY,
+      backLink: ROUTES.QUOTE.BUYER_COUNTRY,
       assertSubmitButton: false,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/quote/need-to-start-again.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/need-to-start-again.spec.js
@@ -1,12 +1,6 @@
-import {
-  heading, submitButton, needToStartAgainPage,
-} from '../../pages/shared';
+import { submitButton, needToStartAgainPage } from '../../pages/shared';
 import partials from '../../partials';
-import {
-  ORGANISATION,
-  LINKS,
-  PAGES,
-} from '../../../../content-strings';
+import { PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../support/forms';
 import { completeAndSubmitBuyerBodyForm } from '../../../support/quote/forms';
@@ -29,46 +23,20 @@ context('Get a Quote - Need to start again exit page', () => {
     cy.url().should('include', ROUTES.QUOTE.NEED_TO_START_AGAIN);
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.QUOTE.NEED_TO_START_AGAIN,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
   });
 
   it('should render a header with href to quote start', () => {
     partials.header.serviceName().should('have.attr', 'href', startRoute);
   });
 
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
-  });
-
   it('renders a reason', () => {
     needToStartAgainPage.reason().should('exist');
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), LINKS.START_AGAIN.TEXT);
   });
 
   describe('clicking the submit button', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/need-to-start-again.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/need-to-start-again.spec.js
@@ -1,6 +1,6 @@
 import { submitButton, needToStartAgainPage } from '../../pages/shared';
 import partials from '../../partials';
-import { PAGES } from '../../../../content-strings';
+import { LINKS, PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../support/forms';
 import { completeAndSubmitBuyerBodyForm } from '../../../support/quote/forms';
@@ -28,6 +28,8 @@ context('Get a Quote - Need to start again exit page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.NEED_TO_START_AGAIN,
       assertSubmitButton: true,
+      submitButtonCopy: LINKS.START_AGAIN.TEXT,
+      assertBackLink: false,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/need-to-start-again.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/need-to-start-again.spec.js
@@ -27,7 +27,6 @@ context('Get a Quote - Need to start again exit page', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.NEED_TO_START_AGAIN,
-      assertSubmitButton: true,
       submitButtonCopy: LINKS.START_AGAIN.TEXT,
       assertBackLink: false,
     });

--- a/e2e-tests/cypress/e2e/journeys/quote/need-to-start-again.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/need-to-start-again.spec.js
@@ -24,7 +24,7 @@ context('Get a Quote - Need to start again exit page', () => {
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.NEED_TO_START_AGAIN,
       assertSubmitButton: true,

--- a/e2e-tests/cypress/e2e/journeys/quote/policy-type/policy-type.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/policy-type/policy-type.spec.js
@@ -42,7 +42,7 @@ context('Policy type page - as an exporter, I want to get UKEF export insurance 
       cy.corePageChecks({
         pageTitle: CONTENT_STRINGS.PAGE_TITLE,
         currentHref: ROUTES.QUOTE.POLICY_TYPE,
-        expectedBackLink: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,
+        backLink: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,
         lightHouseThresholds: {
           // accessibility threshold is reduced here because
           // the radio component from design system has an invalid aria attribute.

--- a/e2e-tests/cypress/e2e/journeys/quote/policy-type/policy-type.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/policy-type/policy-type.spec.js
@@ -43,7 +43,6 @@ context('Policy type page - as an exporter, I want to get UKEF export insurance 
         pageTitle: CONTENT_STRINGS.PAGE_TITLE,
         currentHref: ROUTES.QUOTE.POLICY_TYPE,
         expectedBackLink: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,
-        assertSubmitButton: true,
         lightHouseThresholds: {
           // accessibility threshold is reduced here because
           // the radio component from design system has an invalid aria attribute.

--- a/e2e-tests/cypress/e2e/journeys/quote/policy-type/policy-type.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/policy-type/policy-type.spec.js
@@ -39,7 +39,7 @@ context('Policy type page - as an exporter, I want to get UKEF export insurance 
     });
 
     it('renders core page elements', () => {
-      cy.assertCorePageElements({
+      cy.corePageChecks({
         pageTitle: CONTENT_STRINGS.PAGE_TITLE,
         currentHref: ROUTES.QUOTE.POLICY_TYPE,
         expectedBackLink: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,

--- a/e2e-tests/cypress/e2e/journeys/quote/policy-type/policy-type.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/policy-type/policy-type.spec.js
@@ -4,12 +4,10 @@ import {
   completeAndSubmitExporterLocationForm,
   completeAndSubmitUkContentForm,
 } from '../../../../support/quote/forms';
-import { heading, submitButton } from '../../../pages/shared';
+import { submitButton } from '../../../pages/shared';
 import { policyTypePage } from '../../../pages/quote';
 import partials from '../../../partials';
 import {
-  ORGANISATION,
-  BUTTONS,
   LINKS,
   FIELDS,
   PAGES,
@@ -40,48 +38,23 @@ context('Policy type page - as an exporter, I want to get UKEF export insurance 
       Cypress.Cookies.preserveOnce('connect.sid');
     });
 
-    it('passes the audits', () => {
-      cy.lighthouse({
-        // accessibility threshold is reduced here because
-        // the radio component from design system has an invalid aria attribute.
-        // this is out of our control
-        accessibility: 90,
-        performance: 75,
-        'best-practices': 100,
-        seo: 60,
+    it('renders core page elements', () => {
+      cy.assertCorePageElements({
+        pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+        currentHref: ROUTES.QUOTE.POLICY_TYPE,
+        expectedBackLink: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,
+        assertSubmitButton: true,
+        lightHouseThresholds: {
+          // accessibility threshold is reduced here because
+          // the radio component from design system has an invalid aria attribute.
+          // this is out of our control
+          accessibility: 90,
+        },
       });
-    });
-
-    it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
-      cy.checkText(partials.backLink(), LINKS.BACK);
-
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.UK_GOODS_OR_SERVICES}`;
-
-      partials.backLink().should('have.attr', 'href', expected);
-    });
-
-    it('renders an analytics cookies consent banner that can be accepted', () => {
-      cy.checkAnalyticsCookiesConsentAndAccept();
-    });
-
-    it('renders an analytics cookies consent banner that can be rejected', () => {
-      cy.rejectAnalyticsCookies();
-    });
-
-    it('renders a phase banner', () => {
-      cy.checkPhaseBanner();
     });
 
     it('should render a header with href to quote start', () => {
       partials.header.serviceName().should('have.attr', 'href', startRoute);
-    });
-
-    it('renders a page title and heading', () => {
-      const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-      cy.title().should('eq', expectedPageTitle);
-
-      cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
     });
 
     it('renders `policy type` radio inputs with labels and hints', () => {
@@ -147,12 +120,6 @@ context('Policy type page - as an exporter, I want to get UKEF export insurance 
         const expectedHref = LINKS.EXTERNAL.NBI_FORM;
         multiPolicyType.inset.link().should('have.attr', 'href', expectedHref);
       });
-    });
-
-    it('renders a submit button', () => {
-      submitButton().should('exist');
-
-      cy.checkText(submitButton(), BUTTONS.CONTINUE);
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
@@ -41,7 +41,7 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
 
     it('renders core page elements', () => {
       cy.corePageChecks({
-        pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+        pageTitle: CONTENT_STRINGS.MULTIPLE_POLICY_PAGE_TITLE,
         currentHref: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
         expectedBackLink: ROUTES.QUOTE.POLICY_TYPE,
         assertSubmitButton: true,

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
@@ -40,7 +40,7 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
     });
 
     it('renders core page elements', () => {
-      cy.assertCorePageElements({
+      cy.corePageChecks({
         pageTitle: CONTENT_STRINGS.PAGE_TITLE,
         currentHref: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
         expectedBackLink: ROUTES.QUOTE.POLICY_TYPE,

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
@@ -44,7 +44,6 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
         pageTitle: CONTENT_STRINGS.MULTIPLE_POLICY_PAGE_TITLE,
         currentHref: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
         expectedBackLink: ROUTES.QUOTE.POLICY_TYPE,
-        assertSubmitButton: true,
         lightHouseThresholds: {
           // accessibility threshold is reduced here because
           // the radio component from design system has an invalid aria attribute.

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
@@ -5,12 +5,10 @@ import {
   completeAndSubmitUkContentForm,
   completeAndSubmitPolicyTypeMultiForm,
 } from '../../../../support/quote/forms';
-import { heading, submitButton } from '../../../pages/shared';
+import { submitButton } from '../../../pages/shared';
 import { tellUsAboutYourPolicyPage } from '../../../pages/quote';
 import partials from '../../../partials';
 import {
-  ORGANISATION,
-  BUTTONS,
   LINKS,
   FIELDS,
   PAGES,
@@ -41,40 +39,23 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
       Cypress.Cookies.preserveOnce('connect.sid');
     });
 
-    it('passes the audits', () => {
-      cy.lighthouse({
-        // accessibility threshold is reduced here because
-        // the radio component from design system has an invalid aria attribute.
-        // this is out of our control
-        accessibility: 92,
-        performance: 76,
-        'best-practices': 100,
-        seo: 60,
+    it('renders core page elements', () => {
+      cy.assertCorePageElements({
+        pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+        currentHref: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
+        expectedBackLink: ROUTES.QUOTE.POLICY_TYPE,
+        assertSubmitButton: true,
+        lightHouseThresholds: {
+          // accessibility threshold is reduced here because
+          // the radio component from design system has an invalid aria attribute.
+          // this is out of our control
+          accessibility: 92,
+        },
       });
-    });
-
-    it('renders a phase banner', () => {
-      cy.checkPhaseBanner();
     });
 
     it('should render a header with href to quote start', () => {
       partials.header.serviceName().should('have.attr', 'href', startRoute);
-    });
-
-    it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
-      cy.checkText(partials.backLink(), LINKS.BACK);
-
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.POLICY_TYPE}`;
-
-      partials.backLink().should('have.attr', 'href', expected);
-    });
-
-    it('renders a page title and heading', () => {
-      const expectedPageTitle = `${CONTENT_STRINGS.MULTIPLE_POLICY_PAGE_TITLE} - ${ORGANISATION}`;
-      cy.title().should('eq', expectedPageTitle);
-
-      cy.checkText(heading(), CONTENT_STRINGS.MULTIPLE_POLICY_PAGE_TITLE);
     });
 
     it('renders `currency and amount` legend', () => {
@@ -178,12 +159,6 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
         const expected = ['', '1', '2'];
         expect(actual).to.deep.eq(expected);
       });
-    });
-
-    it('renders a submit button', () => {
-      submitButton().should('exist');
-
-      cy.checkText(submitButton(), BUTTONS.CONTINUE);
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
@@ -43,7 +43,7 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
       cy.corePageChecks({
         pageTitle: CONTENT_STRINGS.MULTIPLE_POLICY_PAGE_TITLE,
         currentHref: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
-        expectedBackLink: ROUTES.QUOTE.POLICY_TYPE,
+        backLink: ROUTES.QUOTE.POLICY_TYPE,
         lightHouseThresholds: {
           // accessibility threshold is reduced here because
           // the radio component from design system has an invalid aria attribute.

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
@@ -5,22 +5,13 @@ import {
   completeAndSubmitUkContentForm,
   completeAndSubmitPolicyTypeSingleForm,
 } from '../../../../support/quote/forms';
-import { heading, submitButton } from '../../../pages/shared';
+import { submitButton } from '../../../pages/shared';
 import { tellUsAboutYourPolicyPage } from '../../../pages/quote';
-import partials from '../../../partials';
-import {
-  ORGANISATION,
-  BUTTONS,
-  LINKS,
-  FIELDS,
-  PAGES,
-} from '../../../../../content-strings';
+import { FIELDS, PAGES } from '../../../../../content-strings';
 import { ROUTES, FIELD_IDS, SUPPORTED_CURRENCIES } from '../../../../../constants';
 import { GBP_CURRENCY_CODE } from '../../../../fixtures/currencies';
 
 const CONTENT_STRINGS = PAGES.QUOTE.TELL_US_ABOUT_YOUR_POLICY;
-
-const startRoute = ROUTES.QUOTE.START;
 
 context('Tell us about your single policy page - as an exporter, I want to provide my Export insurance policy details', () => {
   describe('rendering', () => {
@@ -41,48 +32,13 @@ context('Tell us about your single policy page - as an exporter, I want to provi
       Cypress.Cookies.preserveOnce('connect.sid');
     });
 
-    it('passes the audits', () => {
-      cy.lighthouse({
-        // accessibility threshold is reduced here because
-        // the radio component from design system has an invalid aria attribute.
-        // this is out of our control
-        accessibility: 92,
-        performance: 75,
-        'best-practices': 100,
-        seo: 60,
+    it('renders core page elements', () => {
+      cy.assertCorePageElements({
+        pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+        currentHref: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
+        expectedBackLink: ROUTES.QUOTE.POLICY_TYPE,
+        assertSubmitButton: true,
       });
-    });
-
-    it('should render a header with href to quote start', () => {
-      partials.header.serviceName().should('have.attr', 'href', startRoute);
-    });
-
-    it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
-      cy.checkText(partials.backLink(), LINKS.BACK);
-
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.POLICY_TYPE}`;
-
-      partials.backLink().should('have.attr', 'href', expected);
-    });
-
-    it('renders an analytics cookies consent banner that can be accepted', () => {
-      cy.checkAnalyticsCookiesConsentAndAccept();
-    });
-
-    it('renders an analytics cookies consent banner that can be rejected', () => {
-      cy.rejectAnalyticsCookies();
-    });
-
-    it('renders a phase banner', () => {
-      cy.checkPhaseBanner();
-    });
-
-    it('renders a page title and heading', () => {
-      const expectedPageTitle = `${CONTENT_STRINGS.SINGLE_POLICY_PAGE_TITLE} - ${ORGANISATION}`;
-      cy.title().should('eq', expectedPageTitle);
-
-      cy.checkText(heading(), CONTENT_STRINGS.SINGLE_POLICY_PAGE_TITLE);
     });
 
     it('renders `currency and amount` legend', () => {
@@ -156,12 +112,6 @@ context('Tell us about your single policy page - as an exporter, I want to provi
       field.hint().should('not.exist');
 
       field.input().should('not.exist');
-    });
-
-    it('renders a submit button', () => {
-      submitButton().should('exist');
-
-      cy.checkText(submitButton(), BUTTONS.CONTINUE);
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
@@ -34,7 +34,7 @@ context('Tell us about your single policy page - as an exporter, I want to provi
 
     it('renders core page elements', () => {
       cy.corePageChecks({
-        pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+        pageTitle: CONTENT_STRINGS.SINGLE_POLICY_PAGE_TITLE,
         currentHref: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
         expectedBackLink: ROUTES.QUOTE.POLICY_TYPE,
         assertSubmitButton: true,

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
@@ -33,7 +33,7 @@ context('Tell us about your single policy page - as an exporter, I want to provi
     });
 
     it('renders core page elements', () => {
-      cy.assertCorePageElements({
+      cy.corePageChecks({
         pageTitle: CONTENT_STRINGS.PAGE_TITLE,
         currentHref: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
         expectedBackLink: ROUTES.QUOTE.POLICY_TYPE,

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
@@ -37,7 +37,6 @@ context('Tell us about your single policy page - as an exporter, I want to provi
         pageTitle: CONTENT_STRINGS.SINGLE_POLICY_PAGE_TITLE,
         currentHref: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
         expectedBackLink: ROUTES.QUOTE.POLICY_TYPE,
-        assertSubmitButton: true,
       });
     });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
@@ -36,7 +36,7 @@ context('Tell us about your single policy page - as an exporter, I want to provi
       cy.corePageChecks({
         pageTitle: CONTENT_STRINGS.SINGLE_POLICY_PAGE_TITLE,
         currentHref: ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY,
-        expectedBackLink: ROUTES.QUOTE.POLICY_TYPE,
+        backLink: ROUTES.QUOTE.POLICY_TYPE,
       });
     });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -35,7 +35,6 @@ context('UK goods or services page - as an exporter, I want to check if my expor
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,
       expectedBackLink: ROUTES.QUOTE.EXPORTER_LOCATION,
-      assertSubmitButton: true,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -1,14 +1,8 @@
 import {
-  heading, yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton,
+  yesRadio, yesRadioInput, noRadio, inlineErrorMessage, submitButton,
 } from '../../../pages/shared';
 import partials from '../../../partials';
-import {
-  ORGANISATION,
-  BUTTONS,
-  LINKS,
-  PAGES,
-  ERROR_MESSAGES,
-} from '../../../../../content-strings';
+import { PAGES, ERROR_MESSAGES } from '../../../../../content-strings';
 import { ROUTES, FIELD_IDS } from '../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
 import { completeAndSubmitBuyerBodyForm, completeAndSubmitExporterLocationForm } from '../../../../support/quote/forms';
@@ -36,48 +30,17 @@ context('UK goods or services page - as an exporter, I want to check if my expor
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,
+      expectedBackLink: ROUTES.QUOTE.EXPORTER_LOCATION,
+      assertSubmitButton: true,
     });
-  });
-
-  it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
-    cy.checkText(partials.backLink(), LINKS.BACK);
-
-    partials.backLink().click();
-
-    cy.url().should('include', ROUTES.QUOTE.EXPORTER_LOCATION);
-
-    // go back to page
-    cy.navigateToUrl(ROUTES.QUOTE.UK_GOODS_OR_SERVICES);
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
   });
 
   it('should render a header with href to quote start', () => {
     partials.header.serviceName().should('have.attr', 'href', startRoute);
-  });
-
-  it('renders a page title and heading', () => {
-    const expectedPageTitle = `${CONTENT_STRINGS.PAGE_TITLE} - ${ORGANISATION}`;
-    cy.title().should('eq', expectedPageTitle);
-
-    cy.checkText(heading(), CONTENT_STRINGS.PAGE_TITLE);
   });
 
   it('renders `yes` radio button', () => {
@@ -109,12 +72,6 @@ context('UK goods or services page - as an exporter, I want to check if my expor
       const expected = CONTENT_STRINGS.WILL_CALCULATE_THOROUGHLY;
       cy.checkText(partials.ukGoodsOrServicesDescription.calculateThoroughly(), expected);
     });
-  });
-
-  it('renders a submit button', () => {
-    submitButton().should('exist');
-
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -34,7 +34,7 @@ context('UK goods or services page - as an exporter, I want to check if my expor
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,
-      expectedBackLink: ROUTES.QUOTE.EXPORTER_LOCATION,
+      backLink: ROUTES.QUOTE.EXPORTER_LOCATION,
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -31,7 +31,7 @@ context('UK goods or services page - as an exporter, I want to check if my expor
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.UK_GOODS_OR_SERVICES,
       expectedBackLink: ROUTES.QUOTE.EXPORTER_LOCATION,

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
@@ -59,7 +59,7 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
   });
 
   it('renders core page elements', () => {
-    cy.assertCorePageElements({
+    cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.YOUR_QUOTE,
       expectedBackLink: ROUTES.QUOTE.CHECK_YOUR_ANSWERS,

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
@@ -62,6 +62,7 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.YOUR_QUOTE,
+      assertSubmitButton: false,
       assertBackLink: false,
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
@@ -72,10 +72,6 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
   });
 
   context('panel/quote', () => {
-    it('renders `you can apply` heading', () => {
-      cy.checkText(yourQuotePage.panel.headingText(), CONTENT_STRINGS.PAGE_TITLE);
-    });
-
     it('renders `your quote` heading', () => {
       cy.checkText(yourQuotePage.panel.subHeading(), CONTENT_STRINGS.QUOTE.SUB_HEADING);
     });

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
@@ -58,25 +58,12 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
     Cypress.Cookies.preserveOnce('connect.sid');
   });
 
-  it('passes the audits', () => {
-    cy.lighthouse({
-      accessibility: 100,
-      performance: 75,
-      'best-practices': 100,
-      seo: 60,
+  it('renders core page elements', () => {
+    cy.assertCorePageElements({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ROUTES.QUOTE.YOUR_QUOTE,
+      expectedBackLink: ROUTES.QUOTE.CHECK_YOUR_ANSWERS,
     });
-  });
-
-  it('renders an analytics cookies consent banner that can be accepted', () => {
-    cy.checkAnalyticsCookiesConsentAndAccept();
-  });
-
-  it('renders an analytics cookies consent banner that can be rejected', () => {
-    cy.rejectAnalyticsCookies();
-  });
-
-  it('renders a phase banner', () => {
-    cy.checkPhaseBanner();
   });
 
   it('should render a header with href to quote start', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
@@ -62,7 +62,7 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.YOUR_QUOTE,
-      expectedBackLink: ROUTES.QUOTE.CHECK_YOUR_ANSWERS,
+      assertBackLink: false,
     });
   });
 

--- a/e2e-tests/cypress/e2e/pages/quote/yourQuote.js
+++ b/e2e-tests/cypress/e2e/pages/quote/yourQuote.js
@@ -12,7 +12,7 @@ const {
 
 const yourQuotePage = {
   panel: {
-    headingText: () => cy.get('[data-cy="heading-text"]'),
+    headingText: () => cy.get('[data-cy="heading"]'),
     subHeading: () => cy.get('[data-cy="sub-heading"]'),
     summaryList: {
       [CONTRACT_VALUE]: {

--- a/e2e-tests/cypress/e2e/pages/quote/yourQuote.js
+++ b/e2e-tests/cypress/e2e/pages/quote/yourQuote.js
@@ -12,7 +12,6 @@ const {
 
 const yourQuotePage = {
   panel: {
-    headingText: () => cy.get('[data-cy="heading"]'),
     subHeading: () => cy.get('[data-cy="sub-heading"]'),
     summaryList: {
       [CONTRACT_VALUE]: {

--- a/e2e-tests/cypress/e2e/pages/your-business/broker/broker.js
+++ b/e2e-tests/cypress/e2e/pages/your-business/broker/broker.js
@@ -15,15 +15,12 @@ const {
 } = FIELD_IDS.INSURANCE.EXPORTER_BUSINESS;
 
 const broker = {
+  [HEADING]: () => cy.get(`[data-cy="${HEADING}-heading`),
   [USING_BROKER]: {
-    heading: () => cy.get(`[data-cy="${USING_BROKER}-heading`),
     value: () => cy.get(`[data-cy="${USING_BROKER}`),
     yesRadioInput: () => yesRadioInput().eq(0),
     noRadioInput: () => noRadioInput().eq(0),
     errorMessage: () => cy.get(`[data-cy="${USING_BROKER}-error`),
-  },
-  [HEADING]: {
-    heading: () => cy.get(`[data-cy="${HEADING}-heading`),
   },
   [NAME]: {
     label: () => cy.get(`[data-cy="${NAME}-label`),

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -18,6 +18,8 @@ Cypress.Commands.add('navigateToUrl', require('./navigate-to-url'));
 Cypress.Commands.add('submitAnswersHappyPathSinglePolicy', require('./quote/submit-answers-happy-path-single-policy'));
 Cypress.Commands.add('submitAnswersHappyPathMultiPolicy', require('./quote/submit-answers-happy-path-multi-policy'));
 
+Cypress.Commands.add('corePageChecks', require('./core-page-checks'));
+
 Cypress.Commands.add('checkAnalyticsCookiesConsentAndAccept', analytics.checkAnalyticsCookiesConsentAndAccept);
 Cypress.Commands.add('checkAnalyticsCookieDoesNotExist', analytics.checkAnalyticsCookieDoesNotExist);
 Cypress.Commands.add('checkAnalyticsCookieIsFalse', analytics.checkAnalyticsCookieIsFalse);

--- a/e2e-tests/cypress/support/core-page-checks.js
+++ b/e2e-tests/cypress/support/core-page-checks.js
@@ -45,7 +45,7 @@ export default ({
   pageTitle,
   currentHref,
   expectedBackLink,
-  assertSubmitButton = false,
+  assertSubmitButton = true,
   submitButtonCopy = BUTTONS.CONTINUE,
   assertBackLink = true,
   lightHouseThresholds,

--- a/e2e-tests/cypress/support/core-page-checks.js
+++ b/e2e-tests/cypress/support/core-page-checks.js
@@ -12,7 +12,7 @@ const lighthouseAudit = (lightHouseThresholds = {}) => {
   });
 };
 
-const backLink = (currentHref, expectedHref) => {
+const checkBackLink = (currentHref, expectedHref) => {
   partials.backLink().should('exist');
   cy.checkText(partials.backLink(), LINKS.BACK);
 
@@ -34,7 +34,7 @@ const backLink = (currentHref, expectedHref) => {
   cy.navigateToUrl(`${Cypress.config('baseUrl')}${currentHref}`);
 };
 
-const pageTitleAndHeading = (pageTitle) => {
+const checkPageTitleAndHeading = (pageTitle) => {
   const expectedPageTitle = `${pageTitle} - ${ORGANISATION}`;
   cy.title().should('eq', expectedPageTitle);
 
@@ -66,7 +66,7 @@ const corePageChecks = ({
 
   if (assertBackLink) {
     // check back link
-    backLink(currentHref, backLink);
+    checkBackLink(currentHref, backLink);
   }
 
   // check analytics cookie banner
@@ -77,7 +77,7 @@ const corePageChecks = ({
   cy.checkPhaseBanner();
 
   // check page title and heading
-  pageTitleAndHeading(pageTitle);
+  checkPageTitleAndHeading(pageTitle);
 
   if (assertSubmitButton) {
     // check submit button

--- a/e2e-tests/cypress/support/core-page-checks.js
+++ b/e2e-tests/cypress/support/core-page-checks.js
@@ -12,6 +12,13 @@ const lighthouseAudit = (lightHouseThresholds = {}) => {
   });
 };
 
+/**
+ * checkBackLink
+ * - Check the back link copy, HREF and previous page URL
+ * - Navigate to the original page to continue the tests
+ * @param {String} currentHref - Current HREF/route
+ * @param {String} expectedHref - Expected "back" HREF/route
+ */
 const checkBackLink = (currentHref, expectedHref) => {
   partials.backLink().should('exist');
   cy.checkText(partials.backLink(), LINKS.BACK);
@@ -34,6 +41,11 @@ const checkBackLink = (currentHref, expectedHref) => {
   cy.navigateToUrl(`${Cypress.config('baseUrl')}${currentHref}`);
 };
 
+/**
+ * checkPageTitleAndHeading
+ * Check the page title and heading
+ * @param {String} pageTitle - Expected page title
+ */
 const checkPageTitleAndHeading = (pageTitle) => {
   const expectedPageTitle = `${pageTitle} - ${ORGANISATION}`;
   cy.title().should('eq', expectedPageTitle);

--- a/e2e-tests/cypress/support/core-page-checks.js
+++ b/e2e-tests/cypress/support/core-page-checks.js
@@ -1,8 +1,8 @@
 import { BUTTONS, LINKS, ORGANISATION } from '../../content-strings';
 import partials from '../e2e/partials';
-import { submitButton } from '../e2e/pages/shared';
+import { heading, submitButton } from '../e2e/pages/shared';
 
-const lighthouseAudit = (lightHouseThresholds) => {
+const lighthouseAudit = (lightHouseThresholds = {}) => {
   cy.lighthouse({
     accessibility: 100,
     performance: 75,
@@ -26,14 +26,6 @@ const backLink = (currentHref, expectedHref) => {
   cy.navigateToUrl(`${Cypress.config('baseUrl')}${currentHref}`);
 };
 
-const cookiesConsentBannerCanBeAccepted = () => {
-  cy.checkAnalyticsCookiesConsentAndAccept();
-};
-
-const cookiesConsentBannerCanBeRejected = () => {
-  cy.rejectAnalyticsCookies();
-};
-
 const pageTitleAndHeading = (pageTitle) => {
   const expectedPageTitle = `${pageTitle} - ${ORGANISATION}`;
   cy.title().should('eq', expectedPageTitle);
@@ -46,18 +38,25 @@ export default ({
   currentHref,
   expectedBackLink,
   assertSubmitButton = false,
-  lightHouseThresholds
+  lightHouseThresholds,
 }) => {
+  // run lighthouse audit
   lighthouseAudit(lightHouseThresholds);
 
+  // check back link
   backLink(currentHref, expectedBackLink);
 
+  // check analytics cookie banner
   cy.checkAnalyticsCookiesConsentAndAccept();
-
   cy.rejectAnalyticsCookies();
 
+  // check phase banner
   cy.checkPhaseBanner();
 
+  // check page title and heading
+  pageTitleAndHeading(pageTitle);
+
+  // check submit button
   if (assertSubmitButton) {
     submitButton().should('exist');
 

--- a/e2e-tests/cypress/support/core-page-checks.js
+++ b/e2e-tests/cypress/support/core-page-checks.js
@@ -1,0 +1,66 @@
+import { BUTTONS, LINKS, ORGANISATION } from '../../content-strings';
+import partials from '../e2e/partials';
+import { submitButton } from '../e2e/pages/shared';
+
+const lighthouseAudit = (lightHouseThresholds) => {
+  cy.lighthouse({
+    accessibility: 100,
+    performance: 75,
+    'best-practices': 100,
+    seo: 70,
+    ...lightHouseThresholds,
+  });
+};
+
+const backLink = (currentHref, expectedHref) => {
+  partials.backLink().should('exist');
+  cy.checkText(partials.backLink(), LINKS.BACK);
+
+  partials.backLink().click();
+
+  const expectedUrl = `${Cypress.config('baseUrl')}${expectedHref}`;
+
+  cy.url().should('eq', expectedUrl);
+
+  // go back to the current page
+  cy.navigateToUrl(`${Cypress.config('baseUrl')}${currentHref}`);
+};
+
+const cookiesConsentBannerCanBeAccepted = () => {
+  cy.checkAnalyticsCookiesConsentAndAccept();
+};
+
+const cookiesConsentBannerCanBeRejected = () => {
+  cy.rejectAnalyticsCookies();
+};
+
+const pageTitleAndHeading = (pageTitle) => {
+  const expectedPageTitle = `${pageTitle} - ${ORGANISATION}`;
+  cy.title().should('eq', expectedPageTitle);
+
+  cy.checkText(heading(), pageTitle);
+};
+
+export default ({
+  pageTitle,
+  currentHref,
+  expectedBackLink,
+  assertSubmitButton = false,
+  lightHouseThresholds
+}) => {
+  lighthouseAudit(lightHouseThresholds);
+
+  backLink(currentHref, expectedBackLink);
+
+  cy.checkAnalyticsCookiesConsentAndAccept();
+
+  cy.rejectAnalyticsCookies();
+
+  cy.checkPhaseBanner();
+
+  if (assertSubmitButton) {
+    submitButton().should('exist');
+
+    cy.checkText(submitButton(), BUTTONS.CONTINUE);
+  }
+};

--- a/e2e-tests/cypress/support/core-page-checks.js
+++ b/e2e-tests/cypress/support/core-page-checks.js
@@ -18,7 +18,15 @@ const backLink = (currentHref, expectedHref) => {
 
   partials.backLink().click();
 
-  const expectedUrl = `${Cypress.config('baseUrl')}${expectedHref}`;
+  let expectedUrl = `${Cypress.config('baseUrl')}${expectedHref}`;
+
+  /**
+   * Some back links (start of the eligibility flow) can have external links.
+   * Therefore we don't want to include the cypress baseUrl for these links.
+   */
+  if (expectedHref.includes('http')) {
+    expectedUrl = expectedHref;
+  }
 
   cy.url().should('eq', expectedUrl);
 
@@ -38,13 +46,17 @@ export default ({
   currentHref,
   expectedBackLink,
   assertSubmitButton = false,
+  submitButtonCopy = BUTTONS.CONTINUE,
+  assertBackLink = true,
   lightHouseThresholds,
 }) => {
   // run lighthouse audit
   lighthouseAudit(lightHouseThresholds);
 
-  // check back link
-  backLink(currentHref, expectedBackLink);
+  if (assertBackLink) {
+    // check back link
+    backLink(currentHref, expectedBackLink);
+  }
 
   // check analytics cookie banner
   cy.checkAnalyticsCookiesConsentAndAccept();
@@ -56,10 +68,10 @@ export default ({
   // check page title and heading
   pageTitleAndHeading(pageTitle);
 
-  // check submit button
   if (assertSubmitButton) {
+    // check submit button
     submitButton().should('exist');
 
-    cy.checkText(submitButton(), BUTTONS.CONTINUE);
+    cy.checkText(submitButton(), submitButtonCopy);
   }
 };

--- a/e2e-tests/cypress/support/core-page-checks.js
+++ b/e2e-tests/cypress/support/core-page-checks.js
@@ -41,10 +41,21 @@ const pageTitleAndHeading = (pageTitle) => {
   cy.checkText(heading(), pageTitle);
 };
 
-export default ({
+/**
+ * corePageChecks
+ * Check core/common page elements.
+ * @param {String} pageTitle - Expected page title
+ * @param {String} currentHref - Expected page HREF
+ * @param {String} backLink - Expected "back" HREF
+ * @param {Boolean} assertSubmitButton - Should check submit button (some pages don't have a submit button)
+ * @param {String} submitButtonCopy - Expected submit button copy
+ * @param {Boolean} assertBackLink - Should check "back" link (some pages don't have a back link)
+ * @param {Object} lightHouseThresholds - Custom expected lighthouse thresholds
+ */
+const corePageChecks = ({
   pageTitle,
   currentHref,
-  expectedBackLink,
+  backLink,
   assertSubmitButton = true,
   submitButtonCopy = BUTTONS.CONTINUE,
   assertBackLink = true,
@@ -55,7 +66,7 @@ export default ({
 
   if (assertBackLink) {
     // check back link
-    backLink(currentHref, expectedBackLink);
+    backLink(currentHref, backLink);
   }
 
   // check analytics cookie banner
@@ -75,3 +86,5 @@ export default ({
     cy.checkText(submitButton(), submitButtonCopy);
   }
 };
+
+export default corePageChecks;

--- a/src/ui/templates/insurance/your-business/broker.njk
+++ b/src/ui/templates/insurance/your-business/broker.njk
@@ -6,8 +6,12 @@
 {% import '../../components/yes-no-radio-buttons.njk' as yesNoRadioButtons %}
 {% import '../../components/address-fields.njk' as addressInput %}
 
+{% block pageTitle %}
+  {{ CONTENT_STRINGS.PAGE_TITLE }}
+{% endblock %}
+
 {% set brokerHTML %}
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-5 govuk-!-margin-top-5" data-cy="{{FIELDS.HEADING.ID}}-heading">{{ FIELDS.HEADING.HEADING }}</h2>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-5 govuk-!-margin-top-5" data-cy="{{ FIELDS.HEADING.ID }}-heading">{{ FIELDS.HEADING.HEADING }}</h2>
 
   {{ govukInput({
     id: FIELDS.NAME.ID,
@@ -82,7 +86,6 @@
           submittedAnswer: submittedValues[FIELDS.USING_BROKER.ID],
           errorMessage: validationErrors.errorList[FIELDS.USING_BROKER.ID],
           headerClass: 'govuk-fieldset__legend--xl',
-          datacyHeading: FIELDS.USING_BROKER.ID + '-heading',
           yesNoValueString: true,
           conditionalYesHtml: brokerHTML,
           horizontalRadios: true

--- a/src/ui/templates/insurance/your-business/company-details.njk
+++ b/src/ui/templates/insurance/your-business/company-details.njk
@@ -9,6 +9,10 @@
 {%- from "moj/components/search/macro.njk" import mojSearch -%}
 {% import '../../components/yes-no-radio-buttons.njk' as yesNoRadioButtons %}
 
+{% block pageTitle %}
+  {{ CONTENT_STRINGS.PAGE_TITLE }}
+{% endblock %}
+
 {% block content %}
 
   {{ govukBackLink({

--- a/src/ui/templates/insurance/your-business/nature-of-your-business.njk
+++ b/src/ui/templates/insurance/your-business/nature-of-your-business.njk
@@ -5,6 +5,10 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 
+{% block pageTitle %}
+  {{ CONTENT_STRINGS.PAGE_TITLE }}
+{% endblock %}
+
 {% block content %}
 
   {{ govukBackLink({

--- a/src/ui/templates/insurance/your-business/turnover.njk
+++ b/src/ui/templates/insurance/your-business/turnover.njk
@@ -5,6 +5,10 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/hint/macro.njk" import govukHint %}
 
+{% block pageTitle %}
+  {{ CONTENT_STRINGS.PAGE_TITLE }}
+{% endblock %}
+
 {% block content %}
 
   {{ govukBackLink({

--- a/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
+++ b/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
@@ -30,6 +30,8 @@
     }) }}
   {% endif %}
 
+  <h1 class="govuk-heading-l" data-cy="heading">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
+
   <form method="POST" novalidate="novalidate">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     <div class="govuk-grid-row">

--- a/src/ui/templates/quote/your-quote.njk
+++ b/src/ui/templates/quote/your-quote.njk
@@ -14,7 +14,7 @@
     <div class="govuk-grid-column-three-quarters-from-desktop">
 
       {% set titleHtml %}
-        <span class="govuk-heading-xl govuk-!-display-inline-block ukef-white-text" data-cy="heading-text">{{ CONTENT_STRINGS.PAGE_TITLE }}</span>
+        <span class="govuk-heading-xl govuk-!-display-inline-block ukef-white-text" data-cy="heading">{{ CONTENT_STRINGS.PAGE_TITLE }}</span>
       {% endset %}
 
       {% set panelHtml %}


### PR DESCRIPTION
This PR introduces a new cypress command `corePageChecks`. This command is now called on all core pages and therefore simplifying a lot of E2E tests. This command does the following:

- Run lighthouse audits.
- Test the back link text, HREF and navigation.
- Test the analytics cookie banner(s).
- Test the phase banner.
- Test the submit button.

Some of these are optional checks that can be changed in a test itself, for example:

```js
it('renders core page elements', () => {
  cy.corePageChecks({
    pageTitle: CONTENT_STRINGS.PAGE_TITLE,
    currentHref: ROUTES.EXAMPLE,
    assertSubmitButton: false,
    assertBackLink: false,
  });
});
```
## Changes

- Create new cypress command `corePageChecks`
- Update all core E2E page tests to consume this command instead of having 5-7 individual tests in every page test.
- Add missing page title nunjucks block to all "your business" and the "your buyer" pages.
- Update "your business - company details" E2E page test to navigate via the task list, as per real world user journey.
- Simplify "your business - broker" cypress selectors so we only have 1 heading selector (the actual page heading is now aligned and comes from shared partials).
- Rename the heading cypress selector in "your quote" summary list/panel so that it's aligned.


