### PR TITLE
fix(EMS-1186): Contact us page - Authenticated header

### DIFF
--- a/src/ui/server/controllers/root/contact-us/index.test.ts
+++ b/src/ui/server/controllers/root/contact-us/index.test.ts
@@ -4,6 +4,7 @@ import { ROUTES, TEMPLATES } from '../../../constants';
 import { Request, Response } from '../../../../types';
 import { mockReq, mockRes } from '../../../test-mocks';
 import corePageVariables from '../../../helpers/page-variables/core';
+import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
 
 const startRoute = ROUTES.QUOTE.START;
 
@@ -37,6 +38,7 @@ describe('controllers/root/contact-us', () => {
           PRODUCT: { DESCRIPTION: PRODUCT.DESCRIPTION.GENERIC },
           START_ROUTE: startRoute,
         }),
+        userName: getUserNameFromSession(req.session.user),
       });
     });
   });

--- a/src/ui/server/controllers/root/contact-us/index.ts
+++ b/src/ui/server/controllers/root/contact-us/index.ts
@@ -2,6 +2,7 @@ import { PAGES, PRODUCT } from '../../../content-strings';
 import { ROUTES, TEMPLATES } from '../../../constants';
 import { Request, Response } from '../../../../types';
 import corePageVariables from '../../../helpers/page-variables/core';
+import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
 
 const startRoute = ROUTES.QUOTE.START;
 
@@ -21,5 +22,6 @@ export const get = (req: Request, res: Response) => {
       PRODUCT: { DESCRIPTION: PRODUCT.DESCRIPTION.GENERIC },
       START_ROUTE: startRoute,
     }),
+    userName: getUserNameFromSession(req.session.user),
   });
 };

--- a/src/ui/server/test-mocks/mock-buyer.ts
+++ b/src/ui/server/test-mocks/mock-buyer.ts
@@ -4,7 +4,7 @@ dotenv.config();
 
 const mockBuyer = {
   companyOrOrganisationName: 'Test name',
-  address: 'Test \r\n address',
+  address: 'Address line 1 \r\n Address line 2 \r\n Test town \r\n Test Postcode \r\n United Kingdom',
   country: {
     isoCode: 'GBR',
     name: 'United Kingdom',


### PR DESCRIPTION
# Issue: 
* Contact us page does not show account header links

# Changes made:
* Added authenticated header code to contact-us controller
* Added unit test
* Added more realistic address to mock-buyer test mock