### PR TITLE
feat(EMS-1013): Account creation - only create an account if the email is unique

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -227,6 +227,7 @@ export const ERROR_MESSAGES = {
           },
           [FIELD_IDS.INSURANCE.ACCOUNT.EMAIL]: {
             INCORRECT_FORMAT: 'Enter your email address in the correct format - for example name@example.com',
+            ACCOUNT_ALREADY_EXISTS: 'There is already an account with this email address. Please sign in or reset your password',
           },
           [FIELD_IDS.INSURANCE.ACCOUNT.PASSWORD]: {
             INCORRECT_FORMAT: 'Enter a password in the correct format - for example, 14 characters long with an uppercase letter, lower case letter, number and special character',

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details-validation-account-already-exists.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details-validation-account-already-exists.spec.js
@@ -1,0 +1,67 @@
+import { signInPage } from '../../../../../pages/insurance/account/sign-in';
+import accountFormFields from '../../../../../partials/insurance/accountFormFields';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
+import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
+import mockAccount from '../../../../../../fixtures/account';
+
+const {
+  START,
+  ACCOUNT: {
+    CREATE: { YOUR_DETAILS },
+  },
+} = ROUTES;
+
+const {
+  ACCOUNT: { EMAIL },
+} = INSURANCE_FIELD_IDS;
+
+const {
+  INSURANCE: {
+    ACCOUNT: {
+      CREATE: { YOUR_DETAILS: YOUR_DETAILS_ERROR_MESSAGES },
+    },
+  },
+} = ERROR_MESSAGES;
+
+context('Insurance - Account - Create - Your details page - form validation - As an Exporter, I want the system to verify that the email address that I register against my UKEF digital service account is unique, So that I can be sure that the system does not have multiple digital service accounts with the same email addressa', () => {
+  before(() => {
+    cy.navigateToUrl(START);
+
+    // create and verify an account
+    cy.submitEligibilityAndStartAccountCreation();
+    cy.completeAndSubmitCreateAccountForm();
+
+    cy.verifyAccountEmail();
+
+    // go to create account page
+    signInPage.createAccountLink().click();
+
+    const expected = `${Cypress.config('baseUrl')}${YOUR_DETAILS}`;
+
+    cy.url().should('eq', expected);
+  });
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('_csrf');
+    Cypress.Cookies.preserveOnce('exip-session');
+  });
+
+  after(() => {
+    cy.deleteAccount();
+  });
+
+  describe('when trying to create an account with an email that already has an account', () => {
+    it('should render a validation error', () => {
+      cy.completeAndSubmitCreateAccountForm();
+
+      const field = accountFormFields[EMAIL];
+      const value = mockAccount.email;
+      const fieldIndex = 0;
+      const TOTAL_REQUIRED_FIELDS = 1;
+      const expectedMessage = YOUR_DETAILS_ERROR_MESSAGES[EMAIL].ACCOUNT_ALREADY_EXISTS;
+
+      cy.submitAndAssertFieldErrors(field, value, fieldIndex, TOTAL_REQUIRED_FIELDS, expectedMessage);
+    });
+  });
+});

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -642,44 +642,6 @@ var import_dotenv4 = __toESM(require("dotenv"));
 
 // custom-resolvers/create-account.ts
 var import_crypto = __toESM(require("crypto"));
