### PR TITLE
feat(EMS-1164) Declarations - Confidentiality - data saving, save and go back

### DIFF
--- a/database/exip.sql
+++ b/database/exip.sql
@@ -47,12 +47,14 @@ CREATE TABLE `Application` (
   KEY `Application_eligibility_idx` (`eligibility`),
   KEY `Application_referenceNumber_idx` (`referenceNumber`),
   KEY `Application_policyAndExport_idx` (`policyAndExport`),
+	KEY `Application_exporter_idx` (`exporter`),
   KEY `Application_exporterCompany_idx` (`exporterCompany`),
   KEY `Application_exporterBusiness_idx` (`exporterBusiness`),
   KEY `Application_exporterBroker_idx` (`exporterBroker`),
 	KEY `Application_buyer_idx` (`buyer`),
-	KEY `Application_exporter_idx` (`exporter`),
+	KEY `Application_declaration_idx` (`declaration`),
 	CONSTRAINT `Application_buyer_fkey` FOREIGN KEY (`buyer`) REFERENCES `Buyer` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+	CONSTRAINT `Application_declaration_fkey` FOREIGN KEY (`declaration`) REFERENCES `Declaration` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `Application_eligibility_fkey` FOREIGN KEY (`eligibility`) REFERENCES `Eligibility` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
 	CONSTRAINT `Application_exporter_fkey` FOREIGN KEY (`exporter`) REFERENCES `Exporter` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `Application_exporterBroker_fkey` FOREIGN KEY (`exporterBroker`) REFERENCES `ExporterBroker` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
@@ -341,6 +343,26 @@ VALUES
 /*!40000 ALTER TABLE `Country` ENABLE KEYS */;
 UNLOCK TABLES;
 
+
+# Dump of table Declaration
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `Declaration`;
+
+CREATE TABLE `Declaration` (
+  `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `application` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `confidentiality` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `agreeToConfidentiality` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  KEY `Declaration_application_idx` (`application`),
+  KEY `Declaration_confidentiality_idx` (`confidentiality`),
+  CONSTRAINT `Declaration_application_fkey` FOREIGN KEY (`application`) REFERENCES `Application` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `Declaration_confidentiality_fkey` FOREIGN KEY (`confidentiality`) REFERENCES `DeclarationConfidentiality` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+/*!40000 ALTER TABLE `Declaration` ENABLE KEYS */;
+UNLOCK TABLES;
 
 
 # Dump of table DeclarationConfidentiality

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/confidentiality/confidentiality.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/confidentiality/confidentiality.spec.js
@@ -28,7 +28,7 @@ const {
 
 const FIELD_ID = FIELD_IDS.INSURANCE.DECLARATIONS.AGREE_CONFIDENTIALITY;
 
-context('Insurance - Declarations - Confidentiality page - As an Exporter, I want to make confidentiality declaration for my export insurance application, So that UKEF can be assured of my agreement with regards to confidentiality while processing my export insurance application.', () => {
+context('Insurance - Declarations - Confidentiality page - As an Exporter, I want to make confidentiality declaration for my export insurance application, So that UKEF can be assured of my agreement with regards to confidentiality while processing my export insurance application', () => {
   let referenceNumber;
   let url;
 
@@ -163,17 +163,36 @@ context('Insurance - Declarations - Confidentiality page - As an Exporter, I wan
       });
     });
 
-    it(`should redirect to ${ANTI_BRIBERY}`, () => {
-      cy.navigateToUrl(url);
+    describe('when submitting a fully completed form', () => {
+      it(`should redirect to ${ANTI_BRIBERY}`, () => {
+        cy.navigateToUrl(url);
 
-      const field = confidentialityPage[FIELD_ID];
+        const field = confidentialityPage[FIELD_ID];
 
-      field.input().click();
+        field.input().click();
 
-      submitButton().click();
+        submitButton().click();
 
-      const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ANTI_BRIBERY}`;
-      cy.url().should('eq', expectedUrl);
+        const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ANTI_BRIBERY}`;
+
+        cy.url().should('eq', expectedUrl);
+      });
+
+      describe('when going back to the page', () => {
+        it('should have the submitted value', () => {
+          cy.navigateToUrl(url);
+
+          const field = confidentialityPage[FIELD_ID];
+
+          field.input().click();
+
+          submitButton().click();
+
+          cy.navigateToUrl(url);
+
+          field.input().should('be.checked');
+        });
+      });
     });
   });
 });

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -239,7 +239,8 @@ var lists = {
       exporterBusiness: (0, import_fields.relationship)({ ref: "ExporterBusiness" }),
       exporterCompany: (0, import_fields.relationship)({ ref: "ExporterCompany" }),
       exporterBroker: (0, import_fields.relationship)({ ref: "ExporterBroker" }),
-      buyer: (0, import_fields.relationship)({ ref: "Buyer" })
+      buyer: (0, import_fields.relationship)({ ref: "Buyer" }),
+      declaration: (0, import_fields.relationship)({ ref: "Declaration" })
     },
     hooks: {
       resolveInput: async ({ operation, resolvedData, context }) => {
@@ -308,6 +309,14 @@ var lists = {
                 id: buyerId
               }
             };
+            const { id: declarationId } = await context.db.Declaration.createOne({
+              data: {}
+            });
+            modifiedData.declaration = {
+              connect: {
+                id: declarationId
+              }
+            };
             const now = /* @__PURE__ */ new Date();
             modifiedData.createdAt = now;
             modifiedData.updatedAt = now;
@@ -326,7 +335,7 @@ var lists = {
           try {
             console.info("Adding application ID to relationships");
             const applicationId = item.id;
-            const { referenceNumber, eligibilityId, policyAndExportId, exporterCompanyId, exporterBusinessId, exporterBrokerId, buyerId } = item;
+            const { referenceNumber, eligibilityId, policyAndExportId, exporterCompanyId, exporterBusinessId, exporterBrokerId, buyerId, declarationId } = item;
             await context.db.ReferenceNumber.updateOne({
               where: { id: String(referenceNumber) },
               data: {
@@ -389,6 +398,16 @@ var lists = {
             });
             await context.db.Buyer.updateOne({
               where: { id: buyerId },
+              data: {
+                application: {
+                  connect: {
+                    id: applicationId
+                  }
+                }
+              }
+            });
+            await context.db.Declaration.updateOne({
+              where: { id: declarationId },
               data: {
                 application: {
                   connect: {
@@ -634,6 +653,14 @@ var lists = {
       needPreCreditPeriodCover: (0, import_fields.checkbox)(),
       wantCoverOverMaxAmount: (0, import_fields.checkbox)(),
       wantCoverOverMaxPeriod: (0, import_fields.checkbox)()
+    },
+    access: import_access.allowAll
+  }),
+  Declaration: (0, import_core.list)({
+    fields: {
+      application: (0, import_fields.relationship)({ ref: "Application" }),
+      confidentiality: (0, import_fields.relationship)({ ref: "DeclarationConfidentiality" }),
+      agreeToConfidentiality: (0, import_fields.checkbox)({ defaultValue: false })
     },
     access: import_access.allowAll
   }),

--- a/src/api/keystone.test.ts
+++ b/src/api/keystone.test.ts
@@ -22,7 +22,7 @@ describe('Create an Application', () => {
     application = (await context.query.Application.createOne({
       data: {},
       query:
-        'id createdAt updatedAt referenceNumber submissionDeadline submissionType eligibility { id } policyAndExport { id } exporter { id } exporterCompany { id } exporterBusiness { id } exporterBroker { id } buyer { id }',
+        'id createdAt updatedAt referenceNumber submissionDeadline submissionType eligibility { id } policyAndExport { id } exporter { id } exporterCompany { id } exporterBusiness { id } exporterBroker { id } buyer { id } declaration { id }',
     })) as Application;
   });
 
@@ -101,6 +101,11 @@ describe('Create an Application', () => {
     expect(typeof application.buyer.id).toEqual('string');
   });
 
+  test('it should have a declaration id', () => {
+    expect(application.declaration).toBeDefined();
+    expect(typeof application.declaration.id).toEqual('string');
+  });
+
   test('it should have a default submission type', () => {
     expect(application.submissionType).toEqual(APPLICATION.SUBMISSION_TYPE.MIA);
   });
@@ -123,6 +128,17 @@ describe('Create an Application', () => {
     });
 
     expect(referenceNumber.application.id).toEqual(application.id);
+  });
+
+  test('it should add the application ID to the policy and export entry', async () => {
+    const exporterBusiness = await context.query.ExporterBusiness.findOne({
+      where: {
+        id: application.exporterBusiness.id,
+      },
+      query: 'id application { id }',
+    });
+
+    expect(exporterBusiness.application.id).toEqual(application.id);
   });
 
   test('it should add the application ID to the policy and export entry', async () => {
@@ -158,17 +174,6 @@ describe('Create an Application', () => {
     expect(exporterBroker.application.id).toEqual(application.id);
   });
 
-  test('it should add the application ID to the buyer entry', async () => {
-    const buyer = await context.query.Buyer.findOne({
-      where: {
-        id: application.buyer.id,
-      },
-      query: 'id application { id }',
-    });
-
-    expect(buyer.application.id).toEqual(application.id);
-  });
-
   test('it should add the exporter company ID to the exporter company address entry', async () => {
     const exporterCompany = await context.query.ExporterCompany.findOne({
       where: {
@@ -187,15 +192,26 @@ describe('Create an Application', () => {
     expect(exporterCompanyAddress.exporterCompany.id).toEqual(application.exporterCompany.id);
   });
 
-  test('it should add the application ID to the policy and export entry', async () => {
-    const exporterBusiness = await context.query.ExporterBusiness.findOne({
+  test('it should add the application ID to the buyer entry', async () => {
+    const buyer = await context.query.Buyer.findOne({
       where: {
-        id: application.exporterBusiness.id,
+        id: application.buyer.id,
       },
       query: 'id application { id }',
     });
 
-    expect(exporterBusiness.application.id).toEqual(application.id);
+    expect(buyer.application.id).toEqual(application.id);
+  });
+
+  test('it should add the application ID to the declaration entry', async () => {
+    const declaration = await context.query.Declaration.findOne({
+      where: {
+        id: application.declaration.id,
+      },
+      query: 'id application { id }',
+    });
+
+    expect(declaration.application.id).toEqual(application.id);
   });
 });
 

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -76,6 +76,7 @@ type Application {
   exporterCompany: ExporterCompany
   exporterBroker: ExporterBroker
   buyer: Buyer
+  declaration: Declaration
 }
 
 scalar DateTime @specifiedBy(url: "https://datatracker.ietf.org/doc/html/rfc3339#section-5.6")
@@ -101,6 +102,7 @@ input ApplicationWhereInput {
   exporterCompany: ExporterCompanyWhereInput
   exporterBroker: ExporterBrokerWhereInput
   buyer: BuyerWhereInput
+  declaration: DeclarationWhereInput
 }
 
 input DateTimeNullableFilter {
@@ -175,6 +177,7 @@ input ApplicationUpdateInput {
   exporterCompany: ExporterCompanyRelateToOneForUpdateInput
   exporterBroker: ExporterBrokerRelateToOneForUpdateInput
   buyer: BuyerRelateToOneForUpdateInput
+  declaration: DeclarationRelateToOneForUpdateInput
 }
 
 input EligibilityRelateToOneForUpdateInput {
@@ -219,6 +222,12 @@ input BuyerRelateToOneForUpdateInput {
   disconnect: Boolean
 }
 
+input DeclarationRelateToOneForUpdateInput {
+  create: DeclarationCreateInput
+  connect: DeclarationWhereUniqueInput
+  disconnect: Boolean
+}
+
 input ApplicationUpdateArgs {
   where: ApplicationWhereUniqueInput!
   data: ApplicationUpdateInput!
@@ -237,6 +246,7 @@ input ApplicationCreateInput {
   exporterCompany: ExporterCompanyRelateToOneForCreateInput
   exporterBroker: ExporterBrokerRelateToOneForCreateInput
   buyer: BuyerRelateToOneForCreateInput
+  declaration: DeclarationRelateToOneForCreateInput
 }
 
 input EligibilityRelateToOneForCreateInput {
@@ -272,6 +282,11 @@ input ExporterBrokerRelateToOneForCreateInput {
 input BuyerRelateToOneForCreateInput {
   create: BuyerCreateInput
   connect: BuyerWhereUniqueInput
+}
+
+input DeclarationRelateToOneForCreateInput {
+  create: DeclarationCreateInput
+  connect: DeclarationWhereUniqueInput
 }
 
 type PolicyAndExport {
@@ -1109,6 +1124,60 @@ input EligibilityCreateInput {
   wantCoverOverMaxPeriod: Boolean
 }
 
+type Declaration {
+  id: ID!
+  application: Application
+  confidentiality: DeclarationConfidentiality
+  agreeToConfidentiality: Boolean
+}
+
+input DeclarationWhereUniqueInput {
+  id: ID
+}
+
+input DeclarationWhereInput {
+  AND: [DeclarationWhereInput!]
+  OR: [DeclarationWhereInput!]
+  NOT: [DeclarationWhereInput!]
+  id: IDFilter
+  application: ApplicationWhereInput
+  confidentiality: DeclarationConfidentialityWhereInput
+  agreeToConfidentiality: BooleanFilter
+}
+
+input DeclarationOrderByInput {
+  id: OrderDirection
+  agreeToConfidentiality: OrderDirection
+}
+
+input DeclarationUpdateInput {
+  application: ApplicationRelateToOneForUpdateInput
+  confidentiality: DeclarationConfidentialityRelateToOneForUpdateInput
+  agreeToConfidentiality: Boolean
+}
+
+input DeclarationConfidentialityRelateToOneForUpdateInput {
+  create: DeclarationConfidentialityCreateInput
+  connect: DeclarationConfidentialityWhereUniqueInput
+  disconnect: Boolean
+}
+
+input DeclarationUpdateArgs {
+  where: DeclarationWhereUniqueInput!
+  data: DeclarationUpdateInput!
+}
+
+input DeclarationCreateInput {
+  application: ApplicationRelateToOneForCreateInput
+  confidentiality: DeclarationConfidentialityRelateToOneForCreateInput
+  agreeToConfidentiality: Boolean
+}
+
+input DeclarationConfidentialityRelateToOneForCreateInput {
+  create: DeclarationConfidentialityCreateInput
+  connect: DeclarationConfidentialityWhereUniqueInput
+}
+
 type DeclarationConfidentiality {
   id: ID!
   version: String
@@ -1324,6 +1393,12 @@ type Mutation {
   updateEligibilities(data: [EligibilityUpdateArgs!]!): [Eligibility]
   deleteEligibility(where: EligibilityWhereUniqueInput!): Eligibility
   deleteEligibilities(where: [EligibilityWhereUniqueInput!]!): [Eligibility]
+  createDeclaration(data: DeclarationCreateInput!): Declaration
+  createDeclarations(data: [DeclarationCreateInput!]!): [Declaration]
+  updateDeclaration(where: DeclarationWhereUniqueInput!, data: DeclarationUpdateInput!): Declaration
+  updateDeclarations(data: [DeclarationUpdateArgs!]!): [Declaration]
+  deleteDeclaration(where: DeclarationWhereUniqueInput!): Declaration
+  deleteDeclarations(where: [DeclarationWhereUniqueInput!]!): [Declaration]
   createDeclarationConfidentiality(data: DeclarationConfidentialityCreateInput!): DeclarationConfidentiality
   createDeclarationConfidentialities(data: [DeclarationConfidentialityCreateInput!]!): [DeclarationConfidentiality]
   updateDeclarationConfidentiality(where: DeclarationConfidentialityWhereUniqueInput!, data: DeclarationConfidentialityUpdateInput!): DeclarationConfidentiality
@@ -1425,6 +1500,9 @@ type Query {
   eligibilities(where: EligibilityWhereInput! = {}, orderBy: [EligibilityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: EligibilityWhereUniqueInput): [Eligibility!]
   eligibility(where: EligibilityWhereUniqueInput!): Eligibility
   eligibilitiesCount(where: EligibilityWhereInput! = {}): Int
+  declarations(where: DeclarationWhereInput! = {}, orderBy: [DeclarationOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: DeclarationWhereUniqueInput): [Declaration!]
+  declaration(where: DeclarationWhereUniqueInput!): Declaration
+  declarationsCount(where: DeclarationWhereInput! = {}): Int
   declarationConfidentialities(where: DeclarationConfidentialityWhereInput! = {}, orderBy: [DeclarationConfidentialityOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: DeclarationConfidentialityWhereUniqueInput): [DeclarationConfidentiality!]
   declarationConfidentiality(where: DeclarationConfidentialityWhereUniqueInput!): DeclarationConfidentiality
   declarationConfidentialitiesCount(where: DeclarationConfidentialityWhereInput! = {}): Int

--- a/src/api/schema.prisma
+++ b/src/api/schema.prisma
@@ -40,6 +40,8 @@ model Application {
   exporterBrokerId                  String?            @map("exporterBroker")
   buyer                             Buyer?             @relation("Application_buyer", fields: [buyerId], references: [id])
   buyerId                           String?            @map("buyer")
+  declaration                       Declaration?       @relation("Application_declaration", fields: [declarationId], references: [id])
+  declarationId                     String?            @map("declaration")
   from_ReferenceNumber_application  ReferenceNumber[]  @relation("ReferenceNumber_application")
   from_PolicyAndExport_application  PolicyAndExport[]  @relation("PolicyAndExport_application")
   from_Exporter_applications        Exporter[]         @relation("Exporter_applications")
@@ -48,6 +50,7 @@ model Application {
   from_ExporterCompany_application  ExporterCompany[]  @relation("ExporterCompany_application")
   from_Buyer_application            Buyer[]            @relation("Buyer_application")
   from_Eligibility_application      Eligibility[]      @relation("Eligibility_application")
+  from_Declaration_application      Declaration[]      @relation("Declaration_application")
 
   @@index([eligibilityId])
   @@index([referenceNumber])
@@ -57,6 +60,7 @@ model Application {
   @@index([exporterCompanyId])
   @@index([exporterBrokerId])
   @@index([buyerId])
+  @@index([declarationId])
 }
 
 model PolicyAndExport {
@@ -225,10 +229,24 @@ model Eligibility {
   @@index([buyerCountryId])
 }
 
+model Declaration {
+  id                           String                      @id @default(cuid())
+  application                  Application?                @relation("Declaration_application", fields: [applicationId], references: [id])
+  applicationId                String?                     @map("application")
+  confidentiality              DeclarationConfidentiality? @relation("Declaration_confidentiality", fields: [confidentialityId], references: [id])
+  confidentialityId            String?                     @map("confidentiality")
+  agreeToConfidentiality       Boolean                     @default(false)
+  from_Application_declaration Application[]               @relation("Application_declaration")
+
+  @@index([applicationId])
+  @@index([confidentialityId])
+}
+
 model DeclarationConfidentiality {
-  id      String @id @default(cuid())
-  version String @default("")
-  content Json   @default("[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"}]}]")
+  id                               String        @id @default(cuid())
+  version                          String        @default("")
+  content                          Json          @default("[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"}]}]")
+  from_Declaration_confidentiality Declaration[] @relation("Declaration_confidentiality")
 }
 
 model Page {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -28,6 +28,10 @@ interface ApplicationBuyer {
   id: string;
 }
 
+interface ApplicationDeclaration {
+  id: string;
+}
+
 interface AccountInput {
   createdAt: Date;
   updatedAt: Date;
@@ -68,6 +72,7 @@ interface Application {
   exporterBusiness: ApplicationExporterBusiness;
   exporterBroker: ApplicationExporterBroker;
   buyer: ApplicationBuyer;
+  declaration: ApplicationDeclaration;
 }
 
 type BufferEncoding = 'hex' | 'base64' | 'ascii';

--- a/src/ui/server/api/keystone/application/declarations.ts
+++ b/src/ui/server/api/keystone/application/declarations.ts
@@ -1,6 +1,7 @@
 import { ApolloResponse } from '../../../../types';
 import apollo from '../../../graphql/apollo';
 import getDeclarationConfidentialityQuery from '../../../graphql/queries/declarations/confidentiality';
+import updateApplicationDeclarationMutation from '../../../graphql/mutations/update-application/declaration';
 import isPopulatedArray from '../../../helpers/is-populated-array';
 
 const declarations = {
@@ -27,6 +28,36 @@ const declarations = {
     } catch (err) {
       console.error(err);
       throw new Error('Getting latest declaration - confidentiality');
+    }
+  },
+  update: async (id: string, update: object) => {
+    try {
+      console.info('Updating application declaration');
+
+      const variables = {
+        where: { id },
+        data: update,
+      };
+
+      const response = (await apollo('POST', updateApplicationDeclarationMutation, variables)) as ApolloResponse;
+
+      if (response.errors) {
+        console.error('GraphQL error updating application declaration ', response.errors);
+      }
+
+      if (response?.networkError?.result?.errors) {
+        console.error('GraphQL network error updating application declaration ', response.networkError.result.errors);
+      }
+
+      if (response?.data?.updateDeclaration) {
+        return response.data.updateDeclaration;
+      }
+
+      console.error(response);
+      throw new Error('Updating application declaration');
+    } catch (err) {
+      console.error(err);
+      throw new Error('Updating application declaration');
     }
   },
 };

--- a/src/ui/server/api/keystone/application/index.ts
+++ b/src/ui/server/api/keystone/application/index.ts
@@ -275,6 +275,7 @@ const application = {
         throw new Error('Updating application buyer');
       }
     },
+    declarations: declarations.update,
   },
   eligibility,
   declarations,

--- a/src/ui/server/constants/routes/insurance/declarations.ts
+++ b/src/ui/server/constants/routes/insurance/declarations.ts
@@ -3,5 +3,6 @@ const ROOT = '/declarations';
 export const DECLARATIONS = {
   ROOT,
   CONFIDENTIALITY: `${ROOT}/confidentiality`,
+  CONFIDENTIALITY_SAVE_AND_BACK: `${ROOT}/confidentiality/save-and-go-back`,
   ANTI_BRIBERY: `${ROOT}/anti-bribery`,
 };

--- a/src/ui/server/controllers/insurance/declarations/confidentiality/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/confidentiality/save-and-back/index.test.ts
@@ -1,0 +1,105 @@
+import { post } from '.';
+import { ROUTES } from '../../../../../constants';
+import { Request, Response } from '../../../../../../types';
+import save from '../save-data';
+import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
+
+const {
+  INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS },
+} = ROUTES;
+
+describe('controllers/insurance/declarations/confidentiality/save-and-back', () => {
+  let req: Request;
+  let res: Response;
+
+  jest.mock('../save-data');
+
+  let mockSaveData = jest.fn(() => Promise.resolve(true));
+  save.declaration = mockSaveData;
+
+  const refNumber = Number(mockApplication.referenceNumber);
+
+  const mockFormBody = {
+    _csrf: '1234',
+    mock: true,
+  };
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+
+    res.locals.application = mockApplication;
+    req.params.referenceNumber = String(mockApplication.referenceNumber);
+
+    req.body = mockFormBody;
+  });
+
+  describe('when the form has data', () => {
+    it('should call mapAndSave.policyAndExport with application and req.body', async () => {
+      await post(req, res);
+
+      expect(save.declaration).toHaveBeenCalledTimes(1);
+      expect(save.declaration).toHaveBeenCalledWith(res.locals.application, mockFormBody);
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
+      await post(req, res);
+
+      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+
+      expect(res.redirect).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('when the form does not have any data', () => {
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
+      req.body = { _csrf: '1234' };
+
+      await post(req, res);
+
+      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+
+      expect(res.redirect).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('when there is no application', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
+    });
+
+    it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+      await post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+    });
+  });
+
+  describe('api error handling', () => {
+    describe('when the update declarations call does not return anything', () => {
+      beforeEach(() => {
+        mockSaveData = jest.fn(() => Promise.resolve(false));
+        save.declaration = mockSaveData;
+      });
+
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+      });
+    });
+
+    describe('when the mapAndSave call fails', () => {
+      beforeEach(() => {
+        mockSaveData = jest.fn(() => Promise.reject(new Error('Mock error')));
+        save.declaration = mockSaveData;
+      });
+
+      it(`should redirect to ${ROUTES.PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE);
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/declarations/confidentiality/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/confidentiality/save-and-back/index.ts
@@ -1,0 +1,41 @@
+import { ROUTES } from '../../../../../constants';
+import { Request, Response } from '../../../../../../types';
+import hasFormData from '../../../../../helpers/has-form-data';
+import save from '../save-data';
+
+const {
+  INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS },
+} = ROUTES;
+
+/**
+ * post
+ * Save Declarations - confidentiality field if provided and if successful, redirect to the all sections page
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.redirect} All sections page or error page
+ */
+export const post = async (req: Request, res: Response) => {
+  try {
+    const { application } = res.locals;
+
+    if (!application) {
+      return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+    }
+
+    const { referenceNumber } = req.params;
+
+    if (hasFormData(req.body)) {
+      const saveResponse = await save.declaration(application, req.body);
+
+      if (!saveResponse) {
+        return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+      }
+    }
+
+    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`);
+  } catch (err) {
+    console.error('Error updating application - declarations - confidentiality (save and back) ', { err });
+
+    return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+  }
+};

--- a/src/ui/server/controllers/insurance/declarations/confidentiality/save-data/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/confidentiality/save-data/index.test.ts
@@ -1,0 +1,63 @@
+import save from '.';
+import api from '../../../../../api';
+import { sanitiseData } from '../../../../../helpers/sanitise-data';
+import { FIELD_IDS } from '../../../../../constants';
+import { mockApplication } from '../../../../../test-mocks';
+
+const {
+  DECLARATIONS: { AGREE_CONFIDENTIALITY },
+} = FIELD_IDS.INSURANCE;
+
+describe('controllers/insurance/declarations/save-data', () => {
+  const mockUpdateApplicationResponse = mockApplication;
+  let updateApplicationSpy = jest.fn(() => Promise.resolve(mockUpdateApplicationResponse));
+
+  const mockFormBody = {
+    [AGREE_CONFIDENTIALITY]: 'true',
+  };
+
+  beforeEach(() => {
+    api.keystone.application.update.declarations = updateApplicationSpy;
+  });
+
+  it('should return the API response', async () => {
+    const result = await save.declaration(mockApplication, mockFormBody);
+
+    expect(result).toEqual(mockUpdateApplicationResponse);
+  });
+
+  it('should call api.keystone.application.update.declarations with declaration ID and sanitised data', async () => {
+    await save.declaration(mockApplication, mockFormBody);
+
+    expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
+
+    const expectedSanitisedData = sanitiseData(mockFormBody);
+    expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.declaration.id, expectedSanitisedData);
+  });
+
+  it('should return the API response', async () => {
+    const result = await save.declaration(mockApplication, mockFormBody);
+
+    expect(result).toEqual(mockUpdateApplicationResponse);
+  });
+
+  describe('api error handling', () => {
+    describe('update declarations call', () => {
+      describe('when there is an error', () => {
+        beforeEach(() => {
+          updateApplicationSpy = jest.fn(() => Promise.reject());
+          api.keystone.application.update.declarations = updateApplicationSpy;
+        });
+
+        it('should throw an error', async () => {
+          try {
+            await save.declaration(mockApplication, mockFormBody);
+          } catch (err) {
+            const expected = new Error("Updating application's declarations");
+            expect(err).toEqual(expected);
+          }
+        });
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/declarations/confidentiality/save-data/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/confidentiality/save-data/index.ts
@@ -1,0 +1,32 @@
+import api from '../../../../../api';
+import { sanitiseData } from '../../../../../helpers/sanitise-data';
+import { Application, RequestBody } from '../../../../../../types';
+
+/**
+ * declarations
+ * Update the application.
+ * This is used for any save functionality in the Declarations section of the application
+ * @param {Object} Application
+ * @param {Express.Request.body} Form data
+ * @returns {Object} Saved data
+ */
+const declaration = async (application: Application, formBody: RequestBody) => {
+  // sanitise the form data.
+  const sanitisedData = sanitiseData(formBody);
+
+  // send the form data to the API for database update.
+  const declarationId = application.declaration?.id;
+
+  try {
+    const saveResponse = await api.keystone.application.update.declarations(declarationId, sanitisedData);
+
+    return saveResponse;
+  } catch (err) {
+    console.error(err);
+    throw new Error("Updating application's declarations");
+  }
+};
+
+export default {
+  declaration,
+};

--- a/src/ui/server/graphql/mutations/update-application/declaration.ts
+++ b/src/ui/server/graphql/mutations/update-application/declaration.ts
@@ -1,0 +1,11 @@
+import gql from 'graphql-tag';
+
+const updateApplicationDeclarationMutation = gql`
+  mutation ($where: DeclarationWhereUniqueInput!, $data: DeclarationUpdateInput!) {
+    updateDeclaration(where: $where, data: $data) {
+      id
+    }
+  }
+`;
+
+export default updateApplicationDeclarationMutation;

--- a/src/ui/server/graphql/queries/application.ts
+++ b/src/ui/server/graphql/queries/application.ts
@@ -106,6 +106,10 @@ const applicationQuery = gql`
           exporterIsConnectedWithBuyer
           exporterHasTradedWithBuyer
         }
+        declaration {
+          id
+          agreeToConfidentiality
+        }
       }
     }
   }

