### PR TITLE
feat(EMS-1336): Insurance eligibility - redirect to applications all sections page when creating an application

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online.spec.js
@@ -2,7 +2,7 @@ import { submitButton } from '../../../pages/shared';
 import { insurance } from '../../../pages';
 import partials from '../../../partials';
 import { PAGES } from '../../../../../content-strings';
-import { ROUTES } from '../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
 import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
 import {
   completeStartForm,
@@ -26,13 +26,13 @@ const {
     COMPANIES_HOUSE_NUMBER,
     ACCOUNT_TO_APPLY_ONLINE,
   },
-} = ROUTES.INSURANCE;
+} = INSURANCE_ROUTES;
 
 context('Insurance - Eligibility - You are eligible to apply online page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction', () => {
   let url;
 
   before(() => {
-    cy.navigateToUrl(ROUTES.INSURANCE.START);
+    cy.navigateToUrl(START);
 
     completeStartForm();
     completeCheckIfEligibleForm();
@@ -90,11 +90,9 @@ context('Insurance - Eligibility - You are eligible to apply online page - I wan
       it(`should redirect to ${ACCOUNT_TO_APPLY_ONLINE}`, () => {
         submitButton().click();
 
-        cy.getReferenceNumber().then(() => {
-          const expectedUrl = `${Cypress.config('baseUrl')}${ACCOUNT_TO_APPLY_ONLINE}`;
+        const expectedUrl = `${Cypress.config('baseUrl')}${ACCOUNT_TO_APPLY_ONLINE}`;
 
-          cy.url().should('eq', expectedUrl);
-        });
+        cy.url().should('eq', expectedUrl);
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online/eligible-to-apply-online-already-signed-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online/eligible-to-apply-online-already-signed-in.spec.js
@@ -1,0 +1,44 @@
+import dashboardPage from '../../../../pages/insurance/dashboard';
+import header from '../../../../partials/header';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+
+const { ROOT, ALL_SECTIONS } = INSURANCE_ROUTES;
+
+context("Insurance - Eligibility - You are eligible to apply online page - As an Exporter, I want the system to show the task list page for the Export Insurance Application that I have just completed its online eligibility check, if I'm signed in into my UKEF digital service account when completing the eligibility check, So that I can progress and complete my Export Insurance Application online", () => {
+  let referenceNumbers;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication().then((refNumber) => {
+      referenceNumbers = [refNumber];
+      // go back to dashboard
+      header.navigation.applications().click();
+
+      // start new application/eligibility flow
+      dashboardPage.startNewApplication().click();
+
+      cy.submitInsuranceEligibilityAnswersFromBuyerCountryHappyPath();
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    referenceNumbers.forEach((refNumber) => {
+      cy.deleteApplication(refNumber);
+    });
+
+    cy.deleteAccount();
+  });
+
+  it("should redirect to the new application's `all sections` page", () => {
+    cy.getReferenceNumber().then((newReferenceNumber) => {
+      referenceNumbers = [...referenceNumbers, newReferenceNumber];
+
+      const expectedUrl = `${Cypress.config('baseUrl')}${ROOT}/${newReferenceNumber}${ALL_SECTIONS}`;
+
+      cy.url().should('eq', expectedUrl);
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online/eligible-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online/eligible-to-apply-online.spec.js
@@ -1,9 +1,9 @@
-import { submitButton } from '../../../pages/shared';
-import { insurance } from '../../../pages';
-import partials from '../../../partials';
-import { PAGES } from '../../../../../content-strings';
-import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
-import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
+import { submitButton } from '../../../../pages/shared';
+import { insurance } from '../../../../pages';
+import partials from '../../../../partials';
+import { PAGES } from '../../../../../../content-strings';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
 import {
   completeStartForm,
   completeCheckIfEligibleForm,
@@ -15,7 +15,7 @@ import {
   completeLetterOfCreditForm,
   completePreCreditPeriodForm,
   completeCompaniesHouseNumberForm,
-} from '../../../../support/insurance/eligibility/forms';
+} from '../../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE;
 

--- a/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.test.ts
@@ -9,7 +9,11 @@ import { Request, Response } from '../../../../../types';
 
 const {
   PROBLEM_WITH_SERVICE,
-  INSURANCE: { ELIGIBILITY, DASHBOARD },
+  INSURANCE: {
+    INSURANCE_ROOT,
+    ALL_SECTIONS,
+    ELIGIBILITY: { ACCOUNT_TO_APPLY_ONLINE },
+  },
 } = ROUTES;
 
 describe('controllers/insurance/eligibility/eligible-to-apply-online', () => {
@@ -48,10 +52,10 @@ describe('controllers/insurance/eligibility/eligible-to-apply-online', () => {
   });
 
   describe('post', () => {
-    it(`should redirect to ${ELIGIBILITY.ACCOUNT_TO_APPLY_ONLINE}`, async () => {
+    it(`should redirect to ${ACCOUNT_TO_APPLY_ONLINE}`, async () => {
       await post(req, res);
 
-      const expected = `${ELIGIBILITY.ACCOUNT_TO_APPLY_ONLINE}`;
+      const expected = `${ACCOUNT_TO_APPLY_ONLINE}`;
 
       expect(res.redirect).toHaveBeenCalledWith(expected);
     });
@@ -80,10 +84,10 @@ describe('controllers/insurance/eligibility/eligible-to-apply-online', () => {
         expect(createApplicationSpy).toHaveBeenCalledWith(req.session.submittedData.insuranceEligibility, mockAccount.id);
       });
 
-      it(`should redirect to ${DASHBOARD}`, async () => {
+      it(`should redirect to ${ALL_SECTIONS}`, async () => {
         await post(req, res);
 
-        const expected = `${DASHBOARD}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });

--- a/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.ts
@@ -1,11 +1,18 @@
 import { PAGES } from '../../../../content-strings';
 import { ROUTES, TEMPLATES } from '../../../../constants';
-import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
 import corePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
 import api from '../../../../api';
-
 import { Request, Response } from '../../../../../types';
+
+const {
+  PROBLEM_WITH_SERVICE,
+  INSURANCE: {
+    INSURANCE_ROOT,
+    ALL_SECTIONS,
+    ELIGIBILITY: { ACCOUNT_TO_APPLY_ONLINE },
+  },
+} = ROUTES;
 
 export const PAGE_VARIABLES = {
   PAGE_CONTENT_STRINGS: PAGES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE,
@@ -26,16 +33,19 @@ export const post = async (req: Request, res: Response) => {
 
       if (!application) {
         console.error('Error creating application');
-        return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+
+        return res.redirect(PROBLEM_WITH_SERVICE);
       }
 
-      return res.redirect(INSURANCE_ROUTES.DASHBOARD);
+      const applicationUrl = `${INSURANCE_ROOT}/${application.referenceNumber}${ALL_SECTIONS}`;
+
+      return res.redirect(applicationUrl);
     }
 
     // otherwise, redirect to the next part of the flow - account creation/sign in
-    return res.redirect(INSURANCE_ROUTES.ELIGIBILITY.ACCOUNT_TO_APPLY_ONLINE);
+    return res.redirect(ACCOUNT_TO_APPLY_ONLINE);
   } catch (err) {
     console.error('Error creating application ', { err });
-    return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
+    return res.redirect(PROBLEM_WITH_SERVICE);
   }
 };


### PR DESCRIPTION
This PR improves the the eligibility UX when a user is already signed in and creating an application.

## Changes
- Update the "eligible to apply online" POST controller to redirect to the "all sections" application page if an application is being created, instead of the dashboard page.
- Add E2E test coverage
- Simplfiy some parts of the existing "eligible to apply online" E2E test.