### PR TITLE
feat(EMS-1199-1189): declarations - anti-bribery - code of conduct

### DIFF
--- a/e2e-tests/constants/field-ids/insurance/declarations/index.js
+++ b/e2e-tests/constants/field-ids/insurance/declarations/index.js
@@ -1,4 +1,6 @@
 export const DECLARATIONS = {
   AGREE_CONFIDENTIALITY: 'agreeToConfidentiality',
   AGREE_ANTI_BRIBERY: 'agreeToAntiBribery',
+  HAS_ANTI_BRIBERY_CODE_OF_CONDUCT: 'hasAntiBriberyCodeOfConduct',
+  EXPORTING_WITH_CODE_OF_CONDUCT: 'willExportWithAntiBriberyCodeOfConduct',
 };

--- a/e2e-tests/constants/routes/insurance/declarations.js
+++ b/e2e-tests/constants/routes/insurance/declarations.js
@@ -10,5 +10,7 @@ export const DECLARATIONS = {
     ROOT: ANTI_BRIBERY_ROOT,
     ROOT_SAVE_AND_BACK: `${ANTI_BRIBERY_ROOT}/save-and-go-back`,
     CODE_OF_CONDUCT: `${ANTI_BRIBERY_ROOT}/code-of-conduct`,
+    CODE_OF_CONDUCT_SAVE_AND_BACK: `${ANTI_BRIBERY_ROOT}/exporting/code-of-conduct/save-and-back`,
+    EXPORTING_WITH_CODE_OF_CONDUCT: `${ANTI_BRIBERY_ROOT}/exporting/code-of-conduct`,
   },
 };

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -270,6 +270,9 @@ export const ERROR_MESSAGES = {
       [FIELD_IDS.INSURANCE.DECLARATIONS.AGREE_ANTI_BRIBERY]: {
         IS_EMPTY: 'Confirm that you have read and accept the anti-bribery and corruption declaration',
       },
+      [FIELD_IDS.INSURANCE.DECLARATIONS.HAS_ANTI_BRIBERY_CODE_OF_CONDUCT]: {
+        IS_EMPTY: 'Select whether you have a code of conduct and written procedure in place',
+      },
     },
   },
 };

--- a/e2e-tests/content-strings/fields/insurance/declarations/index.js
+++ b/e2e-tests/content-strings/fields/insurance/declarations/index.js
@@ -1,8 +1,9 @@
 import { FIELD_IDS } from '../../../../constants';
+import { LINKS } from '../../../links';
 
 const { DECLARATIONS } = FIELD_IDS.INSURANCE;
 
-const { AGREE_CONFIDENTIALITY, AGREE_ANTI_BRIBERY } = DECLARATIONS;
+const { AGREE_CONFIDENTIALITY, AGREE_ANTI_BRIBERY, HAS_ANTI_BRIBERY_CODE_OF_CONDUCT } = DECLARATIONS;
 
 const CONFIRM_READ_AND_AGREE = "Confirm you've read and agree with the ";
 
@@ -21,6 +22,18 @@ export const DECLARATIONS_FIELDS = {
     OPTION: {
       TEXT: `${HAVE_READ_AND_AREED} anti-bribery and corruption declaration`,
       VALUE: true,
+    },
+  },
+  [HAS_ANTI_BRIBERY_CODE_OF_CONDUCT]: {
+    HINT: {
+      INTRO: 'If no, your attention is drawn to',
+      LINK: {
+        TEXT: 'Ministry of Justice guidance',
+        HREF: LINKS.EXTERNAL.BRIBERY_ACT_2010_GUIDANCE,
+      },
+    },
+    ANSWER_YES_REVEAL: {
+      TEXT: "We will email you after you submit your application (also known as a 'proposal')  to request your anti-bribery code of conduct.",
     },
   },
 };

--- a/e2e-tests/content-strings/links.js
+++ b/e2e-tests/content-strings/links.js
@@ -23,5 +23,6 @@ export const LINKS = {
     NBI_FORM:
       'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1041659/export-insurance-non-binding-indication-request-form_20170609.pdf',
     FULL_APPLICATION: 'https://www.gov.uk/guidance/apply-for-ukef-export-insurance',
+    BRIBERY_ACT_2010_GUIDANCE: 'https://www.justice.gov.uk/downloads/legislation/bribery-act-2010-guidance.pdf',
   },
 };

