### PR TITLE
feat(EMS-1662): Account password reset - reset auth retries

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -1786,7 +1786,7 @@ var getAuthenticationRetriesByAccountId = async (context, accountId) => {
     return retries;
   } catch (err) {
     console.error(err);
-    throw new Error(`Getting authentication retries ${err}`);
+    throw new Error(`Getting authentication retries by account ID ${err}`);
   }
 };
 var get_authentication_retries_by_account_id_default = getAuthenticationRetriesByAccountId;
@@ -2543,6 +2543,7 @@ var accountPasswordReset = async (root, variables, context) => {
         hasBeenUsedBefore: true
       };
     }
+    await delete_authentication_retries_default(context, accountId);
     const authEntry = {
       account: {
         connect: {

--- a/src/api/custom-resolvers/mutations/account-password-reset.ts
+++ b/src/api/custom-resolvers/mutations/account-password-reset.ts
@@ -5,6 +5,7 @@ import getAccountByField from '../../helpers/get-account-by-field';
 import encryptPassword from '../../helpers/encrypt-password';
 import hasAccountUsedPasswordBefore from '../../helpers/account-has-used-password-before';
 import getPasswordHash from '../../helpers/get-password-hash';
+import deleteAuthenticationRetries from '../../helpers/delete-authentication-retries';
 import createAuthenticationEntry from '../../helpers/create-authentication-entry';
 import { Account, AccountPasswordResetVariables } from '../../types';
 
@@ -101,8 +102,11 @@ const accountPasswordReset = async (root: any, variables: AccountPasswordResetVa
 
     /**
      * Account is OK to proceed with password reset.
-     * 1) Add a new entry to the Authentication table
+     * 1) Wipe the retry entries
+     * 2) Add a new entry to the Authentication table
      */
+    await deleteAuthenticationRetries(context, accountId);
+
     const authEntry = {
       account: {
         connect: {

--- a/src/api/custom-resolvers/mutations/account-sign-in.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in.ts
@@ -81,7 +81,7 @@ const accountSignIn = async (root: any, variables: AccountSignInVariables, conte
      * 1) Check if the password is matches what is encrypted in the database.
      * 2) If the password is valid:
      *   - If the account is unverified, but has a valid has/token, send verification email.
-     *   - If the account is verified, wipe the retry entries generate an OTP/security code and send via email.
+     *   - If the account is verified, generate an OTP/security code and send via email.
      * 3) Otherwise, we return a rejection because either:
      *   - The password is invalid.
      *   - The email was not sent.

--- a/src/api/custom-resolvers/mutations/verify-account-sign-in-code.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-sign-in-code.ts
@@ -13,7 +13,7 @@ const {
 
 /**
  * verifyAccountSignInCode
- * Check if a OTP/security code is valid and if so, generate and return a JWT
+ * Check if a OTP/security code is valid and if so, wipe the retry entries and generate and return a JWT
  * @param {Object} GraphQL root variables
  * @param {Object} GraphQL variables for the AccountSignIn mutation
  * @param {Object} KeystoneJS context API

--- a/src/api/helpers/get-authentication-retries-by-account-id/index.test.ts
+++ b/src/api/helpers/get-authentication-retries-by-account-id/index.test.ts
@@ -1,0 +1,48 @@
+import { getContext } from '@keystone-6/core/context';
+import dotenv from 'dotenv';
+import * as PrismaModule from '.prisma/client'; // eslint-disable-line import/no-extraneous-dependencies
+import getAuthenticationRetriesByAccountId from '.';
+import createAuthenticationRetryEntry from '../create-authentication-retry-entry';
+import baseConfig from '../../keystone';
+import { mockAccount } from '../../test-mocks';
+import { Account } from '../../types';
+import { Context } from '.keystone/types'; // eslint-disable-line
+
+const dbUrl = String(process.env.DATABASE_URL);
+const config = { ...baseConfig, db: { ...baseConfig.db, url: dbUrl } };
+
+dotenv.config();
+
+const context = getContext(config, PrismaModule) as Context;
+
+describe('helpers/get-authentication-retries-by-account-id', () => {
+  let account: Account;
+
+  beforeEach(async () => {
+    // wipe the table so we have a clean slate.
+    const authRetries = await context.query.AuthenticationRetry.findMany();
+
+    await context.query.AuthenticationRetry.deleteMany({
+      where: authRetries,
+    });
+
+    // create a new account
+    account = (await context.query.Account.createOne({
+      data: {
+        ...mockAccount,
+        isBlocked: false,
+      },
+      query: 'id',
+    })) as Account;
+
+    // create some new entries
+    await createAuthenticationRetryEntry(context, account.id);
+    await createAuthenticationRetryEntry(context, account.id);
+  });
+
+  it('should return a auth retries by account ID', async () => {
+    const result = await getAuthenticationRetriesByAccountId(context, account.id);
+
+    expect(result.length).toEqual(2);
+  });
+});

--- a/src/api/helpers/get-authentication-retries-by-account-id/index.ts
+++ b/src/api/helpers/get-authentication-retries-by-account-id/index.ts
@@ -25,7 +25,7 @@ const getAuthenticationRetriesByAccountId = async (context: Context, accountId: 
   } catch (err) {
     console.error(err);
 
-    throw new Error(`Getting authentication retries ${err}`);
+    throw new Error(`Getting authentication retries by account ID ${err}`);
   }
 };
 


### PR DESCRIPTION
This PR updates the account password reset GQL resolver to reset the account's authentication retry entries.

## Changes

- Update account password reset GQL resolver to call `deleteAuthenticationRetries` helper function.
- Fixed some typos.
- Added missing test coverage for `getAuthenticationRetriesByAccountId` helper function.