### PR TITLE
fix(EMS-990): Company Details - Turnover - Allow negative turnover

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
@@ -86,6 +86,17 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
         cy.submitAndAssertFieldErrors(field, value, errorIndex, numberOfExpectedErrors, errorMessage);
       });
     });
+
+    describe(`when ${FIELD_ID} is negative but has a decimal place`, () => {
+      const errorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
+
+      it(`should display validation errors for ${FIELD_ID}`, () => {
+        const { field, numberOfExpectedErrors, errorIndex } = ERROR_ASSERTIONS;
+        const value = '-256.123';
+
+        cy.submitAndAssertFieldErrors(field, value, errorIndex, numberOfExpectedErrors, errorMessage);
+      });
+    });
   });
 
   describe(`when ${FIELD_ID} is correctly entered as a whole number`, () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
@@ -126,4 +126,17 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
       partials.errorSummaryListItems().should('have.length', 1);
     });
   });
+
+  describe(`when ${FIELD_ID} is correctly entered as a negative number`, () => {
+    it('should not display validation errors', () => {
+      cy.navigateToUrl(url);
+
+      const fieldId = FIELD_ID;
+      const field = turnover[fieldId];
+
+      field.input().clear().type('-256');
+      submitButton().click();
+      partials.errorSummaryListItems().should('have.length', 1);
+    });
+  });
 });

--- a/src/ui/server/controllers/insurance/business/nature-of-business/validation/rules/employees-international.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/validation/rules/employees-international.ts
@@ -56,7 +56,7 @@ const employeesInternational = (responseBody: RequestBody, errors: object) => {
 
   const errorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
   // checks that it does not contain special characters
-  return wholeNumberValidation(responseBody, errors, errorMessage, FIELD_ID, MINIMUM);
+  return wholeNumberValidation(responseBody, errors, errorMessage, FIELD_ID);
 };
 
 export default employeesInternational;

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/estimated-annual-turnover.test.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/estimated-annual-turnover.test.ts
@@ -67,6 +67,30 @@ describe('controllers/insurance/business/turnover/validation/rules/estimated-ann
     });
   });
 