--- a/e2e-tests/content-strings/pages/insurance/declarations/index.js
+++ b/e2e-tests/content-strings/pages/insurance/declarations/index.js
@@ -12,7 +12,14 @@ const ANTI_BRIBERY = {
   PAGE_TITLE: 'Anti-bribery and corruption',
 };
 
+const ANTI_BRIBERY_CODE_OF_CONDUCT = {
+  ...SHARED,
+  PAGE_TITLE:
+    'Do you have in place a code of conduct and written procedures of the type contemplated by Section(2) of the Bribery Act to discourage and prevent corrupt activity?',
+};
+
 export default {
   CONFIDENTIALITY,
   ANTI_BRIBERY,
+  ANTI_BRIBERY_CODE_OF_CONDUCT,
 };

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
@@ -1,0 +1,150 @@
+import {
+  headingCaption,
+  submitButton,
+  saveAndBackButton,
+  yesRadio,
+  yesRadioInput,
+  noRadio,
+  inlineErrorMessage,
+} from '../../../../../pages/shared';
+import { codeOfConductPage } from '../../../../../pages/insurance/declarations';
+import partials from '../../../../../partials';
+import {
+  BUTTONS,
+  PAGES,
+  LINKS,
+  ERROR_MESSAGES,
+} from '../../../../../../../content-strings';
+import { DECLARATIONS_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/declarations';
+import { FIELD_IDS } from '../../../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const { taskList } = partials.insurancePartials;
+
+const CONTENT_STRINGS = PAGES.INSURANCE.DECLARATIONS.ANTI_BRIBERY_CODE_OF_CONDUCT;
+
+const {
+  ROOT: INSURANCE_ROOT,
+  DECLARATIONS: {
+    ANTI_BRIBERY: {
+      ROOT: ANTI_BRIBERY_ROOT,
+      CODE_OF_CONDUCT,
+      EXPORTING_WITH_CODE_OF_CONDUCT,
+    },
+  },
+} = INSURANCE_ROUTES;
+
+const FIELD_ID = FIELD_IDS.INSURANCE.DECLARATIONS.HAS_ANTI_BRIBERY_CODE_OF_CONDUCT;
+
+context('Insurance - Declarations - Anti-bribery - Code of conduct page - As an Exporter, I want to confirm if I will use my company’s anti - bribery code of conduct for my export insurance application, So that UKEF can refer to it as applicable when processing my export insurance application.', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication().then((refNumber) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType();
+
+      // go to the page we want to test.
+      taskList.submitApplication.tasks.declarations.link().click();
+
+      cy.completeAndSubmitDeclarationConfidentiality();
+      cy.completeAndSubmitDeclarationAntiBribery();
+
+      url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${CODE_OF_CONDUCT}`;
+
+      cy.url().should('eq', url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteAccount();
+  });
+
+  it('renders core page elements', () => {
+    cy.corePageChecks({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: `${INSURANCE_ROOT}/${referenceNumber}${CODE_OF_CONDUCT}`,
+      backLink: `${INSURANCE_ROOT}/${referenceNumber}${ANTI_BRIBERY_ROOT}`,
+    });
+  });
+
+  describe('page tests', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    it('renders a heading caption', () => {
+      cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
+    });
+
+    it('renders a hint', () => {
+      cy.checkText(codeOfConductPage.hint.intro(), FIELDS[FIELD_ID].HINT.INTRO);
+
+      cy.checkLink(codeOfConductPage.hint.link(), LINKS.EXTERNAL.BRIBERY_ACT_2010_GUIDANCE, FIELDS[FIELD_ID].HINT.LINK.TEXT);
+    });
+
+    it('renders `yes` radio button', () => {
+      yesRadio().should('exist');
+
+      cy.checkText(yesRadio(), 'Yes');
+    });
+
+    it('renders `no` radio button', () => {
+      noRadio().should('exist');
+
+      cy.checkText(noRadio(), 'No');
+    });
+
+    it('renders a `save and back` button', () => {
+      saveAndBackButton().should('exist');
+
+      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+    });
+  });
+
+  describe('form submission', () => {
+    describe('when submitting an empty form', () => {
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+      });
+
+      it('should render a validation error', () => {
+        submitButton().click();
+
+        partials.errorSummaryListItems().should('exist');
+        partials.errorSummaryListItems().should('have.length', 1);
+
+        const expectedMessage = ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY;
+
+        cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
+
+        cy.checkText(inlineErrorMessage(), `Error: ${expectedMessage}`);
+      });
+
+      it('should focus on input when clicking summary error message', () => {
+        submitButton().click();
+
+        partials.errorSummaryListItemLinks().eq(0).click();
+        yesRadioInput().should('have.focus');
+      });
+    });
+
+    describe('when submitting a fully completed form', () => {
+      it(`should redirect to ${EXPORTING_WITH_CODE_OF_CONDUCT}`, () => {
+        cy.navigateToUrl(url);
+
+        cy.completeAndSubmitDeclarationAntiBriberyCodeOfConduct();
+
+        const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT}`;
+
+        cy.url().should('eq', expectedUrl);
+      });
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/pages/insurance/declarations/code-of-conduct.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/declarations/code-of-conduct.js
@@ -1,0 +1,16 @@
+import { FIELD_IDS } from '../../../../../constants';
+
+const {
+  INSURANCE: {
+    DECLARATIONS: { HAS_ANTI_BRIBERY_CODE_OF_CONDUCT },
+  },
+} = FIELD_IDS;
+
+const codeOfConductPage = {
+  hint: {
+    intro: () => cy.get(`[data-cy="${HAS_ANTI_BRIBERY_CODE_OF_CONDUCT}-hint-intro"]`),
+    link: () => cy.get(`[data-cy="${HAS_ANTI_BRIBERY_CODE_OF_CONDUCT}-hint-link"]`),
+  },
+};
+
+export default codeOfConductPage;

--- a/e2e-tests/cypress/e2e/pages/insurance/declarations/index.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/declarations/index.js
@@ -1,7 +1,9 @@
 import confidentialityPage from './confidentiality';
 import antiBriberyPage from './anti-bribery';
+import codeOfConductPage from './code-of-conduct';
 
 export {
   confidentialityPage,
   antiBriberyPage,
+  codeOfConductPage,
 };

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -79,6 +79,7 @@ Cypress.Commands.add('completeAndSubmitWorkingWithBuyerForm', require('./insuran
 
 Cypress.Commands.add('completeAndSubmitDeclarationConfidentiality', require('./insurance/declarations/complete-and-submit-confidentiality-form'));
 Cypress.Commands.add('completeAndSubmitDeclarationAntiBribery', require('./insurance/declarations/complete-and-submit-anti-bribery-form'));
+Cypress.Commands.add('completeAndSubmitDeclarationAntiBriberyCodeOfConduct', require('./insurance/declarations/complete-and-submit-anti-bribery-code-of-conduct-form'));
 
 Cypress.Commands.add('assertChangeAnswersPageUrl', require('./insurance/assert-change-answers-page-url'));
 Cypress.Commands.add('assertSummaryListRowValue', require('./assert-summary-list-row-value'));

--- a/e2e-tests/cypress/support/insurance/declarations/complete-and-submit-anti-bribery-code-of-conduct-form.js
+++ b/e2e-tests/cypress/support/insurance/declarations/complete-and-submit-anti-bribery-code-of-conduct-form.js
@@ -1,0 +1,7 @@
+import { yesRadio, submitButton } from '../../../e2e/pages/shared';
+
+export default () => {
+  yesRadio().click();
+
+  submitButton().click();
+};

--- a/src/ui/server/constants/field-ids/insurance/declarations/index.ts
+++ b/src/ui/server/constants/field-ids/insurance/declarations/index.ts
@@ -1,6 +1,8 @@
 const DECLARATIONS = {
   AGREE_CONFIDENTIALITY: 'agreeToConfidentiality',
   AGREE_ANTI_BRIBERY: 'agreeToAntiBribery',
+  HAS_ANTI_BRIBERY_CODE_OF_CONDUCT: 'hasAntiBriberyCodeOfConduct',
+  EXPORTING_WITH_CODE_OF_CONDUCT: 'willExportWithAntiBriberyCodeOfConduct',
 };
 
 export default DECLARATIONS;

--- a/src/ui/server/constants/routes/insurance/declarations.ts
+++ b/src/ui/server/constants/routes/insurance/declarations.ts
@@ -10,5 +10,7 @@ export const DECLARATIONS = {
     ROOT: ANTI_BRIBERY_ROOT,
     ROOT_SAVE_AND_BACK: `${ANTI_BRIBERY_ROOT}/save-and-go-back`,
     CODE_OF_CONDUCT: `${ANTI_BRIBERY_ROOT}/code-of-conduct`,
+    CODE_OF_CONDUCT_SAVE_AND_BACK: `${ANTI_BRIBERY_ROOT}/exporting/code-of-conduct/save-and-back`,
+    EXPORTING_WITH_CODE_OF_CONDUCT: `${ANTI_BRIBERY_ROOT}/exporting/code-of-conduct`,
   },
 };

--- a/src/ui/server/constants/templates/insurance/declarations/index.ts
+++ b/src/ui/server/constants/templates/insurance/declarations/index.ts
@@ -1,3 +1,6 @@
 export const DECLARATIONS_TEMPLATES = {
   DECLARATION: 'shared-pages/declaration.njk',
+  ANTI_BRIBERY: {
+    CODE_OF_CONDUCT: 'insurance/declarations/anti-bribery/code-of-conduct.njk',
+  },
 };

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -275,6 +275,9 @@ export const ERROR_MESSAGES = {
       [FIELD_IDS.INSURANCE.DECLARATIONS.AGREE_ANTI_BRIBERY]: {
         IS_EMPTY: 'Confirm that you have read and accept the anti-bribery and corruption declaration',
       },
+      [FIELD_IDS.INSURANCE.DECLARATIONS.HAS_ANTI_BRIBERY_CODE_OF_CONDUCT]: {
+        IS_EMPTY: 'Select whether you have a code of conduct and written procedure in place',
+      },
     },
   },
 } as ErrorMessage;

