### PR TITLE
fix(EMS-1398): Application task list - "declarations" task

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/application-submission/submit-an-application.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/application-submission/submit-an-application.spec.js
@@ -1,7 +1,9 @@
 import dashboardPage from '../../../pages/insurance/dashboard';
 import header from '../../../partials/header';
+import taskList from '../../../partials/insurance/taskList';
 import { APPLICATION } from '../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+import { TASKS } from '../../../../../content-strings';
 
 const { table } = dashboardPage;
 
@@ -11,9 +13,15 @@ const {
   APPLICATION_SUBMITTED,
 } = INSURANCE_ROUTES;
 
+const { initialChecks, prepareApplication, submitApplication } = taskList;
+
+const { COMPLETED } = TASKS.STATUS;
+
 context('Insurance - application submitted page - As an Exporter, I want to submit my completed export insurance application, So that UKEF can process and make a decision on my application', () => {
   let referenceNumber;
   let url;
+
+  const dashboardUrl = `${Cypress.config('baseUrl')}${DASHBOARD}`;
 
   before(() => {
     cy.completeSignInAndSubmitAnApplication().then((refNumber) => {
@@ -43,9 +51,7 @@ context('Insurance - application submitted page - As an Exporter, I want to subm
     const submittedStatus = APPLICATION.STATUS.SUBMITTED;
 
     beforeEach(() => {
-      url = `${Cypress.config('baseUrl')}${DASHBOARD}`;
-
-      cy.navigateToUrl(url);
+      cy.navigateToUrl(dashboardUrl);
 
       header.navigation.applications().click();
     });
@@ -54,6 +60,31 @@ context('Insurance - application submitted page - As an Exporter, I want to subm
       const cell = table.body.row(referenceNumber).status();
 
       cy.checkText(cell, submittedStatus);
+    });
+  });
+
+  describe('when going back to the application', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(dashboardUrl);
+
+      const applicationLink = table.body.row(referenceNumber).referenceNumber();
+
+      applicationLink.click();
+    });
+
+    it(`should render 'initial checks' task statuses as ${COMPLETED}`, () => {
+      cy.checkTaskStatus(initialChecks.tasks.eligibility, COMPLETED);
+    });
+
+    it(`should render 'prepare application' task statuses as ${COMPLETED}`, () => {
+      cy.checkTaskStatus(prepareApplication.tasks.policyTypeAndExports, COMPLETED);
+      cy.checkTaskStatus(prepareApplication.tasks.exporterBusiness, COMPLETED);
+      cy.checkTaskStatus(prepareApplication.tasks.buyer, COMPLETED);
+    });
+
+    it(`should render 'submit application' task statuses as ${COMPLETED}`, () => {
+      cy.checkTaskStatus(submitApplication.tasks.checkAnswers, COMPLETED);
+      cy.checkTaskStatus(submitApplication.tasks.declarationsAndSubmit, COMPLETED);
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/dashboard/dashboard.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/dashboard/dashboard.spec.js
@@ -118,28 +118,27 @@ context('Insurance - Dashboard - new application - As an Exporter, I want to acc
 
       describe(`${TABLE_HEADERS.REFERENCE_NUMBER}`, () => {
         let expectedUrl;
+        let applicationLink;
 
         beforeEach(() => {
           cy.navigateToUrl(url);
 
           expectedUrl = `${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+          applicationLink = table.body.row(referenceNumber).referenceNumber();
         });
 
         it('should render a link to the application', () => {
-          const element = table.body.row(referenceNumber).referenceNumber();
-
           const expected = {
             href: expectedUrl,
             text: referenceNumber,
           };
 
-          cy.checkLink(element, expected.href, expected.text);
+          cy.checkLink(applicationLink, expected.href, expected.text);
         });
 
         it('should redirect to the application', () => {
-          const element = table.body.row(referenceNumber).referenceNumber();
-
-          element.click();
+          applicationLink.click();
 
           const expected = `${Cypress.config('baseUrl')}${expectedUrl}`;
           cy.url().should('eq', expected);

--- a/src/api/schema.prisma
+++ b/src/api/schema.prisma
@@ -9,7 +9,6 @@ datasource mysql {
 
 generator client {
   provider = "prisma-client-js"
-  output   = "node_modules/.prisma/client"
 }
 
 model ReferenceNumber {

--- a/src/ui/server/controllers/insurance/all-sections/index.test.ts
+++ b/src/ui/server/controllers/insurance/all-sections/index.test.ts
@@ -31,10 +31,14 @@ describe('controllers/insurance/all-sections', () => {
     it('should render template', () => {
       get(req, res);
 
-      const { referenceNumber, policyAndExport, exporterBroker } = mockApplication;
+      const { referenceNumber, policyAndExport, exporterBroker, declaration } = mockApplication;
+
+      const { policyType } = policyAndExport;
+      const { isUsingBroker } = exporterBroker;
+      const { hasAntiBriberyCodeOfConduct } = declaration;
 
       const flatApplicationData = flattenApplicationData(mockApplication);
-      const taskListStructure = generateGroupsAndTasks(referenceNumber, policyAndExport.policyType, exporterBroker.isUsingBroker);
+      const taskListStructure = generateGroupsAndTasks(referenceNumber, policyType, isUsingBroker, hasAntiBriberyCodeOfConduct);
       const expectedTaskListData = generateTaskList(taskListStructure, flatApplicationData);
 
       const expectedVariables = {

--- a/src/ui/server/controllers/insurance/all-sections/index.ts
+++ b/src/ui/server/controllers/insurance/all-sections/index.ts
@@ -30,6 +30,7 @@ export const get = (req: Request, res: Response) => {
     application.referenceNumber,
     application.policyAndExport.policyType,
     application.exporterBroker.isUsingBroker,
+    application.declaration.hasAntiBriberyCodeOfConduct,
   );
 
   const taskListData = generateTaskList(taskListStructure, flatApplicationData);

--- a/src/ui/server/helpers/required-fields/declarations/index.test.ts
+++ b/src/ui/server/helpers/required-fields/declarations/index.test.ts
@@ -35,6 +35,16 @@ describe('server/helpers/required-fields/declarations', () => {
         expect(result).toEqual(expected);
       });
     });
+
+    describe('when hasAntiBriberyCodeOfConduct is not provided/submitted', () => {
+      it(`should return an array with just ${HAS_ANTI_BRIBERY_CODE_OF_CONDUCT} field ID`, () => {
+        const result = getAntiBriberyCodeOfConductTasks();
+
+        const expected = [HAS_ANTI_BRIBERY_CODE_OF_CONDUCT];
+
+        expect(result).toEqual(expected);
+      });
+    });
   });
 
   describe('requiredFields', () => {

--- a/src/ui/server/helpers/required-fields/declarations/index.ts
+++ b/src/ui/server/helpers/required-fields/declarations/index.ts
@@ -15,11 +15,11 @@ const {
 /**
  * getAntiBriberyCodeOfConductTasks
  * Get anti-bribery code of conduct tasks depending on if "has anti-bribery code of conduct" answer
- * @param {String} Has anti-bribery code of conduct answer
+ * @param {String} Application "Has anti-bribery code of conduct" flag
  * @returns {Array} Anti-bribery code of conduct tasks
  */
-export const getAntiBriberyCodeOfConductTasks = (hasAntiBriberyCodeOfConduct: string): Array<string> => {
-  if (hasAntiBriberyCodeOfConduct === FIELD_VALUES.YES) {
+export const getAntiBriberyCodeOfConductTasks = (hasAntiBriberyCodeOfConduct?: string): Array<string> => {
+  if (hasAntiBriberyCodeOfConduct && hasAntiBriberyCodeOfConduct === FIELD_VALUES.YES) {
     return [HAS_ANTI_BRIBERY_CODE_OF_CONDUCT, WILL_EXPORT_WITH_CODE_OF_CONDUCT];
   }
 
@@ -30,7 +30,7 @@ export const getAntiBriberyCodeOfConductTasks = (hasAntiBriberyCodeOfConduct: st
  * Required fields for the insurance - declarations section
  * @param {Array} Required field IDs
  */
-const requiredFields = (hasAntiBriberyCodeOfConduct: string): Array<string> => {
+const requiredFields = (hasAntiBriberyCodeOfConduct?: string): Array<string> => {
   const fields = [
     AGREE_CONFIDENTIALITY,
     AGREE_ANTI_BRIBERY,

--- a/src/ui/server/helpers/required-fields/eligibility/index.ts
+++ b/src/ui/server/helpers/required-fields/eligibility/index.ts
@@ -4,6 +4,9 @@ const { ACCOUNT_TO_APPLY_ONLINE } = FIELD_IDS.INSURANCE.ELIGIBILITY;
 
 /**
  * Required fields for the insurance - eligibility section
+ * Strip out the ACCOUNT_TO_APPLY_ONLINE field. This field is part of eligibility,
+ * but we don't save this field (has no value). Therefore we do not want to include this
+ * in the list of required eligibility fields.
  * @returns {Array} Required field IDs
  */
 const requiredFields = () => Object.values(FIELD_IDS.INSURANCE.ELIGIBILITY).filter((fieldId) => fieldId !== ACCOUNT_TO_APPLY_ONLINE);

--- a/src/ui/server/helpers/required-fields/exporter-business/index.ts
+++ b/src/ui/server/helpers/required-fields/exporter-business/index.ts
@@ -25,7 +25,7 @@ const { USING_BROKER, NAME, ADDRESS_LINE_1, TOWN, POSTCODE, EMAIL } = BROKER;
 /**
  * getBrokerTasks
  * Get broker section tasks depending on the isUsingBroker field
- * @param {String} isUsingBroker
+ * @param {String} Application "Is using broker" flag
  * @returns {Array} Array of tasks
  */
 export const getBrokerTasks = (isUsingBroker?: string): Array<string> => {

--- a/src/ui/server/helpers/required-fields/policy-and-exports/index.ts
+++ b/src/ui/server/helpers/required-fields/policy-and-exports/index.ts
@@ -21,6 +21,7 @@ export const getContractPolicyTasks = (policyType?: string): object => {
 
 /**
  * Required fields for the insurance - policy and exports section
+ * @param {String} Application "Policy type"
  * @returns {Array} Required field IDs
  */
 const requiredFields = (policyType?: string) =>

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/index.test.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/index.test.ts
@@ -9,10 +9,14 @@ import { mockApplication } from '../../../test-mocks';
 const { INITIAL_CHECKS, PREPARE_APPLICATION, SUBMIT_APPLICATION } = TASKS.LIST;
 
 describe('server/helpers/task-list/generate-groups-and-tasks', () => {
-  const { referenceNumber, policyAndExport } = mockApplication;
+  const { referenceNumber, policyAndExport, exporterBroker, declaration } = mockApplication;
+
+  const { policyType } = policyAndExport;
+  const { isUsingBroker } = exporterBroker;
+  const { hasAntiBriberyCodeOfConduct } = declaration;
 
   it('should return EXIP groups and tasks', () => {
-    const result = generateGroupsAndTasks(referenceNumber, policyAndExport.policyType);
+    const result = generateGroupsAndTasks(referenceNumber, policyType, isUsingBroker, hasAntiBriberyCodeOfConduct);
 
     const initialChecks = {
       title: INITIAL_CHECKS.HEADING,
@@ -23,13 +27,13 @@ describe('server/helpers/task-list/generate-groups-and-tasks', () => {
     const prepareApplication = {
       title: PREPARE_APPLICATION.HEADING,
       id: GROUP_IDS.PREPARE_APPLICATION,
-      tasks: prepareApplicationTasks(referenceNumber, [initialChecks], policyAndExport.policyType),
+      tasks: prepareApplicationTasks(referenceNumber, [initialChecks], policyType, isUsingBroker),
     };
 
     const submitApplication = {
       title: SUBMIT_APPLICATION.HEADING,
       id: GROUP_IDS.SUBMIT_APPLICATION,
-      tasks: submitApplicationTasks(referenceNumber, [initialChecks, prepareApplication]),
+      tasks: submitApplicationTasks(referenceNumber, [initialChecks, prepareApplication], hasAntiBriberyCodeOfConduct),
     };
 
     const expected = [initialChecks, prepareApplication, submitApplication];

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/index.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/index.ts
@@ -10,10 +10,12 @@ const { INITIAL_CHECKS, PREPARE_APPLICATION, SUBMIT_APPLICATION } = TASKS.LIST;
 /**
  * generateGroupsAndTasks
  * @param {Number} Application reference number
- * @param {String} Application policy type
+ * @param {String} Application "Policy type"
+ * @param {String} Application "Is using broker" flag
+ * @param {String} Application "Has anti-bribery code of conduct" flag
  * @returns {Array} Task list groups and tasks
  */
-const generateGroupsAndTasks = (referenceNumber: number, policyType?: string, isUsingBroker?: string): TaskListData => {
+const generateGroupsAndTasks = (referenceNumber: number, policyType?: string, isUsingBroker?: string, hasAntiBriberyCodeOfConduct?: string): TaskListData => {
   let groups = [
     {
       title: INITIAL_CHECKS.HEADING,
@@ -36,7 +38,7 @@ const generateGroupsAndTasks = (referenceNumber: number, policyType?: string, is
     {
       title: SUBMIT_APPLICATION.HEADING,
       id: GROUP_IDS.SUBMIT_APPLICATION,
-      tasks: submitApplicationTasks(referenceNumber, groups),
+      tasks: submitApplicationTasks(referenceNumber, groups, hasAntiBriberyCodeOfConduct),
     },
   ] as TaskListData;
 

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/initial-checks.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/initial-checks.ts
@@ -7,17 +7,13 @@ const { INITIAL_CHECKS } = TASKS.LIST;
 
 /**
  * createInitialChecksTasks
- * @returns {Array} Tasks
+ * @returns {Array} Initial checks tasks
  */
 const createInitialChecksTasks = (): Array<TaskListDataTask> => [
   {
     href: '#',
     title: INITIAL_CHECKS.TASKS.ELIGIBILITY,
     id: TASK_IDS.INITIAL_CHECKS.ELIGIBILITY,
-
-    // strip out the ACCOUNT_TO_APPLY_ONLINE field. This field is part of eligibility,
-    // but we don't save this field (useless). Therefore we do not want to include this
-    // in the list of required eligibility fields.
     fields: requiredFields(),
     dependencies: [],
   } as TaskListDataTask,

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/prepare-application.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/prepare-application.ts
@@ -14,9 +14,10 @@ const { PREPARE_APPLICATION } = TASKS.LIST;
 /**
  * createPrepareApplicationTasks
  * @param {Number} Application reference number
- * @param {String} Application policy type
- * @param {Array} otherGroups Task list groups
- * @returns {Array} Tasks
+ * @param {Array} Task list groups
+ * @param {String} Application "Policy type"
+ * @param {String} Application "Is using broker" flag
+ * @returns {Array} Prepare application tasks
  */
 const createPrepareApplicationTasks = (
   referenceNumber: number,

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/submit-application.test.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/submit-application.test.ts
@@ -4,6 +4,7 @@ import generateGroupsAndTasks from '.';
 import { FIELD_IDS, TASK_IDS } from '../../../constants';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import { TASKS } from '../../../content-strings';
+import declarationsRequiredFields from '../../required-fields/declarations';
 import { mockApplication } from '../../../test-mocks';
 
 const { SUBMIT_APPLICATION } = TASKS.LIST;
@@ -15,23 +16,27 @@ const {
 } = INSURANCE_ROUTES;
 
 const {
-  DECLARATIONS: { AGREE_CONFIDENTIALITY, AGREE_ANTI_BRIBERY },
   CHECK_YOUR_ANSWERS,
   CHECK_YOUR_ANSWERS: { POLICY_AND_EXPORT, EXPORTER_BUSINESS, BUYER },
 } = FIELD_IDS.INSURANCE;
 
 describe('server/helpers/task-list/submit-application', () => {
   it('should return EXIP `submit application` tasks', () => {
-    const { referenceNumber } = mockApplication;
+    const { referenceNumber, policyAndExport, exporterBroker, declaration } = mockApplication;
 
-    const groupsAndTasks = generateGroupsAndTasks(referenceNumber);
+    const groupsAndTasks = generateGroupsAndTasks(
+      referenceNumber,
+      policyAndExport.policyType,
+      exporterBroker.isUsingBroker,
+      declaration.hasAntiBriberyCodeOfConduct,
+    );
 
     const initialChecksGroup = groupsAndTasks[0];
     const prepareApplicationGroup = groupsAndTasks[1];
 
     const previousGroups = [initialChecksGroup, prepareApplicationGroup];
 
-    const result = createSubmitApplicationTasks(referenceNumber, previousGroups);
+    const result = createSubmitApplicationTasks(referenceNumber, previousGroups, declaration.hasAntiBriberyCodeOfConduct);
 
     const initialChecksFields = getAllTasksFieldsInAGroup(initialChecksGroup);
     const prepareApplicationFields = getAllTasksFieldsInAGroup(prepareApplicationGroup);
@@ -50,7 +55,7 @@ describe('server/helpers/task-list/submit-application', () => {
       href: `${INSURANCE_ROOT}/${referenceNumber}${CONFIDENTIALITY}`,
       title: SUBMIT_APPLICATION.TASKS.DECLARATIONS_AND_SUBMIT,
       id: TASK_IDS.SUBMIT_APPLICATION.DECLARATIONS_AND_SUBMIT,
-      fields: [AGREE_CONFIDENTIALITY, AGREE_ANTI_BRIBERY, 'temp'],
+      fields: declarationsRequiredFields(declaration.hasAntiBriberyCodeOfConduct),
       dependencies: expectedDependencies,
     };
 

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/submit-application.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/submit-application.ts
@@ -3,6 +3,7 @@ import { FIELD_IDS, GROUP_IDS, TASK_IDS } from '../../../constants';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import { TASKS } from '../../../content-strings';
 import { getGroupById, getAllTasksFieldsInAGroup } from '../task-helpers';
+import declarationsRequiredFields from '../../required-fields/declarations';
 
 const { SUBMIT_APPLICATION } = TASKS.LIST;
 
@@ -13,17 +14,18 @@ const {
 } = INSURANCE_ROUTES;
 
 const {
-  DECLARATIONS: { AGREE_CONFIDENTIALITY, AGREE_ANTI_BRIBERY },
   CHECK_YOUR_ANSWERS,
   CHECK_YOUR_ANSWERS: { POLICY_AND_EXPORT, EXPORTER_BUSINESS, BUYER },
 } = FIELD_IDS.INSURANCE;
 
 /**
  * createSubmitApplicationTasks
- * @param {Array} otherGroups Task list groups
- * @returns {Array} Tasks
+ * @param { Number } Application reference number
+ * @param {Array} Task list groups
+ * @param { String } Application "Has anti-bribery code of conduct" flag
+ * @returns {Array} Submit application tasks
  */
-const createSubmitApplicationTasks = (referenceNumber: number, otherGroups: TaskListData): Array<TaskListDataTask> => {
+const createSubmitApplicationTasks = (referenceNumber: number, otherGroups: TaskListData, hasAntiBriberyCodeOfConduct?: string): Array<TaskListDataTask> => {
   const initialChecksGroup = getGroupById(otherGroups, GROUP_IDS.INITIAL_CHECKS);
   const prepareApplicationGroup = getGroupById(otherGroups, GROUP_IDS.PREPARE_APPLICATION);
 
@@ -44,7 +46,7 @@ const createSubmitApplicationTasks = (referenceNumber: number, otherGroups: Task
     href: `${INSURANCE_ROOT}/${referenceNumber}${CONFIDENTIALITY}`,
     title: SUBMIT_APPLICATION.TASKS.DECLARATIONS_AND_SUBMIT,
     id: TASK_IDS.SUBMIT_APPLICATION.DECLARATIONS_AND_SUBMIT,
-    fields: [AGREE_CONFIDENTIALITY, AGREE_ANTI_BRIBERY, 'temp'],
+    fields: declarationsRequiredFields(hasAntiBriberyCodeOfConduct),
     dependencies,
   };
 


### PR DESCRIPTION
This PR fixes an issue where the "declarations" task would show as "in progress" when it has been completed.


## Changes
- Remove `temp` field ID from the declarations task fields definition.
- Update declarations task fields definition to consume `declarationsRequiredFields`.
- Add E2E test coverage for checking all task statuses are "completed", after submitting an application.

## Other improvements
- Improved documentation for task definition functions.
- More destructuring in task definition functions, easier to read.