### PR TITLE
fix(EMS-1623): Wipe insurance eligibility session data when creating a new application

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/complete-eligibility-ansewrs-for-a-second-time.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/complete-eligibility-ansewrs-for-a-second-time.spec.js
@@ -1,0 +1,87 @@
+import dashboardPage from '../../pages/insurance/dashboard';
+import { buyerCountryPage } from '../../pages/shared';
+import partials from '../../partials';
+import { ROUTES } from '../../../../constants';
+import { completeAndSubmitBuyerCountryForm } from '../../../support/forms';
+import {
+  completeExporterLocationForm,
+  completeUkGoodsAndServicesForm,
+  completeInsuredAmountForm,
+  completeInsuredPeriodForm,
+  completeOtherPartiesForm,
+  completeLetterOfCreditForm,
+  completePreCreditPeriodForm,
+  completeCompaniesHouseNumberForm,
+} from '../../../support/insurance/eligibility/forms';
+
+const {
+  ELIGIBILITY: { BUYER_COUNTRY },
+} = ROUTES.INSURANCE;
+
+context('Insurance - Eligibility - start and complete for a second time after creating an application', () => {
+  let referenceNumber;
+
+  const buyerCountryUrl = `${Cypress.config('baseUrl')}${BUYER_COUNTRY}`;
+
+  before(() => {
+    cy.deleteAccount();
+
+    cy.completeSignInAndGoToApplication().then((refNumber) => {
+      referenceNumber = refNumber;
+
+      partials.header.navigation.applications().click();
+
+      dashboardPage.startNewApplication().click();
+
+      cy.assertUrl(buyerCountryUrl);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(buyerCountryUrl);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  it('should NOT have prepopulated answers', () => {
+    // buyer country question
+    cy.checkValue(buyerCountryPage, '');
+    completeAndSubmitBuyerCountryForm();
+
+    // exporter location question
+    cy.assertUncheckedYesNoRadios();
+    completeExporterLocationForm();
+
+    // UK goods and services question
+    cy.assertUncheckedYesNoRadios();
+    completeUkGoodsAndServicesForm();
+
+    // insured amount question
+    cy.assertUncheckedYesNoRadios();
+    completeInsuredAmountForm();
+
+    // insured period question
+    cy.assertUncheckedYesNoRadios();
+    completeInsuredPeriodForm();
+
+    // other parties question
+    cy.assertUncheckedYesNoRadios();
+    completeOtherPartiesForm();
+
+    // letter of credit question
+    cy.assertUncheckedYesNoRadios();
+    completeLetterOfCreditForm();
+
+    // pre-credit period question
+    cy.assertUncheckedYesNoRadios();
+    completePreCreditPeriodForm();
+
+    // companies house number question
+    cy.assertUncheckedYesNoRadios();
+    completeCompaniesHouseNumberForm();
+  });
+});

--- a/e2e-tests/cypress/support/assert-unchecked-yes-no-radios.js
+++ b/e2e-tests/cypress/support/assert-unchecked-yes-no-radios.js
@@ -1,0 +1,12 @@
+import { yesRadioInput, noRadioInput } from '../e2e/pages/shared';
+
+/**
+ * assertUncheckedYesNoRadios
+ * Check that both "yes" and "no" inputs are unchecked
+ */
+const assertUncheckedYesNoRadios = () => {
+  yesRadioInput().should('not.be.checked');
+  noRadioInput().should('not.be.checked');
+};
+
+export default assertUncheckedYesNoRadios;

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -119,6 +119,8 @@ Cypress.Commands.add('assertConfirmEmailPageContent', require('./insurance/accou
 
 Cypress.Commands.add('assertSubmitAndSaveButtons', require('./insurance/assert-submit-and-save-buttons'));
 
+Cypress.Commands.add('assertUncheckedYesNoRadios', require('./assert-unchecked-yes-no-radios'));
+
 Cypress.Commands.add('assertCustomerServiceContactDetailsContent', require('./assert-customer-service-contact-details-content'));
 
 Cypress.Commands.add('checkText', require('./check-text'));

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -47,7 +47,7 @@
         "morgan": "1.10.0",
         "node-notifier": "^10.0.1",
         "nodemon": "2.0.22",
-        "nunjucks": "3.2.3",
+        "nunjucks": "3.2.4",
         "path": "0.12.7",
         "postcode-validator": "^3.8.0",
         "ts-node": "^10.9.1",
@@ -10337,9 +10337,9 @@
       }
     },
     "node_modules/nunjucks": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
-      "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
       "dependencies": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -65,7 +65,7 @@
     "morgan": "1.10.0",
     "node-notifier": "^10.0.1",
     "nodemon": "2.0.22",
-    "nunjucks": "3.2.3",
+    "nunjucks": "3.2.4",
     "path": "0.12.7",
     "postcode-validator": "^3.8.0",
     "ts-node": "^10.9.1",

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
@@ -4,7 +4,7 @@ import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../../constants';
 import { ACCOUNT_FIELDS as FIELDS } from '../../../../../content-strings/fields/insurance/account';
 import insuranceCorePageVariables from '../../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../../helpers/get-user-name-from-session';
-import { sanitiseValue } from '../../../../../helpers/sanitise-data';
+import { sanitiseData, sanitiseValue } from '../../../../../helpers/sanitise-data';
 import generateValidationErrors from './validation';
 import securityCodeValidationErrors from './validation/rules/security-code';
 import api from '../../../../../api';
@@ -231,11 +231,19 @@ describe('controllers/insurance/account/sign-in/enter-code', () => {
         });
 
         it('should call api.keystone.application.create', async () => {
+          const eligibilityAnswers = sanitiseData(req.session.submittedData.insuranceEligibility);
+
           await post(req, res);
 
           expect(createApplicationSpy).toHaveBeenCalledTimes(1);
 
-          expect(createApplicationSpy).toHaveBeenCalledWith(req.session.submittedData.insuranceEligibility, verifyAccountSignInCodeResponse.accountId);
+          expect(createApplicationSpy).toHaveBeenCalledWith(eligibilityAnswers, verifyAccountSignInCodeResponse.accountId);
+        });
+
+        it('should wipe req.session.submittedData.insuranceEligibility', async () => {
+          await post(req, res);
+
+          expect(req.session.submittedData.insuranceEligibility).toEqual({});
         });
 
         it(`should redirect to ${DASHBOARD}`, async () => {

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
@@ -3,7 +3,7 @@ import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../../constants';
 import { ACCOUNT_FIELDS as FIELDS } from '../../../../../content-strings/fields/insurance/account';
 import insuranceCorePageVariables from '../../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../../helpers/get-user-name-from-session';
-import { sanitiseValue } from '../../../../../helpers/sanitise-data';
+import { sanitiseData, sanitiseValue } from '../../../../../helpers/sanitise-data';
 import generateValidationErrors from './validation';
 import securityCodeValidationErrors from './validation/rules/security-code';
 import { objectHasKeysAndValues } from '../../../../../helpers/object';
@@ -111,9 +111,9 @@ export const post = async (req: Request, res: Response) => {
         expires,
       };
 
-      // if there is eligibility in the session, create application.
+      // if there is eligibility in the session, create application and wipe eligibility answers
       if (req.session.submittedData && objectHasKeysAndValues(req.session.submittedData.insuranceEligibility)) {
-        const eligibilityAnswers = req.session.submittedData.insuranceEligibility;
+        const eligibilityAnswers = sanitiseData(req.session.submittedData.insuranceEligibility);
 
         const application = await api.keystone.application.create(eligibilityAnswers, accountId);
 
@@ -121,6 +121,8 @@ export const post = async (req: Request, res: Response) => {
           console.error('Error creating application');
           return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
         }
+
+        req.session.submittedData.insuranceEligibility = {};
       }
 
       // otherwise, redirect to the next part of the flow - dashboard

--- a/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.test.ts
@@ -78,13 +78,21 @@ describe('controllers/insurance/eligibility/eligible-to-apply-online', () => {
       });
 
       it('should call api.keystone.application.create', async () => {
+        const eligibilityAnswers = req.session.submittedData.insuranceEligibility;
+
         await post(req, res);
 
         expect(createApplicationSpy).toHaveBeenCalledTimes(1);
 
-        const sanitisedData = sanitiseData(req.session.submittedData.insuranceEligibility);
+        const sanitisedData = sanitiseData(eligibilityAnswers);
 
         expect(createApplicationSpy).toHaveBeenCalledWith(sanitisedData, mockAccount.id);
+      });
+
+      it('should wipe req.session.submittedData.insuranceEligibility', async () => {
+        await post(req, res);
+
+        expect(req.session.submittedData.insuranceEligibility).toEqual({});
       });
 
       it(`should redirect to ${ALL_SECTIONS}`, async () => {

--- a/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.ts
@@ -38,6 +38,8 @@ export const post = async (req: Request, res: Response) => {
         return res.redirect(PROBLEM_WITH_SERVICE);
       }
 
+      req.session.submittedData.insuranceEligibility = {};
+
       const applicationUrl = `${INSURANCE_ROOT}/${application.referenceNumber}${ALL_SECTIONS}`;
 
       return res.redirect(applicationUrl);


### PR DESCRIPTION
This PR updates the UI's "create application" logic so that insurance eligibility session data is wiped after account creation, which in turn forces a user to complete insurance eligibility answers when creating a new application. Previously, eligibility answers would be prepopulated.

## Changes
- Update "sign in - enter code" UI controller to wipe insurance eligibility session data after application creation.
- Update "eligible to apply online" UI controller to wipe insurance eligibility session data after application creation.
- Add E2E test coverage to check the insurance eligibility answers are not prepopulated when going through the flow for a second time. Uses new cypress command, `assertUncheckedYesNoRadios`.

## Other improvements
- Add missing data sanitisation to the "sign in - enter code" UI controller.
- Bump `nunjucks` package.