--- a/src/ui/server/helpers/flatten-application-data/index.test.ts
+++ b/src/ui/server/helpers/flatten-application-data/index.test.ts
@@ -1,11 +1,12 @@
 import flattenApplicationData from '.';
+import getTrueProperties from '../get-true-properties';
 import { mockApplication } from '../../test-mocks';
 
 describe('server/helpers/flatten-application-data', () => {
   it('should return an application with a flat structure with no nested objects', () => {
     const result = flattenApplicationData(mockApplication);
 
-    const { eligibility, policyAndExport, exporterCompany, exporterBroker, exporterBusiness, buyer, ...application } = mockApplication;
+    const { eligibility, policyAndExport, exporterCompany, exporterBroker, exporterBusiness, buyer, declaration, ...application } = mockApplication;
 
     const expected = {
       ...mockApplication.eligibility,
@@ -15,6 +16,7 @@ describe('server/helpers/flatten-application-data', () => {
       ...exporterBusiness,
       ...exporterBroker,
       ...buyer,
+      ...getTrueProperties(declaration),
       ...application,
     };
 

--- a/src/ui/server/helpers/flatten-application-data/index.ts
+++ b/src/ui/server/helpers/flatten-application-data/index.ts
@@ -1,3 +1,4 @@
+import getTrueProperties from '../get-true-properties';
 import { Application, ApplicationFlat } from '../../../types';
 
 /**
@@ -7,9 +8,9 @@ import { Application, ApplicationFlat } from '../../../types';
  * @returns {Object} Application as a single level object
  */
 const flattenApplicationData = (application: Application): ApplicationFlat => {
-  const { eligibility, policyAndExport, exporterCompany, exporterBroker, exporterBusiness, buyer, ...app } = application;
+  const { eligibility, policyAndExport, exporterCompany, exporterBroker, exporterBusiness, buyer, declaration, ...app } = application;
 
-  return {
+  const flattened = {
     ...eligibility,
     buyerCountry: application.eligibility.buyerCountry.isoCode,
     ...policyAndExport,
@@ -17,8 +18,11 @@ const flattenApplicationData = (application: Application): ApplicationFlat => {
     ...exporterBusiness,
     ...exporterBroker,
     ...buyer,
+    ...getTrueProperties(declaration),
     ...app,
   };
+
+  return flattened;
 };
 
 export default flattenApplicationData;

--- a/src/ui/server/helpers/get-true-properties/index.test.ts
+++ b/src/ui/server/helpers/get-true-properties/index.test.ts
@@ -1,0 +1,18 @@
+import getTrueProperties from '.';
+
+describe('server/helpers/get-true-properties', () => {
+  it('should return an object with only true properties', () => {
+    const mockObj = {
+      a: true,
+      b: false,
+    };
+
+    const result = getTrueProperties(mockObj);
+
+    const expected = {
+      a: true,
+    };
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/ui/server/helpers/get-true-properties/index.ts
+++ b/src/ui/server/helpers/get-true-properties/index.ts
@@ -1,0 +1,19 @@
+/**
+ * getTrueProperties
+ * Get true properties in an object
+ * @param {Object}
+ * @returns {Object} Object with only true properties
+ */
+const getTrueProperties = (obj: object) => {
+  const cleanObj = {};
+
+  Object.keys(obj).forEach((key) => {
+    if (obj[key] === true) {
+      cleanObj[key] = true;
+    }
+  });
+
+  return cleanObj;
+};
+
+export default getTrueProperties;

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/submit-application.test.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/submit-application.test.ts
@@ -1,7 +1,7 @@
 import createSubmitApplicationTasks from './submit-application';
 import { getAllTasksFieldsInAGroup } from '../task-helpers';
 import generateGroupsAndTasks from '.';
-import { TASK_IDS } from '../../../constants';
+import { FIELD_IDS, TASK_IDS } from '../../../constants';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import { TASKS } from '../../../content-strings';
 import { mockApplication } from '../../../test-mocks';
@@ -13,6 +13,10 @@ const {
   DECLARATIONS: { CONFIDENTIALITY },
   CHECK_YOUR_ANSWERS: { ELIGIBILITY },
 } = INSURANCE_ROUTES;
+
+const {
+  DECLARATIONS: { AGREE_CONFIDENTIALITY },
+} = FIELD_IDS.INSURANCE;
 
 describe('server/helpers/task-list/submit-application', () => {
   it('should return EXIP `submit application` tasks', () => {
@@ -31,7 +35,7 @@ describe('server/helpers/task-list/submit-application', () => {
       href: `${INSURANCE_ROOT}/${referenceNumber}${CONFIDENTIALITY}`,
       title: SUBMIT_APPLICATION.TASKS.DECLARATIONS,
       id: TASK_IDS.SUBMIT_APPLICATION.DECLARATIONS,
-      fields: ['temp'],
+      fields: [AGREE_CONFIDENTIALITY, 'temp'],
       dependencies: [...getAllTasksFieldsInAGroup(initialChecksGroup), ...getAllTasksFieldsInAGroup(prepareApplicationGroup)],
     };
 

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/submit-application.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/submit-application.ts
@@ -1,5 +1,5 @@
 import { TaskListDataTask, TaskListData } from '../../../../types';
-import { GROUP_IDS, TASK_IDS } from '../../../constants';
+import { FIELD_IDS, GROUP_IDS, TASK_IDS } from '../../../constants';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import { TASKS } from '../../../content-strings';
 import { getGroupById, getAllTasksFieldsInAGroup } from '../task-helpers';
@@ -11,6 +11,10 @@ const {
   DECLARATIONS: { CONFIDENTIALITY },
   CHECK_YOUR_ANSWERS: { ELIGIBILITY },
 } = INSURANCE_ROUTES;
+
+const {
+  DECLARATIONS: { AGREE_CONFIDENTIALITY },
+} = FIELD_IDS.INSURANCE;
 
 /**
  * createSubmitApplicationTasks
@@ -25,7 +29,7 @@ const createSubmitApplicationTasks = (referenceNumber: number, otherGroups: Task
     href: `${INSURANCE_ROOT}/${referenceNumber}${CONFIDENTIALITY}`,
     title: SUBMIT_APPLICATION.TASKS.DECLARATIONS,
     id: TASK_IDS.SUBMIT_APPLICATION.DECLARATIONS,
-    fields: ['temp'],
+    fields: [AGREE_CONFIDENTIALITY, 'temp'],
     dependencies: [...getAllTasksFieldsInAGroup(initialChecksGroup), ...getAllTasksFieldsInAGroup(prepareApplicationGroup)],
   };
 

--- a/src/ui/server/routes/insurance/declarations/index.test.ts
+++ b/src/ui/server/routes/insurance/declarations/index.test.ts
@@ -1,7 +1,7 @@
 import { get, post } from '../../../test-mocks/mock-router';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
-
 import { get as confidentialityGet, post as confidentialityPost } from '../../../controllers/insurance/declarations/confidentiality';
+import { post as confidentialitySaveAndBackPost } from '../../../controllers/insurance/declarations/confidentiality/save-and-back';
 
 describe('routes/insurance/declarations', () => {
   beforeEach(() => {
@@ -14,9 +14,11 @@ describe('routes/insurance/declarations', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(1);
-    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledTimes(2);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY}`, confidentialityGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY}`, confidentialityPost);
+
+    expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY_SAVE_AND_BACK}`, confidentialitySaveAndBackPost);
   });
 });

--- a/src/ui/server/routes/insurance/declarations/index.ts
+++ b/src/ui/server/routes/insurance/declarations/index.ts
@@ -1,11 +1,13 @@
 import express from 'express';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import { get as confidentialityGet, post as confidentialityPost } from '../../../controllers/insurance/declarations/confidentiality';
+import { post as confidentialitySaveAndBackPost } from '../../../controllers/insurance/declarations/confidentiality/save-and-back';
 
 // @ts-ignore
 const insuranceDeclarationsRouter = express.Router();
 
 insuranceDeclarationsRouter.get(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY}`, confidentialityGet);
 insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY}`, confidentialityPost);
+insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY_SAVE_AND_BACK}`, confidentialitySaveAndBackPost);
 
 export default insuranceDeclarationsRouter;

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -17,7 +17,7 @@ describe('routes/insurance', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(58);
-    expect(post).toHaveBeenCalledTimes(58);
+    expect(post).toHaveBeenCalledTimes(59);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);

--- a/src/ui/server/test-mocks/mock-application.ts
+++ b/src/ui/server/test-mocks/mock-application.ts
@@ -88,6 +88,11 @@ export const mockApplicationBuyer = {
   ...mockBuyer,
 };
 
+export const mockApplicationDeclaration = {
+  id: 'clf3te7vx1432cfoqp9rbop73',
+  agreeToConfidentiality: true,
+};
+
 const mockApplication = {
   id: 'clacdgc630000kdoqn7wcgrz1',
   referenceNumber: 10001,
@@ -113,6 +118,7 @@ const mockApplication = {
   exporterBusiness: mockExporterBusiness,
   exporterBroker: mockExporterBroker,
   buyer: mockApplicationBuyer,
+  declaration: mockApplicationDeclaration,
 };
 
 export const mockApplicationMultiplePolicy = {

--- a/src/ui/templates/insurance/declarations/confidentiality.njk
+++ b/src/ui/templates/insurance/declarations/confidentiality.njk
@@ -71,7 +71,8 @@
           value: FIELD.OPTION.VALUE,
           attributes: {
             'data-cy': FIELD.ID + '-input'
-          }
+          },
+          checked: application.declaration[FIELD.ID]
         }
       ],
       errorMessage: validationErrors.errorList[FIELD.ID] and {

--- a/src/ui/types/application.ts
+++ b/src/ui/types/application.ts
@@ -104,6 +104,11 @@ interface ApplicationBuyer {
   exporterHasTradedWithBuyer?: boolean;
 }
 
+interface ApplicationDeclaration {
+  id: string;
+  agreeToConfidentiality?: boolean;
+}
+
 interface Application extends ApplicationCore {
   eligibility: ApplicationEligibility;
   exporter: ApplicationExporter;
@@ -112,6 +117,7 @@ interface Application extends ApplicationCore {
   exporterBusiness: ApplicationExporterBusiness;
   exporterBroker: ApplicationExporterBroker;
   buyer: ApplicationBuyer;
+  declaration: ApplicationDeclaration;
 }
 
 interface ApplicationFlat extends ApplicationCore, InsuranceEligibilityCore, ApplicationPolicyAndExport, ApplicationExporterCompany {
@@ -127,4 +133,5 @@ export {
   ApplicationExporterBusiness,
   ApplicationExporterBroker,
   ApplicationBuyer,
+  ApplicationDeclaration,
 };


### PR DESCRIPTION
This PR updates the Confidentiality page/flow so that the declaration answer is saved via the regular submit button, or the "save and back" button. Also update the task list to change to "in progress" after submitting an answer.


## Changes

- Update the API schema to have a new table, `Declaration` that has a relationship with an application.
- Add a new GQL call from the API to update an application's declarations.
- Update the "get application" GQL call to return an application's declarations answers.
- Update the Declarations - Confidentiality POST endpoint to call the API via `save-data` function.
- Add new endpoint Declarations - Confidentiality "save and back" route and controller.
- Create a new helper function `getTrueProperties` that returns only properties in an object that have a true boolean. This is required to strip out false answers to declarations when the task list logic is run.
- Update the task list for the first Declarations field, therefore making the Declarations task change to "in progress" once the first field is answered correctly.
- E2E test coverage.
- Update DB dump.