### PR TITLE
feat(EMS-1087): Account sign in - Reset verification expiry if account is unverified

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/account/manage/account-manage.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/manage/account-manage.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Account - Manage - As an Exporter, I want the service to ha
 
     cy.verifyAccountEmail();
 
-    cy.completeAndSubmitSignInAccountForm();
+    cy.completeAndSubmitSignInAccountForm({});
   });
 
   beforeEach(() => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/account-password-reset-and-sign-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/account-password-reset-and-sign-in.spec.js
@@ -64,7 +64,7 @@ context('Insurance - Account - Password reset and sign in - As an Exporter, I wa
 
         cy.url().should('eq', signInUrl);
 
-        cy.completeAndSubmitSignInAccountForm();
+        cy.completeAndSubmitSignInAccountForm({});
       });
 
       it(`should redirect to ${enterCodeUrl}`, () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
@@ -134,7 +134,7 @@ context('Insurance - Account - Sign in - As an Exporter, I want to sign in into 
       it(`should redirect to ${ENTER_CODE}`, () => {
         cy.navigateToUrl(url);
 
-        cy.completeAndSubmitSignInAccountForm();
+        cy.completeAndSubmitSignInAccountForm({});
 
         const expected = `${Cypress.config('baseUrl')}${ENTER_CODE}`;
         cy.url().should('eq', expected);

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/enter-code/account-sign-in-enter-code-without-completing-eligibility.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/enter-code/account-sign-in-enter-code-without-completing-eligibility.spec.js
@@ -18,7 +18,7 @@ context('Insurance - Account - Sign in - Enter code - without completing eligibi
 
     cy.verifyAccountEmail();
 
-    cy.completeAndSubmitSignInAccountForm();
+    cy.completeAndSubmitSignInAccountForm({});
   });
 
   beforeEach(() => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/enter-code/account-sign-in-enter-code.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/enter-code/account-sign-in-enter-code.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Account - Sign in - I want to sign in into my UKEF digital 
     before(() => {
       cy.verifyAccountEmail();
 
-      cy.completeAndSubmitSignInAccountForm();
+      cy.completeAndSubmitSignInAccountForm({});
 
       cy.url().should('eq', url);
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/enter-code/validation/account-sign-in-enter-code-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/enter-code/validation/account-sign-in-enter-code-validation.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Account - Sign in - Enter code - validation', () => {
 
     cy.verifyAccountEmail();
 
-    cy.completeAndSubmitSignInAccountForm();
+    cy.completeAndSubmitSignInAccountForm({});
 
     cy.url().should('eq', url);
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/request-new-code/account-sign-in-request-new-code.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/request-new-code/account-sign-in-request-new-code.spec.js
@@ -23,7 +23,7 @@ context('Insurance - Account - Sign in - Request new code page - I want to enter
 
     cy.verifyAccountEmail();
 
-    cy.completeAndSubmitSignInAccountForm();
+    cy.completeAndSubmitSignInAccountForm({});
 
     enterCodePage.requestNewCodeLink().click();
 

--- a/e2e-tests/cypress/support/insurance/account/complete-and-submit-sign-in-account-form.js
+++ b/e2e-tests/cypress/support/insurance/account/complete-and-submit-sign-in-account-form.js
@@ -20,19 +20,26 @@ const {
 /**
  * completeAndSubmitSignInAccountForm
  * Complete and submit the "sign in" form
- * @param {String} Email address
- * @param {String} Password
- * @returns {String} Valid OTP
+ * @param {Object} Object with custom values to submit and flag for asserting success URL.
+ * - emailAddress
+ * - password
+ * - assertSuccessUrl
  */
-const completeAndSubmitSignInAccountForm = (email = account[EMAIL], password = account[PASSWORD]) => {
-  cy.keyboardInput(accountFormFields[EMAIL].input(), email);
+const completeAndSubmitSignInAccountForm = ({
+  emailAddress = account[EMAIL],
+  password = account[PASSWORD],
+  assertSuccessUrl = true,
+}) => {
+  cy.keyboardInput(accountFormFields[EMAIL].input(), emailAddress);
   cy.keyboardInput(accountFormFields[PASSWORD].input(), password);
 
   submitButton().click();
 
-  // assert we are on the 'enter code' page'
-  const expectedUrl = `${Cypress.config('baseUrl')}${ENTER_CODE}`;
-  cy.url().should('eq', expectedUrl);
+  if (assertSuccessUrl) {
+    // assert we are on the 'enter code' page'
+    const expectedUrl = `${Cypress.config('baseUrl')}${ENTER_CODE}`;
+    cy.url().should('eq', expectedUrl);
+  }
 };
 
 export default completeAndSubmitSignInAccountForm;

--- a/e2e-tests/cypress/support/insurance/account/complete-insurance-eligibility-sign-in-and-go-to-dashboard.js
+++ b/e2e-tests/cypress/support/insurance/account/complete-insurance-eligibility-sign-in-and-go-to-dashboard.js
@@ -38,7 +38,7 @@ const completeInsuranceEligibilitySignInAndGoToDashboard = (emailAddress) => {
     cy.navigateToUrl(verifyAccountUrl);
 
     // sign in to the account. Behind the scenes, an application is created at this point.
-    cy.completeAndSubmitSignInAccountForm(emailAddress);
+    cy.completeAndSubmitSignInAccountForm({ emailAddress });
 
     // get the OTP security code
     cy.accountAddAndGetOTP(emailAddress).then((securityCode) => {

--- a/e2e-tests/cypress/support/insurance/account/complete-sign-in-and-go-to-dashboard.js
+++ b/e2e-tests/cypress/support/insurance/account/complete-sign-in-and-go-to-dashboard.js
@@ -18,7 +18,7 @@ const completeSignInAndGoToDashboard = () => cy.createAccount({}).then((verifyAc
   cy.navigateToUrl(verifyAccountUrl);
 
   // sign in to the account. Behind the scenes, an application is created at this point.
-  cy.completeAndSubmitSignInAccountForm();
+  cy.completeAndSubmitSignInAccountForm({});
 
   // get the OTP security code
   cy.accountAddAndGetOTP().then((securityCode) => {

--- a/e2e-tests/cypress/support/insurance/account/sign-in-and-go-to-url.js
+++ b/e2e-tests/cypress/support/insurance/account/sign-in-and-go-to-url.js
@@ -26,7 +26,7 @@ const {
  */
 const signInAndGoToUrl = (url) => {
   cy.navigateToUrl(`${Cypress.config('baseUrl')}${SIGN_IN_ROOT}`);
-  cy.completeAndSubmitSignInAccountForm();
+  cy.completeAndSubmitSignInAccountForm({});
 
   // get the OTP security code
   cy.accountAddAndGetOTP().then((securityCode) => {

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -521,14 +521,14 @@ var callNotify = async (templateId, emailAddress, variables, file, fileIsCsv) =>
 };
 var confirmEmailAddress = async (emailAddress, firstName, verificationHash) => {
   try {
-    console.info("Sending email verification for account creation");
+    console.info("Sending confirm email address email");
     const templateId = EMAIL_TEMPLATE_IDS.ACCOUNT.CONFIRM_EMAIL;
     const variables = { firstName, confirmToken: verificationHash };
     const response = await callNotify(templateId, emailAddress, variables);
     return response;
   } catch (err) {
     console.error(err);
-    throw new Error(`Sending email verification for account creation ${err}`);
+    throw new Error(`Sending confirm email address email ${err}`);
   }
 };
 var securityCodeEmail = async (emailAddress, firstName, securityCode) => {
@@ -1285,9 +1285,15 @@ var lists = {
         ],
         db: { isNullable: true }
       }),
-      improvement: (0, import_fields.text)(),
-      otherComments: (0, import_fields.text)(),
-      referralUrl: (0, import_fields.text)(),
+      improvement: (0, import_fields.text)({
+        db: { nativeType: "VarChar(1000)" }
+      }),
+      otherComments: (0, import_fields.text)({
+        db: { nativeType: "VarChar(1000)" }
+      }),
+      referralUrl: (0, import_fields.text)({
+        db: { nativeType: "VarChar(500)" }
+      }),
       product: (0, import_fields.text)()
     },
     access: import_access.allowAll
@@ -1444,6 +1450,7 @@ var typeDefs = `
     sessionIdentifier: String
     expires: DateTime
     success: Boolean!
+    resentVerificationEmail: Boolean
   }
 
   type AddAndGetOtpResponse {
@@ -1713,12 +1720,13 @@ var getAccountById = async (context, accountId) => {
 };
 var get_account_by_id_default = getAccountById;
 
-// custom-resolvers/mutations/send-email-confirm-email-address.ts
-var sendEmailConfirmEmailAddress = async (root, variables, context) => {
+// helpers/send-email-confirm-email-address/index.ts
+var send = async (context, accountId) => {
   try {
-    const account = await get_account_by_id_default(context, variables.accountId);
+    console.info("Sending email verification");
+    const account = await get_account_by_id_default(context, accountId);
     if (!account) {
-      console.info("Sending email verification for account creation - no account exists with the provided ID");
+      console.info("Sending email verification - no account exists with the provided account ID");
       return {
         success: false
       };
@@ -1728,13 +1736,34 @@ var sendEmailConfirmEmailAddress = async (root, variables, context) => {
     if (emailResponse.success) {
       return emailResponse;
     }
+    throw new Error(`Sending email verification (sendEmailConfirmEmailAddress helper) ${emailResponse}`);
+  } catch (err) {
+    console.error(err);
+    throw new Error(`Sending email verification (sendEmailConfirmEmailAddress helper) ${err}`);
+  }
+};
+var confirmEmailAddressEmail = {
+  send
+};
+var send_email_confirm_email_address_default = confirmEmailAddressEmail;
+
+// custom-resolvers/mutations/send-email-confirm-email-address.ts
+var sendEmailConfirmEmailAddressMutation = async (root, variables, context) => {
+  try {
+    const emailResponse = await send_email_confirm_email_address_default.send(context, variables.accountId);
+    if (emailResponse.success) {
+      return emailResponse;
+    }
     throw new Error(`Sending email verification for account creation (sendEmailConfirmEmailAddress mutation) ${emailResponse}`);
   } catch (err) {
     console.error(err);
     throw new Error(`Sending email verification for account creation (sendEmailConfirmEmailAddress mutation) ${err}`);
   }
 };
-var send_email_confirm_email_address_default = sendEmailConfirmEmailAddress;
+var send_email_confirm_email_address_default2 = sendEmailConfirmEmailAddressMutation;
+
+// custom-resolvers/mutations/account-sign-in.ts
+var import_date_fns3 = require("date-fns");
 
 // helpers/is-valid-account-password/index.ts
 var import_crypto3 = __toESM(require("crypto"));
@@ -1821,20 +1850,45 @@ var generateOTPAndUpdateAccount = async (context, accountId) => {
 var generate_otp_and_update_account_default = generateOTPAndUpdateAccount;
 
 // custom-resolvers/mutations/account-sign-in.ts
+var { EMAIL: EMAIL2 } = ACCOUNT2;
 var accountSignIn = async (root, variables, context) => {
   try {
     console.info("Signing in account");
     const { email, password: password2 } = variables;
-    const account = await get_account_by_field_default(context, FIELD_IDS.INSURANCE.ACCOUNT.EMAIL, email);
-    if (!account) {
+    const accountData = await get_account_by_field_default(context, FIELD_IDS.INSURANCE.ACCOUNT.EMAIL, email);
+    if (!accountData) {
       console.info("Unable to validate account - no account found");
       return { success: false };
     }
-    if (!account.isVerified) {
-      console.info("Unable to validate account - account is not verified");
-      return { success: false };
-    }
+    const account = accountData;
     if (is_valid_account_password_default(password2, account.salt, account.hash)) {
+      if (!account.isVerified) {
+        console.info("Unable to sign in account - account has not been verified yet");
+        const now = /* @__PURE__ */ new Date();
+        const verificationHasExpired = (0, import_date_fns3.isAfter)(now, account.verificationExpiry);
+        if (account.verificationHash && !verificationHasExpired) {
+          console.info("Account has an unexpired verification token - resetting verification expiry");
+          const accountUpdate = {
+            verificationExpiry: EMAIL2.VERIFICATION_EXPIRY()
+          };
+          await context.db.Account.updateOne({
+            where: { id: account.id },
+            data: accountUpdate
+          });
+          console.info("Account has an unexpired verification token - sending verification email");
+          const emailResponse2 = await send_email_confirm_email_address_default.send(context, account.id);
+          if (emailResponse2.success) {
+            return {
+              success: false,
+              resentVerificationEmail: true,
+              accountId: account.id
+            };
+          }
+          return { success: false };
+        }
+        console.info("Unable to sign in account - account has not been verification has expired");
+        return { success: false };
+      }
       const { securityCode } = await generate_otp_and_update_account_default(context, account.id);
       const emailResponse = await emails_default.securityCodeEmail(email, account.firstName, securityCode);
       if (emailResponse.success) {
@@ -1885,7 +1939,7 @@ var accountSignInSendNewCode = async (root, variables, context) => {
 var account_sign_in_new_code_default = accountSignInSendNewCode;
 
 // custom-resolvers/mutations/verify-account-sign-in-code.ts
-var import_date_fns3 = require("date-fns");
+var import_date_fns4 = require("date-fns");
 
 // helpers/is-valid-otp/index.ts
 var import_crypto5 = __toESM(require("crypto"));
@@ -1966,7 +2020,7 @@ var verifyAccountSignInCode = async (root, variables, context) => {
     }
     const { otpSalt, otpHash, otpExpiry } = account;
     const now = /* @__PURE__ */ new Date();
-    const hasExpired = (0, import_date_fns3.isAfter)(now, otpExpiry);
+    const hasExpired = (0, import_date_fns4.isAfter)(now, otpExpiry);
     if (hasExpired) {
       console.info("Unable to verify account sign in code - verification period has expired");
       return {
@@ -2072,7 +2126,7 @@ var sendEmailPasswordResetLink = async (root, variables, context) => {
 var send_email_password_reset_link_default = sendEmailPasswordResetLink;
 
 // custom-resolvers/mutations/account-password-reset.ts
-var import_date_fns4 = require("date-fns");
+var import_date_fns5 = require("date-fns");
 var accountPasswordReset = async (root, variables, context) => {
   console.info("Resetting account password");
   try {
@@ -2088,7 +2142,7 @@ var accountPasswordReset = async (root, variables, context) => {
       return { success: false };
     }
     const now = /* @__PURE__ */ new Date();
-    const hasExpired = (0, import_date_fns4.isAfter)(now, passwordResetExpiry);
+    const hasExpired = (0, import_date_fns5.isAfter)(now, passwordResetExpiry);
     if (hasExpired) {
       console.info("Unable to reset account password - verification period has expired");
       return {
@@ -2211,7 +2265,7 @@ var updateCompanyAndCompanyAddress = async (root, variables, context) => {
 var update_company_and_company_address_default = updateCompanyAndCompanyAddress;
 
 // custom-resolvers/mutations/submit-application.ts
-var import_date_fns6 = require("date-fns");
+var import_date_fns7 = require("date-fns");
 
 // helpers/get-country-by-field/index.ts
 var getCountryByField = async (context, field, value) => {
@@ -2380,12 +2434,12 @@ var getApplicationSubmittedEmailTemplateIds = (application) => {
 var get_application_submitted_email_template_ids_default = getApplicationSubmittedEmailTemplateIds;
 
 // helpers/format-date/index.ts
-var import_date_fns5 = require("date-fns");
-var formatDate = (timestamp3, dateFormat = "d MMMM yyyy") => (0, import_date_fns5.format)(new Date(timestamp3), dateFormat);
+var import_date_fns6 = require("date-fns");
+var formatDate = (timestamp3, dateFormat = "d MMMM yyyy") => (0, import_date_fns6.format)(new Date(timestamp3), dateFormat);
 var format_date_default = formatDate;
 
 // emails/send-application-submitted-emails/index.ts
-var send = async (application, csvPath) => {
+var send2 = async (application, csvPath) => {
   try {
     const { referenceNumber, owner, company, buyer, policyAndExport } = application;
     const { email, firstName } = owner;
@@ -2422,7 +2476,7 @@ var send = async (application, csvPath) => {
   }
 };
 var applicationSubmittedEmails = {
-  send
+  send: send2
 };
 var send_application_submitted_emails_default = applicationSubmittedEmails;
 
@@ -2447,7 +2501,7 @@ var DEFAULT = {
 };
 
 // content-strings/csv.ts
-var { FIRST_NAME, LAST_NAME, EMAIL: EMAIL2 } = account_default;
+var { FIRST_NAME, LAST_NAME, EMAIL: EMAIL3 } = account_default;
 var {
   CONTRACT_POLICY: {
     SINGLE: { CONTRACT_COMPLETION_DATE }
@@ -2474,7 +2528,7 @@ var CSV = {
   FIELDS: {
     [FIRST_NAME]: "Applicant first name",
     [LAST_NAME]: "Applicant last name",
-    [EMAIL2]: "Applicant email address",
+    [EMAIL3]: "Applicant email address",
     [CONTRACT_COMPLETION_DATE]: "Date expected for contract to complete",
     [EXPORTER_COMPANY_NAME]: "Exporter company name",
     [EXPORTER_COMPANY_ADDRESS]: "Exporter registered office address",
@@ -2639,7 +2693,7 @@ var {
   YOUR_COMPANY: { TRADING_ADDRESS, TRADING_NAME, PHONE_NUMBER: PHONE_NUMBER2, WEBSITE: WEBSITE2 },
   NATURE_OF_YOUR_BUSINESS: { GOODS_OR_SERVICES: GOODS_OR_SERVICES2, YEARS_EXPORTING: YEARS_EXPORTING2, EMPLOYEES_UK: EMPLOYEES_UK2, EMPLOYEES_INTERNATIONAL: EMPLOYEES_INTERNATIONAL2 },
   TURNOVER: { FINANCIAL_YEAR_END_DATE, ESTIMATED_ANNUAL_TURNOVER: ESTIMATED_ANNUAL_TURNOVER2, PERCENTAGE_TURNOVER },
-  BROKER: { USING_BROKER: USING_BROKER2, NAME, ADDRESS_LINE_1, EMAIL: EMAIL3 }
+  BROKER: { USING_BROKER: USING_BROKER2, NAME, ADDRESS_LINE_1, EMAIL: EMAIL4 }
 } = EXPORTER_BUSINESS2;
 var FIELDS = {
   COMPANY_DETAILS: {
@@ -2744,7 +2798,7 @@ var FIELDS = {
         TITLE: "Broker's address"
       }
     },
-    [EMAIL3]: {
+    [EMAIL4]: {
       SUMMARY: {
         TITLE: "Broker's email"
       }
@@ -2842,7 +2896,7 @@ var format_time_of_day_default = formatTimeOfDay;
 
 // generate-csv/map-application-to-csv/map-key-information/index.ts
 var { FIELDS: FIELDS2 } = CSV;
-var { FIRST_NAME: FIRST_NAME2, LAST_NAME: LAST_NAME2, EMAIL: EMAIL4 } = account_default;
+var { FIRST_NAME: FIRST_NAME2, LAST_NAME: LAST_NAME2, EMAIL: EMAIL5 } = account_default;
 var mapKeyInformation = (application) => {
   const mapped = [
     csv_row_default(REFERENCE_NUMBER.SUMMARY.TITLE, application.referenceNumber),
@@ -2850,7 +2904,7 @@ var mapKeyInformation = (application) => {
     csv_row_default(TIME_SUBMITTED.SUMMARY.TITLE, format_time_of_day_default(application.submissionDate)),
     csv_row_default(FIELDS2[FIRST_NAME2], application.owner[FIRST_NAME2]),
     csv_row_default(FIELDS2[LAST_NAME2], application.owner[LAST_NAME2]),
-    csv_row_default(FIELDS2[EMAIL4], application.owner[EMAIL4])
+    csv_row_default(FIELDS2[EMAIL5], application.owner[EMAIL5])
   ];
   return mapped;
 };
@@ -3000,7 +3054,7 @@ var {
   YOUR_COMPANY: { TRADING_NAME: TRADING_NAME2, TRADING_ADDRESS: TRADING_ADDRESS2, WEBSITE: WEBSITE3, PHONE_NUMBER: PHONE_NUMBER3 },
   NATURE_OF_YOUR_BUSINESS: { GOODS_OR_SERVICES: GOODS_OR_SERVICES3, YEARS_EXPORTING: YEARS_EXPORTING3, EMPLOYEES_UK: EMPLOYEES_UK3, EMPLOYEES_INTERNATIONAL: EMPLOYEES_INTERNATIONAL3 },
   TURNOVER: { ESTIMATED_ANNUAL_TURNOVER: ESTIMATED_ANNUAL_TURNOVER3, PERCENTAGE_TURNOVER: PERCENTAGE_TURNOVER2 },
-  BROKER: { USING_BROKER: USING_BROKER3, NAME: BROKER_NAME2, ADDRESS_LINE_1: ADDRESS_LINE_12, TOWN, COUNTY, POSTCODE, EMAIL: EMAIL5 }
+  BROKER: { USING_BROKER: USING_BROKER3, NAME: BROKER_NAME2, ADDRESS_LINE_1: ADDRESS_LINE_12, TOWN, COUNTY, POSTCODE, EMAIL: EMAIL6 }
 } = business_default;
 var mapSicCodes2 = (sicCodes) => {
   let mapped = "";
@@ -3018,7 +3072,7 @@ var mapBroker = (application) => {
       ...mapped,
       csv_row_default(CSV.FIELDS[BROKER_NAME2], broker[BROKER_NAME2]),
       csv_row_default(CSV.FIELDS[ADDRESS_LINE_12], `${broker[ADDRESS_LINE_12]} ${csv_new_line_default} ${broker[TOWN]} ${csv_new_line_default} ${broker[COUNTY]} ${csv_new_line_default} ${broker[POSTCODE]}`),
-      csv_row_default(CSV.FIELDS[EMAIL5], broker[EMAIL5])
+      csv_row_default(CSV.FIELDS[EMAIL6], broker[EMAIL6])
     ];
   }
   return mapped;
@@ -3058,7 +3112,7 @@ var CONTENT_STRINGS4 = {
   ...YOUR_BUYER_FIELDS.WORKING_WITH_BUYER
 };
 var {
-  COMPANY_OR_ORGANISATION: { NAME: NAME2, ADDRESS, REGISTRATION_NUMBER, WEBSITE: WEBSITE4, FIRST_NAME: FIRST_NAME3, LAST_NAME: LAST_NAME3, POSITION, EMAIL: EMAIL6, CAN_CONTACT_BUYER },
+  COMPANY_OR_ORGANISATION: { NAME: NAME2, ADDRESS, REGISTRATION_NUMBER, WEBSITE: WEBSITE4, FIRST_NAME: FIRST_NAME3, LAST_NAME: LAST_NAME3, POSITION, EMAIL: EMAIL7, CAN_CONTACT_BUYER },
   WORKING_WITH_BUYER: { CONNECTED_WITH_BUYER, TRADED_WITH_BUYER }
 } = your_buyer_default;
 var mapBuyer = (application) => {
@@ -3069,7 +3123,7 @@ var mapBuyer = (application) => {
     csv_row_default(String(CONTENT_STRINGS4[ADDRESS].SUMMARY?.TITLE), buyer[ADDRESS]),
     csv_row_default(CSV.FIELDS[REGISTRATION_NUMBER], buyer[REGISTRATION_NUMBER]),
     csv_row_default(String(CONTENT_STRINGS4[WEBSITE4].SUMMARY?.TITLE), buyer[WEBSITE4]),
-    csv_row_default(CSV.FIELDS[FIRST_NAME3], `${buyer[FIRST_NAME3]} ${buyer[LAST_NAME3]} ${csv_new_line_default} ${buyer[POSITION]} ${csv_new_line_default} ${buyer[EMAIL6]}`),
+    csv_row_default(CSV.FIELDS[FIRST_NAME3], `${buyer[FIRST_NAME3]} ${buyer[LAST_NAME3]} ${csv_new_line_default} ${buyer[POSITION]} ${csv_new_line_default} ${buyer[EMAIL7]}`),
     csv_row_default(String(CONTENT_STRINGS4[CAN_CONTACT_BUYER].SUMMARY?.TITLE), buyer[CAN_CONTACT_BUYER]),
     csv_row_default(String(CONTENT_STRINGS4[CONNECTED_WITH_BUYER].SUMMARY?.TITLE), buyer[CONNECTED_WITH_BUYER]),
     csv_row_default(String(CONTENT_STRINGS4[TRADED_WITH_BUYER].SUMMARY?.TITLE), buyer[TRADED_WITH_BUYER])
@@ -3177,7 +3231,7 @@ var submitApplication = async (root, variables, context) => {
     if (application) {
       const hasDraftStatus = application.status === APPLICATION.STATUS.DRAFT;
       const now = /* @__PURE__ */ new Date();
-      const validSubmissionDate = (0, import_date_fns6.isAfter)(new Date(application.submissionDeadline), now);
+      const validSubmissionDate = (0, import_date_fns7.isAfter)(new Date(application.submissionDeadline), now);
       const canSubmit = hasDraftStatus && validSubmissionDate;
       if (canSubmit) {
         const update = {
@@ -3391,7 +3445,7 @@ var getAccountPasswordResetToken = async (root, variables, context) => {
 var get_account_password_reset_token_default = getAccountPasswordResetToken;
 
 // custom-resolvers/queries/verify-account-password-reset-token.ts
-var import_date_fns7 = require("date-fns");
+var import_date_fns8 = require("date-fns");
 var {
   ACCOUNT: { PASSWORD_RESET_HASH, PASSWORD_RESET_EXPIRY }
 } = FIELD_IDS.INSURANCE;
@@ -3405,7 +3459,7 @@ var verifyAccountPasswordResetToken = async (root, variables, context) => {
       return { success: false };
     }
     const now = /* @__PURE__ */ new Date();
-    const hasExpired = (0, import_date_fns7.isAfter)(now, account[PASSWORD_RESET_EXPIRY]);
+    const hasExpired = (0, import_date_fns8.isAfter)(now, account[PASSWORD_RESET_EXPIRY]);
     if (hasExpired) {
       console.info("Account password reset token has expired");
       return {
@@ -3427,7 +3481,7 @@ var customResolvers = {
     accountSignIn: account_sign_in_default,
     accountSignInSendNewCode: account_sign_in_new_code_default,
     verifyAccountEmailAddress: verify_account_email_address_default,
-    sendEmailConfirmEmailAddress: send_email_confirm_email_address_default,
+    sendEmailConfirmEmailAddress: send_email_confirm_email_address_default2,
     verifyAccountSignInCode: verify_account_sign_in_code_default,
     addAndGetOTP: add_and_get_OTP_default,
     accountPasswordReset: account_password_reset_default,

--- a/src/api/custom-resolvers/mutations/account-sign-in.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in.ts
@@ -1,10 +1,14 @@
 import { Context } from '.keystone/types'; // eslint-disable-line
-import { FIELD_IDS } from '../../constants';
+import { isAfter } from 'date-fns';
+import { ACCOUNT, FIELD_IDS } from '../../constants';
 import getAccountByField from '../../helpers/get-account-by-field';
+import confirmEmailAddressEmail from '../../helpers/send-email-confirm-email-address';
 import isValidAccountPassword from '../../helpers/is-valid-account-password';
 import generateOTPAndUpdateAccount from '../../helpers/generate-otp-and-update-account';
 import sendEmail from '../../emails';
-import { AccountSignInVariables, AccountSignInResponse } from '../../types';
+import { Account, AccountSignInVariables, AccountSignInResponse } from '../../types';
+
+const { EMAIL } = ACCOUNT;
 
 /**
  * accountSignIn
@@ -23,21 +27,83 @@ const accountSignIn = async (root: any, variables: AccountSignInVariables, conte
     const { email, password } = variables;
 
     // Get the account the email is associated with.
-    const account = await getAccountByField(context, FIELD_IDS.INSURANCE.ACCOUNT.EMAIL, email);
+    const accountData = await getAccountByField(context, FIELD_IDS.INSURANCE.ACCOUNT.EMAIL, email);
 
-    if (!account) {
+    if (!accountData) {
       console.info('Unable to validate account - no account found');
 
       return { success: false };
     }
 
-    if (!account.isVerified) {
-      console.info('Unable to validate account - account is not verified');
+    const account = accountData as Account;
 
-      return { success: false };
-    }
+    // TODO
+    // TODO
+    // TODO
+    // TODO - reset verification expiration
 
+    /**
+     * Account is found and verified. We can therefore:
+     * 1) Check if the password is matches what is encrypted in the database.
+     * 2) If the password is valid:
+     *   - If the account is unverified, but has a valid has/token, send verification email.
+     *   - If the account is verified, generate an OTP/security code and send via email.
+     * 3) Otherwise, we return a rejection because either:
+     *   - The password is invalid.
+     *   - The email was not sent.
+     */
     if (isValidAccountPassword(password, account.salt, account.hash)) {
+      /**
+       * Check if the account:
+       * 1) Is unverified.
+       * 2) Has a verification hash/token.
+       * 3) Has a verification hash/token that has not expired.
+       *
+       * This means that the user has not verified their email address.
+       * We can therefore:
+       * 1) Reset the account's verification expiry.
+       * 2) Re-send the verification link email that was sent during account creation.
+       */
+      if (!account.isVerified) {
+        console.info('Unable to sign in account - account has not been verified yet');
+
+        const now = new Date();
+
+        const verificationHasExpired = isAfter(now, account.verificationExpiry);
+
+        if (account.verificationHash && !verificationHasExpired) {
+          console.info('Account has an unexpired verification token - resetting verification expiry');
+
+          const accountUpdate = {
+            verificationExpiry: EMAIL.VERIFICATION_EXPIRY(),
+          };
+
+          (await context.db.Account.updateOne({
+            where: { id: account.id },
+            data: accountUpdate,
+          })) as Account;
+
+          console.info('Account has an unexpired verification token - sending verification email');
+
+          const emailResponse = await confirmEmailAddressEmail.send(context, account.id);
+
+          if (emailResponse.success) {
+            return {
+              success: false,
+              resentVerificationEmail: true,
+              accountId: account.id,
+            };
+          }
+
+          return { success: false };
+        }
+
+        // reject
+        console.info('Unable to sign in account - account has not been verification has expired');
+
+        return { success: false };
+      }
+
       // generate OTP and update the account
       const { securityCode } = await generateOTPAndUpdateAccount(context, account.id);
 

--- a/src/api/custom-resolvers/mutations/account-sign-in.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in.ts
@@ -37,11 +37,6 @@ const accountSignIn = async (root: any, variables: AccountSignInVariables, conte
 
     const account = accountData as Account;
 
-    // TODO
-    // TODO
-    // TODO
-    // TODO - reset verification expiration
-
     /**
      * Account is found and verified. We can therefore:
      * 1) Check if the password is matches what is encrypted in the database.

--- a/src/api/custom-resolvers/mutations/send-email-confirm-email-address.ts
+++ b/src/api/custom-resolvers/mutations/send-email-confirm-email-address.ts
@@ -1,6 +1,5 @@
 import { Context } from '.keystone/types'; // eslint-disable-line
-import sendEmail from '../../emails';
-import getAccountById from '../../helpers/get-account-by-id';
+import confirmEmailAddressEmail from '../../helpers/send-email-confirm-email-address';
 import { SendExporterEmailVariables } from '../../types';
 
 /**
@@ -8,26 +7,11 @@ import { SendExporterEmailVariables } from '../../types';
  * @param {Object} GraphQL root variables
  * @param {Object} GraphQL variables for the SendEmailConfirmEmailAddress mutation
  * @param {Object} KeystoneJS context API
- * @returns {Object} Object with success flag and emailRecipient
+ * @returns {Object} Object with success flag / result of sendEmailConfirmEmailAddress
  */
-const sendEmailConfirmEmailAddress = async (root: any, variables: SendExporterEmailVariables, context: Context) => {
+const sendEmailConfirmEmailAddressMutation = async (root: any, variables: SendExporterEmailVariables, context: Context) => {
   try {
-    // get the account
-    const account = await getAccountById(context, variables.accountId);
-
-    // ensure that we have found an acount with the requsted ID.
-    if (!account) {
-      console.info('Sending email verification for account creation - no account exists with the provided ID');
-
-      return {
-        success: false,
-      };
-    }
-
-    // send "confirm email" email.
-    const { email, firstName, verificationHash } = account;
-
-    const emailResponse = await sendEmail.confirmEmailAddress(email, firstName, verificationHash);
+    const emailResponse = await confirmEmailAddressEmail.send(context, variables.accountId);
 
     if (emailResponse.success) {
       return emailResponse;
@@ -40,4 +24,4 @@ const sendEmailConfirmEmailAddress = async (root: any, variables: SendExporterEm
   }
 };
 
-export default sendEmailConfirmEmailAddress;
+export default sendEmailConfirmEmailAddressMutation;

--- a/src/api/custom-schema/type-defs.ts
+++ b/src/api/custom-schema/type-defs.ts
@@ -117,6 +117,7 @@ const typeDefs = `
     sessionIdentifier: String
     expires: DateTime
     success: Boolean!
+    resentVerificationEmail: Boolean
   }
 
   type AddAndGetOtpResponse {

--- a/src/api/emails/index.test.ts
+++ b/src/api/emails/index.test.ts
@@ -94,7 +94,7 @@ describe('emails', () => {
         try {
           await sendEmail.confirmEmailAddress(email, firstName, verificationHash);
         } catch (err) {
-          const expected = new Error(`Sending email verification for account creation Error: Sending email ${mockErrorMessage}`);
+          const expected = new Error(`Sending confirm email address email Error: Sending email ${mockErrorMessage}`);
 
           expect(err).toEqual(expected);
         }

--- a/src/api/emails/index.ts
+++ b/src/api/emails/index.ts
@@ -47,7 +47,7 @@ export const callNotify = async (templateId: string, emailAddress: string, varia
  */
 const confirmEmailAddress = async (emailAddress: string, firstName: string, verificationHash: string): Promise<EmailResponse> => {
   try {
-    console.info('Sending email verification for account creation');
+    console.info('Sending confirm email address email');
 
     const templateId = EMAIL_TEMPLATE_IDS.ACCOUNT.CONFIRM_EMAIL;
 
@@ -59,7 +59,7 @@ const confirmEmailAddress = async (emailAddress: string, firstName: string, veri
   } catch (err) {
     console.error(err);
 
-    throw new Error(`Sending email verification for account creation ${err}`);
+    throw new Error(`Sending confirm email address email ${err}`);
   }
 };
 

--- a/src/api/helpers/send-email-confirm-email-address/index.test.ts
+++ b/src/api/helpers/send-email-confirm-email-address/index.test.ts
@@ -1,0 +1,90 @@
+import { getContext } from '@keystone-6/core/context';
+import dotenv from 'dotenv';
+import confirmEmailAddressEmail from '.';
+import baseConfig from '../../keystone';
+import * as PrismaModule from '.prisma/client'; // eslint-disable-line import/no-extraneous-dependencies
+import sendEmail from '../../emails';
+import { mockAccount, mockSendEmailResponse } from '../../test-mocks';
+import { Account } from '../../types';
+import { Context } from '.keystone/types'; // eslint-disable-line
+
+const dbUrl = String(process.env.DATABASE_URL);
+const config = { ...baseConfig, db: { ...baseConfig.db, url: dbUrl } };
+
+dotenv.config();
+
+const context = getContext(config, PrismaModule) as Context;
+
+describe('helpers/send-email-confirm-email-address', () => {
+  let account: Account;
+
+  jest.mock('../../emails');
+
+  let sendEmailConfirmEmailAddressSpy = jest.fn();
+
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  beforeEach(async () => {
+    account = (await context.query.Account.createOne({
+      data: mockAccount,
+      query: 'id firstName lastName email salt hash verificationHash',
+    })) as Account;
+
+    jest.resetAllMocks();
+
+    sendEmailConfirmEmailAddressSpy = jest.fn(() => Promise.resolve(mockSendEmailResponse));
+
+    sendEmail.confirmEmailAddress = sendEmailConfirmEmailAddressSpy;
+  });
+
+  test('it should call sendEmail.confirmEmailAddress and return success=true', async () => {
+    const result = await confirmEmailAddressEmail.send(context, account.id);
+
+    const { email, firstName, verificationHash } = account;
+
+    expect(sendEmailConfirmEmailAddressSpy).toHaveBeenCalledTimes(1);
+    expect(sendEmailConfirmEmailAddressSpy).toHaveBeenCalledWith(email, firstName, verificationHash);
+
+    const expected = {
+      success: true,
+      emailRecipient: mockAccount.email,
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  describe('when no account is found', () => {
+    test('it should return success=false', async () => {
+      // wipe the accounttable so we have a clean slate.
+      const accounts = await context.query.Account.findMany();
+
+      await context.query.Account.deleteMany({
+        where: accounts,
+      });
+
+      const result = await confirmEmailAddressEmail.send(context, account.id);
+
+      const expected = { success: false };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      sendEmail.confirmEmailAddress = jest.fn(() => Promise.reject(mockSendEmailResponse));
+    });
+
+    test('should throw an error', async () => {
+      try {
+        await confirmEmailAddressEmail.send(context, account.id);
+      } catch (err) {
+        const expected = new Error(`Sending email verification (sendEmailConfirmEmailAddress helper) ${mockSendEmailResponse}`);
+
+        expect(err).toEqual(expected);
+      }
+    });
+  });
+});

--- a/src/api/helpers/send-email-confirm-email-address/index.ts
+++ b/src/api/helpers/send-email-confirm-email-address/index.ts
@@ -1,0 +1,48 @@
+import { Context } from '.keystone/types'; // eslint-disable-line
+import getAccountById from '../get-account-by-id';
+import sendEmail from '../../emails';
+import { SuccessResponse } from '../../types';
+
+/**
+ * confirmEmailAddressEmail.send
+ * @param {Object} KeystoneJS context API
+ * @param {String} Account ID
+ * @returns {Object} Object with success flag and emailRecipient
+ */
+const send = async (context: Context, accountId: string): Promise<SuccessResponse> => {
+  try {
+    console.info('Sending email verification');
+
+    // get the account
+    const account = await getAccountById(context, accountId);
+
+    // ensure that we have found an account with the requsted ID.
+    if (!account) {
+      console.info('Sending email verification - no account exists with the provided account ID');
+
+      return {
+        success: false,
+      };
+    }
+
+    // send "confirm email" email.
+    const { email, firstName, verificationHash } = account;
+
+    const emailResponse = await sendEmail.confirmEmailAddress(email, firstName, verificationHash);
+
+    if (emailResponse.success) {
+      return emailResponse;
+    }
+
+    throw new Error(`Sending email verification (sendEmailConfirmEmailAddress helper) ${emailResponse}`);
+  } catch (err) {
+    console.error(err);
+    throw new Error(`Sending email verification (sendEmailConfirmEmailAddress helper) ${err}`);
+  }
+};
+
+const confirmEmailAddressEmail = {
+  send,
+};
+
+export default confirmEmailAddressEmail;

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -2092,6 +2092,7 @@ type AccountSignInResponse {
   sessionIdentifier: String
   expires: DateTime
   success: Boolean!
+  resentVerificationEmail: Boolean
 }
 
 type AddAndGetOtpResponse {

--- a/src/api/schema.prisma
+++ b/src/api/schema.prisma
@@ -315,8 +315,8 @@ model Feedback {
   id            String  @id @default(cuid())
   service       String  @default("")
   satisfaction  String?
-  improvement   String  @default("")
-  otherComments String  @default("")
-  referralUrl   String  @default("")
+  improvement   String  @default("") @mysql.VarChar(1000)
+  otherComments String  @default("") @mysql.VarChar(1000)
+  referralUrl   String  @default("") @mysql.VarChar(500)
   product       String  @default("")
 }

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -390,7 +390,7 @@ export const lists = {
           accountInputData.createdAt = now;
           accountInputData.updatedAt = now;
 
-          // send "confirm email" email
+          // send "confirm email address" email
           try {
             const { firstName, email, verificationHash } = accountInputData;
 

--- a/src/api/test-mocks/index.ts
+++ b/src/api/test-mocks/index.ts
@@ -8,6 +8,8 @@ const {
   ACCOUNT: { PASSWORD_RESET_HASH },
 } = FIELD_IDS.INSURANCE;
 
+const now = new Date();
+
 export const mockAccount = {
   firstName: 'first',
   lastName: 'last',
@@ -15,7 +17,7 @@ export const mockAccount = {
   ...encryptPassword(String(process.env.MOCK_ACCOUNT_PASSWORD)),
   isVerified: true,
   verificationHash: 'mockVerificationHash',
-  verificationExpiry: ACCOUNT.EMAIL.VERIFICATION_EXPIRY(),
+  verificationExpiry: new Date(now.setMinutes(now.getMinutes() + 1)).toISOString(),
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
   [PASSWORD_RESET_HASH]: 'mockResetHash',

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -259,6 +259,7 @@ interface InsuranceFeedbackVariables {
 
 interface AccountSignInResponse extends SuccessResponse {
   accountId?: string;
+  resentVerificationEmail?: boolean;
 }
 
 interface VerifyAccountSignInCodeVariables {

--- a/src/ui/server/controllers/insurance/account/sign-in/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/index.test.ts
@@ -18,6 +18,7 @@ const {
   INSURANCE: {
     ACCOUNT: {
       SIGN_IN: { ENTER_CODE },
+      CREATE: { CONFIRM_EMAIL_RESENT },
     },
     DASHBOARD,
   },
@@ -240,6 +241,28 @@ describe('controllers/insurance/account/sign-in', () => {
             submittedValues: req.body,
             validationErrors: generateValidationErrors({}),
           });
+        });
+      });
+
+      describe('when the api.keystone.account.signIn returns resentVerificationEmail=true', () => {
+        beforeEach(() => {
+          accountSignInSpy = jest.fn(() =>
+            Promise.resolve({
+              ...accountSignInResponse,
+              success: false,
+              resentVerificationEmail: true,
+            }),
+          );
+
+          api.keystone.account.signIn = accountSignInSpy;
+        });
+
+        it(`should redirect to ${CONFIRM_EMAIL_RESENT} with ID param`, async () => {
+          await post(req, res);
+
+          const expected = `${CONFIRM_EMAIL_RESENT}?id=${accountSignInResponse.accountId}`;
+
+          expect(res.redirect).toHaveBeenCalledWith(expected);
         });
       });
     });

--- a/src/ui/server/controllers/insurance/account/sign-in/index.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/index.ts
@@ -16,6 +16,7 @@ const {
   INSURANCE: {
     ACCOUNT: {
       SIGN_IN: { ENTER_CODE },
+      CREATE: { CONFIRM_EMAIL_RESENT },
     },
     DASHBOARD,
   },
@@ -113,6 +114,10 @@ export const post = async (req: Request, res: Response) => {
       req.session.accountId = response.accountId;
 
       return res.redirect(ENTER_CODE);
+    }
+
+    if (response.resentVerificationEmail) {
+      return res.redirect(`${CONFIRM_EMAIL_RESENT}?id=${response.accountId}`);
     }
 
     // invalid credentials - force validation errors by mimicking empty form submission

--- a/src/ui/server/graphql/mutations/account/sign-in.ts
+++ b/src/ui/server/graphql/mutations/account/sign-in.ts
@@ -5,6 +5,7 @@ const accountSignInMutation = gql`
     accountSignIn(email: $email, password: $password) {
       accountId
       success
+      resentVerificationEmail
     }
   }
 `;


### PR DESCRIPTION
This PR improves a the account sign in process for unverified users. If a user has not verified their email during the account creation process, when they attempt to sign in, we now do the following:

- If an account has a verification hash/token and the expiry period has not passed:
  - Reset the verification period.
  - Resend the "verify your email address" email (with the token).
  - In the UI, redirect to the user to the "new link has been sent" page.

## Changes
- Update account sign in resolver to execute the above checks and return a new flag, `resentVerificationEmail` for the UI. Also improved documentation and logging.
- Extract the email sending logic in `sendEmailConfirmEmailAddress` resolver, into a new helper function to be DRY as it is now executed in multiple places.
- Update the UI to redirect to `CONFIRM_EMAIL_RESENT` route with account ID param, if a `resentVerificationEmail` flag is returned from the API.
- Update "form submission with unverified account" E2E test.
- Update the `completeAndSubmitSignInAccountForm` cypress command so it accepts params as an object. We can therefore easily add a new param `assertSuccessUrl` and this allows us to _not_ assert the sucess URL in the unverified account E2E test, as it does not redirec to the success URL.