### PR TITLE
fix(EMS-1522-1555): Application submitted page authenticated header and start new application redirect

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/need-to-start-new-application/need-to-start-new-application-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/need-to-start-new-application/need-to-start-new-application-page.spec.js
@@ -8,6 +8,7 @@ const {
   ROOT: INSURANCE_ROOT,
   START,
   ALL_SECTIONS,
+  ELIGIBILITY: { BUYER_COUNTRY },
   CHECK_YOUR_ANSWERS: { ELIGIBILITY, START_NEW_APPLICATION },
 } = ROUTES.INSURANCE;
 
@@ -84,7 +85,7 @@ context('Insurance - Check your answers - Need to start new application page', (
     });
 
     it('renders a `start new application` link button', () => {
-      cy.checkLink(linkButtons.startNewApplication(), START, BUTTONS.START_A_NEW_APPLICATION);
+      cy.checkLink(linkButtons.startNewApplication(), BUYER_COUNTRY, BUTTONS.START_A_NEW_APPLICATION);
     });
 
     it('renders a `return to my existing application` link button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/need-to-start-new-application/need-to-start-new-application-start-new-application.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/need-to-start-new-application/need-to-start-new-application-start-new-application.spec.js
@@ -42,7 +42,7 @@ context('Insurance - Check your answers - Need to start new application - start 
 
   describe('after completing eligibility for the new application', () => {
     before(() => {
-      cy.submitInsuranceEligibilityAnswersHappyPath();
+      cy.submitInsuranceEligibilityAnswersHappyPath(true);
     });
 
     beforeEach(() => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/need-to-start-new-application/need-to-start-new-application-start-new-application.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/need-to-start-new-application/need-to-start-new-application-start-new-application.spec.js
@@ -42,7 +42,7 @@ context('Insurance - Check your answers - Need to start new application - start 
 
   describe('after completing eligibility for the new application', () => {
     before(() => {
-      cy.submitInsuranceEligibilityAnswersHappyPath(true);
+      cy.submitInsuranceEligibilityAnswersFromBuyerCountryHappyPath();
     });
 
     beforeEach(() => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/no-access-application-submitted.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/no-access-application-submitted.spec.js
@@ -57,7 +57,6 @@ context('Insurance - no access to application when application is submitted', ()
         currentHref: NO_ACCESS_APPLICATION_SUBMITTED,
         assertSubmitButton: false,
         backLink: DASHBOARD,
-        assertAuthenticatedHeader: false,
       });
     });
 

--- a/e2e-tests/cypress/support/insurance/eligibility/submit-answers-happy-path.js
+++ b/e2e-tests/cypress/support/insurance/eligibility/submit-answers-happy-path.js
@@ -2,8 +2,15 @@ import submitInsuranceEligibilityAnswersFromBuyerCountryHappyPath from './submit
 
 import { completeStartForm, completeCheckIfEligibleForm } from './forms';
 
-export default () => {
-  completeStartForm();
-  completeCheckIfEligibleForm();
+/**
+ * startNewApplication defaults to false
+ * if true, means on the start new application page from check your answers which redirects to buyer country page
+ * if true, then do not need to complete start form or check if eligible
+ */
+export default (startNewApplication = false) => {
+  if (!startNewApplication) {
+    completeStartForm();
+    completeCheckIfEligibleForm();
+  }
   submitInsuranceEligibilityAnswersFromBuyerCountryHappyPath();
 };

--- a/e2e-tests/cypress/support/insurance/eligibility/submit-answers-happy-path.js
+++ b/e2e-tests/cypress/support/insurance/eligibility/submit-answers-happy-path.js
@@ -2,15 +2,8 @@ import submitInsuranceEligibilityAnswersFromBuyerCountryHappyPath from './submit
 
 import { completeStartForm, completeCheckIfEligibleForm } from './forms';
 
-/**
- * startNewApplication defaults to false
- * if true, means on the start new application page from check your answers which redirects to buyer country page
- * if true, then do not need to complete start form or check if eligible
- */
-export default (startNewApplication = false) => {
-  if (!startNewApplication) {
-    completeStartForm();
-    completeCheckIfEligibleForm();
-  }
+export default () => {
+  completeStartForm();
+  completeCheckIfEligibleForm();
   submitInsuranceEligibilityAnswersFromBuyerCountryHappyPath();
 };

--- a/src/ui/server/controllers/insurance/check-your-answers/start-new-application/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/start-new-application/index.test.ts
@@ -9,7 +9,11 @@ import { Request, Response } from '../../../../../types';
 
 const {
   PROBLEM_WITH_SERVICE,
-  INSURANCE: { INSURANCE_ROOT, START, ALL_SECTIONS },
+  INSURANCE: {
+    INSURANCE_ROOT,
+    ALL_SECTIONS,
+    ELIGIBILITY: { BUYER_COUNTRY },
+  },
 } = ROUTES;
 
 describe('controllers/insurance/check-your-answers/start-new-application', () => {
@@ -29,7 +33,7 @@ describe('controllers/insurance/check-your-answers/start-new-application', () =>
       const result = pageVariables(mockApplication.referenceNumber);
 
       const expected = {
-        START_NEW_APPLICATION_URL: START,
+        START_NEW_APPLICATION_URL: BUYER_COUNTRY,
         RETURN_TO_APPLICATION_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALL_SECTIONS}`,
       };
 

--- a/src/ui/server/controllers/insurance/check-your-answers/start-new-application/index.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/start-new-application/index.ts
@@ -9,7 +9,11 @@ export const TEMPLATE = TEMPLATES.INSURANCE.NEED_TO_START_NEW_APPLICATION;
 
 const {
   PROBLEM_WITH_SERVICE,
-  INSURANCE: { START, INSURANCE_ROOT, ALL_SECTIONS },
+  INSURANCE: {
+    INSURANCE_ROOT,
+    ALL_SECTIONS,
+    ELIGIBILITY: { BUYER_COUNTRY },
+  },
 } = ROUTES;
 
 /**
@@ -19,7 +23,7 @@ const {
  * @returns {Object} Page variables
  */
 export const pageVariables = (referenceNumber: number) => ({
-  START_NEW_APPLICATION_URL: START,
+  START_NEW_APPLICATION_URL: BUYER_COUNTRY,
   RETURN_TO_APPLICATION_URL: `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`,
 });
 

--- a/src/ui/server/controllers/insurance/no-access-application-submitted/index.test.ts
+++ b/src/ui/server/controllers/insurance/no-access-application-submitted/index.test.ts
@@ -2,6 +2,7 @@ import { TEMPLATE, get } from '.';
 import { PAGES } from '../../../content-strings';
 import { TEMPLATES } from '../../../constants';
 import insuranceCorePageVariables from '../../../helpers/page-variables/core/insurance';
+import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
 import { Request, Response } from '../../../../types';
 import { mockReq, mockRes } from '../../../test-mocks';
 
@@ -24,10 +25,13 @@ describe('controllers/insurance/no-access-application-submitted', () => {
     it('should render template', () => {
       get(req, res);
 
-      const expectedVariables = insuranceCorePageVariables({
-        PAGE_CONTENT_STRINGS: PAGES.INSURANCE.NO_ACCESS_APPLICATION_SUBMITTED_PAGE,
-        BACK_LINK: req.headers.referer,
-      });
+      const expectedVariables = {
+        ...insuranceCorePageVariables({
+          PAGE_CONTENT_STRINGS: PAGES.INSURANCE.NO_ACCESS_APPLICATION_SUBMITTED_PAGE,
+          BACK_LINK: req.headers.referer,
+        }),
+        userName: getUserNameFromSession(req.session.user),
+      };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
     });

--- a/src/ui/server/controllers/insurance/no-access-application-submitted/index.ts
+++ b/src/ui/server/controllers/insurance/no-access-application-submitted/index.ts
@@ -2,6 +2,7 @@ import { PAGES } from '../../../content-strings';
 import { TEMPLATES } from '../../../constants';
 import { Request, Response } from '../../../../types';
 import insuranceCorePageVariables from '../../../helpers/page-variables/core/insurance';
+import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
 
 export const TEMPLATE = TEMPLATES.INSURANCE.NO_ACCESS_APPLICATION_SUBMITTED;
 
@@ -17,4 +18,5 @@ export const get = (req: Request, res: Response) =>
       PAGE_CONTENT_STRINGS: PAGES.INSURANCE.NO_ACCESS_APPLICATION_SUBMITTED_PAGE,
       BACK_LINK: req.headers.referer,
     }),
+    userName: getUserNameFromSession(req.session.user),
   });


### PR DESCRIPTION
# Issue: 
* start new application button in check your answers section redirected to insurance start
* no access to application application submitted page did not have authenticated header

# Changes made:
* Added authenticated header to no access application submitted page
* Added correct redirect to buyerCountry for start new application
* Updated tests 