--- a/src/ui/server/content-strings/fields/insurance/declarations/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/declarations/index.ts
@@ -1,8 +1,9 @@
 import { FIELD_IDS } from '../../../../constants';
+import { LINKS } from '../../../links';
 
 const { DECLARATIONS } = FIELD_IDS.INSURANCE;
 
-const { AGREE_CONFIDENTIALITY, AGREE_ANTI_BRIBERY } = DECLARATIONS;
+const { AGREE_CONFIDENTIALITY, AGREE_ANTI_BRIBERY, HAS_ANTI_BRIBERY_CODE_OF_CONDUCT } = DECLARATIONS;
 
 const CONFIRM_READ_AND_AGREE = "Confirm you've read and agree with the ";
 
@@ -21,6 +22,18 @@ export const DECLARATIONS_FIELDS = {
     OPTION: {
       TEXT: `${HAVE_READ_AND_AREED} anti-bribery and corruption declaration`,
       VALUE: true,
+    },
+  },
+  [HAS_ANTI_BRIBERY_CODE_OF_CONDUCT]: {
+    HINT: {
+      INTRO: 'If no, your attention is drawn to',
+      LINK: {
+        TEXT: 'Ministry of Justice guidance',
+        HREF: LINKS.EXTERNAL.BRIBERY_ACT_2010_GUIDANCE,
+      },
+    },
+    ANSWER_YES_REVEAL: {
+      TEXT: "We will email you after you submit your application (also known as a 'proposal')  to request your anti-bribery code of conduct.",
     },
   },
 };

