### PR TITLE
feat(EMS-870): account sign in - security code page setup

### DIFF
--- a/e2e-tests/constants/field-ids/insurance/account/index.js
+++ b/e2e-tests/constants/field-ids/insurance/account/index.js
@@ -3,4 +3,5 @@ export const ACCOUNT = {
   LAST_NAME: 'lastName',
   EMAIL: 'email',
   PASSWORD: 'password',
+  SECURITY_CODE: 'securityCode',
 };

--- a/e2e-tests/constants/routes/insurance/account.js
+++ b/e2e-tests/constants/routes/insurance/account.js
@@ -15,6 +15,7 @@ const CREATE = {
 const SIGN_IN = {
   ROOT: `${INSURANCE_ROOT}${SIGN_IN_ROOT}`,
   ENTER_CODE: `${INSURANCE_ROOT}${SIGN_IN_ROOT}/enter-code`,
+  REQUEST_NEW_CODE: `${INSURANCE_ROOT}${SIGN_IN_ROOT}/request-new-code`,
 };
 
 const RESET_PASSWORD = {

--- a/e2e-tests/content-strings/fields/insurance/account/index.js
+++ b/e2e-tests/content-strings/fields/insurance/account/index.js
@@ -2,7 +2,7 @@ import { FIELD_IDS } from '../../../../constants';
 
 const { ACCOUNT } = FIELD_IDS.INSURANCE;
 const {
-  FIRST_NAME, LAST_NAME, EMAIL, PASSWORD,
+  FIRST_NAME, LAST_NAME, EMAIL, PASSWORD, SECURITY_CODE,
 } = ACCOUNT;
 
 export const ACCOUNT_FIELDS = {
@@ -14,6 +14,9 @@ export const ACCOUNT_FIELDS = {
       SHOW: 'Show',
       HIDE: 'Hide',
     },
+  },
+  [SECURITY_CODE]: {
+    LABEL: 'Security code',
   },
   CREATE: {
     YOUR_DETAILS: {

--- a/e2e-tests/content-strings/pages/insurance/account/index.js
+++ b/e2e-tests/content-strings/pages/insurance/account/index.js
@@ -54,6 +54,14 @@ const ACCOUNT = {
         },
       },
     },
+    ENTER_CODE: {
+      PAGE_TITLE: 'Check your email',
+      INTRO: "We've sent you an email with a security code. This code will expire after 5 minutes.",
+      REQUEST_NEW_CODE: {
+        TEXT: 'Request a new security code',
+        HREF: INSURANCE_ROUTES.ACCOUNT.SIGN_IN.REQUEST_NEW_CODE,
+      },
+    },
   },
 };
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/enter-code/account-sign-in-enter-code.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/enter-code/account-sign-in-enter-code.spec.js
@@ -1,0 +1,78 @@
+import partials from '../../../../../partials';
+import { enterCodePage } from '../../../../../pages/insurance/account/sign-in';
+import accountFormFields from '../../../../../partials/insurance/accountFormFields';
+import { PAGES } from '../../../../../../../content-strings';
+import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
+import { ACCOUNT_FIELDS } from '../../../../../../../content-strings/fields/insurance/account';
+import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const CONTENT_STRINGS = PAGES.INSURANCE.ACCOUNT.SIGN_IN.ENTER_CODE;
+
+const {
+  START,
+  ACCOUNT: {
+    SIGN_IN: { ROOT: SIGN_IN_ROOT, ENTER_CODE, REQUEST_NEW_CODE },
+  },
+} = ROUTES;
+
+const {
+  ACCOUNT: { SECURITY_CODE },
+} = INSURANCE_FIELD_IDS;
+
+const FIELD_STRINGS = ACCOUNT_FIELDS[SECURITY_CODE];
+
+context('Insurance - Account - Sign in - I want to sign in into my UKEF digital service account after completing eligibility, So that I can complete my application for a UKEF Export Insurance Policy', () => {
+  before(() => {
+    cy.navigateToUrl(START);
+
+    cy.submitEligibilityAndStartAccountSignIn();
+    cy.completeAndSubmitSignInAccountForm();
+
+    const expected = `${Cypress.config('baseUrl')}${ENTER_CODE}`;
+
+    cy.url().should('eq', expected);
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('exip-session');
+  });
+
+  it('renders core page elements', () => {
+    cy.corePageChecks({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: ENTER_CODE,
+      backLink: SIGN_IN_ROOT,
+    });
+  });
+
+  it('should render a header with href to insurance start', () => {
+    partials.header.serviceName().should('have.attr', 'href', START);
+  });
+
+  it('renders `security code` label and input', () => {
+    const fieldId = SECURITY_CODE;
+    const field = accountFormFields[fieldId];
+
+    field.label().should('exist');
+    cy.checkText(field.label(), FIELD_STRINGS.LABEL);
+
+    field.input().should('exist');
+  });
+
+  it('renders a `request new code` link', () => {
+    cy.checkText(enterCodePage.requestNewCodeLink(), CONTENT_STRINGS.REQUEST_NEW_CODE.TEXT);
+
+    enterCodePage.requestNewCodeLink().should('have.attr', 'href', CONTENT_STRINGS.REQUEST_NEW_CODE.HREF);
+  });
+
+  describe('when clicking `request new code`', () => {
+    it(`should rediect to ${REQUEST_NEW_CODE}`, () => {
+      enterCodePage.requestNewCodeLink().click();
+
+      const expectedUrl = `${Cypress.config('baseUrl')}${REQUEST_NEW_CODE}`;
+
+      cy.url().should('eq', expectedUrl);
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/pages/insurance/account/sign-in/enterCode.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/account/sign-in/enterCode.js
@@ -1,0 +1,5 @@
+const enterCodePage = {
+  requestNewCodeLink: () => cy.get('[data-cy="request-new-code"]'),
+};
+
+export default enterCodePage;

--- a/e2e-tests/cypress/e2e/pages/insurance/account/sign-in/index.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/account/sign-in/index.js
@@ -1,5 +1,7 @@
 import signInPage from './signIn';
+import enterCodePage from './enterCode';
 
 export {
   signInPage,
+  enterCodePage,
 };

--- a/e2e-tests/cypress/e2e/pages/insurance/account/sign-in/signIn.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/account/sign-in/signIn.js
@@ -1,4 +1,4 @@
-const yourDetailsPage = {
+const signInPage = {
   successBanner: {
     container: () => cy.get('[data-cy="success-banner"]'),
     heading: () => cy.get('[data-cy="success-banner-heading"]'),
@@ -9,4 +9,4 @@ const yourDetailsPage = {
   createAccountLink: () => cy.get('[data-cy="create-account"]'),
 };
 
-export default yourDetailsPage;
+export default signInPage;

--- a/e2e-tests/cypress/e2e/partials/insurance/accountFormFields.js
+++ b/e2e-tests/cypress/e2e/partials/insurance/accountFormFields.js
@@ -1,6 +1,6 @@
 import { ACCOUNT } from '../../../../constants/field-ids/insurance/account';
 
-const { EMAIL, PASSWORD } = ACCOUNT;
+const { EMAIL, PASSWORD, SECURITY_CODE } = ACCOUNT;
 
 const accountFormFields = {
   [EMAIL]: {
@@ -13,6 +13,11 @@ const accountFormFields = {
     input: () => cy.get(`[data-cy="${PASSWORD}-input"]`),
     revealButton: () => cy.get('.moj-password-reveal__button'),
     errorMessage: () => cy.get(`[data-cy="${PASSWORD}-error-message"]`),
+  },
+  [SECURITY_CODE]: {
+    label: () => cy.get(`[data-cy="${SECURITY_CODE}-label"]`),
+    input: () => cy.get(`[data-cy="${SECURITY_CODE}-input"]`),
+    errorMessage: () => cy.get(`[data-cy="${SECURITY_CODE}-error-message"]`),
   },
 };
 

--- a/src/ui/server/constants/field-ids/insurance/account/index.ts
+++ b/src/ui/server/constants/field-ids/insurance/account/index.ts
@@ -3,6 +3,7 @@ const ACCOUNT = {
   LAST_NAME: 'lastName',
   EMAIL: 'email',
   PASSWORD: 'password',
+  SECURITY_CODE: 'securityCode',
 };
 
 export default ACCOUNT;

--- a/src/ui/server/constants/routes/insurance/account.ts
+++ b/src/ui/server/constants/routes/insurance/account.ts
@@ -15,6 +15,7 @@ const CREATE = {
 const SIGN_IN = {
   ROOT: `${INSURANCE_ROOT}${SIGN_IN_ROOT}`,
   ENTER_CODE: `${INSURANCE_ROOT}${SIGN_IN_ROOT}/enter-code`,
+  REQUEST_NEW_CODE: `${INSURANCE_ROOT}${SIGN_IN_ROOT}/request-new-code`,
 };
 
 const RESET_PASSWORD = {

--- a/src/ui/server/constants/routes/insurance/index.ts
+++ b/src/ui/server/constants/routes/insurance/index.ts
@@ -32,6 +32,7 @@ export const INSURANCE_ROUTES = {
   SPEAK_TO_UKEF_EFM: `${INSURANCE_ROOT}/speak-to-UKEF-EFM`,
   PAGE_NOT_FOUND: `${INSURANCE_ROOT}/page-not-found`,
   ACCOUNT,
+  DASHBOARD: `${INSURANCE_ROOT}/dashboard`,
   ALL_SECTIONS: '/all-sections',
   EXPORTER_BUSINESS,
   POLICY_AND_EXPORTS,

--- a/src/ui/server/constants/templates/insurance/account/index.ts
+++ b/src/ui/server/constants/templates/insurance/account/index.ts
@@ -6,5 +6,6 @@ export const ACCOUNT_TEMPLATES = {
   },
   SIGN_IN: {
     ROOT: 'insurance/account/sign-in/sign-in.njk',
+    ENTER_CODE: 'insurance/account/sign-in/enter-code.njk',
   },
 };

--- a/src/ui/server/content-strings/fields/insurance/account/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/account/index.ts
@@ -1,7 +1,7 @@
 import { FIELD_IDS } from '../../../../constants';
 
 const { ACCOUNT } = FIELD_IDS.INSURANCE;
-const { FIRST_NAME, LAST_NAME, EMAIL, PASSWORD } = ACCOUNT;
+const { FIRST_NAME, LAST_NAME, EMAIL, PASSWORD, SECURITY_CODE } = ACCOUNT;
 
 export const ACCOUNT_FIELDS = {
   [EMAIL]: {
@@ -12,6 +12,9 @@ export const ACCOUNT_FIELDS = {
       SHOW: 'Show',
       HIDE: 'Hide',
     },
+  },
+  [SECURITY_CODE]: {
+    LABEL: 'Security code',
   },
   CREATE: {
     YOUR_DETAILS: {

--- a/src/ui/server/content-strings/pages/insurance/account/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/account/index.ts
@@ -54,6 +54,14 @@ const ACCOUNT = {
         },
       },
     },
+    ENTER_CODE: {
+      PAGE_TITLE: 'Check your email',
+      INTRO: "We've sent you an email with a security code. This code will expire after 5 minutes.",
+      REQUEST_NEW_CODE: {
+        TEXT: 'Request a new security code',
+        HREF: INSURANCE_ROUTES.ACCOUNT.SIGN_IN.REQUEST_NEW_CODE,
+      },
+    },
   },
 };
 

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
@@ -1,0 +1,74 @@
+import { PAGE_VARIABLES, TEMPLATE, PAGE_CONTENT_STRINGS, get, post } from '.';
+import { PAGES } from '../../../../../content-strings';
+import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../../constants';
+import { ACCOUNT_FIELDS as FIELDS } from '../../../../../content-strings/fields/insurance/account';
+import insuranceCorePageVariables from '../../../../../helpers/page-variables/core/insurance';
+import { Request, Response } from '../../../../../../types';
+import { mockReq, mockRes } from '../../../../../test-mocks';
+
+const {
+  ACCOUNT: { SECURITY_CODE },
+} = FIELD_IDS.INSURANCE;
+
+const {
+  INSURANCE: { DASHBOARD },
+} = ROUTES;
+
+describe('controllers/insurance/account/sign-in/enter-code', () => {
+  let req: Request;
+  let res: Response;
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+  });
+
+  describe('PAGE_VARIABLES', () => {
+    it('should have correct properties', () => {
+      const expected = {
+        FIELDS: {
+          SECURITY_CODE: {
+            ID: SECURITY_CODE,
+            ...FIELDS[SECURITY_CODE],
+          },
+        },
+      };
+
+      expect(PAGE_VARIABLES).toEqual(expected);
+    });
+  });
+
+  describe('TEMPLATE', () => {
+    it('should have the correct template defined', () => {
+      expect(TEMPLATE).toEqual(TEMPLATES.INSURANCE.ACCOUNT.SIGN_IN.ENTER_CODE);
+    });
+  });
+
+  describe('PAGE_CONTENT_STRINGS', () => {
+    it('should have the correct strings', () => {
+      expect(PAGE_CONTENT_STRINGS).toEqual(PAGES.INSURANCE.ACCOUNT.SIGN_IN.ENTER_CODE);
+    });
+  });
+
+  describe('get', () => {
+    it('should render template', () => {
+      get(req, res);
+
+      expect(res.render).toHaveBeenCalledWith(TEMPLATE, {
+        ...insuranceCorePageVariables({
+          PAGE_CONTENT_STRINGS,
+          BACK_LINK: req.headers.referer,
+        }),
+        ...PAGE_VARIABLES,
+      });
+    });
+  });
+
+  describe('post', () => {
+    it(`should redirect to ${DASHBOARD}`, () => {
+      post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(DASHBOARD);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
@@ -26,11 +26,9 @@ describe('controllers/insurance/account/sign-in/enter-code', () => {
   describe('PAGE_VARIABLES', () => {
     it('should have correct properties', () => {
       const expected = {
-        FIELDS: {
-          SECURITY_CODE: {
-            ID: SECURITY_CODE,
-            ...FIELDS[SECURITY_CODE],
-          },
+        FIELD: {
+          ID: SECURITY_CODE,
+          ...FIELDS[SECURITY_CODE],
         },
       };
 

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
@@ -1,0 +1,56 @@
+import { PAGES } from '../../../../../content-strings';
+import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../../constants';
+import { ACCOUNT_FIELDS as FIELDS } from '../../../../../content-strings/fields/insurance/account';
+import insuranceCorePageVariables from '../../../../../helpers/page-variables/core/insurance';
+import { Request, Response } from '../../../../../../types';
+
+const {
+  ACCOUNT: { SECURITY_CODE },
+} = FIELD_IDS.INSURANCE;
+
+const {
+  INSURANCE: { DASHBOARD },
+} = ROUTES;
+
+/**
+ * PAGE_VARIABLES
+ * Page fields
+ * @returns {Object} Page variables
+ */
+export const PAGE_VARIABLES = {
+  FIELDS: {
+    SECURITY_CODE: {
+      ID: SECURITY_CODE,
+      ...FIELDS[SECURITY_CODE],
+    },
+  },
+};
+
+export const TEMPLATE = TEMPLATES.INSURANCE.ACCOUNT.SIGN_IN.ENTER_CODE;
+
+export const PAGE_CONTENT_STRINGS = PAGES.INSURANCE.ACCOUNT.SIGN_IN.ENTER_CODE;
+
+/**
+ * get
+ * Render the Enter code page
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.render} Enter code page
+ */
+export const get = (req: Request, res: Response) =>
+  res.render(TEMPLATE, {
+    ...insuranceCorePageVariables({
+      PAGE_CONTENT_STRINGS,
+      BACK_LINK: req.headers.referer,
+    }),
+    ...PAGE_VARIABLES,
+  });
+
+/**
+ * post
+ * Temporary redirect to the dashboard route.
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.redirect} Next part of the flow
+ */
+export const post = (req: Request, res: Response) => res.redirect(DASHBOARD);

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
@@ -18,11 +18,9 @@ const {
  * @returns {Object} Page variables
  */
 export const PAGE_VARIABLES = {
-  FIELDS: {
-    SECURITY_CODE: {
-      ID: SECURITY_CODE,
-      ...FIELDS[SECURITY_CODE],
-    },
+  FIELD: {
+    ID: SECURITY_CODE,
+    ...FIELDS[SECURITY_CODE],
   },
 };
 

--- a/src/ui/server/routes/insurance/account/index.test.ts
+++ b/src/ui/server/routes/insurance/account/index.test.ts
@@ -5,6 +5,7 @@ import { get as confirmEmailGet } from '../../../controllers/insurance/account/c
 import { get as confirmEmailResentGet } from '../../../controllers/insurance/account/create/confirm-email-resent';
 import { get as verifyEmailGet } from '../../../controllers/insurance/account/create/verify-email';
 import { get as signInGet, post as signInPost } from '../../../controllers/insurance/account/sign-in';
+import { get as enterCodeGet, post as enterCodePost } from '../../../controllers/insurance/account/sign-in/enter-code';
 
 describe('routes/insurance/account', () => {
   beforeEach(() => {
@@ -16,8 +17,8 @@ describe('routes/insurance/account', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(5);
-    expect(post).toHaveBeenCalledTimes(2);
+    expect(get).toHaveBeenCalledTimes(6);
+    expect(post).toHaveBeenCalledTimes(3);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.ACCOUNT.CREATE.YOUR_DETAILS, yourDetailsGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.ACCOUNT.CREATE.YOUR_DETAILS, yourDetailsPost);
@@ -29,5 +30,8 @@ describe('routes/insurance/account', () => {
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.ACCOUNT.SIGN_IN.ROOT, signInGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.ACCOUNT.SIGN_IN.ROOT, signInPost);
+
+    expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.ACCOUNT.SIGN_IN.ENTER_CODE, enterCodeGet);
+    expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.ACCOUNT.SIGN_IN.ENTER_CODE, enterCodePost);
   });
 });

--- a/src/ui/server/routes/insurance/account/index.ts
+++ b/src/ui/server/routes/insurance/account/index.ts
@@ -5,6 +5,7 @@ import { get as confirmEmailGet } from '../../../controllers/insurance/account/c
 import { get as confirmEmailResentGet } from '../../../controllers/insurance/account/create/confirm-email-resent';
 import { get as verifyEmailGet } from '../../../controllers/insurance/account/create/verify-email';
 import { get as signInGet, post as signInPost } from '../../../controllers/insurance/account/sign-in';
+import { get as enterCodeGet, post as enterCodePost } from '../../../controllers/insurance/account/sign-in/enter-code';
 
 // @ts-ignore
 const insuranceAccountRouter = express.Router();
@@ -19,5 +20,8 @@ insuranceAccountRouter.get(INSURANCE_ROUTES.ACCOUNT.CREATE.VERIFY_EMAIL, verifyE
 
 insuranceAccountRouter.get(INSURANCE_ROUTES.ACCOUNT.SIGN_IN.ROOT, signInGet);
 insuranceAccountRouter.post(INSURANCE_ROUTES.ACCOUNT.SIGN_IN.ROOT, signInPost);
+
+insuranceAccountRouter.get(INSURANCE_ROUTES.ACCOUNT.SIGN_IN.ENTER_CODE, enterCodeGet);
+insuranceAccountRouter.post(INSURANCE_ROUTES.ACCOUNT.SIGN_IN.ENTER_CODE, enterCodePost);
 
 export default insuranceAccountRouter;

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -14,8 +14,8 @@ describe('routes/insurance', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(40);
-    expect(post).toHaveBeenCalledTimes(40);
+    expect(get).toHaveBeenCalledTimes(41);
+    expect(post).toHaveBeenCalledTimes(41);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);

--- a/src/ui/templates/insurance/account/sign-in/enter-code.njk
+++ b/src/ui/templates/insurance/account/sign-in/enter-code.njk
@@ -38,24 +38,24 @@
 
         {{ govukInput({
           label: {
-            text: FIELDS.SECURITY_CODE.LABEL,
+            text: FIELD.LABEL,
             attributes: {
-              'data-cy': FIELDS.SECURITY_CODE.ID + '-label'
+              'data-cy': FIELD.ID + '-label'
             }
           },
           classes: "govuk-input--width-4",
           attributes: {
-            'data-cy': FIELDS.SECURITY_CODE.ID + '-input'
+            'data-cy': FIELD.ID + '-input'
           },
-          id: FIELDS.SECURITY_CODE.ID,
-          name: FIELDS.SECURITY_CODE.ID,
+          id: FIELD.ID,
+          name: FIELD.ID,
           inputmode: "numeric",
           pattern: "[0-9]*",
           spellcheck: false,
-          errorMessage: validationErrors.errorList[FIELDS.SECURITY_CODE.ID] and {
-            text: validationErrors.errorList[FIELDS.SECURITY_CODE.ID].text,
+          errorMessage: validationErrors.errorList[FIELD.ID] and {
+            text: validationErrors.errorList[FIELD.ID].text,
             attributes: {
-              "data-cy": FIELDS.SECURITY_CODE.ID + "-error-message"
+              "data-cy": FIELD.ID + "-error-message"
             }
           }
         }) }}

--- a/src/ui/templates/insurance/account/sign-in/enter-code.njk
+++ b/src/ui/templates/insurance/account/sign-in/enter-code.njk
@@ -1,0 +1,79 @@
+{% extends 'index.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from 'govuk/components/button/macro.njk' import govukButton %}
+
+{% block pageTitle %}
+  {{ CONTENT_STRINGS.PAGE_TITLE }}
+{% endblock %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: CONTENT_STRINGS.LINKS.BACK,
+    href: BACK_LINK,
+    attributes: {
+      "data-cy": "back-link"
+    }
+  }) }}
+
+  {% if validationErrors.summary %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: validationErrors.summary
+    }) }}
+  {% endif %}
+
+  <h1 class="govuk-heading-xl" data-cy="heading">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
+
+  <p data-cy="intro">{{ CONTENT_STRINGS.INTRO }}</p>
+
+  <form method="POST" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half-from-desktop">
+
+        {{ govukInput({
+          label: {
+            text: FIELDS.SECURITY_CODE.LABEL,
+            attributes: {
+              'data-cy': FIELDS.SECURITY_CODE.ID + '-label'
+            }
+          },
+          classes: "govuk-input--width-4",
+          attributes: {
+            'data-cy': FIELDS.SECURITY_CODE.ID + '-input'
+          },
+          id: FIELDS.SECURITY_CODE.ID,
+          name: FIELDS.SECURITY_CODE.ID,
+          inputmode: "numeric",
+          pattern: "[0-9]*",
+          spellcheck: false,
+          errorMessage: validationErrors.errorList[FIELDS.SECURITY_CODE.ID] and {
+            text: validationErrors.errorList[FIELDS.SECURITY_CODE.ID].text,
+            attributes: {
+              "data-cy": FIELDS.SECURITY_CODE.ID + "-error-message"
+            }
+          }
+        }) }}
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: CONTENT_STRINGS.BUTTONS.CONTINUE,
+            attributes: {
+              'data-cy': 'submit-button'
+            }
+          }) }}
+        </div>
+
+      </div>
+    </div>
+
+    <a class="govuk-link" href="{{ CONTENT_STRINGS.REQUEST_NEW_CODE.HREF }}" data-cy="request-new-code">{{ CONTENT_STRINGS.REQUEST_NEW_CODE.TEXT }}</a>
+
+  </form>
+
+{% endblock %}


### PR DESCRIPTION
This PR sets up the "security code" page/form for the Account sign in flow.

Note: there is no form validation or actual security code functionality, this PR just sets up the GET route and renders the form.

## Changes

- Setup route, controller and nunjucks template.
- Add temporary POST route that redirects to dashboard route (this will be updated in a future PR for validation API response handling).
- Add E2E test coverage.