### PR TITLE
feat(EMS-1181): Declarations - Anti-bribery - data saving, save and go back functionality

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -267,6 +267,9 @@ export const ERROR_MESSAGES = {
       [FIELD_IDS.INSURANCE.DECLARATIONS.AGREE_CONFIDENTIALITY]: {
         IS_EMPTY: 'Confirm that you have read and accept the confidentiality declaration',
       },
+      [FIELD_IDS.INSURANCE.DECLARATIONS.AGREE_ANTI_BRIBERY]: {
+        IS_EMPTY: 'Confirm that you have read and accept the anti-bribery and corruption declaration',
+      },
     },
   },
 };

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/save-and-back.spec.js
@@ -1,0 +1,103 @@
+import { saveAndBackButton, submitButton } from '../../../../pages/shared';
+import { antiBriberyPage } from '../../../../pages/insurance/declarations';
+import partials from '../../../../partials';
+import { TASKS } from '../../../../../../content-strings';
+import { FIELD_IDS } from '../../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+
+const { STATUS: { IN_PROGRESS } } = TASKS;
+
+const { taskList } = partials.insurancePartials;
+
+const {
+  ROOT: INSURANCE_ROOT,
+  ALL_SECTIONS,
+  DECLARATIONS: {
+    ANTI_BRIBERY: { ROOT: ANTI_BRIBERY_ROOT },
+  },
+} = INSURANCE_ROUTES;
+
+const FIELD_ID = FIELD_IDS.INSURANCE.DECLARATIONS.AGREE_ANTI_BRIBERY;
+
+const task = taskList.submitApplication.tasks.declarations;
+
+context('Insurance - Declarations - Anti-bribery page - Save and go back', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication().then((refNumber) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType();
+
+      // go to the page we want to test.
+      task.link().click();
+
+      cy.completeAndSubmitDeclarationConfidentiality();
+
+      url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ANTI_BRIBERY_ROOT}`;
+
+      cy.url().should('eq', url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteAccount();
+  });
+
+  describe('when submitting an empty form via `save and go back` button', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      saveAndBackButton().click();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      cy.url().should('eq', expected);
+    });
+
+    it('should retain the status of task `declarations` as `in progress`', () => {
+      cy.checkTaskStatus(task, IN_PROGRESS);
+    });
+  });
+
+  describe('when submitting an answer via `save and go back` button', () => {
+    let field;
+
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      field = antiBriberyPage[FIELD_ID];
+
+      field.input().click();
+
+      saveAndBackButton().click();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      cy.url().should('eq', expected);
+    });
+
+    it('should retain the status of task `declarations` as `in progress`', () => {
+      cy.checkTaskStatus(task, IN_PROGRESS);
+    });
+
+    it('should have the originally submitted answer selected when going back to the page after submission', () => {
+      task.link().click();
+
+      // go to the page
+      submitButton().click();
+
+      field.input().should('be.checked');
+    });
+  });
+});

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -78,6 +78,7 @@ Cypress.Commands.add('completeAndSubmitCompanyOrOrganisationForm', require('./in
 Cypress.Commands.add('completeAndSubmitWorkingWithBuyerForm', require('./insurance/your-buyer/complete-and-submit-working-with-buyer-form'));
 
 Cypress.Commands.add('completeAndSubmitDeclarationConfidentiality', require('./insurance/declarations/complete-and-submit-confidentiality-form'));
+Cypress.Commands.add('completeAndSubmitDeclarationAntiBribery', require('./insurance/declarations/complete-and-submit-anti-bribery-form'));
 
 Cypress.Commands.add('assertChangeAnswersPageUrl', require('./insurance/assert-change-answers-page-url'));
 Cypress.Commands.add('assertSummaryListRowValue', require('./assert-summary-list-row-value'));

--- a/e2e-tests/cypress/support/insurance/declarations/complete-and-submit-anti-bribery-form.js
+++ b/e2e-tests/cypress/support/insurance/declarations/complete-and-submit-anti-bribery-form.js
@@ -1,0 +1,13 @@
+import { FIELD_IDS } from '../../../../constants';
+import { submitButton } from '../../../e2e/pages/shared';
+import { antiBriberyPage } from '../../../e2e/pages/insurance/declarations';
+
+const FIELD_ID = FIELD_IDS.INSURANCE.DECLARATIONS.AGREE_ANTI_BRIBERY;
+
+const field = antiBriberyPage[FIELD_ID];
+
+export default () => {
+  field.input().click();
+
+  submitButton().click();
+};

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -272,6 +272,9 @@ export const ERROR_MESSAGES = {
       [FIELD_IDS.INSURANCE.DECLARATIONS.AGREE_CONFIDENTIALITY]: {
         IS_EMPTY: 'Confirm that you have read and accept the confidentiality declaration',
       },
+      [FIELD_IDS.INSURANCE.DECLARATIONS.AGREE_ANTI_BRIBERY]: {
+        IS_EMPTY: 'Confirm that you have read and accept the anti-bribery and corruption declaration',
+      },
     },
   },
 } as ErrorMessage;

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/index.test.ts
@@ -1,10 +1,12 @@
-import { pageVariables, TEMPLATE, get } from '.';
-import { PAGES } from '../../../../content-strings';
+import { pageVariables, TEMPLATE, get, post } from '.';
+import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, TEMPLATES, ROUTES } from '../../../../constants';
 import { DECLARATIONS_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance/declarations';
 import api from '../../../../api';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import keystoneDocumentRendererConfig from '../../../../helpers/keystone-document-renderer-config';
+import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import save from '../save-data';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes, mockApplication, mockDeclarations } from '../../../../test-mocks';
 
@@ -15,11 +17,17 @@ const { INSURANCE, PROBLEM_WITH_SERVICE } = ROUTES;
 const {
   INSURANCE_ROOT,
   DECLARATIONS: {
-    ANTI_BRIBERY: { ROOT_SAVE_AND_BACK: ANTI_BRIBERY_SAVE_AND_BACK },
+    ANTI_BRIBERY: { ROOT_SAVE_AND_BACK: ANTI_BRIBERY_SAVE_AND_BACK, CODE_OF_CONDUCT },
   },
 } = INSURANCE;
 
 describe('controllers/insurance/declarations/anti-bribery', () => {
+  jest.mock('../save-data');
+
+  let mockSaveDeclaration = jest.fn(() => Promise.resolve({}));
+
+  save.declaration = mockSaveDeclaration;
+
   let req: Request;
   let res: Response;
 
@@ -103,6 +111,125 @@ describe('controllers/insurance/declarations/anti-bribery', () => {
           await get(req, res);
 
           expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+        });
+      });
+    });
+  });
+
+  describe('post', () => {
+    const validBody = {
+      [FIELD_ID]: 'true',
+    };
+
+    beforeEach(() => {
+      getLatestAntiBriberySpy = jest.fn(() => Promise.resolve(mockDeclarations.confidentiality));
+
+      api.keystone.application.declarations.getLatestAntiBribery = getLatestAntiBriberySpy;
+    });
+
+    describe('when there are no validation errors', () => {
+      beforeEach(() => {
+        req.body = validBody;
+      });
+
+      it(`should redirect to ${CODE_OF_CONDUCT}`, async () => {
+        await post(req, res);
+
+        const expected = `${INSURANCE_ROOT}/${req.params.referenceNumber}${CODE_OF_CONDUCT}`;
+
+        expect(res.redirect).toHaveBeenCalledWith(expected);
+      });
+
+      it('should call save.declaration with application and req.body', async () => {
+        await post(req, res);
+
+        expect(save.declaration).toHaveBeenCalledTimes(1);
+        expect(save.declaration).toHaveBeenCalledWith(mockApplication, validBody);
+      });
+    });
+
+    describe('when there are validation errors', () => {
+      it('should call api.keystone.application.declarations.getLatestConfidentiality', async () => {
+        await post(req, res);
+
+        expect(getLatestAntiBriberySpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('should render template with validation errors', async () => {
+        await post(req, res);
+
+        const expectedVariables = {
+          ...insuranceCorePageVariables({
+            PAGE_CONTENT_STRINGS: PAGES.INSURANCE.DECLARATIONS.CONFIDENTIALITY,
+            BACK_LINK: req.headers.referer,
+          }),
+          ...pageVariables(mockApplication.referenceNumber),
+          documentContent: mockDeclarations.confidentiality.content.document,
+          documentConfig: keystoneDocumentRendererConfig(),
+          validationErrors: generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY),
+        };
+
+        expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
+      });
+    });
+
+    describe('when there is no application', () => {
+      beforeEach(() => {
+        res.locals = { csrfToken: '1234' };
+      });
+
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+      });
+    });
+
+    describe('api error handling', () => {
+      describe('get latest anti-bribery call', () => {
+        describe('when the get latest anti-bribery API call fails', () => {
+          beforeEach(() => {
+            getLatestAntiBriberySpy = jest.fn(() => Promise.reject());
+            api.keystone.application.declarations.getLatestAntiBribery = getLatestAntiBriberySpy;
+          });
+
+          it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+            await post(req, res);
+
+            expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+          });
+        });
+      });
+
+      describe('save data call', () => {
+        describe('when the save data API call does not return anything', () => {
+          beforeEach(() => {
+            mockSaveDeclaration = jest.fn(() => Promise.resolve(false));
+            save.declaration = mockSaveDeclaration;
+
+            req.body = validBody;
+          });
+
+          it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+            await post(req, res);
+
+            expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+          });
+        });
+
+        describe('when the save data API call fails', () => {
+          beforeEach(() => {
+            mockSaveDeclaration = jest.fn(() => Promise.reject());
+            save.declaration = mockSaveDeclaration;
+
+            req.body = validBody;
+          });
+
+          it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+            await post(req, res);
+
+            expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+          });
         });
       });
     });

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/index.ts
@@ -1,9 +1,11 @@
-import { PAGES } from '../../../../content-strings';
+import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
 import { FIELD_IDS, TEMPLATES, ROUTES } from '../../../../constants';
 import { DECLARATIONS_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance/declarations';
 import api from '../../../../api';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import keystoneDocumentRendererConfig from '../../../../helpers/keystone-document-renderer-config';
+import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import save from '../save-data';
 import { Request, Response } from '../../../../../types';
 
 const FIELD_ID = FIELD_IDS.INSURANCE.DECLARATIONS.AGREE_ANTI_BRIBERY;
@@ -13,7 +15,7 @@ const { INSURANCE, PROBLEM_WITH_SERVICE } = ROUTES;
 const {
   INSURANCE_ROOT,
   DECLARATIONS: {
-    ANTI_BRIBERY: { ROOT_SAVE_AND_BACK: ANTI_BRIBERY_SAVE_AND_BACK },
+    ANTI_BRIBERY: { ROOT_SAVE_AND_BACK: ANTI_BRIBERY_SAVE_AND_BACK, CODE_OF_CONDUCT },
   },
 } = INSURANCE;
 
@@ -67,5 +69,61 @@ export const get = async (req: Request, res: Response) => {
     console.error("Error getting declarations - anti-bribery and rendering 'anti-bribery' page ", { err });
 
     return res.redirect(PROBLEM_WITH_SERVICE);
+  }
+};
+
+/**
+ * post
+ * Check Declarations - Anti-bribery validation errors and if successful, redirect to the next part of the flow.
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.redirect} Next part of the flow or error page
+ */
+export const post = async (req: Request, res: Response) => {
+  const { application } = res.locals;
+
+  if (!application) {
+    return res.redirect(PROBLEM_WITH_SERVICE);
+  }
+
+  const { referenceNumber } = req.params;
+  const refNumber = Number(referenceNumber);
+
+  const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY);
+
+  if (validationErrors) {
+    try {
+      const antiBriberyContent = await api.keystone.application.declarations.getLatestAntiBribery();
+
+      return res.render(TEMPLATE, {
+        ...insuranceCorePageVariables({
+          PAGE_CONTENT_STRINGS: PAGES.INSURANCE.DECLARATIONS.CONFIDENTIALITY,
+          BACK_LINK: req.headers.referer,
+        }),
+        ...pageVariables(refNumber),
+        documentContent: antiBriberyContent.content.document,
+        documentConfig: keystoneDocumentRendererConfig(),
+        validationErrors,
+      });
+    } catch (err) {
+      console.error("Error getting declarations - confidentiality and rendering 'confidentiality' page ", { err });
+
+      return res.redirect(PROBLEM_WITH_SERVICE);
+    }
+  }
+
+  try {
+    // save the application
+    const saveResponse = await save.declaration(application, req.body);
+
+    if (!saveResponse) {
+      return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+    }
+
+    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CODE_OF_CONDUCT}`);
+  } catch (err) {
+    console.error('Error updating application - declarations - anti-bribery ', { err });
+
+    return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
   }
 };