--- a/src/ui/server/content-strings/links.ts
+++ b/src/ui/server/content-strings/links.ts
@@ -23,5 +23,6 @@ export const LINKS = {
     NBI_FORM:
       'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1041659/export-insurance-non-binding-indication-request-form_20170609.pdf',
     FULL_APPLICATION: 'https://www.gov.uk/guidance/apply-for-ukef-export-insurance',
+    BRIBERY_ACT_2010_GUIDANCE: 'https://www.justice.gov.uk/downloads/legislation/bribery-act-2010-guidance.pdf',
   },
 };

--- a/src/ui/server/content-strings/pages/insurance/declarations/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/declarations/index.ts
@@ -12,7 +12,14 @@ const ANTI_BRIBERY = {
   PAGE_TITLE: 'Anti-bribery and corruption',
 };
 
+const ANTI_BRIBERY_CODE_OF_CONDUCT = {
+  ...SHARED,
+  PAGE_TITLE:
+    'Do you have in place a code of conduct and written procedures of the type contemplated by Section(2) of the Bribery Act to discourage and prevent corrupt activity?',
+};
+
 export default {
   CONFIDENTIALITY,
   ANTI_BRIBERY,
+  ANTI_BRIBERY_CODE_OF_CONDUCT,
 };

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.test.ts
@@ -1,0 +1,127 @@
+import { pageVariables, TEMPLATE, get, post } from '.';
+import { PAGES, ERROR_MESSAGES } from '../../../../../content-strings';
+import { DECLARATIONS_FIELDS } from '../../../../../content-strings/fields/insurance/declarations';
+import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../../constants';
+import singleInputPageVariables from '../../../../../helpers/page-variables/single-input/insurance';
+import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
+import { Request, Response } from '../../../../../../types';
+import { mockReq, mockRes, mockApplication } from '../../../../../test-mocks';
+
+const FIELD_ID = FIELD_IDS.INSURANCE.DECLARATIONS.HAS_ANTI_BRIBERY_CODE_OF_CONDUCT;
+
+const { INSURANCE, PROBLEM_WITH_SERVICE } = ROUTES;
+
+const {
+  INSURANCE_ROOT,
+  DECLARATIONS: {
+    ANTI_BRIBERY: { EXPORTING_WITH_CODE_OF_CONDUCT, CODE_OF_CONDUCT_SAVE_AND_BACK },
+  },
+} = INSURANCE;
+
+const PAGE_CONTENT_STRINGS = PAGES.INSURANCE.DECLARATIONS.ANTI_BRIBERY_CODE_OF_CONDUCT;
+
+describe('controllers/insurance/declarations/anti-bribery/code-of-conduct', () => {
+  let req: Request;
+  let res: Response;
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+
+    res.locals.application = mockApplication;
+  });
+
+  describe('pageVariables', () => {
+    it('should have correct properties', () => {
+      const result = pageVariables(mockApplication.referenceNumber);
+
+      const expected = {
+        FIELD: {
+          ID: FIELD_ID,
+          ...DECLARATIONS_FIELDS[FIELD_ID],
+        },
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CODE_OF_CONDUCT_SAVE_AND_BACK}`,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('TEMPLATE', () => {
+    it('should have the correct template defined', () => {
+      expect(TEMPLATE).toEqual(TEMPLATES.INSURANCE.DECLARATIONS.ANTI_BRIBERY.CODE_OF_CONDUCT);
+    });
+  });
+
+  describe('get', () => {
+    it('should render template', async () => {
+      await get(req, res);
+
+      const expectedVariables = {
+        ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer }),
+        ...pageVariables(mockApplication.referenceNumber),
+        application: res.locals.application,
+      };
+
+      expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
+    });
+
+    describe('when there is no application', () => {
+      beforeEach(() => {
+        res.locals = { csrfToken: '1234' };
+      });
+
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await get(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+      });
+    });
+  });
+
+  describe('post', () => {
+    const validBody = {
+      [FIELD_ID]: 'Yes',
+    };
+
+    describe('when there are no validation errors', () => {
+      beforeEach(() => {
+        req.body = validBody;
+      });
+
+      it(`should redirect to ${EXPORTING_WITH_CODE_OF_CONDUCT}`, async () => {
+        await post(req, res);
+
+        const expected = `${INSURANCE_ROOT}/${req.params.referenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT}`;
+
+        expect(res.redirect).toHaveBeenCalledWith(expected);
+      });
+    });
+
+    describe('when there are validation errors', () => {
+      it('should render template with validation errors', async () => {
+        await post(req, res);
+
+        const expectedVariables = {
+          ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer }),
+          ...pageVariables(mockApplication.referenceNumber),
+          validationErrors: generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY),
+        };
+
+        expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
+      });
+    });
+
+    describe('when there is no application', () => {
+      beforeEach(() => {
+        res.locals = { csrfToken: '1234' };
+      });
+
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.ts
@@ -1,0 +1,89 @@
+import { PAGES, ERROR_MESSAGES } from '../../../../../content-strings';
+import { DECLARATIONS_FIELDS } from '../../../../../content-strings/fields/insurance/declarations';
+import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../../constants';
+import singleInputPageVariables from '../../../../../helpers/page-variables/single-input/insurance';
+import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
+import { Request, Response } from '../../../../../../types';
+
+const FIELD_ID = FIELD_IDS.INSURANCE.DECLARATIONS.HAS_ANTI_BRIBERY_CODE_OF_CONDUCT;
+
+const { INSURANCE, PROBLEM_WITH_SERVICE } = ROUTES;
+
+const {
+  INSURANCE_ROOT,
+  DECLARATIONS: {
+    ANTI_BRIBERY: { EXPORTING_WITH_CODE_OF_CONDUCT, CODE_OF_CONDUCT_SAVE_AND_BACK },
+  },
+} = INSURANCE;
+
+const PAGE_CONTENT_STRINGS = PAGES.INSURANCE.DECLARATIONS.ANTI_BRIBERY_CODE_OF_CONDUCT;
+
+/**
+ * pageVariables
+ * Page fields and "save and go back" URL
+ * @param {Number} Application reference number
+ * @returns {Object} Page variables
+ */
+export const pageVariables = (referenceNumber: number) => ({
+  FIELD: {
+    ID: FIELD_ID,
+    ...DECLARATIONS_FIELDS[FIELD_ID],
+  },
+  SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${CODE_OF_CONDUCT_SAVE_AND_BACK}`,
+});
+
+export const TEMPLATE = TEMPLATES.INSURANCE.DECLARATIONS.ANTI_BRIBERY.CODE_OF_CONDUCT;
+
+/**
+ * get
+ * Render the Declarations - Anti-bribery - Code of conduct page
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.render} Declarations - Anti-bribery - Code of conduct page
+ */
+export const get = (req: Request, res: Response) => {
+  const { application } = res.locals;
+
+  if (!application) {
+    return res.redirect(PROBLEM_WITH_SERVICE);
+  }
+
+  const { referenceNumber } = req.params;
+  const refNumber = Number(referenceNumber);
+
+  return res.render(TEMPLATE, {
+    ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer }),
+    ...pageVariables(refNumber),
+    application: res.locals.application,
+  });
+};
+
+/**
+ * post
+ * Check Declarations - Anti-bribery - Code of conduct validation errors and if successful, redirect to the next part of the flow.
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.redirect} Next part of the flow or error page
+ */
+export const post = (req: Request, res: Response) => {
+  const { application } = res.locals;
+
+  if (!application) {
+    return res.redirect(PROBLEM_WITH_SERVICE);
+  }
+
+  const { referenceNumber } = req.params;
+  const refNumber = Number(referenceNumber);
+
+  const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY);
+
+  if (validationErrors) {
+    return res.render(TEMPLATE, {
+      ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer }),
+      ...pageVariables(refNumber),
+      validationErrors,
+    });
+  }
+
+  return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT}`);
+};

--- a/src/ui/server/routes/insurance/declarations/index.test.ts
+++ b/src/ui/server/routes/insurance/declarations/index.test.ts
@@ -2,6 +2,7 @@ import { get, post } from '../../../test-mocks/mock-router';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import { get as confidentialityGet, post as confidentialityPost } from '../../../controllers/insurance/declarations/confidentiality';
 import { get as antiBriberyGet, post as antiBriberyPost } from '../../../controllers/insurance/declarations/anti-bribery';
+import { get as codeOfConductGet, post as codeOfConductPost } from '../../../controllers/insurance/declarations/anti-bribery/code-of-conduct';
 import { post as saveAndBackPost } from '../../../controllers/insurance/declarations/save-and-back';
 
 describe('routes/insurance/declarations', () => {
@@ -14,8 +15,8 @@ describe('routes/insurance/declarations', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(2);
-    expect(post).toHaveBeenCalledTimes(4);
+    expect(get).toHaveBeenCalledTimes(3);
+    expect(post).toHaveBeenCalledTimes(5);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY}`, confidentialityGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY}`, confidentialityPost);
@@ -24,5 +25,8 @@ describe('routes/insurance/declarations', () => {
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.ROOT}`, antiBriberyGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.ROOT}`, antiBriberyPost);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.ROOT_SAVE_AND_BACK}`, saveAndBackPost);
+
+    expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.CODE_OF_CONDUCT}`, codeOfConductGet);
+    expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.CODE_OF_CONDUCT}`, codeOfConductPost);
   });
 });

