### PR TITLE
fix(EMS-849): Account verification - handle invalid tokens UI redirection

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email-verification-link-expired.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email-verification-link-expired.spec.js
@@ -33,7 +33,7 @@ context('Insurance - Account - Create - Confirm email page - expired token - As 
     cy.deleteAccount();
   });
 
-  describe(`when a verification token has expired and exporter navigates to ${VERIFY_EMAIL} with the expired token`, () => {
+  describe(`When a verification token has expired and exporter navigates to ${VERIFY_EMAIL} with the expired token`, () => {
     let updatedExporter;
 
     beforeEach(async () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email-verification-link-invalid.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/confirm-email/confirm-email-verification-link-invalid.spec.js
@@ -1,0 +1,21 @@
+import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const { ACCOUNT: { CREATE: VERIFY_EMAIL, VERIFY_EMAIL_LINK_EXPIRED } } = ROUTES;
+
+context('Insurance - Account - Create - Confirm email page - invalid token - As an Exporter I want to verify my email address, So that I can activate my email address and use it to create a digital service account with UKEF', () => {
+  describe(`When an account does not exist, verification token is invalid and exporter navigates to ${VERIFY_EMAIL} with the invalid token`, () => {
+    before(() => {
+      cy.saveSession();
+
+      const invalidVerificationHash = 'INVALID-VERIFICAITON-TOKEN';
+
+      cy.navigateToUrl(`${Cypress.config('baseUrl')}${VERIFY_EMAIL}?token=${invalidVerificationHash}`);
+    });
+
+    it(`should redirect to ${VERIFY_EMAIL_LINK_EXPIRED}`, () => {
+      const expectedUrl = `${Cypress.config('baseUrl')}${VERIFY_EMAIL_LINK_EXPIRED}?id=null`;
+
+      cy.url().should('eq', expectedUrl);
+    });
+  });
+});

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -1388,7 +1388,7 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
 
       type VerifyAccountEmailAddressResponse {
         success: Boolean!
-        accountId: String!
+        accountId: String
       }
 
       type Mutation {

--- a/src/api/custom-schema.ts
+++ b/src/api/custom-schema.ts
@@ -149,7 +149,7 @@ export const extendGraphqlSchema = (schema: GraphQLSchema) =>
 
       type VerifyAccountEmailAddressResponse {
         success: Boolean!
-        accountId: String!
+        accountId: String
       }
 
       type Mutation {

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -1749,5 +1749,5 @@ type AddAndGetOtpResponse {
 
 type VerifyAccountEmailAddressResponse {
   success: Boolean!
-  accountId: String!
+  accountId: String
 }


### PR DESCRIPTION
This PR fixes an issue where if an account verification token is invalid, or the account does not exist - it would redirect to the "problem with service" page instead of the "link expired" page.

## Changes

- Update `VerifyAccountEmailAddressResponse` type to have an optional  `accountId` instead of optional, therefore the an error will not be thrown if an account is not found.
- Add E2E test coverage.