### PR TITLE
fix(EMS-1254): Application submission - fix incorrect flag used for sending emails

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -2351,7 +2351,7 @@ var getApplicationSubmittedEmailTemplateIds = (application) => {
     templateIds.exporter = EXPORTER.SEND_DOCUMENTS.ANTI_BRIBERY;
     templateIds.underwritingTeam = UNDERWRITING_TEAM.NOTIFICATION_ANTI_BRIBERY;
   }
-  const isConnectedWithBuyer = buyer.exporterIsConnectedWithBuyer && buyer.exporterIsConnectedWithBuyer === ANSWERS.YES;
+  const isConnectedWithBuyer = buyer.exporterHasTradedWithBuyer && buyer.exporterHasTradedWithBuyer === ANSWERS.YES;
   if (isConnectedWithBuyer) {
     templateIds.exporter = EXPORTER.SEND_DOCUMENTS.TRADING_HISTORY;
     templateIds.underwritingTeam = UNDERWRITING_TEAM.NOTIFICATION_TRADING_HISTORY;

--- a/src/api/emails/send-application-submitted-emails/index.test.ts
+++ b/src/api/emails/send-application-submitted-emails/index.test.ts
@@ -94,11 +94,16 @@ describe('emails/send-email-application-submitted', () => {
       expect(documentsEmailSpy).toHaveBeenCalledWith(expectedSendEmailVars, templateId);
     });
 
-    describe('when the declaration has an answer of `No` for hasAntiBriberyCodeOfConduct and buyer has exporterIsConnectedWithBuyer answer of `Yes`', () => {
+    describe('when the declaration has an answer of `No` for hasAntiBriberyCodeOfConduct and buyer has exporterHasTradedWithBuyer answer of `Yes`', () => {
       beforeEach(() => {
         application.declaration = {
           ...application.declaration,
           hasAntiBriberyCodeOfConduct: ANSWERS.NO,
+        };
+
+        application.buyer = {
+          ...application.buyer,
+          exporterHasTradedWithBuyer: ANSWERS.YES,
         };
       });
 
@@ -113,7 +118,7 @@ describe('emails/send-email-application-submitted', () => {
       });
     });
 
-    describe('when the declaration has an answer of `No` for hasAntiBriberyCodeOfConduct and does NOT have exporterIsConnectedWithBuyer', () => {
+    describe('when the declaration has an answer of `No` for hasAntiBriberyCodeOfConduct and does NOT have exporterHasTradedWithBuyer', () => {
       beforeEach(() => {
         application.declaration = {
           ...application.declaration,
@@ -122,7 +127,7 @@ describe('emails/send-email-application-submitted', () => {
 
         application.buyer = {
           ...application.buyer,
-          exporterIsConnectedWithBuyer: ANSWERS.NO,
+          exporterHasTradedWithBuyer: ANSWERS.NO,
         };
       });
 
@@ -133,7 +138,7 @@ describe('emails/send-email-application-submitted', () => {
       });
     });
 
-    describe('when the declaration has an answer of `Yes` for hasAntiBriberyCodeOfConduct and does NOT have exporterIsConnectedWithBuyer', () => {
+    describe('when the declaration has an answer of `Yes` for hasAntiBriberyCodeOfConduct and does NOT have exporterHasTradedWithBuyer', () => {
       beforeEach(async () => {
         application.declaration = {
           ...application.declaration,
@@ -142,7 +147,7 @@ describe('emails/send-email-application-submitted', () => {
 
         application.buyer = {
           ...application.buyer,
-          exporterIsConnectedWithBuyer: ANSWERS.NO,
+          exporterHasTradedWithBuyer: ANSWERS.NO,
         };
       });
 

--- a/src/api/helpers/get-application-submitted-email-template-ids/index.test.ts
+++ b/src/api/helpers/get-application-submitted-email-template-ids/index.test.ts
@@ -25,7 +25,7 @@ describe('helpers/get-application-submitted-email-template-ids', () => {
     expect(result).toEqual(expected);
   });
 
-  describe('when the declaration has an answer of `No` for hasAntiBriberyCodeOfConduct and buyer has exporterIsConnectedWithBuyer answer of `Yes`', () => {
+  describe('when the declaration has an answer of `No` for hasAntiBriberyCodeOfConduct and buyer has exporterHasTradedWithBuyer answer of `Yes`', () => {
     beforeEach(() => {
       application = {
         ...mockApplication,
@@ -48,7 +48,7 @@ describe('helpers/get-application-submitted-email-template-ids', () => {
     });
   });
 
-  describe('when the declaration has an answer of `No` for hasAntiBriberyCodeOfConduct and does NOT have exporterIsConnectedWithBuyer', () => {
+  describe('when the declaration has an answer of `No` for hasAntiBriberyCodeOfConduct and does NOT have exporterHasTradedWithBuyer', () => {
     beforeEach(() => {
       application = {
         ...mockApplication,
@@ -59,7 +59,7 @@ describe('helpers/get-application-submitted-email-template-ids', () => {
         },
         buyer: {
           ...mockApplication.buyer,
-          exporterIsConnectedWithBuyer: ANSWERS.NO,
+          exporterHasTradedWithBuyer: ANSWERS.NO,
         },
       };
     });
@@ -76,7 +76,7 @@ describe('helpers/get-application-submitted-email-template-ids', () => {
     });
   });
 
-  describe('when the declaration has an answer of `Yes` for hasAntiBriberyCodeOfConduct and does NOT have exporterIsConnectedWithBuyer', () => {
+  describe('when the declaration has an answer of `Yes` for hasAntiBriberyCodeOfConduct and does NOT have exporterHasTradedWithBuyer', () => {
     beforeEach(async () => {
       application = {
         ...mockApplication,
@@ -86,7 +86,7 @@ describe('helpers/get-application-submitted-email-template-ids', () => {
         },
         buyer: {
           ...mockApplication.buyer,
-          exporterIsConnectedWithBuyer: ANSWERS.NO,
+          exporterHasTradedWithBuyer: ANSWERS.NO,
         },
       };
     });

--- a/src/api/helpers/get-application-submitted-email-template-ids/index.ts
+++ b/src/api/helpers/get-application-submitted-email-template-ids/index.ts
@@ -28,7 +28,7 @@ const getApplicationSubmittedEmailTemplateIds = (application: Application) => {
     templateIds.underwritingTeam = UNDERWRITING_TEAM.NOTIFICATION_ANTI_BRIBERY;
   }
 
-  const isConnectedWithBuyer = buyer.exporterIsConnectedWithBuyer && buyer.exporterIsConnectedWithBuyer === ANSWERS.YES;
+  const isConnectedWithBuyer = buyer.exporterHasTradedWithBuyer && buyer.exporterHasTradedWithBuyer === ANSWERS.YES;
 
   if (isConnectedWithBuyer) {
     templateIds.exporter = EXPORTER.SEND_DOCUMENTS.TRADING_HISTORY;

--- a/src/api/test-mocks/mock-buyer.ts
+++ b/src/api/test-mocks/mock-buyer.ts
@@ -19,7 +19,7 @@ const mockBuyer = {
   contactEmail: process.env.GOV_NOTIFY_EMAIL_RECIPIENT_1,
   canContactBuyer: true,
   exporterIsConnectedWithBuyer: ANSWERS.YES,
-  exporterHasTradedWithBuyer: true,
+  exporterHasTradedWithBuyer: ANSWERS.YES,
 };
 
 export default mockBuyer;


### PR DESCRIPTION
This PR fixes an issue where an incorrect flag was being used in a condition to trigger a particular email template from being sent as part of application submission.

## Changes
- Rename usage of `buyer.exporterIsConnectedWithBuyer` with `buyer.exporterHasTradedWithBuyer` in the `getApplicationSubmittedEmailTemplateIds` function.
- Update `exporterHasTradedWithBuyer` mock data/answer to reflect what is actually stored in the DB.