### PR TITLE
fix(EMS-1329): Declarations - Anti-bribery - typo

### DIFF
--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/index.test.ts
@@ -160,7 +160,7 @@ describe('controllers/insurance/declarations/anti-bribery', () => {
 
         const expectedVariables = {
           ...insuranceCorePageVariables({
-            PAGE_CONTENT_STRINGS: PAGES.INSURANCE.DECLARATIONS.CONFIDENTIALITY,
+            PAGE_CONTENT_STRINGS: PAGES.INSURANCE.DECLARATIONS.ANTI_BRIBERY,
             BACK_LINK: req.headers.referer,
           }),
           ...pageVariables(mockApplication.referenceNumber),

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/index.ts
@@ -97,7 +97,7 @@ export const post = async (req: Request, res: Response) => {
 
       return res.render(TEMPLATE, {
         ...insuranceCorePageVariables({
-          PAGE_CONTENT_STRINGS: PAGES.INSURANCE.DECLARATIONS.CONFIDENTIALITY,
+          PAGE_CONTENT_STRINGS: PAGES.INSURANCE.DECLARATIONS.ANTI_BRIBERY,
           BACK_LINK: req.headers.referer,
         }),
         ...pageVariables(refNumber),


### PR DESCRIPTION
This PR adds the correct content strings to the Anti-bribery declaration page when the POST returns validation errors.