### PR TITLE
fix(EMS-991): Your business - Turnover - Percentage Turnover allowed commas

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -111,7 +111,8 @@ export const ERROR_MESSAGES = {
       },
       [FIELD_IDS.INSURANCE.EXPORTER_BUSINESS.TURNOVER.PERCENTAGE_TURNOVER]: {
         IS_EMPTY: 'Enter your estimated percentage of turnover from exports',
-        INCORRECT_FORMAT: 'Enter your estimated percentage of turnover from exports in the correct format - for example, a whole number like 50',
+        INCORRECT_FORMAT:
+        'Enter your estimated percentage of turnover from exports in the correct format, without special characters - for example, a whole number like 50',
         BELOW_MINIMUM: 'Your percentage of turnover from exports must be a number between 0 to 100',
         ABOVE_MAXIMUM: 'Your percentage of turnover from exports must be a number between 0 to 100',
       },

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
@@ -76,6 +76,17 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
       });
     });
 
+    describe(`when ${FIELD_ID} has a comma`, () => {
+      const errorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
+
+      it(`should display validation errors for ${FIELD_ID}`, () => {
+        const { field, numberOfExpectedErrors, errorIndex } = ERROR_ASSERTIONS;
+        const value = '4,4';
+
+        cy.submitAndAssertFieldErrors(field, value, errorIndex, numberOfExpectedErrors, errorMessage);
+      });
+    });
+
     describe(`when ${FIELD_ID} has special characters`, () => {
       const errorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
 
@@ -116,17 +127,6 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
       const field = turnover[FIELD_ID];
 
       cy.keyboardInput(field.input(), '5');
-      submitButton().click();
-      partials.errorSummaryListItems().should('have.length', 1);
-    });
-  });
-
-  describe(`when ${FIELD_ID} is correctly entered with a comma`, () => {
-    it('should not display validation errors', () => {
-      cy.navigateToUrl(url);
-      const field = turnover[FIELD_ID];
-
-      cy.keyboardInput(field.input(), '5,0');
       submitButton().click();
       partials.errorSummaryListItems().should('have.length', 1);
     });

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -115,7 +115,8 @@ export const ERROR_MESSAGES = {
       },
       [FIELD_IDS.INSURANCE.EXPORTER_BUSINESS.TURNOVER.PERCENTAGE_TURNOVER]: {
         IS_EMPTY: 'Enter your estimated percentage of turnover from exports',
-        INCORRECT_FORMAT: 'Enter your estimated percentage of turnover from exports in the correct format - for example, a whole number like 50',
+        INCORRECT_FORMAT:
+          'Enter your estimated percentage of turnover from exports in the correct format, without special characters - for example, a whole number like 50',
         BELOW_MINIMUM: 'Your percentage of turnover from exports must be a number between 0 to 100',
         ABOVE_MAXIMUM: 'Your percentage of turnover from exports must be a number between 0 to 100',
       },

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.test.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.test.ts
@@ -2,7 +2,6 @@ import percentageTurnover from './percentage-of-turnover';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/exporter-business';
 import { RequestBody, NumberErrorMessage } from '../../../../../../../types';
-import generateValidationErrors from '../../../../../../helpers/validation';
 import percentageNumberValidation from '../../../../../../helpers/percentage-number-validation';
 
 const {
@@ -23,17 +22,17 @@ describe('controllers/insurance/business/turnover/validation/rules/percentage-of
   } as RequestBody;
 
   const errorMessages = {
+    IS_EMPTY: ERROR_MESSAGE.IS_EMPTY,
     INCORRECT_FORMAT: ERROR_MESSAGE.INCORRECT_FORMAT,
     BELOW_MINIMUM: ERROR_MESSAGE.BELOW_MINIMUM,
     ABOVE_MAXIMUM: ERROR_MESSAGE.ABOVE_MAXIMUM,
   } as NumberErrorMessage;
 
   describe(`when the ${PERCENTAGE_TURNOVER} input is empty`, () => {
-    it('should return a validation error', () => {
+    it('should return result of `percentageNumberValidation`', () => {
       const response = percentageTurnover(mockBody, mockErrors);
 
-      const errorMessage = ERROR_MESSAGE.IS_EMPTY;
-      const expected = generateValidationErrors(PERCENTAGE_TURNOVER, errorMessage, mockErrors);
+      const expected = percentageNumberValidation(mockBody, PERCENTAGE_TURNOVER, mockErrors, errorMessages);
 
       expect(response).toEqual(expected);
     });

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.test.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.test.ts
@@ -1,8 +1,9 @@
 import percentageTurnover from './percentage-of-turnover';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/exporter-business';
-import { RequestBody } from '../../../../../../../types';
+import { RequestBody, Errors } from '../../../../../../../types';
 import generateValidationErrors from '../../../../../../helpers/validation';
+import percentageNumberValidation from '../../../../../../helpers/percentage-number-validation';
 
 const {
   TURNOVER: { PERCENTAGE_TURNOVER },
@@ -21,6 +22,12 @@ describe('controllers/insurance/business/turnover/validation/rules/percentage-of
     [PERCENTAGE_TURNOVER]: '',
   } as RequestBody;
 
+  const errorMessages = {
+    INCORRECT_FORMAT: ERROR_MESSAGE.INCORRECT_FORMAT,
+    BELOW_MINIMUM: ERROR_MESSAGE.BELOW_MINIMUM,
+    ABOVE_MAXIMUM: ERROR_MESSAGE.ABOVE_MAXIMUM,
+  } as Errors;
+
   describe(`when the ${PERCENTAGE_TURNOVER} input is empty`, () => {
     it('should return a validation error', () => {
       const response = percentageTurnover(mockBody, mockErrors);
@@ -32,80 +39,19 @@ describe('controllers/insurance/business/turnover/validation/rules/percentage-of
     });
   });
 
-  describe(`when the ${PERCENTAGE_TURNOVER} input contains a letter`, () => {
-    it('should return a validation error', () => {
-      mockBody[PERCENTAGE_TURNOVER] = 'I5';
+  describe(`when the ${PERCENTAGE_TURNOVER} input is invaluid`, () => {
+    it('should return result of `percentageNumberValidation`', () => {
+      mockBody[PERCENTAGE_TURNOVER] = '-1,5';
       const response = percentageTurnover(mockBody, mockErrors);
 
-      const errorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
-      const expected = generateValidationErrors(PERCENTAGE_TURNOVER, errorMessage, mockErrors);
-
-      expect(response).toEqual(expected);
-    });
-  });
-
-  describe(`when the ${PERCENTAGE_TURNOVER} input contains a decimal place`, () => {
-    it('should return a validation error', () => {
-      mockBody[PERCENTAGE_TURNOVER] = '3.1';
-      const response = percentageTurnover(mockBody, mockErrors);
-
-      const errorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
-      const expected = generateValidationErrors(PERCENTAGE_TURNOVER, errorMessage, mockErrors);
-
-      expect(response).toEqual(expected);
-    });
-  });
-
-  describe(`when the ${PERCENTAGE_TURNOVER} input contains a special character`, () => {
-    it('should return a validation error', () => {
-      mockBody[PERCENTAGE_TURNOVER] = '1*';
-      const response = percentageTurnover(mockBody, mockErrors);
-
-      const errorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
-      const expected = generateValidationErrors(PERCENTAGE_TURNOVER, errorMessage, mockErrors);
-
-      expect(response).toEqual(expected);
-    });
-  });
-
-  describe(`when the ${PERCENTAGE_TURNOVER} input contains a special character and is below 0`, () => {
-    it('should return a validation error', () => {
-      mockBody[PERCENTAGE_TURNOVER] = '-1*';
-      const response = percentageTurnover(mockBody, mockErrors);
-
-      const errorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
-      const expected = generateValidationErrors(PERCENTAGE_TURNOVER, errorMessage, mockErrors);
-
-      expect(response).toEqual(expected);
-    });
-  });
-
-  describe(`when the ${PERCENTAGE_TURNOVER} input is below 0`, () => {
-    it('should return a validation error', () => {
-      mockBody[PERCENTAGE_TURNOVER] = '-1';
-      const response = percentageTurnover(mockBody, mockErrors);
-
-      const errorMessage = ERROR_MESSAGE.BELOW_MINIMUM;
-      const expected = generateValidationErrors(PERCENTAGE_TURNOVER, errorMessage, mockErrors);
-
-      expect(response).toEqual(expected);
-    });
-  });
-
-  describe(`when the ${PERCENTAGE_TURNOVER} input is above 100`, () => {
-    it('should return a validation error', () => {
-      mockBody[PERCENTAGE_TURNOVER] = '125';
-      const response = percentageTurnover(mockBody, mockErrors);
-
-      const errorMessage = ERROR_MESSAGE.ABOVE_MAXIMUM;
-      const expected = generateValidationErrors(PERCENTAGE_TURNOVER, errorMessage, mockErrors);
+      const expected = percentageNumberValidation(mockBody, PERCENTAGE_TURNOVER, mockErrors, errorMessages);
 
       expect(response).toEqual(expected);
     });
   });
 
   describe(`when the ${PERCENTAGE_TURNOVER} input is valid`, () => {
-    it('should return a validation error', () => {
+    it('should return result of `percentageNumberValidation`', () => {
       mockBody[PERCENTAGE_TURNOVER] = '8';
       const response = percentageTurnover(mockBody, mockErrors);
 

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.test.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.test.ts
@@ -1,7 +1,7 @@
 import percentageTurnover from './percentage-of-turnover';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/exporter-business';
-import { RequestBody, Errors } from '../../../../../../../types';
+import { RequestBody, NumberErrorMessage } from '../../../../../../../types';
 import generateValidationErrors from '../../../../../../helpers/validation';
 import percentageNumberValidation from '../../../../../../helpers/percentage-number-validation';
 
@@ -26,7 +26,7 @@ describe('controllers/insurance/business/turnover/validation/rules/percentage-of
     INCORRECT_FORMAT: ERROR_MESSAGE.INCORRECT_FORMAT,
     BELOW_MINIMUM: ERROR_MESSAGE.BELOW_MINIMUM,
     ABOVE_MAXIMUM: ERROR_MESSAGE.ABOVE_MAXIMUM,
-  } as Errors;
+  } as NumberErrorMessage;
 
   describe(`when the ${PERCENTAGE_TURNOVER} input is empty`, () => {
     it('should return a validation error', () => {
@@ -39,7 +39,7 @@ describe('controllers/insurance/business/turnover/validation/rules/percentage-of
     });
   });
 
-  describe(`when the ${PERCENTAGE_TURNOVER} input is invaluid`, () => {
+  describe(`when the ${PERCENTAGE_TURNOVER} input is invalid`, () => {
     it('should return result of `percentageNumberValidation`', () => {
       mockBody[PERCENTAGE_TURNOVER] = '-1,5';
       const response = percentageTurnover(mockBody, mockErrors);

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.ts
@@ -1,6 +1,6 @@
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/exporter-business';
-import { Errors, RequestBody } from '../../../../../../../types';
+import { NumberErrorMessage, RequestBody } from '../../../../../../../types';
 import percentageNumberValidation from '../../../../../../helpers/percentage-number-validation';
 import { objectHasProperty } from '../../../../../../helpers/object';
 import generateValidationErrors from '../../../../../../helpers/validation';
@@ -15,7 +15,7 @@ const {
 
 /**
  * validates percentage turnover
- * only numbers without decimals or special characters or commas
+ * only numbers without decimals, special characters or commas
  * only allows numbers between 0 and 100
  * @param {RequestBody} responseBody
  * @param {object} errors
@@ -32,7 +32,7 @@ const percentageTurnover = (responseBody: RequestBody, errors: object) => {
     INCORRECT_FORMAT: ERROR_MESSAGE.INCORRECT_FORMAT,
     BELOW_MINIMUM: ERROR_MESSAGE.BELOW_MINIMUM,
     ABOVE_MAXIMUM: ERROR_MESSAGE.ABOVE_MAXIMUM,
-  } as Errors;
+  } as NumberErrorMessage;
 
   return percentageNumberValidation(responseBody, FIELD_ID, errors, errorMessages);
 };

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.ts
@@ -2,8 +2,6 @@ import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/exporter-business';
 import { NumberErrorMessage, RequestBody } from '../../../../../../../types';
 import percentageNumberValidation from '../../../../../../helpers/percentage-number-validation';
-import { objectHasProperty } from '../../../../../../helpers/object';
-import generateValidationErrors from '../../../../../../helpers/validation';
 
 const {
   TURNOVER: { PERCENTAGE_TURNOVER: FIELD_ID },
@@ -13,6 +11,13 @@ const {
   EXPORTER_BUSINESS: { [FIELD_ID]: ERROR_MESSAGE },
 } = ERROR_MESSAGES.INSURANCE;
 
+const errorMessages = {
+  IS_EMPTY: ERROR_MESSAGE.IS_EMPTY,
+  INCORRECT_FORMAT: ERROR_MESSAGE.INCORRECT_FORMAT,
+  BELOW_MINIMUM: ERROR_MESSAGE.BELOW_MINIMUM,
+  ABOVE_MAXIMUM: ERROR_MESSAGE.ABOVE_MAXIMUM,
+} as NumberErrorMessage;
+
 /**
  * validates percentage turnover
  * only numbers without decimals, special characters or commas
@@ -21,20 +26,6 @@ const {
  * @param {object} errors
  * @returns {object} errors
  */
-const percentageTurnover = (responseBody: RequestBody, errors: object) => {
-  if (!objectHasProperty(responseBody, FIELD_ID)) {
-    const errorMessage = ERROR_MESSAGE.IS_EMPTY;
-
-    return generateValidationErrors(FIELD_ID, errorMessage, errors);
-  }
-
-  const errorMessages = {
-    INCORRECT_FORMAT: ERROR_MESSAGE.INCORRECT_FORMAT,
-    BELOW_MINIMUM: ERROR_MESSAGE.BELOW_MINIMUM,
-    ABOVE_MAXIMUM: ERROR_MESSAGE.ABOVE_MAXIMUM,
-  } as NumberErrorMessage;
-
-  return percentageNumberValidation(responseBody, FIELD_ID, errors, errorMessages);
-};
+const percentageTurnover = (responseBody: RequestBody, errors: object) => percentageNumberValidation(responseBody, FIELD_ID, errors, errorMessages);
 
 export default percentageTurnover;

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.ts
@@ -1,11 +1,9 @@
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/exporter-business';
-import { RequestBody } from '../../../../../../../types';
-import wholeNumberValidation from '../../../../../../helpers/whole-number-validation';
+import { Errors, RequestBody } from '../../../../../../../types';
+import percentageNumberValidation from '../../../../../../helpers/percentage-number-validation';
 import { objectHasProperty } from '../../../../../../helpers/object';
 import generateValidationErrors from '../../../../../../helpers/validation';
-import { isNumberAboveMaximum, isNumberBelowMinimum } from '../../../../../../helpers/number';
-import { stripCommas } from '../../../../../../helpers/string';
 
 const {
   TURNOVER: { PERCENTAGE_TURNOVER: FIELD_ID },
@@ -15,55 +13,28 @@ const {
   EXPORTER_BUSINESS: { [FIELD_ID]: ERROR_MESSAGE },
 } = ERROR_MESSAGES.INSURANCE;
 
-const MINIMUM = 0;
-const MAXIMUM = 100;
-
 /**
  * validates percentage turnover
- * only numbers without decimals or special characters
+ * only numbers without decimals or special characters or commas
  * only allows numbers between 0 and 100
  * @param {RequestBody} responseBody
  * @param {object} errors
  * @returns {object} errors
  */
 const percentageTurnover = (responseBody: RequestBody, errors: object) => {
-  let updatedErrors = errors;
-  const value = responseBody[FIELD_ID];
-
   if (!objectHasProperty(responseBody, FIELD_ID)) {
     const errorMessage = ERROR_MESSAGE.IS_EMPTY;
 
     return generateValidationErrors(FIELD_ID, errorMessage, errors);
   }
 
-  // strip commas - commas are valid.
-  const numberWithoutCommas = stripCommas(value);
+  const errorMessages = {
+    INCORRECT_FORMAT: ERROR_MESSAGE.INCORRECT_FORMAT,
+    BELOW_MINIMUM: ERROR_MESSAGE.BELOW_MINIMUM,
+    ABOVE_MAXIMUM: ERROR_MESSAGE.ABOVE_MAXIMUM,
+  } as Errors;
 
-  /**
-   * checks if number does not have any special characters or decimal places
-   * However, only if number is 0 or above
-   * If number is below 0, then different error message is required
-   */
-  if (!isNumberBelowMinimum(Number(numberWithoutCommas), 0)) {
-    const wholeNumberErrorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
-    updatedErrors = wholeNumberValidation(responseBody, updatedErrors, wholeNumberErrorMessage, FIELD_ID);
-  }
-
-  // checks if number is below 0 and returns different error message
-  if (isNumberBelowMinimum(Number(numberWithoutCommas), MINIMUM)) {
-    const errorMessage = ERROR_MESSAGE.BELOW_MINIMUM;
-
-    return generateValidationErrors(FIELD_ID, errorMessage, updatedErrors);
-  }
-
-  // checks if number is above 100
-  if (isNumberAboveMaximum(Number(numberWithoutCommas), MAXIMUM)) {
-    const errorMessage = ERROR_MESSAGE.ABOVE_MAXIMUM;
-
-    return generateValidationErrors(FIELD_ID, errorMessage, updatedErrors);
-  }
-
-  return updatedErrors;
+  return percentageNumberValidation(responseBody, FIELD_ID, errors, errorMessages);
 };
 
 export default percentageTurnover;

--- a/src/ui/server/helpers/percentage-number-validation/index.test.ts
+++ b/src/ui/server/helpers/percentage-number-validation/index.test.ts
@@ -15,10 +15,33 @@ describe('server/helpers/percentage-number-validation', () => {
   const FIELD = 'testField';
 
   const errorMessages = {
+    IS_EMPTY: 'Is empty',
     INCORRECT_FORMAT: 'Incorrect format',
     BELOW_MINIMUM: 'Below minimum',
     ABOVE_MAXIMUM: 'Above maximum',
   } as NumberErrorMessage;
+
+  describe('percentage is an empty string', () => {
+    it('should return a validation error', () => {
+      mockBody.testField = '';
+      const response = percentageNumberValidation(mockBody, FIELD, mockErrors, errorMessages);
+
+      const expected = generateValidationErrors(FIELD, errorMessages.IS_EMPTY, mockErrors);
+
+      expect(response).toEqual(expected);
+    });
+  });
+
+  describe('percentage is null', () => {
+    it('should return a validation error', () => {
+      mockBody.testField = null;
+      const response = percentageNumberValidation(mockBody, FIELD, mockErrors, errorMessages);
+
+      const expected = generateValidationErrors(FIELD, errorMessages.IS_EMPTY, mockErrors);
+
+      expect(response).toEqual(expected);
+    });
+  });
 
   describe('percentage is a letter', () => {
     it('should return a validation error', () => {

--- a/src/ui/server/helpers/percentage-number-validation/index.test.ts
+++ b/src/ui/server/helpers/percentage-number-validation/index.test.ts
@@ -1,0 +1,119 @@
+import percentageNumberValidation from '.';
+import { RequestBody, Errors } from '../../../types';
+import generateValidationErrors from '../validation';
+
+describe('server/helpers/percentage-number-validation', () => {
+  const mockErrors = {
+    summary: [],
+    errorList: {},
+  };
+
+  const mockBody = {
+    testField: '',
+  } as RequestBody;
+
+  const FIELD = 'testField';
+
+  const errorMessages = {
+    INCORRECT_FORMAT: 'Incorrect format',
+    BELOW_MINIMUM: 'Below minimum',
+    ABOVE_MAXIMUM: 'Above maximum',
+  } as Errors;
+
+  describe('percentage is a letter', () => {
+    it('should return a validation error', () => {
+      mockBody.testField = 'a';
+      const response = percentageNumberValidation(mockBody, FIELD, mockErrors, errorMessages);
+
+      const expected = generateValidationErrors(FIELD, errorMessages.INCORRECT_FORMAT, mockErrors);
+
+      expect(response).toEqual(expected);
+    });
+  });
+
+  describe('percentage contains a letter', () => {
+    it('should return a validation error', () => {
+      mockBody.testField = '4S';
+      const response = percentageNumberValidation(mockBody, FIELD, mockErrors, errorMessages);
+
+      const expected = generateValidationErrors(FIELD, errorMessages.INCORRECT_FORMAT, mockErrors);
+
+      expect(response).toEqual(expected);
+    });
+  });
+
+  describe('perentage is a special character', () => {
+    it('should return a validation error', () => {
+      mockBody.testField = '!';
+      const response = percentageNumberValidation(mockBody, FIELD, mockErrors, errorMessages);
+
+      const expected = generateValidationErrors(FIELD, errorMessages.INCORRECT_FORMAT, mockErrors);
+
+      expect(response).toEqual(expected);
+    });
+  });
+
+  describe('percentage contains a special character', () => {
+    it('should return a validation error', () => {
+      mockBody.testField = '3!';
+      const response = percentageNumberValidation(mockBody, FIELD, mockErrors, errorMessages);
+
+      const expected = generateValidationErrors(FIELD, errorMessages.INCORRECT_FORMAT, mockErrors);
+
+      expect(response).toEqual(expected);
+    });
+  });
+
+  describe('percentage contains a comma', () => {
+    it('should return a validation error', () => {
+      mockBody.testField = '3,5';
+      const response = percentageNumberValidation(mockBody, FIELD, mockErrors, errorMessages);
+
+      const expected = generateValidationErrors(FIELD, errorMessages.INCORRECT_FORMAT, mockErrors);
+
+      expect(response).toEqual(expected);
+    });
+  });
+
+  describe('percentage is negative', () => {
+    it('should return a validation error', () => {
+      mockBody.testField = '-1';
+      const response = percentageNumberValidation(mockBody, FIELD, mockErrors, errorMessages);
+
+      const expected = generateValidationErrors(FIELD, errorMessages.BELOW_MINIMUM, mockErrors);
+
+      expect(response).toEqual(expected);
+    });
+  });
+
+  describe('percentage is negative and contains a special character', () => {
+    it('should return a validation error', () => {
+      mockBody.testField = '-1!';
+      const response = percentageNumberValidation(mockBody, FIELD, mockErrors, errorMessages);
+
+      const expected = generateValidationErrors(FIELD, errorMessages.INCORRECT_FORMAT, mockErrors);
+
+      expect(response).toEqual(expected);
+    });
+  });
+
+  describe('percentage is above 100', () => {
+    it('should return a validation error', () => {
+      mockBody.testField = '101';
+      const response = percentageNumberValidation(mockBody, FIELD, mockErrors, errorMessages);
+
+      const expected = generateValidationErrors(FIELD, errorMessages.ABOVE_MAXIMUM, mockErrors);
+
+      expect(response).toEqual(expected);
+    });
+  });
+
+  describe('number is valid', () => {
+    it('should not return a validation error', () => {
+      mockBody.testField = '3';
+      const response = percentageNumberValidation(mockBody, FIELD, mockErrors, errorMessages);
+
+      expect(response).toEqual(mockErrors);
+    });
+  });
+});

--- a/src/ui/server/helpers/percentage-number-validation/index.test.ts
+++ b/src/ui/server/helpers/percentage-number-validation/index.test.ts
@@ -1,5 +1,5 @@
 import percentageNumberValidation from '.';
-import { RequestBody, Errors } from '../../../types';
+import { RequestBody, NumberErrorMessage } from '../../../types';
 import generateValidationErrors from '../validation';
 
 describe('server/helpers/percentage-number-validation', () => {
@@ -18,7 +18,7 @@ describe('server/helpers/percentage-number-validation', () => {
     INCORRECT_FORMAT: 'Incorrect format',
     BELOW_MINIMUM: 'Below minimum',
     ABOVE_MAXIMUM: 'Above maximum',
-  } as Errors;
+  } as NumberErrorMessage;
 
   describe('percentage is a letter', () => {
     it('should return a validation error', () => {

--- a/src/ui/server/helpers/percentage-number-validation/index.ts
+++ b/src/ui/server/helpers/percentage-number-validation/index.ts
@@ -1,0 +1,44 @@
+import { RequestBody, Errors } from '../../../types';
+import generateValidationErrors from '../validation';
+import { isNumber, numberHasDecimal, isNumberBelowMinimum, isNumberAboveMaximum } from '../number';
+
+const MINIMUM = 0;
+const MAXIMUM = 100;
+
+/**
+ * percentageNumberValidation
+ * validates if field is whole number and between 0 and 100.
+ * returns validation error if is not a number, has a decimal place or special characters or a comma or is below 0 or above 100.
+ * @param {RequestBody} responseBody
+ * @param {String} field fieldId of the field being checked
+ * @param {object} errors
+ * @param {Errors} errorMessages object with different error messages
+ * @returns {object} errors
+ */
+const percentageNumberValidation = (responseBody: RequestBody, field: string, errors: object, errorMessages: Errors) => {
+  const { INCORRECT_FORMAT, BELOW_MINIMUM, ABOVE_MAXIMUM } = errorMessages;
+
+  const value = responseBody[field];
+
+  const isFieldANumber = isNumber(value);
+  const hasDecimal = numberHasDecimal(Number(value));
+
+  // if the incorrect format
+  if (!isFieldANumber || hasDecimal) {
+    return generateValidationErrors(field, INCORRECT_FORMAT, errors);
+  }
+
+  // if below the set minimum
+  if (isNumberBelowMinimum(Number(value), MINIMUM)) {
+    return generateValidationErrors(field, BELOW_MINIMUM, errors);
+  }
+
+  // if above the set maximum
+  if (isNumberAboveMaximum(Number(value), MAXIMUM)) {
+    return generateValidationErrors(field, ABOVE_MAXIMUM, errors);
+  }
+
+  return errors;
+};
+
+export default percentageNumberValidation;

--- a/src/ui/server/helpers/percentage-number-validation/index.ts
+++ b/src/ui/server/helpers/percentage-number-validation/index.ts
@@ -1,5 +1,6 @@
 import { RequestBody, NumberErrorMessage } from '../../../types';
 import generateValidationErrors from '../validation';
+import { objectHasProperty } from '../object';
 import { isNumber, numberHasDecimal, isNumberBelowMinimum, isNumberAboveMaximum } from '../number';
 
 const MINIMUM = 0;
@@ -7,8 +8,9 @@ const MAXIMUM = 100;
 
 /**
  * percentageNumberValidation
+ * validates if field is empty or not
  * validates if field is whole number and between 0 and 100.
- * returns validation error if is not a number, has a decimal place or special characters or a comma or is below 0 or above 100.
+ * returns validation error if is not a number, has a decimal place, special characters, a comma, is empty or is below 0 or above 100.
  * @param {RequestBody} responseBody
  * @param {String} field fieldId of the field being checked
  * @param {object} errors
@@ -16,7 +18,12 @@ const MAXIMUM = 100;
  * @returns {object} errors
  */
 const percentageNumberValidation = (responseBody: RequestBody, field: string, errors: object, errorMessages: NumberErrorMessage) => {
-  const { INCORRECT_FORMAT, BELOW_MINIMUM, ABOVE_MAXIMUM } = errorMessages;
+  const { IS_EMPTY, INCORRECT_FORMAT, BELOW_MINIMUM, ABOVE_MAXIMUM } = errorMessages;
+
+  // if empty then return validation error
+  if (!objectHasProperty(responseBody, field)) {
+    return generateValidationErrors(field, IS_EMPTY, errors);
+  }
 
   const value = responseBody[field];
 

--- a/src/ui/server/helpers/percentage-number-validation/index.ts
+++ b/src/ui/server/helpers/percentage-number-validation/index.ts
@@ -1,4 +1,4 @@
-import { RequestBody, Errors } from '../../../types';
+import { RequestBody, NumberErrorMessage } from '../../../types';
 import generateValidationErrors from '../validation';
 import { isNumber, numberHasDecimal, isNumberBelowMinimum, isNumberAboveMaximum } from '../number';
 
@@ -12,10 +12,10 @@ const MAXIMUM = 100;
  * @param {RequestBody} responseBody
  * @param {String} field fieldId of the field being checked
  * @param {object} errors
- * @param {Errors} errorMessages object with different error messages
+ * @param {NumberErrorMessage} errorMessages object with different error messages
  * @returns {object} errors
  */
-const percentageNumberValidation = (responseBody: RequestBody, field: string, errors: object, errorMessages: Errors) => {
+const percentageNumberValidation = (responseBody: RequestBody, field: string, errors: object, errorMessages: NumberErrorMessage) => {
   const { INCORRECT_FORMAT, BELOW_MINIMUM, ABOVE_MAXIMUM } = errorMessages;
 
   const value = responseBody[field];

--- a/src/ui/types/errors.ts
+++ b/src/ui/types/errors.ts
@@ -1,7 +1,7 @@
-interface Errors {
+interface NumberErrorMessage {
   INCORRECT_FORMAT: string;
   BELOW_MINIMUM: string;
   ABOVE_MAXIMUM: string;
 }
 
-export { Errors };
+export { NumberErrorMessage };

--- a/src/ui/types/errors.ts
+++ b/src/ui/types/errors.ts
@@ -1,4 +1,5 @@
 interface NumberErrorMessage {
+  IS_EMPTY: string;
   INCORRECT_FORMAT: string;
   BELOW_MINIMUM: string;
   ABOVE_MAXIMUM: string;

--- a/src/ui/types/errors.ts
+++ b/src/ui/types/errors.ts
@@ -1,0 +1,7 @@
+interface Errors {
+  INCORRECT_FORMAT: string;
+  BELOW_MINIMUM: string;
+  ABOVE_MAXIMUM: string;
+}
+
+export { Errors };

--- a/src/ui/types/index.d.ts
+++ b/src/ui/types/index.d.ts
@@ -15,6 +15,7 @@ import { CompanyDetails, SicCode } from './company-details';
 import { CompanyHouseResponse } from './company-house-response';
 import { Country } from './country';
 import { Currency } from './currency';
+import { Errors } from './errors';
 import { ExporterBusiness } from './exporter-business';
 import { Next, Request, RequestBody, RequestSession, Response } from './express';
 import { RequiredDataStateInsuranceEligibility, RequiredDataStateQuoteEligibility } from './required-data-state';
@@ -67,6 +68,7 @@ export {
   CorePageVariables,
   Country,
   Currency,
+  Errors,
   ExporterBusiness,
   InsuranceEligibility,
   InsuranceEligibilityCore,

--- a/src/ui/types/index.d.ts
+++ b/src/ui/types/index.d.ts
@@ -15,7 +15,7 @@ import { CompanyDetails, SicCode } from './company-details';
 import { CompanyHouseResponse } from './company-house-response';
 import { Country } from './country';
 import { Currency } from './currency';
-import { Errors } from './errors';
+import { NumberErrorMessage } from './errors';
 import { ExporterBusiness } from './exporter-business';
 import { Next, Request, RequestBody, RequestSession, Response } from './express';
 import { RequiredDataStateInsuranceEligibility, RequiredDataStateQuoteEligibility } from './required-data-state';
@@ -68,7 +68,7 @@ export {
   CorePageVariables,
   Country,
   Currency,
-  Errors,
+  NumberErrorMessage,
   ExporterBusiness,
   InsuranceEligibility,
   InsuranceEligibilityCore,


### PR DESCRIPTION
# Issue:
* percentageTurnover field allowed commas as valid input

# Changes made:
* Added new helper to handle all validation for percentage numbers
* Removed commas being valid for percentages
* Added tests