### PR TITLE
feat(EMS-1344-1346): Application access - E2E test coverage

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/cannot-skip-flow/declarations/navigate-to-declarations-pages-without-completing-previous-sections.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/cannot-skip-flow/declarations/navigate-to-declarations-pages-without-completing-previous-sections.spec.js
@@ -15,9 +15,9 @@ const {
   },
 } = INSURANCE_ROUTES;
 
-context('Insurance - Declaration - cannot skip to any Declarations page without completing other required fields/sections', () => {
-  const insuranceRoute = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}`;
+const insuranceRoute = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}`;
 
+context('Insurance - Declaration - cannot skip to any Declarations page without completing other required fields/sections', () => {
   let referenceNumber;
   let completeOtherSectionsUrl;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/cannot-skip-flow/declarations/navigate-to-declarations-pages-without-completing-previous-sections.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/cannot-skip-flow/declarations/navigate-to-declarations-pages-without-completing-previous-sections.spec.js
@@ -15,7 +15,8 @@ const {
   },
 } = INSURANCE_ROUTES;
 
-const insuranceRoute = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}`;
+const baseUrl = Cypress.config('baseUrl');
+const insuranceRoute = `${baseUrl}${INSURANCE_ROOT}`;
 
 context('Insurance - Declaration - cannot skip to any Declarations page without completing other required fields/sections', () => {
   let referenceNumber;

--- a/e2e-tests/cypress/e2e/journeys/insurance/dashboard/dashboard-only-my-applications.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/dashboard/dashboard-only-my-applications.spec.js
@@ -67,6 +67,7 @@ context("Insurance - Dashboard - As an Exporter, I want to access only my UKEF e
       // sign out of the current account
       header.navigation.signOut().click();
 
+      // sign into a different accont
       cy.completeSignInAndGoToApplication(secondAccountEmail).then((refNumber) => {
         referenceNumbers = [...referenceNumbers, refNumber];
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/no-access-application-submitted/no-access-application-submitted-check-your-answers.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/no-access-application-submitted/no-access-application-submitted-check-your-answers.spec.js
@@ -1,0 +1,69 @@
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+
+const {
+  ROOT: INSURANCE_ROOT,
+  CHECK_YOUR_ANSWERS: {
+    ELIGIBILITY,
+    TYPE_OF_POLICY,
+    YOUR_BUSINESS,
+    YOUR_BUYER,
+  },
+  NO_ACCESS_APPLICATION_SUBMITTED,
+} = INSURANCE_ROUTES;
+
+const baseUrl = Cypress.config('baseUrl');
+const insuranceRoute = `${baseUrl}${INSURANCE_ROOT}`;
+
+const noAccessApplicationSubmittedUrl = `${baseUrl}${NO_ACCESS_APPLICATION_SUBMITTED}`;
+
+context('Insurance - no access to application when application is submitted - check yor answers pages', () => {
+  let referenceNumber;
+
+  before(() => {
+    cy.completeSignInAndSubmitAnApplication({}).then((refNumber) => {
+      referenceNumber = refNumber;
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteAccountAndApplication(referenceNumber);
+  });
+
+  describe('when trying to access a "check your answers" page in an application that is already sbumitted', () => {
+    it(`should redirect to ${NO_ACCESS_APPLICATION_SUBMITTED} when navigating to the Check your answers - Eligibility page directly`, () => {
+      const url = `${insuranceRoute}/${referenceNumber}${ELIGIBILITY}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(noAccessApplicationSubmittedUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_APPLICATION_SUBMITTED} when navigating to the Check your answers - Policy and exports page directly`, () => {
+      const url = `${insuranceRoute}/${referenceNumber}${TYPE_OF_POLICY}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(noAccessApplicationSubmittedUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_APPLICATION_SUBMITTED} when navigating to the Check your answers - Your business page directly`, () => {
+      const url = `${insuranceRoute}/${referenceNumber}${YOUR_BUSINESS}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(noAccessApplicationSubmittedUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_APPLICATION_SUBMITTED} when navigating to the Check your answers - Your buyer page directly`, () => {
+      const url = `${insuranceRoute}/${referenceNumber}${YOUR_BUYER}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(noAccessApplicationSubmittedUrl);
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/no-access-application-submitted/no-access-application-submitted-declarations.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/no-access-application-submitted/no-access-application-submitted-declarations.spec.js
@@ -1,0 +1,89 @@
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+
+const {
+  ROOT: INSURANCE_ROOT,
+  DECLARATIONS: {
+    CONFIDENTIALITY,
+    ANTI_BRIBERY: {
+      ROOT: ANTI_BRIBERY_ROOT,
+      CODE_OF_CONDUCT,
+      EXPORTING_WITH_CODE_OF_CONDUCT,
+    },
+    CONFIRMATION_AND_ACKNOWLEDGEMENTS,
+    HOW_YOUR_DATA_WILL_BE_USED,
+  },
+  NO_ACCESS_APPLICATION_SUBMITTED,
+} = INSURANCE_ROUTES;
+
+const baseUrl = Cypress.config('baseUrl');
+const insuranceRoute = `${baseUrl}${INSURANCE_ROOT}`;
+
+const noAccessApplicationSubmittedUrl = `${baseUrl}${NO_ACCESS_APPLICATION_SUBMITTED}`;
+
+context('Insurance - no access to application when application is submitted - declarations pages', () => {
+  let referenceNumber;
+
+  before(() => {
+    cy.completeSignInAndSubmitAnApplication({}).then((refNumber) => {
+      referenceNumber = refNumber;
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteAccountAndApplication(referenceNumber);
+  });
+
+  describe('when trying to access a "declarations" page in an application that is already sbumitted', () => {
+    it(`should redirect to ${NO_ACCESS_APPLICATION_SUBMITTED} when navigating to the Declarations - Confidentiality page directly`, () => {
+      const url = `${insuranceRoute}/${referenceNumber}${CONFIDENTIALITY}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(noAccessApplicationSubmittedUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_APPLICATION_SUBMITTED} when navigating to the Declarations - Anti-bribery page directly`, () => {
+      const url = `${insuranceRoute}/${referenceNumber}${ANTI_BRIBERY_ROOT}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(noAccessApplicationSubmittedUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_APPLICATION_SUBMITTED} when navigating to the Declarations - Anti-bribery - Code of conduct page directly`, () => {
+      const url = `${insuranceRoute}/${referenceNumber}${CODE_OF_CONDUCT}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(noAccessApplicationSubmittedUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_APPLICATION_SUBMITTED} when navigating to the Declarations - Anti-bribery - Exporting with code of conduct page directly`, () => {
+      const url = `${insuranceRoute}/${referenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(noAccessApplicationSubmittedUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_APPLICATION_SUBMITTED} when navigating to the Declarations - Confirmation and acknowledgements page directly`, () => {
+      const url = `${insuranceRoute}/${referenceNumber}${CONFIRMATION_AND_ACKNOWLEDGEMENTS}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(noAccessApplicationSubmittedUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_APPLICATION_SUBMITTED} when navigating to the Declarations - How your data will be used page directly`, () => {
+      const url = `${insuranceRoute}/${referenceNumber}${HOW_YOUR_DATA_WILL_BE_USED}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(noAccessApplicationSubmittedUrl);
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/no-access-application-submitted/no-access-application-submitted.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/no-access-application-submitted/no-access-application-submitted.spec.js
@@ -1,6 +1,6 @@
-import noAccessApplicationSubmittedPage from '../../pages/insurance/noAccessApplicationSubmitted';
-import { PAGES } from '../../../../content-strings';
-import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
+import noAccessApplicationSubmittedPage from '../../../pages/insurance/noAccessApplicationSubmitted';
+import { PAGES } from '../../../../../content-strings';
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.NO_ACCESS_APPLICATION_SUBMITTED_PAGE;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/no-access-to-application/acannot-access-application-signed-in-check-your-answers.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/no-access-to-application/acannot-access-application-signed-in-check-your-answers.spec.js
@@ -1,0 +1,89 @@
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+
+const {
+  ROOT: INSURANCE_ROOT,
+  NO_ACCESS_TO_APPLICATION,
+  CHECK_YOUR_ANSWERS: {
+    ELIGIBILITY,
+    TYPE_OF_POLICY,
+    YOUR_BUSINESS,
+    YOUR_BUYER,
+  },
+} = INSURANCE_ROUTES;
+
+const firstAccountEmail = Cypress.env('GOV_NOTIFY_EMAIL_RECIPIENT_1');
+const secondAccountEmail = Cypress.env('GOV_NOTIFY_EMAIL_RECIPIENT_2');
+
+const baseUrl = Cypress.config('baseUrl');
+const insuranceRoute = `${baseUrl}${INSURANCE_ROOT}`;
+
+const cannotAccessUrl = `${baseUrl}${NO_ACCESS_TO_APPLICATION}`;
+
+context('Insurance - no access to application page - signed in - check your answers', () => {
+  let firstApplicationReferenceNumber;
+  let referenceNumbers;
+
+  before(() => {
+    cy.saveSession();
+
+    // sign into an account, create an application.
+    cy.completeSignInAndGoToApplication().then((refNumber) => {
+      firstApplicationReferenceNumber = refNumber;
+
+      referenceNumbers = [refNumber];
+    });
+  });
+
+  after(() => {
+    referenceNumbers.forEach((refNumber) => {
+      cy.deleteApplication(refNumber);
+    });
+
+    cy.deleteAccount(firstAccountEmail);
+    cy.deleteAccount(secondAccountEmail);
+  });
+
+  describe('when trying to access a "check your answers" page in an application created by another user', () => {
+    before(() => {
+      // clear the session - means we are not a logged in user.
+      cy.clearCookie('exip-session');
+
+      // sign into a different accont
+      cy.completeSignInAndGoToApplication(secondAccountEmail).then((refNumber) => {
+        referenceNumbers = [...referenceNumbers, refNumber];
+      });
+    });
+
+    it(`should redirect to ${NO_ACCESS_TO_APPLICATION} when navigating to the Check your answers - Eligibility page directly`, () => {
+      const url = `${insuranceRoute}/${firstApplicationReferenceNumber}${ELIGIBILITY}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(cannotAccessUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_TO_APPLICATION} when navigating to the Check your answers - Policy and exports page directly`, () => {
+      const url = `${insuranceRoute}/${firstApplicationReferenceNumber}${TYPE_OF_POLICY}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(cannotAccessUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_TO_APPLICATION} when navigating to the Check your answers - Your business page directly`, () => {
+      const url = `${insuranceRoute}/${firstApplicationReferenceNumber}${YOUR_BUSINESS}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(cannotAccessUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_TO_APPLICATION} when navigating to the Check your answers - Your buyer page directly`, () => {
+      const url = `${insuranceRoute}/${firstApplicationReferenceNumber}${YOUR_BUYER}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(cannotAccessUrl);
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/no-access-to-application/cannot-access-application-signed-in-check-your-answers.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/no-access-to-application/cannot-access-application-signed-in-check-your-answers.spec.js
@@ -45,7 +45,7 @@ context('Insurance - no access to application page - signed in - check your answ
 
   describe('when trying to access a "check your answers" page in an application created by another user', () => {
     before(() => {
-      // clear the session - means we are not a logged in user.
+      // clear the session - means we are not a signed in user.
       cy.clearCookie('exip-session');
 
       // sign into a different accont

--- a/e2e-tests/cypress/e2e/journeys/insurance/no-access-to-application/cannot-access-application-signed-in-check-your-answers.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/no-access-to-application/cannot-access-application-signed-in-check-your-answers.spec.js
@@ -19,7 +19,7 @@ const insuranceRoute = `${baseUrl}${INSURANCE_ROOT}`;
 
 const cannotAccessUrl = `${baseUrl}${NO_ACCESS_TO_APPLICATION}`;
 
-context('Insurance - no access to application page - signed in - check your answers', () => {
+context('Insurance - no access to application page - signed in - check your answers pages', () => {
   let firstApplicationReferenceNumber;
   let referenceNumbers;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/no-access-to-application/cannot-access-application-signed-in-declarations.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/no-access-to-application/cannot-access-application-signed-in-declarations.spec.js
@@ -23,7 +23,7 @@ const insuranceRoute = `${baseUrl}${INSURANCE_ROOT}`;
 
 const cannotAccessUrl = `${baseUrl}${NO_ACCESS_TO_APPLICATION}`;
 
-context('Insurance - no access to application page - signed in - declarations', () => {
+context('Insurance - no access to application page - signed in - declarations pages', () => {
   let firstApplicationReferenceNumber;
   let referenceNumbers;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/no-access-to-application/cannot-access-application-signed-in-declarations.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/no-access-to-application/cannot-access-application-signed-in-declarations.spec.js
@@ -49,7 +49,7 @@ context('Insurance - no access to application page - signed in - declarations pa
 
   describe('when trying to access a "declarations" page in an application created by another user', () => {
     before(() => {
-      // clear the session - means we are not a logged in user.
+      // clear the session - means we are not a signed in user.
       cy.clearCookie('exip-session');
 
       // sign into a different accont

--- a/e2e-tests/cypress/e2e/journeys/insurance/no-access-to-application/cannot-access-application-signed-in-declarations.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/no-access-to-application/cannot-access-application-signed-in-declarations.spec.js
@@ -1,0 +1,109 @@
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+
+const {
+  ROOT: INSURANCE_ROOT,
+  NO_ACCESS_TO_APPLICATION,
+  DECLARATIONS: {
+    CONFIDENTIALITY,
+    ANTI_BRIBERY: {
+      ROOT: ANTI_BRIBERY_ROOT,
+      CODE_OF_CONDUCT,
+      EXPORTING_WITH_CODE_OF_CONDUCT,
+    },
+    CONFIRMATION_AND_ACKNOWLEDGEMENTS,
+    HOW_YOUR_DATA_WILL_BE_USED,
+  },
+} = INSURANCE_ROUTES;
+
+const firstAccountEmail = Cypress.env('GOV_NOTIFY_EMAIL_RECIPIENT_1');
+const secondAccountEmail = Cypress.env('GOV_NOTIFY_EMAIL_RECIPIENT_2');
+
+const baseUrl = Cypress.config('baseUrl');
+const insuranceRoute = `${baseUrl}${INSURANCE_ROOT}`;
+
+const cannotAccessUrl = `${baseUrl}${NO_ACCESS_TO_APPLICATION}`;
+
+context('Insurance - no access to application page - signed in - declarations', () => {
+  let firstApplicationReferenceNumber;
+  let referenceNumbers;
+
+  before(() => {
+    cy.saveSession();
+
+    // sign into an account, create an application.
+    cy.completeSignInAndGoToApplication().then((refNumber) => {
+      firstApplicationReferenceNumber = refNumber;
+
+      referenceNumbers = [refNumber];
+    });
+  });
+
+  after(() => {
+    referenceNumbers.forEach((refNumber) => {
+      cy.deleteApplication(refNumber);
+    });
+
+    cy.deleteAccount(firstAccountEmail);
+    cy.deleteAccount(secondAccountEmail);
+  });
+
+  describe('when trying to access a "declarations" page in an application created by another user', () => {
+    before(() => {
+      // clear the session - means we are not a logged in user.
+      cy.clearCookie('exip-session');
+
+      // sign into a different accont
+      cy.completeSignInAndGoToApplication(secondAccountEmail).then((refNumber) => {
+        referenceNumbers = [...referenceNumbers, refNumber];
+      });
+    });
+
+    it(`should redirect to ${NO_ACCESS_TO_APPLICATION} when navigating to the Declarations - Confidentiality page directly`, () => {
+      const url = `${insuranceRoute}/${firstApplicationReferenceNumber}${CONFIDENTIALITY}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(cannotAccessUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_TO_APPLICATION} when navigating to the Declarations - Anti-bribery page directly`, () => {
+      const url = `${insuranceRoute}/${firstApplicationReferenceNumber}${ANTI_BRIBERY_ROOT}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(cannotAccessUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_TO_APPLICATION} when navigating to the Declarations - Anti-bribery - Code of conduct page directly`, () => {
+      const url = `${insuranceRoute}/${firstApplicationReferenceNumber}${CODE_OF_CONDUCT}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(cannotAccessUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_TO_APPLICATION} when navigating to the Declarations - Anti-bribery - Exporting with code of conduct page directly`, () => {
+      const url = `${insuranceRoute}/${firstApplicationReferenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(cannotAccessUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_TO_APPLICATION} when navigating to the Declarations - Confirmation and acknowledgements page directly`, () => {
+      const url = `${insuranceRoute}/${firstApplicationReferenceNumber}${CONFIRMATION_AND_ACKNOWLEDGEMENTS}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(cannotAccessUrl);
+    });
+
+    it(`should redirect to ${NO_ACCESS_TO_APPLICATION} when navigating to the Declarations - How your data will be used page directly`, () => {
+      const url = `${insuranceRoute}/${firstApplicationReferenceNumber}${HOW_YOUR_DATA_WILL_BE_USED}`;
+
+      cy.navigateToUrl(url);
+
+      cy.assertUrl(cannotAccessUrl);
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/no-access-to-application/no-access-to-application.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/no-access-to-application/no-access-to-application.spec.js
@@ -1,6 +1,6 @@
-import noAccessToApplicationPage from '../../pages/insurance/noAccessToApplication';
-import { PAGES } from '../../../../content-strings';
-import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
+import noAccessToApplicationPage from '../../../pages/insurance/noAccessToApplication';
+import { PAGES } from '../../../../../content-strings';
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.NO_ACCESS_TO_APPLICATION_PAGE;
 
@@ -10,9 +10,9 @@ const {
   NO_ACCESS_TO_APPLICATION,
 } = INSURANCE_ROUTES;
 
-context('Insurance - no access to application page', () => {
+context('Insurance - no access to application page - signed out', () => {
   let referenceNumber;
-  let url;
+  let applicationUrl;
 
   before(() => {
     cy.saveSession();
@@ -21,9 +21,9 @@ context('Insurance - no access to application page', () => {
     cy.completeSignInAndGoToApplication().then((refNumber) => {
       referenceNumber = refNumber;
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+      applicationUrl = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
-      cy.url().should('eq', url);
+      cy.assertUrl(applicationUrl);
     });
   });
 
@@ -31,18 +31,18 @@ context('Insurance - no access to application page', () => {
     cy.deleteAccountAndApplication(referenceNumber);
   });
 
-  describe('when trying to access an application created by another user', () => {
+  describe('when trying to access an application', () => {
     beforeEach(() => {
-      // clear the session - means we are not a logged in user.
+      // clear the session - means we are not a signed in user.
       cy.clearCookie('exip-session');
 
-      cy.navigateToUrl(url);
+      cy.navigateToUrl(applicationUrl);
     });
 
     it(`should redirect to ${NO_ACCESS_TO_APPLICATION}`, () => {
       const expectedUrl = `${Cypress.config('baseUrl')}${NO_ACCESS_TO_APPLICATION}`;
 
-      cy.url().should('eq', expectedUrl);
+      cy.assertUrl(expectedUrl);
     });
 
     it('renders core page elements', () => {

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -1285,9 +1285,15 @@ var lists = {
         ],
         db: { isNullable: true }
       }),
-      improvement: (0, import_fields.text)(),
-      otherComments: (0, import_fields.text)(),
-      referralUrl: (0, import_fields.text)(),
+      improvement: (0, import_fields.text)({
+        db: { nativeType: "VarChar(1000)" }
+      }),
+      otherComments: (0, import_fields.text)({
+        db: { nativeType: "VarChar(1000)" }
+      }),
+      referralUrl: (0, import_fields.text)({
+        db: { nativeType: "VarChar(500)" }
+      }),
       product: (0, import_fields.text)()
     },
     access: import_access.allowAll

--- a/src/api/schema.prisma
+++ b/src/api/schema.prisma
@@ -315,8 +315,8 @@ model Feedback {
   id            String  @id @default(cuid())
   service       String  @default("")
   satisfaction  String?
-  improvement   String  @default("")
-  otherComments String  @default("")
-  referralUrl   String  @default("")
+  improvement   String  @default("") @mysql.VarChar(1000)
+  otherComments String  @default("") @mysql.VarChar(1000)
+  referralUrl   String  @default("") @mysql.VarChar(500)
   product       String  @default("")
 }


### PR DESCRIPTION
This PR adds E2E test coverage to ensure that:

- A user cannot access any "declarations" page if the user is not the application owner.
- A user cannot access any "check yor answers" page  if the user is not the application owner.
- A user cannot access any "declarations" page if the application is submitted.
- A user cannot access any "check yor answers" page if the application is submitted.

Also aligned a few comments/conventions.