-var { EMAIL, ENCRYPTION } = ACCOUNT;
-var {
-  RANDOM_BYTES_SIZE,
-  STRING_TYPE,
-  PBKDF2: { ITERATIONS, DIGEST_ALGORITHM },
-  PASSWORD: {
-    PBKDF2: { KEY_LENGTH }
-  }
-} = ENCRYPTION;
-var createAccount = async (root, variables, context) => {
-  console.info("Creating new exporter account for ", variables.email);
-  try {
-    const { firstName, lastName, email, password: password2 } = variables;
-    const salt = import_crypto.default.randomBytes(RANDOM_BYTES_SIZE).toString(STRING_TYPE);
-    const passwordHash = import_crypto.default.pbkdf2Sync(password2, salt, ITERATIONS, KEY_LENGTH, DIGEST_ALGORITHM).toString(STRING_TYPE);
-    const verificationHash = import_crypto.default.pbkdf2Sync(password2, salt, ITERATIONS, KEY_LENGTH, DIGEST_ALGORITHM).toString(STRING_TYPE);
-    const verificationExpiry = EMAIL.VERIFICATION_EXPIRY();
-    const account = {
-      firstName,
-      lastName,
-      email,
-      salt,
-      hash: passwordHash,
-      verificationHash,
-      verificationExpiry
-    };
-    const response = await context.db.Exporter.createOne({
-      data: account
-    });
-    return response;
-  } catch (err) {
-    throw new Error(`Creating new exporter account ${err}`);
-  }
-};
-var create_account_default = createAccount;
-
-// custom-resolvers/verify-account-email-address.ts
-var import_date_fns2 = require("date-fns");
 
 // helpers/get-account-by-field.ts
 var getAccountByField = async (context, field, value) => {
@@ -704,7 +666,53 @@ var getAccountByField = async (context, field, value) => {
 };
 var get_account_by_field_default = getAccountByField;
 
+// custom-resolvers/create-account.ts
+var { EMAIL, ENCRYPTION } = ACCOUNT;
+var {
+  RANDOM_BYTES_SIZE,
+  STRING_TYPE,
+  PBKDF2: { ITERATIONS, DIGEST_ALGORITHM },
+  PASSWORD: {
+    PBKDF2: { KEY_LENGTH }
+  }
+} = ENCRYPTION;
+var createAccount = async (root, variables, context) => {
+  console.info("Creating new exporter account for ", variables.email);
+  try {
+    const { firstName, lastName, email, password: password2 } = variables;
+    const exporter = await get_account_by_field_default(context, "email", email);
+    if (exporter) {
+      console.info(`Unable to create new exporter account for ${variables.email} - account already exists`);
+      return { success: false };
+    }
+    const salt = import_crypto.default.randomBytes(RANDOM_BYTES_SIZE).toString(STRING_TYPE);
+    const passwordHash = import_crypto.default.pbkdf2Sync(password2, salt, ITERATIONS, KEY_LENGTH, DIGEST_ALGORITHM).toString(STRING_TYPE);
+    const verificationHash = import_crypto.default.pbkdf2Sync(password2, salt, ITERATIONS, KEY_LENGTH, DIGEST_ALGORITHM).toString(STRING_TYPE);
+    const verificationExpiry = EMAIL.VERIFICATION_EXPIRY();
+    const account = {
+      firstName,
+      lastName,
+      email,
+      salt,
+      hash: passwordHash,
+      verificationHash,
+      verificationExpiry
+    };
+    const response = await context.db.Exporter.createOne({
+      data: account
+    });
+    return {
+      ...response,
+      success: true
+    };
+  } catch (err) {
+    throw new Error(`Creating new exporter account ${err}`);
+  }
+};
+var create_account_default = createAccount;
+
 // custom-resolvers/verify-account-email-address.ts
+var import_date_fns2 = require("date-fns");
 var verifyAccountEmailAddress = async (root, variables, context) => {
   try {
     console.info("Verifying exporter email address");
@@ -1153,6 +1161,14 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
         password: String
       }
 
+      type CreateAccountReaponse {
+        success: Boolean
+        id: String
+        firstName: String
+        lastName: String
+        email: String
+      }
+
       # fields from registered_office_address object
       type CompaniesHouseCompanyAddress {
         addressLine1: String
@@ -1258,7 +1274,7 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
           lastName: String!
           email: String!
           password: String!
-        ): Account
+        ): CreateAccountReaponse
 
         """ verify an account's email address """
         verifyAccountEmailAddress(
@@ -1305,6 +1321,7 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
         getAccountByEmail(
           email: String!
         ): Account
+
         """ get companies house information """
         getCompaniesHouseInformation(
           companiesHouseNumber: String!

--- a/src/api/custom-resolvers/account-sign-in.test.ts
+++ b/src/api/custom-resolvers/account-sign-in.test.ts
@@ -45,7 +45,7 @@ describe('custom-resolvers/account-sign-in', () => {
 
   let result: AccountSignInResponse;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     // wipe the table so we have a clean slate.
     const exporters = await context.query.Exporter.findMany();
 

--- a/src/api/custom-resolvers/create-account.test.ts
+++ b/src/api/custom-resolvers/create-account.test.ts
@@ -1,0 +1,101 @@
+import { getContext } from '@keystone-6/core/context';
+import dotenv from 'dotenv';
+import * as PrismaModule from '.prisma/client'; // eslint-disable-line import/no-extraneous-dependencies
+import baseConfig from '../keystone';
+import createAccount from './create-account';
+import { ACCOUNT } from '../constants';
+import { mockAccount } from '../test-mocks';
+import { Account } from '../types';
+import { Context } from '.keystone/types'; // eslint-disable-line
+
+const dbUrl = String(process.env.DATABASE_URL);
+const config = { ...baseConfig, db: { ...baseConfig.db, url: dbUrl } };
+
+dotenv.config();
+
+const context = getContext(config, PrismaModule) as Context;
+
+const { ENCRYPTION } = ACCOUNT;
+
+const {
+  RANDOM_BYTES_SIZE,
+  PASSWORD: {
+    PBKDF2: { KEY_LENGTH },
+  },
+} = ENCRYPTION;
+
+describe('custom-resolvers/create-account', () => {
+  let account: Account;
+
+  const mockPassword = String(process.env.MOCK_ACCOUNT_PASSWORD);
+
+  const variables = {
+    firstName: 'a',
+    lastName: 'b',
+    email: mockAccount.email,
+    password: mockPassword,
+  };
+
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  beforeEach(async () => {
+    // wipe the table so we have a clean slate.
+    const exporters = await context.query.Exporter.findMany();
+
+    await context.query.Exporter.deleteMany({
+      where: exporters,
+    });
+
+    // create an account
+    account = (await createAccount({}, variables, context)) as Account;
+  });
+
+  it('should generate and return the created account with added salt and hashes', () => {
+    // expect(account).toEqual({ test: true });
+
+    expect(account.firstName).toEqual(variables.firstName);
+    expect(account.lastName).toEqual(variables.lastName);
+    expect(account.email).toEqual(variables.email);
+    expect(account.salt.length).toEqual(RANDOM_BYTES_SIZE * 2);
+    expect(account.hash.length).toEqual(KEY_LENGTH * 2);
+    expect(account.verificationHash.length).toEqual(KEY_LENGTH * 2);
+  });
+
+  it('should generate and return the created account with added salt and hashes', () => {
+    const now = new Date();
+
+    const tomorrowDay = new Date(now.setDate(1)).getDay();
+
+    const expiry = new Date(account.verificationExpiry);
+
+    const expiryDay = expiry.getDay();
+
+    expect(expiryDay).toEqual(tomorrowDay);
+  });
+
+  describe('when an account with the provided email already exists', () => {
+    let result: Account;
+
+    beforeAll(async () => {
+      // attempt to create account with the same email
+      result = (await createAccount({}, variables, context)) as Account;
+    });
+
+    it('should return success=false', () => {
+      const expected = {
+        success: false,
+      };
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should not create the account', async () => {
+      const exporters = await context.query.Exporter.findMany();
+
+      // should only have the first created account
+      expect(exporters.length).toEqual(1);
+    });
+  });
+});

--- a/src/api/custom-resolvers/create-account.test.ts
+++ b/src/api/custom-resolvers/create-account.test.ts
@@ -53,8 +53,6 @@ describe('custom-resolvers/create-account', () => {
   });
 
   it('should generate and return the created account with added salt and hashes', () => {
-    // expect(account).toEqual({ test: true });
-
     expect(account.firstName).toEqual(variables.firstName);
     expect(account.lastName).toEqual(variables.lastName);
     expect(account.email).toEqual(variables.email);
@@ -63,10 +61,10 @@ describe('custom-resolvers/create-account', () => {
     expect(account.verificationHash.length).toEqual(KEY_LENGTH * 2);
   });
 
-  it('should generate and return the created account with added salt and hashes', () => {
+  it('should generate and return verification expiry date', () => {
     const now = new Date();
 
-    const tomorrowDay = new Date(now.setDate(1)).getDay();
+    const tomorrowDay = new Date(now).getDay() + 1;
 
     const expiry = new Date(account.verificationExpiry);
 

--- a/src/api/custom-resolvers/create-account.ts
+++ b/src/api/custom-resolvers/create-account.ts
@@ -1,6 +1,7 @@
 import { Context } from '.keystone/types'; // eslint-disable-line
 import crypto from 'crypto';
 import { ACCOUNT } from '../constants';
+import getAccountByField from '../helpers/get-account-by-field';
 import { AccountCreationVariables } from '../types';
 
 const { EMAIL, ENCRYPTION } = ACCOUNT;
@@ -19,6 +20,15 @@ const createAccount = async (root: any, variables: AccountCreationVariables, con
 
   try {
     const { firstName, lastName, email, password } = variables;
+
+    // check if an account with the email already exists
+    const exporter = await getAccountByField(context, 'email', email);
+
+    if (exporter) {
+      console.info(`Unable to create new exporter account for ${variables.email} - account already exists`);
+
+      return { success: false };
+    }
 
     const salt = crypto.randomBytes(RANDOM_BYTES_SIZE).toString(STRING_TYPE);
 
@@ -42,7 +52,10 @@ const createAccount = async (root: any, variables: AccountCreationVariables, con
       data: account,
     });
 
-    return response;
+    return {
+      ...response,
+      success: true,
+    };
   } catch (err) {
     throw new Error(`Creating new exporter account ${err}`);
   }

--- a/src/api/custom-schema.ts
+++ b/src/api/custom-schema.ts
@@ -39,6 +39,14 @@ export const extendGraphqlSchema = (schema: GraphQLSchema) =>
         password: String
       }
 
+      type CreateAccountReaponse {
+        success: Boolean
+        id: String
+        firstName: String
+        lastName: String
+        email: String
+      }
+
       # fields from registered_office_address object
       type CompaniesHouseCompanyAddress {
         addressLine1: String
@@ -144,7 +152,7 @@ export const extendGraphqlSchema = (schema: GraphQLSchema) =>
           lastName: String!
           email: String!
           password: String!
-        ): Account
+        ): CreateAccountReaponse
 
         """ verify an account's email address """
         verifyAccountEmailAddress(
@@ -191,6 +199,7 @@ export const extendGraphqlSchema = (schema: GraphQLSchema) =>
         getAccountByEmail(
           email: String!
         ): Account
+
         """ get companies house information """
         getCompaniesHouseInformation(
           companiesHouseNumber: String!

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -1147,7 +1147,7 @@ type Mutation {
   createInitialUser(data: CreateInitialUserInput!): UserAuthenticationWithPasswordSuccess!
 
   """ create an account """
-  createAccount(firstName: String!, lastName: String!, email: String!, password: String!): Account
+  createAccount(firstName: String!, lastName: String!, email: String!, password: String!): CreateAccountReaponse
 
   """ verify an account's email address """
   verifyAccountEmailAddress(token: String!): EmailResponse
@@ -1360,6 +1360,14 @@ input AccountInput {
   lastName: String
   email: String
   password: String
+}
+
+type CreateAccountReaponse {
+  success: Boolean
+  id: String
+  firstName: String
+  lastName: String
+  email: String
 }
 
 type CompaniesHouseCompanyAddress {

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -231,6 +231,7 @@ export const ERROR_MESSAGES = {
           },
           [FIELD_IDS.INSURANCE.ACCOUNT.EMAIL]: {
             INCORRECT_FORMAT: 'Enter your email address in the correct format - for example name@example.com',
+            ACCOUNT_ALREADY_EXISTS: 'There is already an account with this email address. Please sign in or reset your password',
           },
           [FIELD_IDS.INSURANCE.ACCOUNT.PASSWORD]: {
             INCORRECT_FORMAT:

--- a/src/ui/server/controllers/insurance/account/create/your-details/index.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/index.ts
@@ -3,6 +3,7 @@ import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../../constants';
 import { ACCOUNT_FIELDS as FIELDS } from '../../../../../content-strings/fields/insurance/account';
 import insuranceCorePageVariables from '../../../../../helpers/page-variables/core/insurance';
 import generateValidationErrors from './validation';
+import generateAccountAlreadyExistsValidationErrors from './validation/account-already-exists';
 import saveData from './save-data';
 import { Request, Response } from '../../../../../../types';
 
@@ -74,7 +75,7 @@ export const get = (req: Request, res: Response) =>
  * @returns {Express.Response.redirect} Next part of the flow or error page
  */
 export const post = async (req: Request, res: Response) => {
-  const validationErrors = generateValidationErrors(req.body);
+  let validationErrors = generateValidationErrors(req.body);
 
   if (validationErrors) {
     return res.render(TEMPLATE, {
@@ -94,6 +95,22 @@ export const post = async (req: Request, res: Response) => {
 
     if (!saveResponse) {
       return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+    }
+
+    if (!saveResponse.success) {
+      validationErrors = generateAccountAlreadyExistsValidationErrors();
+
+      if (validationErrors) {
+        return res.render(TEMPLATE, {
+          ...insuranceCorePageVariables({
+            PAGE_CONTENT_STRINGS,
+            BACK_LINK: req.headers.referer,
+          }),
+          ...PAGE_VARIABLES,
+          submittedValues: req.body,
+          validationErrors,
+        });
+      }
     }
 
     // store the exporter account ID in local session, for consumption in the next part of the flow.

--- a/src/ui/server/controllers/insurance/account/create/your-details/validation/account-already-exists/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/validation/account-already-exists/index.test.ts
@@ -1,0 +1,28 @@
+import accountAlreadyExistsValidation from '.';
+import INSURANCE_FIELD_IDS from '../../../../../../../constants/field-ids/insurance';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import generateValidationErrors from '../../../../../../../helpers/validation';
+
+const {
+  ACCOUNT: { EMAIL },
+} = INSURANCE_FIELD_IDS;
+
+const {
+  ACCOUNT: {
+    CREATE: {
+      YOUR_DETAILS: {
+        [EMAIL]: { ACCOUNT_ALREADY_EXISTS: ERROR_MESSAGE },
+      },
+    },
+  },
+} = ERROR_MESSAGES.INSURANCE;
+
+describe('controllers/insurance/account/create/your-details/validation/account-already-exists', () => {
+  it('should return the result of generateValidationErrors', () => {
+    const result = accountAlreadyExistsValidation();
+
+    const expected = generateValidationErrors(EMAIL, ERROR_MESSAGE);
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/ui/server/controllers/insurance/account/create/your-details/validation/account-already-exists/index.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/validation/account-already-exists/index.ts
@@ -1,0 +1,27 @@
+import INSURANCE_FIELD_IDS from '../../../../../../../constants/field-ids/insurance';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import generateValidationErrors from '../../../../../../../helpers/validation';
+import { ValidationErrors } from '../../../../../../../../types';
+
+const {
+  ACCOUNT: { EMAIL },
+} = INSURANCE_FIELD_IDS;
+
+const {
+  ACCOUNT: {
+    CREATE: {
+      YOUR_DETAILS: {
+        [EMAIL]: { ACCOUNT_ALREADY_EXISTS: ERROR_MESSAGE },
+      },
+    },
+  },
+} = ERROR_MESSAGES.INSURANCE;
+
+/**
+ * accountAlreadyExistsValidation
+ * Generate an error count, error list and summary for GOV design errors.
+ * @returns {ValidationErrors} Error count, error list and summary
+ */
+const accountAlreadyExistsValidation = (): ValidationErrors => generateValidationErrors(EMAIL, ERROR_MESSAGE);
+
+export default accountAlreadyExistsValidation;

--- a/src/ui/server/graphql/mutations/account/create.ts
+++ b/src/ui/server/graphql/mutations/account/create.ts
@@ -3,6 +3,7 @@ import gql from 'graphql-tag';
 const createExporterMutation = gql`
   mutation CreateAccount($firstName: String!, $lastName: String!, $email: String!, $password: String!) {
     createAccount(firstName: $firstName, lastName: $lastName, email: $email, password: $password) {
+      success
       id
       firstName
       lastName


### PR DESCRIPTION
This PR updates account creation to ensure that an account can only be created if the email is unique and has not been used before.

## Changes

- Update `createAccount` resolver to reject if an account has already been created with the provided email address.
- Render a new validation error in the UI if an account already exists.
- Improve/add test coverage for the `createAccount` resolver.