+  describe(`when the ${ESTIMATED_ANNUAL_TURNOVER} input is below 0 but has a decimal place`, () => {
+    it('should return a validation error', () => {
+      mockBody[ESTIMATED_ANNUAL_TURNOVER] = '-3.123';
+      const response = yearsExporting(mockBody, mockErrors);
+
+      const errorMessage = EXPORTER_BUSINESS[ESTIMATED_ANNUAL_TURNOVER].INCORRECT_FORMAT;
+      const expected = generateValidationErrors(ESTIMATED_ANNUAL_TURNOVER, errorMessage, mockErrors);
+
+      expect(response).toEqual(expected);
+    });
+  });
+
+  describe(`when the ${ESTIMATED_ANNUAL_TURNOVER} input is below 0 but has a decimal place and letters`, () => {
+    it('should return a validation error', () => {
+      mockBody[ESTIMATED_ANNUAL_TURNOVER] = '-3.AB123';
+      const response = yearsExporting(mockBody, mockErrors);
+
+      const errorMessage = EXPORTER_BUSINESS[ESTIMATED_ANNUAL_TURNOVER].INCORRECT_FORMAT;
+      const expected = generateValidationErrors(ESTIMATED_ANNUAL_TURNOVER, errorMessage, mockErrors);
+
+      expect(response).toEqual(expected);
+    });
+  });
+
   describe(`when the ${ESTIMATED_ANNUAL_TURNOVER} input is below 0`, () => {
     it('should not return a validation error', () => {
       mockBody[ESTIMATED_ANNUAL_TURNOVER] = '-1';

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/estimated-annual-turnover.test.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/estimated-annual-turnover.test.ts
@@ -68,19 +68,16 @@ describe('controllers/insurance/business/turnover/validation/rules/estimated-ann
   });
 
   describe(`when the ${ESTIMATED_ANNUAL_TURNOVER} input is below 0`, () => {
-    it('should return a validation error', () => {
+    it('should not return a validation error', () => {
       mockBody[ESTIMATED_ANNUAL_TURNOVER] = '-1';
       const response = yearsExporting(mockBody, mockErrors);
 
-      const errorMessage = EXPORTER_BUSINESS[ESTIMATED_ANNUAL_TURNOVER].INCORRECT_FORMAT;
-      const expected = generateValidationErrors(ESTIMATED_ANNUAL_TURNOVER, errorMessage, mockErrors);
-
-      expect(response).toEqual(expected);
+      expect(response).toEqual(mockErrors);
     });
   });
 
   describe(`when the ${ESTIMATED_ANNUAL_TURNOVER} input is valid`, () => {
-    it('should return a validation error', () => {
+    it('should not return a validation error', () => {
       mockBody[ESTIMATED_ANNUAL_TURNOVER] = '8';
       const response = yearsExporting(mockBody, mockErrors);
 

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/estimated-annual-turnover.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/estimated-annual-turnover.ts
@@ -28,7 +28,9 @@ const estimatedAnnualTurnover = (responseBody: RequestBody, errors: object) => {
   }
 
   const errorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
+
   const allowNegativeValue = true;
+
   return wholeNumberValidation(responseBody, errors, errorMessage, FIELD_ID, allowNegativeValue);
 };
 

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/estimated-annual-turnover.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/estimated-annual-turnover.ts
@@ -28,7 +28,8 @@ const estimatedAnnualTurnover = (responseBody: RequestBody, errors: object) => {
   }
 
   const errorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
-  return wholeNumberValidation(responseBody, errors, errorMessage, FIELD_ID);
+  const allowNegativeValue = true;
+  return wholeNumberValidation(responseBody, errors, errorMessage, FIELD_ID, allowNegativeValue);
 };
 
 export default estimatedAnnualTurnover;

--- a/src/ui/server/helpers/whole-number-validation/index.test.ts
+++ b/src/ui/server/helpers/whole-number-validation/index.test.ts
@@ -71,6 +71,15 @@ describe('server/helpers/whole-number-validation', () => {
     });
   });
 
+  describe('number is negative but "allowNegativeValue" is set to "true"', () => {
+    it('should not return a validation error', () => {
+      mockBody.testField = '-3';
+      const response = wholeNumberValidation(mockBody, mockErrors, errorMessage, FIELD, true);
+
+      expect(response).toEqual(mockErrors);
+    });
+  });
+
   describe('number is valid', () => {
     it('should not return a validation error', () => {
       mockBody.testField = '3';

--- a/src/ui/server/helpers/whole-number-validation/index.ts
+++ b/src/ui/server/helpers/whole-number-validation/index.ts
@@ -11,7 +11,7 @@ import { stripCommas } from '../string';
  * @param {object} errors
  * @param {string} errorMessage
  * @param {string} field fieldId of the field being checked
- * @param {Boolean} allowNegativeValue optional field set to false which allows for negative numbers below 0
+ * @param {Boolean} allowNegativeValue false as default, if false then allows for negative numbers below 0.
  * @returns {object} errors
  */
 const wholeNumberValidation = (responseBody: RequestBody, errors: object, errorMessage: string, field: string, allowNegativeValue = false) => {

--- a/src/ui/server/helpers/whole-number-validation/index.ts
+++ b/src/ui/server/helpers/whole-number-validation/index.ts
@@ -11,7 +11,7 @@ import { stripCommas } from '../string';
  * @param {object} errors
  * @param {string} errorMessage
  * @param {string} field fieldId of the field being checked
- * @param {Boolean} allowNegativeValue false as default, if false then allows for negative numbers below 0.
+ * @param {Boolean} allowNegativeValue false as default, if true then allows for negative numbers below 0.
  * @returns {object} errors
  */
 const wholeNumberValidation = (responseBody: RequestBody, errors: object, errorMessage: string, field: string, allowNegativeValue = false) => {

--- a/src/ui/server/helpers/whole-number-validation/index.ts
+++ b/src/ui/server/helpers/whole-number-validation/index.ts
@@ -4,9 +4,9 @@ import { isNumber, numberHasDecimal, isNumberBelowMinimum } from '../number';
 import { stripCommas } from '../string';
 
 /**
- * validates if field is whole number and above 0 and handles commas in the input
- * if allowNegativeNumbers is set to true, then will return validation error if number below 0
- * returns validation error if is not a number, has a decimal place or special characters
+ * validates if field is whole number and above 0 and handles commas in the input.
+ * if allowNegativeNumbers is set to true, then will return validation error if number below 0.
+ * returns validation error if is not a number, has a decimal place or special characters.
  * @param {RequestBody} responseBody
  * @param {object} errors
  * @param {string} errorMessage

--- a/src/ui/server/helpers/whole-number-validation/index.ts
+++ b/src/ui/server/helpers/whole-number-validation/index.ts
@@ -5,21 +5,28 @@ import { stripCommas } from '../string';
 
 /**
  * validates if field is whole number and above 0 and handles commas in the input
- * returns validation error if is not a number, has a decimal place or special characters or is below 0
+ * if allowNegativeNumbers is set to true, then will return validation error if number below 0
+ * returns validation error if is not a number, has a decimal place or special characters
  * @param {RequestBody} responseBody
  * @param {object} errors
  * @param {string} errorMessage
  * @param {string} field fieldId of the field being checked
- * @param {number} minimum optional minimum value of field - default 0
+ * @param {Boolean} allowNegativeValue optional field set to false which allows for negative numbers below 0
  * @returns {object} errors
  */
-const wholeNumberValidation = (responseBody: RequestBody, errors: object, errorMessage: string, field: string, minimum = 0) => {
+const wholeNumberValidation = (responseBody: RequestBody, errors: object, errorMessage: string, field: string, allowNegativeValue = false) => {
   // strip commas - commas are valid.
   const numberWithoutCommas = stripCommas(responseBody[field]);
 
   const isFieldANumber = isNumber(numberWithoutCommas);
   const hasDecimal = numberHasDecimal(Number(numberWithoutCommas));
-  const isBelowMinimum = isNumberBelowMinimum(Number(numberWithoutCommas), minimum);
+
+  let isBelowMinimum = false;
+
+  // if flag is false, then number cannot be below 0
+  if (!allowNegativeValue) {
+    isBelowMinimum = isNumberBelowMinimum(Number(numberWithoutCommas), 0);
+  }
 
   if (!isFieldANumber || hasDecimal || isBelowMinimum) {
     return generateValidationErrors(field, errorMessage, errors);


### PR DESCRIPTION
# Issue:
* `estimatedTurnover` did not allow values below 0

# Changes made:
* Added optional `allowNegativeValue` variable to `wholeNumberValidation`.  If set to true, then will allow numbers below 0
* Updated validation for estimate-annual-turnover to set flag to true
* Updated tests