### PR TITLE
feat(EMS-1687): Quote - Update 'full application' link, refactor some page content

### DIFF
--- a/e2e-tests/content-strings/pages/quote.js
+++ b/e2e-tests/content-strings/pages/quote.js
@@ -1,4 +1,5 @@
 import { LINKS } from '../links';
+import { INSURANCE_ROUTES } from '../../constants/routes/insurance';
 
 const BUYER_BODY = {
   PAGE_TITLE: 'Is your buyer a government or public sector body?',
@@ -95,66 +96,34 @@ const YOUR_QUOTE = {
   NOTICE_3: 'Your price may be higher if our underwriters find additional risks with your export or buyer.',
   WHAT_HAPPENS_NEXT: {
     HEADING: 'What happens next?',
-    INTRO: [
-      [
-        {
-          text: 'You can now submit a',
-        },
-        {
-          text: 'full application',
-          href: LINKS.EXTERNAL.FULL_APPLICATION,
-        },
-        {
-          text: '. ',
-        },
-        {
-          text: 'It takes about 2 weeks to get a decision from UKEF.',
-        },
-      ],
-      [
-        {
-          text: 'You can get help with the application process from export finance managers or brokers.',
-        },
-      ],
-    ],
+    INTRO: {
+      CAN_NOW_SUBMIT: 'You can now submit a',
+      FULL_APPLICATION: {
+        TEXT: 'full application',
+        HREF: INSURANCE_ROUTES.START,
+      },
+      TIMEFRAME: 'It takes about 2 weeks to get a decision from UKEF.',
+      CAN_GET_HELP: 'You can get help with the application process from export finance managers or brokers.',
+    },
     EXPORT_FINANCE_MANAGERS: {
       HEADING: 'Export finance managers',
-      ITEMS: [
-        [
-          {
-            text: 'They work for UKEF and are available in every region. They can give you free guidance when making a full application. Find your',
-          },
-          {
-            text: 'nearest export finance manager',
-            href: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
-          },
-          {
-            text: '.',
-          },
-        ],
-      ],
+      AVAILABLE: 'They work for UKEF and are available in every region. They can give you free guidance when making a full application. Find your',
+      NEAREST_EFM: {
+        TEXT: 'nearest export finance manager',
+        HREF: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
+      },
     },
     BROKERS: {
       HEADING: 'Brokers',
-      ITEMS: [
-        [
-          {
-            text: 'They act as an agent between you and UKEF. They can also help you with the application process.',
-          },
-        ],
-        [
-          {
-            text: 'They receive a 15% fee for providing any successful policies at no extra cost to you. UKEF will pay their fee out of the policy premium you pay.',
-          },
-          {
-            text: 'Use our approved broker list',
-            href: LINKS.EXTERNAL.APPROVED_BROKER_LIST,
-          },
-          {
-            text: ' to find a broker to help you.',
-          },
-        ],
-      ],
+      ACT_AS: 'They act as an agent between you and UKEF. They can also help you with the application process.',
+      THEY_RECEIVE: {
+        INTRO: 'They receive a 15% fee for providing any successful policies at no extra cost to you. UKEF will pay their fee out of the policy premium you pay.',
+        LINK: {
+          TEXT: 'Use our approved broker list',
+          HREF: LINKS.EXTERNAL.APPROVED_BROKER_LIST,
+        },
+        OUTRO: 'to find a broker to help you.',
+      },
     },
   },
 };

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/link-sent/account-password-reset-link-sent.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/link-sent/account-password-reset-link-sent.spec.js
@@ -37,6 +37,8 @@ const goToPasswordResetLinkSentPage = () => {
 
 context('Insurance - Account - Password reset - link sent page - As an Exporter, I want to reset the password on my UKEF digital service account, So that I can securely access my UKEF digital service account', () => {
   before(() => {
+    cy.deleteAccount();
+
     cy.navigateToUrl(START);
     cy.submitEligibilityAndStartAccountCreation();
     cy.completeAndSubmitCreateAccountForm();
@@ -44,10 +46,6 @@ context('Insurance - Account - Password reset - link sent page - As an Exporter,
 
   beforeEach(() => {
     cy.saveSession();
-  });
-
-  after(() => {
-    cy.deleteAccount();
   });
 
   describe('when visiting the page', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
@@ -205,19 +205,86 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
       cy.checkText(yourQuotePage.noticeList.item3(), CONTENT_STRINGS.NOTICE_3);
     });
 
-    // TODO
-    // describe('what happens next', () => {
-    //   it('renders intro heading and copy', () => {
+    describe('what happens next', () => {
+      it('renders intro heading and copy', () => {
+        cy.checkText(yourQuotePage.whatHappensNext.heading(), CONTENT_STRINGS.WHAT_HAPPENS_NEXT.HEADING);
+      });
 
-    //   });
-    //   it('renders finance managers heading and copy', () => {
+      it('renders `can start a new application` copy and link', () => {
+        cy.checkText(
+          yourQuotePage.whatHappensNext.intro.youCan(),
+          CONTENT_STRINGS.WHAT_HAPPENS_NEXT.INTRO.CAN_NOW_SUBMIT,
+        );
 
-    //   });
+        cy.checkLink(
+          yourQuotePage.whatHappensNext.intro.fullApplicationLink(),
+          ROUTES.INSURANCE.START,
+          CONTENT_STRINGS.WHAT_HAPPENS_NEXT.INTRO.FULL_APPLICATION.TEXT,
+        );
+      });
 
-    //   it('renders brokers heading and copy', () => {
+      it('renders `timeframe` and `can get help` copy', () => {
+        cy.checkText(
+          yourQuotePage.whatHappensNext.intro.timeframe(),
+          CONTENT_STRINGS.WHAT_HAPPENS_NEXT.INTRO.TIMEFRAME,
+        );
 
-    //   });
-    // });
+        cy.checkText(
+          yourQuotePage.whatHappensNext.intro.canGetHelp(),
+          CONTENT_STRINGS.WHAT_HAPPENS_NEXT.INTRO.CAN_GET_HELP,
+        );
+      });
+
+      it('renders `finance managers` heading and copy', () => {
+        cy.checkText(
+          yourQuotePage.whatHappensNext.financeManagers.heading(),
+          CONTENT_STRINGS.WHAT_HAPPENS_NEXT.EXPORT_FINANCE_MANAGERS.HEADING,
+        );
+      });
+
+      it('renders `finance managers available` copy and link', () => {
+        cy.checkText(
+          yourQuotePage.whatHappensNext.financeManagers.available(),
+          CONTENT_STRINGS.WHAT_HAPPENS_NEXT.EXPORT_FINANCE_MANAGERS.AVAILABLE,
+        );
+
+        cy.checkLink(
+          yourQuotePage.whatHappensNext.financeManagers.link(),
+          CONTENT_STRINGS.WHAT_HAPPENS_NEXT.EXPORT_FINANCE_MANAGERS.NEAREST_EFM.HREF,
+          CONTENT_STRINGS.WHAT_HAPPENS_NEXT.EXPORT_FINANCE_MANAGERS.NEAREST_EFM.TEXT,
+        );
+      });
+
+      it('renders `brokers` heading and `act as` copy', () => {
+        cy.checkText(
+          yourQuotePage.whatHappensNext.brokers.heading(),
+          CONTENT_STRINGS.WHAT_HAPPENS_NEXT.BROKERS.HEADING,
+        );
+
+        cy.checkText(
+          yourQuotePage.whatHappensNext.brokers.actAs(),
+          CONTENT_STRINGS.WHAT_HAPPENS_NEXT.BROKERS.ACT_AS,
+        );
+      });
+
+      it('renders `brokers - they receive` copy and link', () => {
+        cy.checkText(
+          yourQuotePage.whatHappensNext.brokers.theyReceive.intro(),
+          CONTENT_STRINGS.WHAT_HAPPENS_NEXT.BROKERS.THEY_RECEIVE.INTRO,
+        );
+
+        cy.checkLink(
+          yourQuotePage.whatHappensNext.brokers.theyReceive.link(),
+          CONTENT_STRINGS.WHAT_HAPPENS_NEXT.BROKERS.THEY_RECEIVE.LINK.HREF,
+          CONTENT_STRINGS.WHAT_HAPPENS_NEXT.BROKERS.THEY_RECEIVE.LINK.TEXT,
+        );
+
+        cy.checkText(
+          yourQuotePage.whatHappensNext.brokers.theyReceive.outro(),
+          CONTENT_STRINGS.WHAT_HAPPENS_NEXT.BROKERS.THEY_RECEIVE.OUTRO,
+        );
+      });
+    });
 
     it('renders a `feedback` link', () => {
       yourQuotePage.links.feedback().should('exist');
@@ -236,10 +303,6 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
     });
 
     context('clicking `start again`', () => {
-      // beforeEach(() => {
-      //   cy.navigateToUrl(url);
-      // });
-
       it('redirects to the first page of the flow', () => {
         yourQuotePage.links.startAgain().click();
         cy.url().should('include', ROUTES.QUOTE.BUYER_COUNTRY);

--- a/e2e-tests/cypress/e2e/pages/quote/yourQuote.js
+++ b/e2e-tests/cypress/e2e/pages/quote/yourQuote.js
@@ -72,17 +72,26 @@ const yourQuotePage = {
     item3: () => cy.get('[data-cy="notice-list-item-3"]'),
   },
   whatHappensNext: {
+    heading: () => cy.get('[data-cy="what-happens-next-heading"]'),
     intro: {
-      heading: () => cy.get('[data-cy="what-happens-next-heading"]'),
-      listItems: () => cy.get('[data-cy="what-happens-next-intro"] li'),
+      youCan: () => cy.get('[data-cy="what-happens-next-intro-you-can"]'),
+      fullApplicationLink: () => cy.get('[data-cy="what-happens-next-full-application-link"]'),
+      timeframe: () => cy.get('[data-cy="what-happens-next-intro-timeframe"]'),
+      canGetHelp: () => cy.get('[data-cy="what-happens-next-intro-can-get-help"]'),
     },
     financeManagers: {
       heading: () => cy.get('[data-cy="what-happens-next-finance-managers-heading"]'),
-      listItems: () => cy.get('[data-cy="what-happens-next-finance-managers"] li'),
+      available: () => cy.get('[data-cy="what-happens-next-finance-managers-available"]'),
+      link: () => cy.get('[data-cy="what-happens-next-finance-managers-link"]'),
     },
     brokers: {
       heading: () => cy.get('[data-cy="what-happens-next-brokers-heading"]'),
-      listItems: () => cy.get('[data-cy="what-happens-next-brokers"] li'),
+      actAs: () => cy.get('[data-cy="what-happens-next-brokers-act-as"]'),
+      theyReceive: {
+        intro: () => cy.get('[data-cy="what-happens-next-brokers-they-receive-intro"]'),
+        link: () => cy.get('[data-cy="what-happens-next-brokers-link"]'),
+        outro: () => cy.get('[data-cy="what-happens-next-brokers-outro"]'),
+      },
     },
   },
   links: {

--- a/src/ui/server/content-strings/pages/quote.ts
+++ b/src/ui/server/content-strings/pages/quote.ts
@@ -1,4 +1,5 @@
 import { LINKS } from '../links';
+import { INSURANCE_ROUTES } from '../../constants/routes/insurance';
 
 const BUYER_BODY = {
   PAGE_TITLE: 'Is your buyer a government or public sector body?',
@@ -67,66 +68,35 @@ const YOUR_QUOTE = {
   NOTICE_3: 'Your price may be higher if our underwriters find additional risks with your export or buyer.',
   WHAT_HAPPENS_NEXT: {
     HEADING: 'What happens next?',
-    INTRO: [
-      [
-        {
-          text: 'You can now submit a',
-        },
-        {
-          text: 'full application',
-          href: LINKS.EXTERNAL.FULL_APPLICATION,
-        },
-        {
-          text: '. ',
-        },
-        {
-          text: 'It takes about 2 weeks to get a decision from UKEF.',
-        },
-      ],
-      [
-        {
-          text: 'You can get help with the application process from export finance managers or brokers.',
-        },
-      ],
-    ],
+    INTRO: {
+      CAN_NOW_SUBMIT: 'You can now submit a',
+      FULL_APPLICATION: {
+        TEXT: 'full application',
+        HREF: INSURANCE_ROUTES.START,
+      },
+      TIMEFRAME: 'It takes about 2 weeks to get a decision from UKEF.',
+      CAN_GET_HELP: 'You can get help with the application process from export finance managers or brokers.',
+    },
     EXPORT_FINANCE_MANAGERS: {
       HEADING: 'Export finance managers',
-      ITEMS: [
-        [
-          {
-            text: 'They work for UKEF and are available in every region. They can give you free guidance when making a full application. Find your',
-          },
-          {
-            text: 'nearest export finance manager',
-            href: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
-          },
-          {
-            text: '.',
-          },
-        ],
-      ],
+      AVAILABLE: 'They work for UKEF and are available in every region. They can give you free guidance when making a full application. Find your',
+      NEAREST_EFM: {
+        TEXT: 'nearest export finance manager',
+        HREF: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
+      },
     },
     BROKERS: {
       HEADING: 'Brokers',
-      ITEMS: [
-        [
-          {
-            text: 'They act as an agent between you and UKEF. They can also help you with the application process.',
-          },
-        ],
-        [
-          {
-            text: 'They receive a 15% fee for providing any successful policies at no extra cost to you. UKEF will pay their fee out of the policy premium you pay.',
-          },
-          {
-            text: 'Use our approved broker list',
-            href: LINKS.EXTERNAL.APPROVED_BROKER_LIST,
-          },
-          {
-            text: ' to find a broker to help you.',
-          },
-        ],
-      ],
+      ACT_AS: 'They act as an agent between you and UKEF. They can also help you with the application process.',
+      THEY_RECEIVE: {
+        INTRO:
+          'They receive a 15% fee for providing any successful policies at no extra cost to you. UKEF will pay their fee out of the policy premium you pay.',
+        LINK: {
+          TEXT: 'Use our approved broker list',
+          HREF: LINKS.EXTERNAL.APPROVED_BROKER_LIST,
+        },
+        OUTRO: 'to find a broker to help you.',
+      },
     },
   },
 };

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/contract-completion-date.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/contract-completion-date.test.ts
@@ -164,7 +164,7 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/validat
       const day = nextYear.getDate();
 
       let nextYear1week = new Date(nextYear);
-      nextYear1week = new Date(nextYear1week.setDate(day + 1));
+      nextYear1week = new Date(nextYear1week.setDate(day + 1 * 7));
 
       it('should return validation error', () => {
         const mockSubmittedData = {

--- a/src/ui/templates/quote/your-quote.njk
+++ b/src/ui/templates/quote/your-quote.njk
@@ -2,7 +2,6 @@
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
-{% import "../components/details-text.njk" as detailsText %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -48,22 +47,30 @@
 
   <h3 class="govuk-heading-m" data-cy="what-happens-next-heading">{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.HEADING }}</h3>
 
-  {{ detailsText.render({
-    items: CONTENT_STRINGS.WHAT_HAPPENS_NEXT.INTRO
-  }) }}
+  <p class="govuk-body">
+    <span data-cy="what-happens-next-intro-you-can">{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.INTRO.CAN_NOW_SUBMIT }}</span>
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.INTRO.FULL_APPLICATION.HREF }}" data-cy="what-happens-next-full-application-link">{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.INTRO.FULL_APPLICATION.TEXT }}</a>.
+  </p>
+
+  <p class="govuk-body" data-cy="what-happens-next-intro-timeframe">{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.INTRO.TIMEFRAME }}</p>
+  <p class="govuk-body" data-cy="what-happens-next-intro-can-get-help">{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.INTRO.CAN_GET_HELP }}</p>
 
   <h4 data-cy="what-happens-next-finance-managers-heading">{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.EXPORT_FINANCE_MANAGERS.HEADING }}</h4>
 
-  {{ detailsText.render({
-    items: CONTENT_STRINGS.WHAT_HAPPENS_NEXT.EXPORT_FINANCE_MANAGERS.ITEMS
-  }) }}
-
+  <p class="govuk-body">
+    <span data-cy="what-happens-next-finance-managers-available">{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.EXPORT_FINANCE_MANAGERS.AVAILABLE }}</span>
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.EXPORT_FINANCE_MANAGERS.NEAREST_EFM.HREF }}" data-cy="what-happens-next-finance-managers-link">{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.EXPORT_FINANCE_MANAGERS.NEAREST_EFM.TEXT }}</a>.
+  </p>
 
   <h4 data-cy="what-happens-next-brokers-heading">{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.BROKERS.HEADING }}</h4>
 
-  {{ detailsText.render({
-    items: CONTENT_STRINGS.WHAT_HAPPENS_NEXT.BROKERS.ITEMS
-  }) }}
+  <p class="govuk-body" data-cy="what-happens-next-brokers-act-as">{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.BROKERS.ACT_AS }}</p>
+  
+  <p class="govuk-body">
+    <span data-cy="what-happens-next-brokers-they-receive-intro">{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.BROKERS.THEY_RECEIVE.INTRO }}</span>
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.BROKERS.THEY_RECEIVE.LINK.HREF }}" data-cy="what-happens-next-brokers-link">{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.BROKERS.THEY_RECEIVE.LINK.TEXT }}</a>
+    <span data-cy="what-happens-next-brokers-outro">{{ CONTENT_STRINGS.WHAT_HAPPENS_NEXT.BROKERS.THEY_RECEIVE.OUTRO }}</span>
+  </p>
 
   <p><a class="govuk-link govuk-link--no-visited-state" href="{{ CONTENT_STRINGS.LINKS.START_AGAIN.HREF }}" data-cy="start-again">{{ CONTENT_STRINGS.LINKS.START_AGAIN.TEXT }}</a></p>
   <p><a class="govuk-link govuk-link--no-visited-state" href="{{ CONTENT_STRINGS.LINKS.EXTERNAL.FEEDBACK }}" data-cy="feedback">{{ CONTENT_STRINGS.LINKS.GIVE_FEEDBACK }}</a></p>


### PR DESCRIPTION
This PR updates the "start full application" link in the "your quote" page to point to the insurance start page, instead of an external PDF form.

## Changes
- Update the "start full application" link.
- Refactor some content in the "your quote page to use standard HTML elements instead of `detailsText` nunjucks component - makes it easier to read and maintain.
- Add missing E2E test coverage for the "what happens next" section and refactored content.

## Other fixes
- Fixed a UI unit test relating to date stub/time of year.
- Added a missing `deleteAccount` cypress command in an E2E test for password reset.