### PR TITLE
fix(docker): downgraded docker image to Node 18.15

### DIFF
--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -2,7 +2,7 @@
 # 1. BUILD
 ###################
 
-FROM node:19.8-alpine3.16 AS build
+FROM node:18.15-alpine3.16 AS build
 
 # Build variables
 ARG GITHUB_SHA
@@ -56,8 +56,7 @@ USER node
 # 2. PRODUCTION
 ###################
 
-# NPM 9.5.1 Alpine linux image
-FROM node:19.8-alpine3.16 AS production
+FROM node:18.15-alpine3.16 AS production
 
 WORKDIR /app
 

--- a/src/ui/Dockerfile
+++ b/src/ui/Dockerfile
@@ -2,7 +2,7 @@
 # 1. BUILD
 ###################
 
-FROM node:19.8.1-alpine3.16 AS build
+FROM node:18.15-alpine3.16 AS build
 
 # Build variables
 ARG GITHUB_SHA
@@ -44,8 +44,7 @@ RUN npm ci --legacy-peer-deps --omit=dev --ignore-scripts
 # 2. PRODUCTION
 ###################
 
-# NPM 9.5.1 Alpine linux image
-FROM node:19.8.1-alpine3.16 AS production
+FROM node:18.15-alpine3.16 AS production
 
 WORKDIR /app
 


### PR DESCRIPTION
## Introduction
Azure Web App containers are not compatible to run Node >= 19 base docker image.

## Resolution
* Downgraded to base image containing node `18.15`.