--- a/src/ui/server/routes/insurance/declarations/index.ts
+++ b/src/ui/server/routes/insurance/declarations/index.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import { get as confidentialityGet, post as confidentialityPost } from '../../../controllers/insurance/declarations/confidentiality';
 import { get as antiBriberyGet, post as antiBriberyPost } from '../../../controllers/insurance/declarations/anti-bribery';
+import { get as codeOfConductGet, post as codeOfConductPost } from '../../../controllers/insurance/declarations/anti-bribery/code-of-conduct';
 import { post as saveAndBackPost } from '../../../controllers/insurance/declarations/save-and-back';
 
 // @ts-ignore
@@ -14,5 +15,8 @@ insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIO
 insuranceDeclarationsRouter.get(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.ROOT}`, antiBriberyGet);
 insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.ROOT}`, antiBriberyPost);
 insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.ROOT_SAVE_AND_BACK}`, saveAndBackPost);
+
+insuranceDeclarationsRouter.get(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.CODE_OF_CONDUCT}`, codeOfConductGet);
+insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.ANTI_BRIBERY.CODE_OF_CONDUCT}`, codeOfConductPost);
 
 export default insuranceDeclarationsRouter;

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -16,8 +16,8 @@ describe('routes/insurance', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(59);
-    expect(post).toHaveBeenCalledTimes(61);
+    expect(get).toHaveBeenCalledTimes(60);
+    expect(post).toHaveBeenCalledTimes(62);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);

--- a/src/ui/templates/components/yes-no-radio-buttons.njk
+++ b/src/ui/templates/components/yes-no-radio-buttons.njk
@@ -5,6 +5,7 @@
   {% set fieldId = params.fieldId %}
   {% set heading = params.heading %}
   {% set hintText = params.hintText %}
+  {% set hintHtml = params.hintHtml %}
   {% set submittedAnswer = params.submittedAnswer %}
   {% set errorMessage = params.errorMessage %}
   {% set yesNoValueString = params.yesNoValueString %}
@@ -52,6 +53,7 @@
     },
     hint: {
       text: hintText,
+      html: hintHtml,
       attributes: {
         'data-cy': dataCyHint
       }

--- a/src/ui/templates/insurance/declarations/anti-bribery/code-of-conduct.njk
+++ b/src/ui/templates/insurance/declarations/anti-bribery/code-of-conduct.njk
@@ -1,0 +1,83 @@
+{% extends 'index.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from 'govuk/components/button/macro.njk' import govukButton %}
+{% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
+{% import '../../../components/yes-no-radio-buttons.njk' as yesNoRadioButtons %}
+
+{% block pageTitle %}
+  {{ CONTENT_STRINGS.PAGE_TITLE }}
+{% endblock %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: CONTENT_STRINGS.LINKS.BACK,
+    href: BACK_LINK,
+    attributes: {
+      "data-cy": "back-link"
+    }
+  }) }}
+
+  {% if validationErrors.summary %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: validationErrors.summary
+    }) }}
+  {% endif %}
+
+  <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+
+  <form method="POST" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+    {% set hintHtml %}
+      <p>
+        <span data-cy="{{ FIELD.ID }}-hint-intro">{{ FIELD.HINT.INTRO }}</span>
+        <a class="govuk-link" href="{{ FIELD.HINT.LINK.HREF }}" data-cy="{{ FIELD.ID }}-hint-link">{{ FIELD.HINT.LINK.TEXT }}</a>.
+      </p>
+    {% endset %}
+
+    {% set conditionalYesHtml %}
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+
+          <p class="govuk-hint">{{ FIELD.ANSWER_YES_REVEAL.TEXT }}</p>
+
+        </div>
+      </div>
+    {% endset %}
+
+    {{ yesNoRadioButtons.render({
+      fieldId: FIELD.ID,
+      heading: CONTENT_STRINGS.PAGE_TITLE,
+      submittedAnswer: submittedValues[FIELD.ID],
+      errorMessage: validationErrors.errorList[FIELD.ID],
+      headerClass: 'govuk-heading-xl',
+      hintHtml: hintHtml,
+      horizontalRadios: true,
+      conditionalYesHtml: conditionalYesHtml
+    }) }}
+
+    <div class="govuk-button-group">
+      {{ govukButton({
+        text: CONTENT_STRINGS.BUTTONS.CONTINUE,
+        attributes: {
+          'data-cy': 'submit-button'
+        }
+      }) }}
+
+      {{ govukButton({
+        text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
+        classes: "govuk-button--secondary",
+        attributes: {
+          formaction: SAVE_AND_BACK_URL,
+          'data-cy': 'save-and-back-button'
+        }
+      }) }}
+    </div>
+
+  </form>
+
+{% endblock %}


### PR DESCRIPTION
⚠️ Need this PR merged first https://github.com/UK-Export-Finance/exip/pull/374

This PR adds the "code of conduct" page/form to the declarations flow.

## Changes

- Create GET route, controller and page.
- Add `hasAntiBriberyCodeOfConduct` field.
- Update `yesNoRadioButtons` nunjucks component to accept hintHtml`.
- Add E2E test coverage.