--- a/src/ui/server/controllers/insurance/declarations/confidentiality/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/confidentiality/index.test.ts
@@ -164,7 +164,10 @@ describe('controllers/insurance/declarations/confidentiality', () => {
             BACK_LINK: req.headers.referer,
           }),
           ...pageVariables(mockApplication.referenceNumber),
-          content: mockDeclarations.confidentiality.content.document,
+          documentContent: mockDeclarations.confidentiality.content.document,
+          documentConfig: keystoneDocumentRendererConfig({
+            firstLevelListClass: 'counter-list counter-list--bold',
+          }),
           validationErrors: generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY),
         };
 
@@ -185,8 +188,8 @@ describe('controllers/insurance/declarations/confidentiality', () => {
     });
 
     describe('api error handling', () => {
-      describe('get countries call', () => {
-        describe('when the get countries API call fails', () => {
+      describe('get latest confidentiality call', () => {
+        describe('when the get latest confidentiality API call fails', () => {
           beforeEach(() => {
             getLatestConfidentialitySpy = jest.fn(() => Promise.reject());
             api.keystone.application.declarations.getLatestConfidentiality = getLatestConfidentialitySpy;

--- a/src/ui/server/controllers/insurance/declarations/confidentiality/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/confidentiality/index.test.ts
@@ -6,7 +6,7 @@ import api from '../../../../api';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import keystoneDocumentRendererConfig from '../../../../helpers/keystone-document-renderer-config';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
-import save from './save-data';
+import save from '../save-data';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes, mockApplication, mockDeclarations } from '../../../../test-mocks';
 
@@ -20,7 +20,7 @@ const {
 } = INSURANCE;
 
 describe('controllers/insurance/declarations/confidentiality', () => {
-  jest.mock('./save-data');
+  jest.mock('../save-data');
 
   let mockSaveDeclaration = jest.fn(() => Promise.resolve({}));
 

--- a/src/ui/server/controllers/insurance/declarations/confidentiality/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/confidentiality/index.ts
@@ -5,7 +5,7 @@ import api from '../../../../api';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import keystoneDocumentRendererConfig from '../../../../helpers/keystone-document-renderer-config';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
-import save from './save-data';
+import save from '../save-data';
 import { Request, Response } from '../../../../../types';
 
 const FIELD_ID = FIELD_IDS.INSURANCE.DECLARATIONS.AGREE_CONFIDENTIALITY;

--- a/src/ui/server/controllers/insurance/declarations/confidentiality/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/confidentiality/index.ts
@@ -101,7 +101,10 @@ export const post = async (req: Request, res: Response) => {
           BACK_LINK: req.headers.referer,
         }),
         ...pageVariables(refNumber),
-        content: confidentialityContent.content.document,
+        documentContent: confidentialityContent.content.document,
+        documentConfig: keystoneDocumentRendererConfig({
+          firstLevelListClass: 'counter-list counter-list--bold',
+        }),
         validationErrors,
       });
     } catch (err) {

--- a/src/ui/server/controllers/insurance/declarations/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/save-and-back/index.test.ts
@@ -1,8 +1,8 @@
 import { post } from '.';
-import { ROUTES } from '../../../../../constants';
-import { Request, Response } from '../../../../../../types';
+import { ROUTES } from '../../../../constants';
+import { Request, Response } from '../../../../../types';
 import save from '../save-data';
-import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockApplication, mockReq, mockRes } from '../../../../test-mocks';
 
 const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS },

--- a/src/ui/server/controllers/insurance/declarations/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/save-and-back/index.ts
@@ -1,6 +1,6 @@
-import { ROUTES } from '../../../../../constants';
-import { Request, Response } from '../../../../../../types';
-import hasFormData from '../../../../../helpers/has-form-data';
+import { ROUTES } from '../../../../constants';
+import { Request, Response } from '../../../../../types';
+import hasFormData from '../../../../helpers/has-form-data';
 import save from '../save-data';
 
 const {
@@ -34,7 +34,7 @@ export const post = async (req: Request, res: Response) => {
 
     return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`);
   } catch (err) {
-    console.error('Error updating application - declarations - confidentiality (save and back) ', { err });
+    console.error('Error updating application - declarations (save and back) ', { err });
 
     return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
   }

--- a/src/ui/server/controllers/insurance/declarations/save-data/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/save-data/index.test.ts
@@ -1,8 +1,8 @@
 import save from '.';
-import api from '../../../../../api';
-import { sanitiseData } from '../../../../../helpers/sanitise-data';
-import { FIELD_IDS } from '../../../../../constants';
-import { mockApplication } from '../../../../../test-mocks';
+import api from '../../../../api';
+import { sanitiseData } from '../../../../helpers/sanitise-data';
+import { FIELD_IDS } from '../../../../constants';
+import { mockApplication } from '../../../../test-mocks';
 
 const {
   DECLARATIONS: { AGREE_CONFIDENTIALITY },

--- a/src/ui/server/controllers/insurance/declarations/save-data/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/save-data/index.ts
@@ -1,6 +1,6 @@
-import api from '../../../../../api';
-import { sanitiseData } from '../../../../../helpers/sanitise-data';
-import { Application, RequestBody } from '../../../../../../types';
+import api from '../../../../api';
+import { sanitiseData } from '../../../../helpers/sanitise-data';
+import { Application, RequestBody } from '../../../../../types';
 
 /**
  * declarations

--- a/src/ui/server/graphql/queries/application.ts
+++ b/src/ui/server/graphql/queries/application.ts
@@ -109,6 +109,7 @@ const applicationQuery = gql`
         declaration {
           id
           agreeToConfidentiality
+          agreeToAntiBribery
         }
       }
     }

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/submit-application.test.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/submit-application.test.ts
@@ -15,7 +15,7 @@ const {
 } = INSURANCE_ROUTES;
 
 const {
-  DECLARATIONS: { AGREE_CONFIDENTIALITY },
+  DECLARATIONS: { AGREE_CONFIDENTIALITY, AGREE_ANTI_BRIBERY },
 } = FIELD_IDS.INSURANCE;
 
 describe('server/helpers/task-list/submit-application', () => {
@@ -35,7 +35,7 @@ describe('server/helpers/task-list/submit-application', () => {
       href: `${INSURANCE_ROOT}/${referenceNumber}${CONFIDENTIALITY}`,
       title: SUBMIT_APPLICATION.TASKS.DECLARATIONS,
       id: TASK_IDS.SUBMIT_APPLICATION.DECLARATIONS,
-      fields: [AGREE_CONFIDENTIALITY, 'temp'],
+      fields: [AGREE_CONFIDENTIALITY, AGREE_ANTI_BRIBERY, 'temp'],
       dependencies: [...getAllTasksFieldsInAGroup(initialChecksGroup), ...getAllTasksFieldsInAGroup(prepareApplicationGroup)],
     };
 

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/submit-application.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/submit-application.ts
@@ -13,7 +13,7 @@ const {
 } = INSURANCE_ROUTES;
 
 const {
-  DECLARATIONS: { AGREE_CONFIDENTIALITY },
+  DECLARATIONS: { AGREE_CONFIDENTIALITY, AGREE_ANTI_BRIBERY },
 } = FIELD_IDS.INSURANCE;
 
 /**
@@ -29,7 +29,7 @@ const createSubmitApplicationTasks = (referenceNumber: number, otherGroups: Task
     href: `${INSURANCE_ROOT}/${referenceNumber}${CONFIDENTIALITY}`,
     title: SUBMIT_APPLICATION.TASKS.DECLARATIONS,
     id: TASK_IDS.SUBMIT_APPLICATION.DECLARATIONS,
-    fields: [AGREE_CONFIDENTIALITY, 'temp'],
+    fields: [AGREE_CONFIDENTIALITY, AGREE_ANTI_BRIBERY, 'temp'],
     dependencies: [...getAllTasksFieldsInAGroup(initialChecksGroup), ...getAllTasksFieldsInAGroup(prepareApplicationGroup)],
   };
 

--- a/src/ui/server/routes/insurance/declarations/index.test.ts
+++ b/src/ui/server/routes/insurance/declarations/index.test.ts
@@ -1,7 +1,7 @@
 import { get, post } from '../../../test-mocks/mock-router';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import { get as confidentialityGet, post as confidentialityPost } from '../../../controllers/insurance/declarations/confidentiality';
-import { get as antiBriberyGet } from '../../../controllers/insurance/declarations/anti-bribery';
+import { get as antiBriberyGet, post as antiBriberyPost } from '../../../controllers/insurance/declarations/anti-bribery';
 import { post as saveAndBackPost } from '../../../controllers/insurance/declarations/save-and-back';
 
 describe('routes/insurance/declarations', () => {
@@ -15,12 +15,14 @@ describe('routes/insurance/declarations', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(2);
-    expect(post).toHaveBeenCalledTimes(2);
+    expect(post).toHaveBeenCalledTimes(4);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY}`, confidentialityGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY}`, confidentialityPost);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY_SAVE_AND_BACK}`, saveAndBackPost);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.ROOT}`, antiBriberyGet);
+    expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.ROOT}`, antiBriberyPost);
+    expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.ROOT_SAVE_AND_BACK}`, saveAndBackPost);
   });
 });

--- a/src/ui/server/routes/insurance/declarations/index.test.ts
+++ b/src/ui/server/routes/insurance/declarations/index.test.ts
@@ -1,8 +1,8 @@
 import { get, post } from '../../../test-mocks/mock-router';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import { get as confidentialityGet, post as confidentialityPost } from '../../../controllers/insurance/declarations/confidentiality';
-import { post as confidentialitySaveAndBackPost } from '../../../controllers/insurance/declarations/confidentiality/save-and-back';
 import { get as antiBriberyGet } from '../../../controllers/insurance/declarations/anti-bribery';
+import { post as saveAndBackPost } from '../../../controllers/insurance/declarations/save-and-back';
 
 describe('routes/insurance/declarations', () => {
   beforeEach(() => {
@@ -19,7 +19,7 @@ describe('routes/insurance/declarations', () => {
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY}`, confidentialityGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY}`, confidentialityPost);
-    expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY_SAVE_AND_BACK}`, confidentialitySaveAndBackPost);
+    expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY_SAVE_AND_BACK}`, saveAndBackPost);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.ROOT}`, antiBriberyGet);
   });

--- a/src/ui/server/routes/insurance/declarations/index.ts
+++ b/src/ui/server/routes/insurance/declarations/index.ts
@@ -1,15 +1,15 @@
 import express from 'express';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import { get as confidentialityGet, post as confidentialityPost } from '../../../controllers/insurance/declarations/confidentiality';
-import { post as confidentialitySaveAndBackPost } from '../../../controllers/insurance/declarations/confidentiality/save-and-back';
 import { get as antiBriberyGet } from '../../../controllers/insurance/declarations/anti-bribery';
+import { post as saveAndBackPost } from '../../../controllers/insurance/declarations/save-and-back';
 
 // @ts-ignore
 const insuranceDeclarationsRouter = express.Router();
 
 insuranceDeclarationsRouter.get(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY}`, confidentialityGet);
 insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY}`, confidentialityPost);
-insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY_SAVE_AND_BACK}`, confidentialitySaveAndBackPost);
+insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY_SAVE_AND_BACK}`, saveAndBackPost);
 
 insuranceDeclarationsRouter.get(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.ROOT}`, antiBriberyGet);
 

--- a/src/ui/server/routes/insurance/declarations/index.ts
+++ b/src/ui/server/routes/insurance/declarations/index.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import { get as confidentialityGet, post as confidentialityPost } from '../../../controllers/insurance/declarations/confidentiality';
-import { get as antiBriberyGet } from '../../../controllers/insurance/declarations/anti-bribery';
+import { get as antiBriberyGet, post as antiBriberyPost } from '../../../controllers/insurance/declarations/anti-bribery';
 import { post as saveAndBackPost } from '../../../controllers/insurance/declarations/save-and-back';
 
 // @ts-ignore
@@ -12,5 +12,7 @@ insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIO
 insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY_SAVE_AND_BACK}`, saveAndBackPost);
 
 insuranceDeclarationsRouter.get(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.ROOT}`, antiBriberyGet);
+insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.ROOT}`, antiBriberyPost);
+insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.ROOT_SAVE_AND_BACK}`, saveAndBackPost);
 
 export default insuranceDeclarationsRouter;

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -17,7 +17,7 @@ describe('routes/insurance', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(59);
-    expect(post).toHaveBeenCalledTimes(59);
+    expect(post).toHaveBeenCalledTimes(61);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);

--- a/src/ui/server/test-mocks/mock-application.ts
+++ b/src/ui/server/test-mocks/mock-application.ts
@@ -91,6 +91,7 @@ export const mockApplicationBuyer = {
 export const mockApplicationDeclaration = {
   id: 'clf3te7vx1432cfoqp9rbop73',
   agreeToConfidentiality: true,
+  agreeToAntiBribery: true,
 };
 
 const mockApplication = {

--- a/src/ui/types/application.ts
+++ b/src/ui/types/application.ts
@@ -108,6 +108,7 @@ interface ApplicationBuyer {
 interface ApplicationDeclaration {
   id: string;
   agreeToConfidentiality?: boolean;
+  agreeToAntiBribery?: boolean;
 }
 
 interface Application extends ApplicationCore {


### PR DESCRIPTION
⚠️  Need this PR merged first https://github.com/UK-Export-Finance/exip/pull/373


This PR updates Anti-bribery to POST the declaration to the API/DB and continue the flow, as well as adding "save and go back" functionality.

## Changes
- Move `saveData` and `saveAndBack` functions into generic declarations directory.
- Add POST route for regular POST, with UI validation.
- Add "save and back" POST route.
- Add `agreeToAntiBribery` field to the application GQL query.
- E2E test coverage.
- Add new cypress command to complete the anti-bribery form, `completeAndSubmitDeclarationAntiBribery`.