### PR TITLE
fix(EMS-1263): application access - add a check for exporter ID

### DIFF
--- a/src/ui/server/middleware/insurance/application-access/index.test.ts
+++ b/src/ui/server/middleware/insurance/application-access/index.test.ts
@@ -84,6 +84,24 @@ describe('middleware/insurance/application-access', () => {
       });
     });
 
+    describe('when res.locals.application does not have an exporter ID', () => {
+      beforeEach(() => {
+        res.locals.application = {
+          ...mockApplication,
+          // @ts-ignore
+          exporter: {},
+        };
+
+        next = nextSpy;
+      });
+
+      it(`should redirect to ${NO_ACCESS_TO_APPLICATION}`, async () => {
+        await applicationAccessMiddleware(req, res, next);
+
+        expect(res.redirect).toHaveBeenCalledWith(NO_ACCESS_TO_APPLICATION);
+      });
+    });
+
     describe('when there is no req.session.accountID or res.locals.application', () => {
       beforeEach(() => {
         delete req.session.accountId;

--- a/src/ui/server/middleware/insurance/application-access/index.ts
+++ b/src/ui/server/middleware/insurance/application-access/index.ts
@@ -29,11 +29,11 @@ export const applicationAccessMiddleware = async (req: Request, res: Response, n
    * Otherwise, redirect to the "no access" page.
    */
   if (req.session.user && res.locals.application) {
-    const { id } = req.session.user;
+    const { id: userId } = req.session.user;
 
     const { exporter } = res.locals.application;
 
-    if (exporter.id === id) {
+    if (exporter && exporter.id === userId) {
       return next();
     }
 


### PR DESCRIPTION
Currently in dev if an application does not have an exporter ID, the application access middleware fails because it cannot read the ID and then the server crashes.

The middleware might be running somewhere were it doesn't need to - need to look into this (not a quick thing). In the meantime, need this changes merged so we can unblock QA / dev environment.

## Changes

- Add an additional check to make sure exporter object exists.