### PR TITLE
feat(EMS-1639): Account sign in - reject if already blocked

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/sign-in-already-blocked/account-sign-in-already-blocked.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/sign-in-already-blocked/account-sign-in-already-blocked.spec.js
@@ -1,0 +1,39 @@
+import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const {
+  ACCOUNT: {
+    SIGN_IN: { ROOT: SIGN_IN_ROOT },
+    SUSPENDED: { ROOT: SUSPENDED_ROOT },
+  },
+} = ROUTES;
+
+context('Insurance - Account - Sign in - Submitting the form when already blocked', () => {
+  const baseUrl = Cypress.config('baseUrl');
+  const signInUrl = `${baseUrl}${SIGN_IN_ROOT}`;
+  const accountSuspendedUrl = `${baseUrl}${SUSPENDED_ROOT}`;
+
+  before(() => {
+    cy.deleteAccount();
+
+    cy.completeAndSubmitCreateAccountForm({ navigateToAccountCreationPage: true });
+
+    cy.verifyAccountEmail();
+
+    cy.assertUrl(signInUrl);
+
+    // force the account to be blocked
+    cy.completeAndSubmitSignInAccountFormMaximumRetries();
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(signInUrl);
+
+    cy.completeAndSubmitSignInAccountForm({ assertRedirectUrl: false });
+  });
+
+  it(`should redirect to ${SUSPENDED_ROOT}`, () => {
+    cy.assertUrl(accountSuspendedUrl);
+  });
+});

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -2150,6 +2150,11 @@ var accountSignIn = async (root, variables, context) => {
     if (!newRetriesEntry.success) {
       return { success: false };
     }
+    const { isBlocked } = account;
+    if (isBlocked) {
+      console.info("Unable to sign in account - account is already blocked");
+      return { success: false, isBlocked: true };
+    }
     const needToBlockAccount = await should_block_account_default(context, accountId);
     if (needToBlockAccount) {
       const blocked = await block_account_default(context, accountId);

--- a/src/api/custom-resolvers/mutations/account-sign-in.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in.ts
@@ -57,6 +57,18 @@ const accountSignIn = async (root: any, variables: AccountSignInVariables, conte
     }
 
     /**
+     * Check if the account is blocked
+     * If so, return isBlocked=false
+     */
+    const { isBlocked } = account as Account;
+
+    if (isBlocked) {
+      console.info('Unable to sign in account - account is already blocked');
+
+      return { success: false, isBlocked: true };
+    }
+
+    /**
      * Check if the account should be blocked.
      * If so, update the account and return isBlocked=true
      */


### PR DESCRIPTION
This PR updates account sign in so that if an account is already blocked, we reject the sign in.

## Changes

- Update the sign in GQL resolver to return `isBlocked=true`, if the account is already blocked.
- Add E2E test coverage for this scenario.