### PR TITLE
chore(EMS-976): E2E tests - move backLink selector into pages/shared, clickBackLink cypress command

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/resend-confirm-email/resend-confirm-email-go-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/resend-confirm-email/resend-confirm-email-go-back.spec.js
@@ -1,5 +1,4 @@
 import { confirmEmailPage } from '../../../../../pages/insurance/account/create';
-import partials from '../../../../../partials';
 import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
 import api from '../../../../../../support/api';
 
@@ -48,7 +47,7 @@ context('Insurance - Account - Create - Resend confirm email page - Go back to c
 
         cy.url().should('eq', expectedUrl);
 
-        partials.backLink().click();
+        cy.clickBackLink();
       });
     });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/validation/account-sign-in-validation-unverified-account.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/validation/account-sign-in-validation-unverified-account.spec.js
@@ -1,6 +1,5 @@
 import accountFormFields from '../../../../../partials/insurance/accountFormFields';
 import { yourDetailsPage } from '../../../../../pages/insurance/account/create';
-import partials from '../../../../../partials';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -31,7 +30,7 @@ context('Insurance - Account - Sign in - Validation - unverified account', () =>
     cy.submitEligibilityAndStartAccountCreation();
     cy.completeAndSubmitCreateAccountForm();
 
-    partials.backLink().click();
+    cy.clickBackLink();
 
     yourDetailsPage.signInButtonLink().click();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-country-only-apply-offline.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-country-only-apply-offline.spec.js
@@ -1,5 +1,4 @@
-import { buyerCountryPage, submitButton } from '../../../../pages/shared';
-import partials from '../../../../partials';
+import { backLink, buyerCountryPage, submitButton } from '../../../../pages/shared';
 import { ROUTES } from '../../../../../../constants';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility/forms';
 
@@ -30,16 +29,16 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
     const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY}`;
 
-    partials.backLink().should('have.attr', 'href', expected);
+    backLink().should('have.attr', 'href', expected);
   });
 
   describe('when going back to the page', () => {
     it('should NOT have the originally submitted answer selected', () => {
-      partials.backLink().click();
+      cy.clickBackLink();
 
       buyerCountryPage.results().should('have.length', 0);
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-unsupported-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-unsupported-country.spec.js
@@ -1,5 +1,6 @@
-import { buyerCountryPage, cannotApplyPage, submitButton } from '../../../../pages/shared';
-import partials from '../../../../partials';
+import {
+  backLink, buyerCountryPage, cannotApplyPage, submitButton,
+} from '../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility/forms';
@@ -41,16 +42,16 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
     const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY}`;
 
