### PR TITLE
fix(gha): use qa environment for gha

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Timezone
-        uses: szenius/set-timezone@v1.0
+        uses: szenius/set-timezone@v1.2
         with:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
   

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
     - 'generate-exip-pricing-grid/**'
 
 env:
-  environment: dev
+  environment: qa
   timezone: 'Europe/London'
 
 jobs:
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Timezone
-        uses: szenius/set-timezone@v1.0
+        uses: szenius/set-timezone@v1.2
         with:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
@@ -59,10 +59,10 @@ jobs:
       - name: UI
         working-directory: ./src/ui
         env:
-          API_URL: ${{ secrets.QA_API_URL }}
-          DATABASE_URL: ${{ secrets.QA_DATABASE_URL_DETACHED }}
+          API_URL: ${{ secrets.API_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL_DETACHED }}
           MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
-          MYSQL_ROOT_PASSWORD: ${{ secrets.QA_MYSQL_ROOT_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
           SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
           BASIC_AUTH_KEY: ${{ secrets.BASIC_AUTH_KEY }}
           BASIC_AUTH_SECRET: ${{ secrets.BASIC_AUTH_SECRET }}
@@ -86,10 +86,10 @@ jobs:
       - name: API
         working-directory: ./
         env:
-          API_URL: ${{ secrets.QA_API_URL }}
-          DATABASE_URL: ${{ secrets.QA_DATABASE_URL_DETACHED }}
+          API_URL: ${{ secrets.API_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL_DETACHED }}
           MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
-          MYSQL_ROOT_PASSWORD: ${{ secrets.QA_MYSQL_ROOT_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
           SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
           BASIC_AUTH_KEY: ${{ secrets.BASIC_AUTH_KEY }}
           BASIC_AUTH_SECRET: ${{ secrets.BASIC_AUTH_SECRET }}
@@ -108,21 +108,11 @@ jobs:
           MOCK_ACCOUNT_PASSWORD: ${{ secrets.MOCK_ACCOUNT_PASSWORD }}
           JWT_SIGNING_KEY: ${{ secrets.JWT_SIGNING_KEY }}
           JWT_VALIDATING_KEY: ${{ secrets.JWT_VALIDATING_KEY }}
-
         run: |
           docker-compose up --build -d
           npm i --legacy-peer-deps --prefix ./src/api
           npm run test --prefix ./src/api
 
-      - name: Notification
-        uses: act10ns/slack@v1
-        with:
-          status: ${{ job.status }}
-          steps: ${{ toJson(steps) }}
-          channel: '#exip-github-actions'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: failure()
 
 # 3. E2E - E2E Journey test cases
   e2e-tests:
@@ -140,7 +130,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Timezone
-        uses: szenius/set-timezone@v1.0
+        uses: szenius/set-timezone@v1.2
         with:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
@@ -150,10 +140,10 @@ jobs:
 
       - name: Docker    
         env:
-          API_URL: ${{ secrets.QA_API_URL }}
-          DATABASE_URL: ${{ secrets.QA_DATABASE_URL }}
+          API_URL: ${{ secrets.API_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
-          MYSQL_ROOT_PASSWORD: ${{ secrets.QA_MYSQL_ROOT_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
           SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
           BASIC_AUTH_KEY: ${{ secrets.BASIC_AUTH_KEY }}
           BASIC_AUTH_SECRET: ${{ secrets.BASIC_AUTH_SECRET }}
@@ -194,12 +184,3 @@ jobs:
           GOV_NOTIFY_EMAIL_RECIPIENT_2: ${{ secrets.GOV_NOTIFY_EMAIL_RECIPIENT_2 }}
           MOCK_ACCOUNT_PASSWORD: ${{ secrets.MOCK_ACCOUNT_PASSWORD }}
 
-      - name: Notification
-        uses: act10ns/slack@v1
-        with:
-          status: ${{ job.status }}
-          steps: ${{ toJson(steps) }}
-          channel: '#exip-github-actions'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: failure()


### PR DESCRIPTION
## Introduction
GHA `test.yml` responsible for executing various QA tests upon a PR creation refers to `dev` GH environment. This environment has few overlapping variables consumed by both deployment and QA processes.

Few variables values do not apply to PR QA tests and therefore require their own unique values.

## Resolution
* `qa` GH environment introduction. This environment will only be used for executing QA tests.

## Miscelleanous
* Updated GH plugin `szenius/set-timezone` from `1.0` to `1.2`.