### PR TITLE
feat(EMS-1183): Declarations - Code of conduct - yes/no redirections

### DIFF
--- a/e2e-tests/constants/field-values.js
+++ b/e2e-tests/constants/field-values.js
@@ -16,4 +16,6 @@ export const FIELD_VALUES = {
     MULTIPLE: 12,
   },
   TOTAL_MONTHS_OF_COVER: Array.from(Array(POLICY_AND_EXPORT.TOTAL_MONTHS_OF_COVER).keys()),
+  YES: 'Yes',
+  NO: 'No',
 };

--- a/e2e-tests/cypress/e2e/journeys/insurance/dashboard/dashboard-multiple-applications.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/dashboard/dashboard-multiple-applications.spec.js
@@ -7,12 +7,12 @@ const { table } = dashboardPage;
 const { DASHBOARD } = ROUTES.INSURANCE;
 
 context('Insurance - Dashboard - new application', () => {
-  let referenceNumbers;
+  let referenceNumber;
   let url;
 
   before(() => {
     cy.completeSignInAndGoToApplication().then((refNumber) => {
-      referenceNumbers = [refNumber];
+      referenceNumber = refNumber;
 
       url = `${Cypress.config('baseUrl')}${DASHBOARD}`;
 
@@ -30,12 +30,12 @@ context('Insurance - Dashboard - new application', () => {
   });
 
   after(() => {
-    referenceNumbers.forEach((refNumber) => {
-      cy.deleteApplication(refNumber);
-    });
+    cy.deleteApplication(referenceNumber);
   });
 
   describe('when starting and completing insurance eligibility via the `start new` button ', () => {
+    let secondReferenceNumber;
+
     before(() => {
       dashboardPage.startNewApplication().click();
 
@@ -50,7 +50,7 @@ context('Insurance - Dashboard - new application', () => {
       table.body.firstRow.referenceNumber().click();
 
       cy.getReferenceNumber().then((refNumber) => {
-        referenceNumbers = [...referenceNumbers, refNumber];
+        secondReferenceNumber = refNumber;
 
         // go back to the dashboard
         backLink().click();
@@ -62,7 +62,7 @@ context('Insurance - Dashboard - new application', () => {
     });
 
     after(() => {
-      cy.deleteAccount();
+      cy.deleteAccountAndApplication(secondReferenceNumber);
     });
 
     it('should render the newly created application and the previously created application', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-no.spec.js
@@ -1,0 +1,63 @@
+import { submitButton, noRadioInput, backLink } from '../../../../../pages/shared';
+import partials from '../../../../../partials';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const { taskList } = partials.insurancePartials;
+
+const {
+  ROOT: INSURANCE_ROOT,
+  DECLARATIONS: {
+    ANTI_BRIBERY: {
+      CODE_OF_CONDUCT,
+    },
+    CONFIRMATION_AND_ACKNOWLEDGEMENTS,
+  },
+} = INSURANCE_ROUTES;
+
+context('Insurance - Declarations - Anti-bribery - Code of conduct page - As an Exporter, I want to confirm my company do not have code of conduct procedure, So that UKEF can have clarity about how my company operates processing my export insurance application', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication().then((refNumber) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType();
+
+      // go to the page we want to test.
+      taskList.submitApplication.tasks.declarations.link().click();
+
+      cy.completeAndSubmitDeclarationConfidentiality();
+      cy.completeAndSubmitDeclarationAntiBribery();
+
+      url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${CODE_OF_CONDUCT}`;
+
+      cy.url().should('eq', url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+
+    noRadioInput().click();
+    submitButton().click();
+  });
+
+  after(() => {
+    cy.deleteAccountAndApplication(referenceNumber);
+  });
+
+  it(`should redirect to ${CONFIRMATION_AND_ACKNOWLEDGEMENTS}`, () => {
+    const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${CONFIRMATION_AND_ACKNOWLEDGEMENTS}`;
+
+    cy.url().should('eq', expectedUrl);
+  });
+
+  it('should have the originally submitted answer selected when going back to the page after submission', () => {
+    backLink().click();
+
+    noRadioInput().should('be.checked');
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-yes.spec.js
@@ -1,0 +1,63 @@
+import { submitButton, yesRadioInput, backLink } from '../../../../../pages/shared';
+import partials from '../../../../../partials';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const { taskList } = partials.insurancePartials;
+
+const {
+  ROOT: INSURANCE_ROOT,
+  DECLARATIONS: {
+    ANTI_BRIBERY: {
+      CODE_OF_CONDUCT,
+      EXPORTING_WITH_CODE_OF_CONDUCT,
+    },
+  },
+} = INSURANCE_ROUTES;
+
+context('Insurance - Declarations - Anti-bribery - Code of conduct page - As an Exporter, I want to confirm my company does have code of conduct procedure, So that UKEF can have clarity about how my company operates processing my export insurance application', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication().then((refNumber) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType();
+
+      // go to the page we want to test.
+      taskList.submitApplication.tasks.declarations.link().click();
+
+      cy.completeAndSubmitDeclarationConfidentiality();
+      cy.completeAndSubmitDeclarationAntiBribery();
+
+      url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${CODE_OF_CONDUCT}`;
+
+      cy.url().should('eq', url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+
+    yesRadioInput().click();
+    submitButton().click();
+  });
+
+  after(() => {
+    cy.deleteAccountAndApplication(referenceNumber);
+  });
+
+  it(`should redirect to ${EXPORTING_WITH_CODE_OF_CONDUCT}`, () => {
+    const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT}`;
+
+    cy.url().should('eq', expectedUrl);
+  });
+
+  it('should have the originally submitted answer selected when going back to the page after submission', () => {
+    backLink().click();
+
+    yesRadioInput().should('be.checked');
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
@@ -29,7 +29,6 @@ const {
     ANTI_BRIBERY: {
       ROOT: ANTI_BRIBERY_ROOT,
       CODE_OF_CONDUCT,
-      EXPORTING_WITH_CODE_OF_CONDUCT,
     },
   },
 } = INSURANCE_ROUTES;
@@ -132,26 +131,6 @@ context("Insurance - Declarations - Anti-bribery - Code of conduct page - As an 
 
         partials.errorSummaryListItemLinks().eq(0).click();
         yesRadioInput().should('have.focus');
-      });
-    });
-
-    describe('when submitting a fully completed form', () => {
-      it(`should redirect to ${EXPORTING_WITH_CODE_OF_CONDUCT}`, () => {
-        cy.navigateToUrl(url);
-
-        cy.completeAndSubmitDeclarationAntiBriberyCodeOfConduct();
-
-        const expectedUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT}`;
-
-        cy.url().should('eq', expectedUrl);
-      });
-
-      describe('when going back to the page', () => {
-        it('should have the submitted value', () => {
-          cy.navigateToUrl(url);
-
-          yesRadioInput().should('be.checked');
-        });
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/code-of-conduct/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/code-of-conduct/save-and-back.spec.js
@@ -2,9 +2,11 @@ import {
   saveAndBackButton,
   submitButton,
   yesRadioInput,
+  noRadioInput,
 } from '../../../../../pages/shared';
 import partials from '../../../../../partials';
 import { TASKS } from '../../../../../../../content-strings';
+import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 
 const { STATUS: { IN_PROGRESS } } = TASKS;
@@ -20,6 +22,16 @@ const {
 } = INSURANCE_ROUTES;
 
 const task = taskList.submitApplication.tasks.declarations;
+
+const navigateBackToPage = () => {
+  task.link().click();
+
+  // go through the 1st declaration - confidentiality
+  submitButton().click();
+
+  // go through the 2nd declaration - anti-bribery
+  submitButton().click();
+};
 
 context('Insurance - Declarations - Anti-bribery - Code of conduct page - Save and go back', () => {
   let referenceNumber;
@@ -69,7 +81,7 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - Save a
     });
   });
 
-  describe('when submitting an answer via `save and go back` button', () => {
+  describe(`when submitting an answer of ${FIELD_VALUES.YES} via 'save and go back' button`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
 
@@ -79,9 +91,7 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - Save a
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
-      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
-
-      cy.url().should('eq', expected);
+      cy.assertAllSectionsUrl(referenceNumber);
     });
 
     it('should retain the status of task `declarations` as `in progress`', () => {
@@ -89,15 +99,33 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - Save a
     });
 
     it('should have the originally submitted answer selected when going back to the page after submission', () => {
-      task.link().click();
-
-      // go through the 1st declaration - confidentiality
-      submitButton().click();
-
-      // go through the 2nd declaration - anti-bribery
-      submitButton().click();
+      navigateBackToPage();
 
       yesRadioInput().should('be.checked');
+    });
+  });
+
+  describe(`when submitting an answer of ${FIELD_VALUES.NO} via 'save and go back' button`, () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      noRadioInput().click();
+
+      saveAndBackButton().click();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      cy.assertAllSectionsUrl(referenceNumber);
+    });
+
+    it('should retain the status of task `declarations` as `in progress`', () => {
+      cy.checkTaskStatus(task, IN_PROGRESS);
+    });
+
+    it('should have the originally submitted answer selected when going back to the page after submission', () => {
+      navigateBackToPage();
+
+      noRadioInput().should('be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/exporting-with-code-of-conduct/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/exporting-with-code-of-conduct/save-and-back.spec.js
@@ -2,9 +2,11 @@ import {
   saveAndBackButton,
   submitButton,
   yesRadioInput,
+  noRadioInput,
 } from '../../../../../pages/shared';
 import partials from '../../../../../partials';
 import { TASKS } from '../../../../../../../content-strings';
+import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 
 const { STATUS: { IN_PROGRESS } } = TASKS;
@@ -20,6 +22,19 @@ const {
 } = INSURANCE_ROUTES;
 
 const task = taskList.submitApplication.tasks.declarations;
+
+const navigateBackToPage = () => {
+  task.link().click();
+
+  // go through the 1st declaration - confidentiality
+  submitButton().click();
+
+  // go through the 2nd declaration - anti-bribery
+  submitButton().click();
+
+  // go through the 3rd declaration - anti-bribery - code of conduct
+  submitButton().click();
+};
 
 context('Insurance - Declarations - Exporting with code of conduct page - Save and go back', () => {
   let referenceNumber;
@@ -70,7 +85,7 @@ context('Insurance - Declarations - Exporting with code of conduct page - Save a
     });
   });
 
-  describe('when submitting an answer via `save and go back` button', () => {
+  describe(`when submitting an answer of ${FIELD_VALUES.YES} via 'save and go back' button`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
 
@@ -80,9 +95,7 @@ context('Insurance - Declarations - Exporting with code of conduct page - Save a
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
-      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
-
-      cy.url().should('eq', expected);
+      cy.assertAllSectionsUrl(referenceNumber);
     });
 
     it('should retain the status of task `declarations` as `in progress`', () => {
@@ -90,18 +103,33 @@ context('Insurance - Declarations - Exporting with code of conduct page - Save a
     });
 
     it('should have the originally submitted answer selected when going back to the page after submission', () => {
-      task.link().click();
-
-      // go through the 1st declaration - confidentiality
-      submitButton().click();
-
-      // go through the 2nd declaration - anti-bribery
-      submitButton().click();
-
-      // go through the 3rd declaration - anti-bribery - code of conduct
-      submitButton().click();
+      navigateBackToPage();
 
       yesRadioInput().should('be.checked');
+    });
+  });
+
+  describe(`when submitting an answer of ${FIELD_VALUES.NO} via 'save and go back' button`, () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      noRadioInput().click();
+
+      saveAndBackButton().click();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      cy.assertAllSectionsUrl(referenceNumber);
+    });
+
+    it('should retain the status of task `declarations` as `in progress`', () => {
+      cy.checkTaskStatus(task, IN_PROGRESS);
+    });
+
+    it('should have the originally submitted answer selected when going back to the page after submission', () => {
+      navigateBackToPage();
+
+      noRadioInput().should('be.checked');
     });
   });
 });

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -89,6 +89,8 @@ Cypress.Commands.add('completeAndSubmitDeclarationAntiBriberyCodeOfConduct', req
 Cypress.Commands.add('completeAndSubmitDeclarationAntiBriberyExportingWithCodeOfConduct', require('./insurance/declarations/complete-and-submit-anti-bribery-exporting-with-code-of-conduct-form'));
 Cypress.Commands.add('completeAndSubmitDeclarationConfirmationAndAcknowledgements', require('./insurance/declarations/complete-and-submit-confirmation-and-acknowledgements-form'));
 
+Cypress.Commands.add('assertAllSectionsUrl', require('./insurance/assert-all-sections-url'));
+
 Cypress.Commands.add('assertChangeAnswersPageUrl', require('./insurance/assert-change-answers-page-url'));
 Cypress.Commands.add('assertSummaryListRowValue', require('./assert-summary-list-row-value'));
 Cypress.Commands.add('assertSummaryListRowValueNew', require('./assert-summary-list-row-value-new'));

--- a/e2e-tests/cypress/support/insurance/assert-all-sections-url.js
+++ b/e2e-tests/cypress/support/insurance/assert-all-sections-url.js
@@ -1,0 +1,15 @@
+import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
+
+const { ROOT: INSURANCE_ROOT, ALL_SECTIONS } = INSURANCE_ROUTES;
+
+/**
+ * assertAllSectionsUrl
+ * @param {Number} Application reference number
+ */
+const assertAllSectionsUrl = (referenceNumber) => {
+  const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+  cy.url().should('eq', expected);
+};
+
+export default assertAllSectionsUrl;

--- a/e2e-tests/cypress/support/insurance/your-buyer/complete-and-submit-company-or-organisation-form.js
+++ b/e2e-tests/cypress/support/insurance/your-buyer/complete-and-submit-company-or-organisation-form.js
@@ -34,5 +34,7 @@ export default () => {
   companyOrOrganisationPage[CAN_CONTACT_BUYER].yesRadioInput().click();
   companyOrOrganisationPage[COUNTRY].input().select(countryToSelect);
 
+  // when running all the E2E tests, we seem to be temporarily blocked from companies house as it is called alot of times.
+  cy.wait(1000);
   submitButton().click();
 };

--- a/e2e-tests/cypress/support/insurance/your-buyer/complete-and-submit-company-or-organisation-form.js
+++ b/e2e-tests/cypress/support/insurance/your-buyer/complete-and-submit-company-or-organisation-form.js
@@ -35,6 +35,6 @@ export default () => {
   companyOrOrganisationPage[COUNTRY].input().select(countryToSelect);
 
   // when running all the E2E tests, we seem to be temporarily blocked from companies house as it is called alot of times.
-  cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+  cy.wait(8000); // eslint-disable-line cypress/no-unnecessary-waiting
   submitButton().click();
 };

--- a/e2e-tests/cypress/support/insurance/your-buyer/complete-and-submit-company-or-organisation-form.js
+++ b/e2e-tests/cypress/support/insurance/your-buyer/complete-and-submit-company-or-organisation-form.js
@@ -35,6 +35,6 @@ export default () => {
   companyOrOrganisationPage[COUNTRY].input().select(countryToSelect);
 
   // when running all the E2E tests, we seem to be temporarily blocked from companies house as it is called alot of times.
-  cy.wait(8000); // eslint-disable-line cypress/no-unnecessary-waiting
+  cy.wait(10000); // eslint-disable-line cypress/no-unnecessary-waiting
   submitButton().click();
 };

--- a/e2e-tests/cypress/support/insurance/your-buyer/complete-and-submit-company-or-organisation-form.js
+++ b/e2e-tests/cypress/support/insurance/your-buyer/complete-and-submit-company-or-organisation-form.js
@@ -35,6 +35,6 @@ export default () => {
   companyOrOrganisationPage[COUNTRY].input().select(countryToSelect);
 
   // when running all the E2E tests, we seem to be temporarily blocked from companies house as it is called alot of times.
-  cy.wait(1000);
+  cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
   submitButton().click();
 };

--- a/src/ui/server/constants/field-values.ts
+++ b/src/ui/server/constants/field-values.ts
@@ -16,4 +16,6 @@ export const FIELD_VALUES = {
     MULTIPLE: 12,
   },
   TOTAL_MONTHS_OF_COVER: Array.from(Array(POLICY_AND_EXPORT.TOTAL_MONTHS_OF_COVER).keys()),
+  YES: 'Yes',
+  NO: 'No',
 };

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.test.ts
@@ -1,7 +1,7 @@
 import { pageVariables, TEMPLATE, get, post } from '.';
 import { PAGES, ERROR_MESSAGES } from '../../../../../content-strings';
 import { DECLARATIONS_FIELDS } from '../../../../../content-strings/fields/insurance/declarations';
-import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../../constants';
+import { FIELD_IDS, FIELD_VALUES, ROUTES, TEMPLATES } from '../../../../../constants';
 import singleInputPageVariables from '../../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import save from '../../save-data';
@@ -16,6 +16,7 @@ const {
   INSURANCE_ROOT,
   DECLARATIONS: {
     ANTI_BRIBERY: { EXPORTING_WITH_CODE_OF_CONDUCT, CODE_OF_CONDUCT_SAVE_AND_BACK },
+    CONFIRMATION_AND_ACKNOWLEDGEMENTS,
   },
 } = INSURANCE;
 
@@ -103,12 +104,32 @@ describe('controllers/insurance/declarations/anti-bribery/code-of-conduct', () =
         expect(save.declaration).toHaveBeenCalledWith(mockApplication, validBody);
       });
 
-      it(`should redirect to ${EXPORTING_WITH_CODE_OF_CONDUCT}`, async () => {
-        await post(req, res);
+      describe(`when the answer is ${FIELD_VALUES.YES}`, () => {
+        it(`should redirect to ${EXPORTING_WITH_CODE_OF_CONDUCT}`, async () => {
+          req.body = {
+            [FIELD_ID]: FIELD_VALUES.YES,
+          };
 
-        const expected = `${INSURANCE_ROOT}/${req.params.referenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT}`;
+          await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(expected);
+          const expected = `${INSURANCE_ROOT}/${req.params.referenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT}`;
+
+          expect(res.redirect).toHaveBeenCalledWith(expected);
+        });
+      });
+
+      describe(`when the answer is ${FIELD_VALUES.NO}`, () => {
+        it(`should redirect to ${CONFIRMATION_AND_ACKNOWLEDGEMENTS}`, async () => {
+          req.body = {
+            [FIELD_ID]: FIELD_VALUES.NO,
+          };
+
+          await post(req, res);
+
+          const expected = `${INSURANCE_ROOT}/${req.params.referenceNumber}${CONFIRMATION_AND_ACKNOWLEDGEMENTS}`;
+
+          expect(res.redirect).toHaveBeenCalledWith(expected);
+        });
       });
     });
 

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.ts
@@ -1,6 +1,6 @@
 import { PAGES, ERROR_MESSAGES } from '../../../../../content-strings';
 import { DECLARATIONS_FIELDS } from '../../../../../content-strings/fields/insurance/declarations';
-import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../../constants';
+import { FIELD_IDS, FIELD_VALUES, ROUTES, TEMPLATES } from '../../../../../constants';
 import singleInputPageVariables from '../../../../../helpers/page-variables/single-input/insurance';
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import save from '../../save-data';
@@ -14,6 +14,7 @@ const {
   INSURANCE_ROOT,
   DECLARATIONS: {
     ANTI_BRIBERY: { EXPORTING_WITH_CODE_OF_CONDUCT, CODE_OF_CONDUCT_SAVE_AND_BACK },
+    CONFIRMATION_AND_ACKNOWLEDGEMENTS,
   },
 } = INSURANCE;
 
@@ -94,7 +95,15 @@ export const post = async (req: Request, res: Response) => {
       return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
     }
 
-    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT}`);
+    const answer = req.body[FIELD_ID];
+
+    if (answer === FIELD_VALUES.YES) {
+      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT}`);
+    }
+
+    if (answer === FIELD_VALUES.NO) {
+      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CONFIRMATION_AND_ACKNOWLEDGEMENTS}`);
+    }
   } catch (err) {
     console.error('Error updating application - declarations - anti-bribery - exporting with code of conduct ', { err });
 


### PR DESCRIPTION
This PR updates the "code of conduct" declaration to redirect to the appropriate place depending on yes or no answer. Also improves E2E test coverage for answering yes/no in all declaration forms via "save and back" button.

## Changes

- Update code of conduct controller to redirect to a different page depending on the answer.
- Add yes/no field values constants.
- Add and improve E2E test coverage.
- Create new cypress command: `assertAllSectionsUrl`
- Add `cy.wait()` to company/organisation form submission function used throughout the E2E tests. As we are adding more E2E tests, we are pinging the companies house API very frequently. Without introducing a delay, the API call starts to fail when running the entire E2E suite.