-    partials.backLink().should('have.attr', 'href', expected);
+    backLink().should('have.attr', 'href', expected);
   });
 
   describe('when going back to the page', () => {
     it('should NOT have the originally submitted answer selected', () => {
-      partials.backLink().click();
+      cy.clickBackLink();
 
       buyerCountryPage.results().should('have.length', 0);
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
@@ -1,5 +1,4 @@
-import { buyerCountryPage, submitButton } from '../../../../pages/shared';
-import partials from '../../../../partials';
+import { backLink, buyerCountryPage, submitButton } from '../../../../pages/shared';
 import { ROUTES } from '../../../../../../constants';
 import { PAGES } from '../../../../../../content-strings';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility/forms';
@@ -74,11 +73,11 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
       });
 
       it('renders a back link with correct url', () => {
-        partials.backLink().should('exist');
+        backLink().should('exist');
 
         const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY}`;
 
-        partials.backLink().should('have.attr', 'href', expected);
+        backLink().should('have.attr', 'href', expected);
       });
 
       it('should focus on input when clicking summary error message', () => {
@@ -102,7 +101,7 @@ context('Insurance - Buyer location page - as an exporter, I want to check if UK
 
       describe('when going back to the page', () => {
         it('should have the originally submitted answer selected', () => {
-          partials.backLink().click();
+          cy.clickBackLink();
 
           const expectedValue = 'Algeria';
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
@@ -1,7 +1,6 @@
 import {
-  cannotApplyPage, noRadio, noRadioInput, submitButton,
+  backLink, cannotApplyPage, noRadio, noRadioInput, submitButton,
 } from '../../../../pages/shared';
-import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
@@ -48,11 +47,11 @@ context('Insurance - Eligibility - Companies house number page - I want to check
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
     const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`;
 
-    partials.backLink().should('have.attr', 'href', expectedUrl);
+    backLink().should('have.attr', 'href', expectedUrl);
   });
 
   it('renders a specific reason', () => {
@@ -62,7 +61,7 @@ context('Insurance - Eligibility - Companies house number page - I want to check
 
   describe('when going back to the page', () => {
     it('should NOT have the originally submitted answer selected', () => {
-      partials.backLink().click();
+      cy.clickBackLink();
 
       noRadioInput().should('not.be.checked');
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
@@ -107,7 +107,7 @@ context('Insurance - Eligibility - Companies house number page - I want to check
 
       describe('when going back to the page', () => {
         it('should have the originally submitted answer selected', () => {
-          partials.backLink().click();
+          cy.clickBackLink();
 
           yesRadioInput().should('be.checked');
         });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location-answer-no.spec.js
@@ -1,7 +1,6 @@
 import {
-  cannotApplyPage, noRadio, noRadioInput, submitButton,
+  backLink, cannotApplyPage, noRadio, noRadioInput, submitButton,
 } from '../../../../pages/shared';
-import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
@@ -33,11 +32,11 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
     const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION}`;
 
-    partials.backLink().should('have.attr', 'href', expectedUrl);
+    backLink().should('have.attr', 'href', expectedUrl);
   });
 
   it('renders a specific reason', () => {
@@ -47,7 +46,7 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
 
   describe('when going back to the page', () => {
     it('should NOT have the originally submitted answer selected', () => {
-      partials.backLink().click();
+      cy.clickBackLink();
 
       noRadioInput().should('not.be.checked');
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
@@ -79,7 +79,7 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
 
       describe('when going back to the page', () => {
         it('should have the originally submitted answer selected', () => {
-          partials.backLink().click();
+          cy.clickBackLink();
 
           yesRadioInput().should('be.checked');
         });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount-answer-yes.spec.js
@@ -1,7 +1,6 @@
 import {
-  cannotApplyPage, yesRadio, yesRadioInput, submitButton,
+  backLink, cannotApplyPage, yesRadio, yesRadioInput, submitButton,
 } from '../../../../pages/shared';
-import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
@@ -38,11 +37,11 @@ context('Insurance - Insured amount page - I want to check if I can use online s
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
     const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT}`;
 
-    partials.backLink().should('have.attr', 'href', expectedUrl);
+    backLink().should('have.attr', 'href', expectedUrl);
   });
 
   it('renders a specific reason', () => {
@@ -52,7 +51,7 @@ context('Insurance - Insured amount page - I want to check if I can use online s
 
   describe('when going back to the page', () => {
     it('should NOT have the originally submitted answer selected', () => {
-      partials.backLink().click();
+      cy.clickBackLink();
 
       yesRadioInput().should('not.be.checked');
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
@@ -97,7 +97,7 @@ context('Insurance - Insured amount page - I want to check if I can use online s
 
       describe('when going back to the page', () => {
         it('should have the originally submitted answer selected', () => {
-          partials.backLink().click();
+          cy.clickBackLink();
 
           noRadioInput().should('be.checked');
         });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit-answer-yes.spec.js
@@ -1,7 +1,6 @@
 import {
-  cannotApplyPage, yesRadio, yesRadioInput, submitButton,
+  backLink, cannotApplyPage, yesRadio, yesRadioInput, submitButton,
 } from '../../../../pages/shared';
-import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
@@ -44,11 +43,11 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
     const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`;
 
-    partials.backLink().should('have.attr', 'href', expectedUrl);
+    backLink().should('have.attr', 'href', expectedUrl);
   });
 
   it('renders a specific reason', () => {
@@ -58,7 +57,7 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
 
   describe('when going back to the page', () => {
     it('should NOT have the originally submitted answer selected', () => {
-      partials.backLink().click();
+      cy.clickBackLink();
 
       yesRadioInput().should('not.be.checked');
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
@@ -103,7 +103,7 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
 
       describe('when going back to the page', () => {
         it('should have the originally submitted answer selected', () => {
-          partials.backLink().click();
+          cy.clickBackLink();
 
           noRadioInput().should('be.checked');
         });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties-answer-yes.spec.js
@@ -1,7 +1,6 @@
 import {
-  cannotApplyPage, yesRadio, yesRadioInput, submitButton,
+  backLink, cannotApplyPage, yesRadio, yesRadioInput, submitButton,
 } from '../../../../pages/shared';
-import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
@@ -42,11 +41,11 @@ context('Insurance - Insured amount page - I want to check if I can use online s
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
     const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED}`;
 
-    partials.backLink().should('have.attr', 'href', expectedUrl);
+    backLink().should('have.attr', 'href', expectedUrl);
   });
 
   it('renders a specific reason', () => {
@@ -56,7 +55,7 @@ context('Insurance - Insured amount page - I want to check if I can use online s
 
   describe('when going back to the page', () => {
     it('should NOT have the originally submitted answer selected', () => {
-      partials.backLink().click();
+      cy.clickBackLink();
 
       yesRadioInput().should('not.be.checked');
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
@@ -130,7 +130,7 @@ context('Insurance - Other parties page - I want to check if I can use online se
 
       describe('when going back to the page', () => {
         it('should have the originally submitted answer selected', () => {
-          partials.backLink().click();
+          cy.clickBackLink();
 
           noRadioInput().should('be.checked');
         });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period-answer-yes.spec.js
@@ -1,7 +1,6 @@
 import {
-  cannotApplyPage, yesRadio, yesRadioInput, submitButton,
+  backLink, cannotApplyPage, yesRadio, yesRadioInput, submitButton,
 } from '../../../../pages/shared';
-import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
@@ -46,11 +45,11 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
     const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD}`;
 
-    partials.backLink().should('have.attr', 'href', expectedUrl);
+    backLink().should('have.attr', 'href', expectedUrl);
   });
 
   it('renders a specific reason', () => {
@@ -60,7 +59,7 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
 
   describe('when going back to the page', () => {
     it('should NOT have the originally submitted answer selected', () => {
-      partials.backLink().click();
+      cy.clickBackLink();
 
       yesRadioInput().should('not.be.checked');
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -155,7 +155,7 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
 
       describe('when going back to the page', () => {
         it('should have the originally submitted answer selected', () => {
-          partials.backLink().click();
+          cy.clickBackLink();
 
           noRadioInput().should('be.checked');
         });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
@@ -1,7 +1,6 @@
 import {
-  cannotApplyPage, noRadio, noRadioInput, submitButton,
+  backLink, cannotApplyPage, noRadio, noRadioInput, submitButton,
 } from '../../../../pages/shared';
-import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeStartForm, completeCheckIfEligibleForm, completeExporterLocationForm } from '../../../../../support/insurance/eligibility/forms';
@@ -34,11 +33,11 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
     const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES}`;
 
-    partials.backLink().should('have.attr', 'href', expectedUrl);
+    backLink().should('have.attr', 'href', expectedUrl);
   });
 
   it('renders a specific reason', () => {
@@ -48,7 +47,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
 
   describe('when going back to the page', () => {
     it('should NOT have the originally submitted answer selected', () => {
-      partials.backLink().click();
+      cy.clickBackLink();
 
       noRadioInput().should('not.be.checked');
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -139,7 +139,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
 
       describe('when going back to the page', () => {
         it('should have the originally submitted answer selected', () => {
-          partials.backLink().click();
+          cy.clickBackLink();
 
           yesRadioInput().should('be.checked');
         });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/about-goods-or-services.spec.js
@@ -155,7 +155,7 @@ context('Insurance - Policy and exports - About goods or services page - As an e
       });
 
       it('should retain the submitted value when going back to the page', () => {
-        partials.backLink().click();
+        cy.clickBackLink();
 
         descriptionField.input().should('have.value', submittedValue);
       });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/about-goods-or-services/save-and-back.spec.js
@@ -113,7 +113,7 @@ context('Insurance - Policy and exports - About goods or services page - Save an
       saveAndBackButton().click();
 
       // go back to the page
-      partials.backLink().click();
+      cy.clickBackLink();
 
       field.input().clear();
       saveAndBackButton().click();

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/change-your-answers/change-your-answers-change-policy-type-single-to-multiple.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/change-your-answers/change-your-answers-change-policy-type-single-to-multiple.spec.js
@@ -123,17 +123,17 @@ context('Insurance - Policy and exports - Change your answers - Policy type - si
         summaryList[TOTAL_MONTHS_OF_COVER].changeLink().click();
         cy.assertChangeAnswersPageUrl(referenceNumber, MULTIPLE_CONTRACT_POLICY_CHANGE, TOTAL_MONTHS_OF_COVER, 'label');
 
-        partials.backLink().click();
+        cy.clickBackLink();
 
         summaryList[TOTAL_SALES_TO_BUYER].changeLink().click();
         cy.assertChangeAnswersPageUrl(referenceNumber, MULTIPLE_CONTRACT_POLICY_CHANGE, TOTAL_SALES_TO_BUYER, 'label');
 
-        partials.backLink().click();
+        cy.clickBackLink();
 
         summaryList[MAXIMUM_BUYER_WILL_OWE].changeLink().click();
         cy.assertChangeAnswersPageUrl(referenceNumber, MULTIPLE_CONTRACT_POLICY_CHANGE, MAXIMUM_BUYER_WILL_OWE, 'label');
 
-        partials.backLink().click();
+        cy.clickBackLink();
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -236,7 +236,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
       });
 
       it('should retain the submitted value when going back to the page', () => {
-        partials.backLink().click();
+        cy.clickBackLink();
 
         creditPeriodField.input().should('have.value', submittedValue);
       });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/save-and-back.spec.js
@@ -145,7 +145,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - Save a
       saveAndBackButton().click();
 
       // go back to the page
-      partials.backLink().click();
+      cy.clickBackLink();
 
       field.input().clear();
       saveAndBackButton().click();

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-maximum-buyer-will-owe.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-maximum-buyer-will-owe.spec.js
@@ -175,7 +175,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
   describe('when maximum buyer will owe is valid and contains a comma', () => {
     it('should redirect to the next page as all fields are valid', () => {
       cy.completeAndSubmitMultipleContractPolicyForm();
-      partials.backLink().click();
+      cy.clickBackLink();
 
       cy.keyboardInput(multipleContractPolicyPage[MAXIMUM_BUYER_WILL_OWE].input(), '1,234');
       submitButton().click();

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-total-sales-to-buyer.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation-total-sales-to-buyer.spec.js
@@ -151,7 +151,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
   describe('when total sales to buyer is valid and contains a comma', () => {
     it('should redirect to the next page as all fields are valid', () => {
       cy.completeAndSubmitMultipleContractPolicyForm();
-      partials.backLink().click();
+      cy.clickBackLink();
 
       cy.keyboardInput(multipleContractPolicyPage[TOTAL_SALES_TO_BUYER].input(), '1,234');
       submitButton().click();

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/save-and-back.spec.js
@@ -163,7 +163,7 @@ context('Insurance - Policy and exports - Single contract policy page - Save and
       saveAndBackButton().click();
 
       // go back to the page
-      partials.backLink().click();
+      cy.clickBackLink();
 
       field.input().clear();
       saveAndBackButton().click();

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
@@ -220,7 +220,7 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
       });
 
       it('should retain the submitted value when going back to the page', () => {
-        partials.backLink().click();
+        cy.clickBackLink();
 
         creditPeriodField.input().should('have.value', submittedValue);
       });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-total-contract-value.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-total-contract-value.spec.js
@@ -185,7 +185,7 @@ context('Insurance - Policy and exports - Single contract policy page - form val
   describe('when total contract value is valid and contains a comma', () => {
     it('should redirect to the next page as all fields are valid', () => {
       cy.completeAndSubmitSingleContractPolicyForm();
-      partials.backLink().click();
+      cy.clickBackLink();
 
       cy.keyboardInput(field.input(), '1,234');
       submitButton().click();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-continue-no-errors.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-continue-no-errors.spec.js
@@ -74,11 +74,11 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
   describe('when resubmitting company number on company details page', () => {
     before(() => {
       // navigate back to company details page from nature of business
-      partials.backLink().click();
+      cy.clickBackLink();
       // resubmit form
       submitButton().click();
       // return to company details page after redirect to nature of business
-      partials.backLink().click();
+      cy.clickBackLink();
     });
 
     it('should remove old sic codes from company summary list', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-no-companies-house-link.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-no-companies-house-link.spec.js
@@ -1,6 +1,5 @@
 import { companyDetails } from '../../../../pages/your-business';
 import { insurance } from '../../../../pages';
-import partials from '../../../../partials';
 import {
   cannotApplyPage,
 } from '../../../../pages/shared';
@@ -61,7 +60,7 @@ context('Insurance - Your business - Company details page - As an Exporter it sh
   });
 
   it('should take you back to company-details page when pressing the back button', () => {
-    partials.backLink().click();
+    cy.clickBackLink();
 
     cy.url().should('eq', `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${COMPANY_DETAILS}`);
   });

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body-answer-yes.spec.js
@@ -1,6 +1,7 @@
-import { yesRadio, yesRadioInput, submitButton } from '../../../pages/shared';
+import {
+  backLink, yesRadio, yesRadioInput, submitButton,
+} from '../../../pages/shared';
 import { getAQuoteByEmailPage } from '../../../pages/quote';
-import partials from '../../../partials';
 import { PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
@@ -26,9 +27,9 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
-    partials.backLink().should('have.attr', 'href', ROUTES.QUOTE.BUYER_BODY);
+    backLink().should('have.attr', 'href', ROUTES.QUOTE.BUYER_BODY);
   });
 
   it('renders a specific reason and description', () => {
@@ -41,7 +42,7 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
 
   describe('navigating back to the buyer body page', () => {
     it('auto checks the previously submitted answer', () => {
-      partials.backLink().click();
+      cy.clickBackLink();
 
       yesRadioInput().should('be.checked');
     });

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country-country-only-get-a-quote-by-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country-country-only-get-a-quote-by-email.spec.js
@@ -1,5 +1,4 @@
-import { buyerCountryPage, submitButton } from '../../../pages/shared';
-import partials from '../../../partials';
+import { backLink, buyerCountryPage, submitButton } from '../../../pages/shared';
 import { ROUTES } from '../../../../../constants';
 
 const COUNTRY_NAME_QUOTE_BY_EMAIL_ONLY = 'Egypt';
@@ -22,10 +21,10 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
     const expected = ROUTES.QUOTE.BUYER_COUNTRY;
 
-    partials.backLink().should('have.attr', 'href', expected);
+    backLink().should('have.attr', 'href', expected);
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country-unsupported-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country-unsupported-country.spec.js
@@ -1,5 +1,6 @@
-import { buyerCountryPage, cannotApplyPage, submitButton } from '../../../pages/shared';
-import partials from '../../../partials';
+import {
+  backLink, buyerCountryPage, cannotApplyPage, submitButton,
+} from '../../../pages/shared';
 import { PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 
@@ -25,9 +26,9 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
-    partials.backLink().should('have.attr', 'href', ROUTES.QUOTE.BUYER_COUNTRY);
+    backLink().should('have.attr', 'href', ROUTES.QUOTE.BUYER_COUNTRY);
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
@@ -1,5 +1,4 @@
-import { buyerCountryPage, submitButton } from '../../../pages/shared';
-import partials from '../../../partials';
+import { backLink, buyerCountryPage, submitButton } from '../../../pages/shared';
 import { LINKS, PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import {
@@ -70,11 +69,11 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
       });
 
       it('renders a back link with correct url', () => {
-        partials.backLink().should('exist');
+        backLink().should('exist');
 
         const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.BUYER_COUNTRY}`;
 
-        partials.backLink().should('have.attr', 'href', expected);
+        backLink().should('have.attr', 'href', expected);
       });
 
       it('should focus on input when clicking summary error message', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-policy-type-multiple-times-via-back-button.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-policy-type-multiple-times-via-back-button.spec.js
@@ -3,7 +3,6 @@ import {
   policyTypePage,
   tellUsAboutYourPolicyPage,
 } from '../../../pages/quote';
-import partials from '../../../partials';
 import { FIELD_IDS, ROUTES } from '../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
 import {
@@ -38,7 +37,7 @@ context('Change your answers (policy type) - multiple times via back button - as
   });
 
   it(`clicking the back button redirects to ${ROUTES.QUOTE.POLICY_TYPE}`, () => {
-    partials.backLink().click();
+    cy.clickBackLink();
     cy.url().should('include', ROUTES.QUOTE.POLICY_TYPE);
   });
 
@@ -59,7 +58,7 @@ context('Change your answers (policy type) - multiple times via back button - as
 
   context('change for a second time - policy type from multiple to single', () => {
     before(() => {
-      partials.backLink().click();
+      cy.clickBackLink();
       cy.url().should('include', ROUTES.QUOTE.POLICY_TYPE);
 
       policyTypePage[POLICY_TYPE].single.input().click();
@@ -80,7 +79,7 @@ context('Change your answers (policy type) - multiple times via back button - as
 
   context('change for a third time - policy type from single to multi', () => {
     before(() => {
-      partials.backLink().click();
+      cy.clickBackLink();
       cy.url().should('include', ROUTES.QUOTE.POLICY_TYPE);
 
       policyTypePage[POLICY_TYPE].multiple.input().click();

--- a/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-export-fields.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-export-fields.spec.js
@@ -1,4 +1,6 @@
-import { buyerCountryPage, yesRadioInput, submitButton } from '../../../pages/shared';
+import {
+  backLink, buyerCountryPage, yesRadioInput, submitButton,
+} from '../../../pages/shared';
 import { checkYourAnswersPage } from '../../../pages/quote';
 import partials from '../../../partials';
 import { FIELD_IDS, ROUTES } from '../../../../../constants';
@@ -39,10 +41,10 @@ context('Change your answers (export fields) - as an exporter, I want to change 
     });
 
     it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
+      backLink().should('exist');
 
       const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
-      partials.backLink().should('have.attr', 'href', expected);
+      backLink().should('have.attr', 'href', expected);
     });
 
     it('has originally submitted answer selected', () => {
@@ -93,10 +95,10 @@ context('Change your answers (export fields) - as an exporter, I want to change 
     });
 
     it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
+      backLink().should('exist');
 
       const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
-      partials.backLink().should('have.attr', 'href', expected);
+      backLink().should('have.attr', 'href', expected);
     });
 
     it('has originally submitted answer selected', () => {
@@ -126,10 +128,10 @@ context('Change your answers (export fields) - as an exporter, I want to change 
     });
 
     it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
+      backLink().should('exist');
 
       const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
-      partials.backLink().should('have.attr', 'href', expected);
+      backLink().should('have.attr', 'href', expected);
     });
 
     it('has originally submitted answer', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-policy-fields-multi-policy-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-policy-fields-multi-policy-credit-period.spec.js
@@ -1,9 +1,8 @@
-import { submitButton } from '../../../pages/shared';
+import { backLink, submitButton } from '../../../pages/shared';
 import {
   tellUsAboutYourPolicyPage,
   checkYourAnswersPage,
 } from '../../../pages/quote';
-import partials from '../../../partials';
 import { FIELD_IDS, ROUTES } from '../../../../../constants';
 
 const { CREDIT_PERIOD } = FIELD_IDS;
@@ -36,10 +35,10 @@ context('Change your answers (policy fields) - as an exporter, I want to change 
     });
 
     it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
+      backLink().should('exist');
 
       const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
-      partials.backLink().should('have.attr', 'href', expected);
+      backLink().should('have.attr', 'href', expected);
     });
 
     it('has originally submitted answer', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-policy-type-and-length.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-policy-type-and-length.spec.js
@@ -1,10 +1,9 @@
-import { submitButton } from '../../../pages/shared';
+import { backLink, submitButton } from '../../../pages/shared';
 import {
   policyTypePage,
   checkYourAnswersPage,
   tellUsAboutYourPolicyPage,
 } from '../../../pages/quote';
-import partials from '../../../partials';
 import { FIELD_IDS, FIELD_VALUES, ROUTES } from '../../../../../constants';
 
 const {
@@ -52,10 +51,10 @@ context('Change your answers (policy type and length fields) - as an exporter, I
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
     const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
-    partials.backLink().should('have.attr', 'href', expected);
+    backLink().should('have.attr', 'href', expected);
   });
 
   it('has originally submitted `policy type` (single)', () => {
@@ -111,10 +110,10 @@ context('Change your answers (policy type and length fields) - as an exporter, I
     });
 
     it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
+      backLink().should('exist');
 
       const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
-      partials.backLink().should('have.attr', 'href', expected);
+      backLink().should('have.attr', 'href', expected);
     });
 
     it('has previously submitted `policy type` (multi)', () => {
@@ -204,10 +203,10 @@ context('Change your answers (policy type and length fields) - as an exporter, I
     });
 
     it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
+      backLink().should('exist');
 
       const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
-      partials.backLink().should('have.attr', 'href', expected);
+      backLink().should('have.attr', 'href', expected);
     });
 
     it(`redirects to ${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY} when submitting new answers`, () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location-answer-no.spec.js
@@ -1,5 +1,6 @@
-import { cannotApplyPage, noRadio, submitButton } from '../../../pages/shared';
-import partials from '../../../partials';
+import {
+  backLink, cannotApplyPage, noRadio, submitButton,
+} from '../../../pages/shared';
 import { PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
@@ -24,9 +25,9 @@ context('Exporter location page - as an exporter, I want to check if my company 
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
-    partials.backLink().should('have.attr', 'href', ROUTES.QUOTE.EXPORTER_LOCATION);
+    backLink().should('have.attr', 'href', ROUTES.QUOTE.EXPORTER_LOCATION);
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
@@ -1,5 +1,6 @@
-import { cannotApplyPage, noRadio, submitButton } from '../../../pages/shared';
-import partials from '../../../partials';
+import {
+  backLink, cannotApplyPage, noRadio, submitButton,
+} from '../../../pages/shared';
 import { PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
@@ -25,9 +26,9 @@ context('UK goods or services page - as an exporter, I want to check if my expor
   });
 
   it('renders a back link with correct url', () => {
-    partials.backLink().should('exist');
+    backLink().should('exist');
 
-    partials.backLink().should('have.attr', 'href', ROUTES.QUOTE.UK_GOODS_OR_SERVICES);
+    backLink().should('have.attr', 'href', ROUTES.QUOTE.UK_GOODS_OR_SERVICES);
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-change-answers-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-change-answers-multi-policy.spec.js
@@ -1,6 +1,5 @@
-import { buyerCountryPage, submitButton } from '../../../pages/shared';
+import { backLink, buyerCountryPage, submitButton } from '../../../pages/shared';
 import { tellUsAboutYourPolicyPage, yourQuotePage } from '../../../pages/quote';
-import partials from '../../../partials';
 import { FIELD_IDS, ROUTES } from '../../../../../constants';
 
 const {
@@ -40,10 +39,10 @@ context('Your quote page - change answers (policy type and length from multiple 
     });
 
     it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
+      backLink().should('exist');
 
       const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
-      partials.backLink().should('have.attr', 'href', expected);
+      backLink().should('have.attr', 'href', expected);
     });
 
     it(`redirects to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS} when submitting a new answer`, () => {
@@ -79,10 +78,10 @@ context('Your quote page - change answers (policy type and length from multiple 
     });
 
     it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
+      backLink().should('exist');
 
       const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
-      partials.backLink().should('have.attr', 'href', expected);
+      backLink().should('have.attr', 'href', expected);
     });
 
     it(`redirects to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS} when submitting a new answer`, () => {
@@ -118,10 +117,10 @@ context('Your quote page - change answers (policy type and length from multiple 
     });
 
     it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
+      backLink().should('exist');
 
       const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
-      partials.backLink().should('have.attr', 'href', expected);
+      backLink().should('have.attr', 'href', expected);
     });
 
     it(`redirects to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS} when submitting a new answer`, () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-change-answers-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-change-answers-single-policy.spec.js
@@ -1,10 +1,9 @@
-import { buyerCountryPage, submitButton } from '../../../pages/shared';
+import { backLink, buyerCountryPage, submitButton } from '../../../pages/shared';
 import {
   policyTypePage,
   tellUsAboutYourPolicyPage,
   yourQuotePage,
 } from '../../../pages/quote';
-import partials from '../../../partials';
 import { ROUTES, FIELD_IDS, FIELD_VALUES } from '../../../../../constants';
 
 const {
@@ -49,10 +48,10 @@ context('Your quote page - change answers (single policy type to multiple policy
     });
 
     it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
+      backLink().should('exist');
 
       const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
-      partials.backLink().should('have.attr', 'href', expected);
+      backLink().should('have.attr', 'href', expected);
     });
 
     it(`redirects to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS} when submitting a new answer`, () => {
@@ -88,10 +87,10 @@ context('Your quote page - change answers (single policy type to multiple policy
     });
 
     it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
+      backLink().should('exist');
 
       const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
-      partials.backLink().should('have.attr', 'href', expected);
+      backLink().should('have.attr', 'href', expected);
     });
 
     it(`redirects to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS} when submitting a new answer`, () => {
@@ -127,10 +126,10 @@ context('Your quote page - change answers (single policy type to multiple policy
     });
 
     it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
+      backLink().should('exist');
 
       const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
-      partials.backLink().should('have.attr', 'href', expected);
+      backLink().should('have.attr', 'href', expected);
     });
 
     it(`redirects to ${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY} when submitting a new answer`, () => {
@@ -175,10 +174,10 @@ context('Your quote page - change answers (single policy type to multiple policy
     });
 
     it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
+      backLink().should('exist');
 
       const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
-      partials.backLink().should('have.attr', 'href', expected);
+      backLink().should('have.attr', 'href', expected);
     });
 
     it(`redirects to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS} when submitting a new answer`, () => {
@@ -216,10 +215,10 @@ context('Your quote page - change answers (single policy type to multiple policy
     });
 
     it('renders a back link with correct url', () => {
-      partials.backLink().should('exist');
+      backLink().should('exist');
 
       const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
-      partials.backLink().should('have.attr', 'href', expected);
+      backLink().should('have.attr', 'href', expected);
     });
 
     it(`redirects to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS} when submitting a new answer`, () => {

--- a/e2e-tests/cypress/e2e/pages/shared/index.js
+++ b/e2e-tests/cypress/e2e/pages/shared/index.js
@@ -4,6 +4,7 @@ import exporterLocationPage from './exporterLocation';
 import needToStartAgainPage from './needToStartAgain';
 import ukGoodsOrServicesPage from './ukGoodsOrServices';
 
+const backLink = () => cy.get('[data-cy="back-link"]');
 const heading = () => cy.get('[data-cy="heading"]');
 const headingCaption = () => cy.get('[data-cy="heading-caption"]');
 const yesNoRadioHint = () => cy.get('[data-cy="yes-no-input-hint"]');
@@ -17,6 +18,7 @@ const saveAndBackButton = () => cy.get('[data-cy="save-and-back-button"]');
 const tempCreateAccountButton = () => cy.get('[data-cy="temp-create-an-account-button"]');
 
 export {
+  backLink,
   heading,
   headingCaption,
   yesNoRadioHint,

--- a/e2e-tests/cypress/e2e/partials/index.js
+++ b/e2e-tests/cypress/e2e/partials/index.js
@@ -8,7 +8,6 @@ import ukGoodsOrServicesDescription from './ukGoodsAndServicesDescription';
 import yourBusinessSummaryList from './yourBusinessSummaryList';
 
 const partials = {
-  backLink: () => cy.get('[data-cy="back-link"]'),
   ukGoodsOrServicesCalculateDescription,
   cookieBanner,
   errorSummaryListItems: () => cy.get('.govuk-error-summary li'),

--- a/e2e-tests/cypress/support/click-back-link.js
+++ b/e2e-tests/cypress/support/click-back-link.js
@@ -1,0 +1,7 @@
+import { backLink } from '../e2e/pages/shared';
+
+const clickBackLink = () => {
+  backLink().click();
+};
+
+export default clickBackLink;

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -13,6 +13,7 @@ import analytics from './analytics';
 Cypress.Commands.add('login', require('./login'));
 Cypress.Commands.add('checkPhaseBanner', require('./check-phase-banner'));
 Cypress.Commands.add('navigateToUrl', require('./navigate-to-url'));
+Cypress.Commands.add('clickBackLink', require('./click-back-link'));
 
 Cypress.Commands.add('submitQuoteAnswersHappyPathSinglePolicy', require('./quote/submit-answers-happy-path-single-policy'));
 Cypress.Commands.add('submitQuoteAnswersHappyPathMultiplePolicy', require('./quote/submit-answers-happy-path-multiple-policy'));

--- a/e2e-tests/cypress/support/core-page-checks.js
+++ b/e2e-tests/cypress/support/core-page-checks.js
@@ -1,6 +1,5 @@
 import { BUTTONS, LINKS, ORGANISATION } from '../../content-strings';
-import partials from '../e2e/partials';
-import { heading, submitButton } from '../e2e/pages/shared';
+import { backLink as backLinkSelector, heading, submitButton } from '../e2e/pages/shared';
 
 const lighthouseAudit = (lightHouseThresholds = {}) => {
   cy.lighthouse({
@@ -20,10 +19,10 @@ const lighthouseAudit = (lightHouseThresholds = {}) => {
  * @param {String} expectedHref - Expected "back" HREF/route
  */
 const checkBackLink = (currentHref, expectedHref) => {
-  partials.backLink().should('exist');
-  cy.checkText(partials.backLink(), LINKS.BACK);
+  backLinkSelector().should('exist');
+  cy.checkText(backLinkSelector(), LINKS.BACK);
 
-  partials.backLink().click();
+  cy.clickBackLink();
 
   let expectedUrl = `${Cypress.config('baseUrl')}${expectedHref}`;
 


### PR DESCRIPTION
This PR simplifies our tests where the back link is involved.

- Move the back link selector into pages/shared, removing the need to import an additional file.
- Add a new cypress command `clickBackLink` so we can just call `cy.clickBackLink` instead of having to import the selector.