### PR TITLE
chore(tech): Fix typo, E2E test coverage improvement

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/resend-confirm-email/resend-confirm-email-go-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/resend-confirm-email/resend-confirm-email-go-back.spec.js
@@ -55,5 +55,7 @@ context('Insurance - Account - Create - Resend confirm email page - Go back to c
     expectedUrl = `${Cypress.config('baseUrl')}${CONFIRM_EMAIL}?id=${account.id}`;
 
     cy.url().should('eq', expectedUrl);
+
+    cy.assertConfirmEmailPageContent(account.id);
   });
 });

--- a/e2e-tests/cypress/support/insurance/account/assert-confirm-email-page-content.js
+++ b/e2e-tests/cypress/support/insurance/account/assert-confirm-email-page-content.js
@@ -26,10 +26,11 @@ const havingProblemsSection = {
   requestNewLink: (accountId) => {
     cy.checkText(confirmEmailPage.havingProblems.requestNew.youCan(), YOU_CAN);
 
-    cy.checkText(confirmEmailPage.havingProblems.requestNew.link(), LINK.TEXT);
-
-    const expected = `${LINK.HREF}?id=${accountId}`;
-    confirmEmailPage.havingProblems.requestNew.link().should('have.attr', 'href', expected);
+    cy.checkLink(
+      confirmEmailPage.havingProblems.requestNew.link(),
+      `${LINK.HREF}?id=${accountId}`,
+      LINK.TEXT,
+    );
 
     cy.checkText(confirmEmailPage.havingProblems.requestNew.ifNotReceived(), IF_NOT_RECEIVED);
   },

--- a/src/ui/server/controllers/insurance/business/nature-of-business/map-submitted-data/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/map-submitted-data/index.test.ts
@@ -1,7 +1,7 @@
 import { RequestBody } from '../../../../../../types';
 import { FIELD_IDS } from '../../../../../constants';
 import mapSubmittedData from '.';
-import { mockExporterNatureOfBusiness } from '../../../../../test-mocks';
+import { mockBusinessNatureOfBusiness } from '../../../../../test-mocks';
 import { stripCommas } from '../../../../../helpers/string';
 
 const { EXPORTER_BUSINESS } = FIELD_IDS.INSURANCE;
@@ -12,7 +12,7 @@ describe('controllers/insurance/business/nature-of-business/map-submitted-data',
     it('should return the formBody with the commas replaced', () => {
       const mockBody = {
         _csrf: '1234',
-        ...mockExporterNatureOfBusiness,
+        ...mockBusinessNatureOfBusiness,
       } as RequestBody;
 
       const response = mapSubmittedData(mockBody);

--- a/src/ui/server/controllers/insurance/business/nature-of-business/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/save-and-back/index.test.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from '../../../../../../types';
 import { post } from '.';
 import { FIELD_IDS, ROUTES } from '../../../../../constants';
-import { mockReq, mockRes, mockApplication, mockExporterNatureOfBusiness } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockBusinessNatureOfBusiness } from '../../../../../test-mocks';
 import mapAndSave from '../../map-and-save';
 
 const {
@@ -34,7 +34,7 @@ describe('controllers/insurance/business/nature-of-business/save-and-back', () =
     describe('when there are no validation errors', () => {
       it('should redirect to all sections page', async () => {
         req.body = {
-          ...mockExporterNatureOfBusiness,
+          ...mockBusinessNatureOfBusiness,
         };
 
         await post(req, res);
@@ -44,7 +44,7 @@ describe('controllers/insurance/business/nature-of-business/save-and-back', () =
 
       it('should call mapAndSave.natureOfBusiness once', async () => {
         req.body = {
-          ...mockExporterNatureOfBusiness,
+          ...mockBusinessNatureOfBusiness,
         };
 
         await post(req, res);

--- a/src/ui/server/test-mocks/index.ts
+++ b/src/ui/server/test-mocks/index.ts
@@ -12,7 +12,7 @@ import mockApplications from './mock-applications';
 import mockUrlOrigin from './mock-url-origin';
 import mockPhoneNumbers from './mock-phone-numbers';
 import mockSicCodes from './mock-sic-codes';
-import mockExporterNatureOfBusiness from './mock-business-nature-of-business';
+import mockBusinessNatureOfBusiness from './mock-business-nature-of-business';
 import mockBusinessTurnover from './mock-business-turnover';
 import mockBroker from './mock-broker';
 import mockBuyer from './mock-buyer';
@@ -81,7 +81,7 @@ export {
   mockCompany,
   mockCurrencies,
   mockDeclarations,
-  mockExporterNatureOfBusiness,
+  mockBusinessNatureOfBusiness,
   mockBusinessTurnover,
   mockInsuranceFeedback,
   mockNext,

--- a/src/ui/server/test-mocks/mock-business-nature-of-business.ts
+++ b/src/ui/server/test-mocks/mock-business-nature-of-business.ts
@@ -1,10 +1,10 @@
 import { Business } from '../../types';
 
-const mockExporterNatureOfBusiness = {
+const mockBusinessNatureOfBusiness = {
   goodsOrServicesSupplied: 'ABC',
   totalYearsExporting: '2,0',
   totalEmployeesInternational: '1,000',
   totalEmployeesUK: '4,00',
 } as Business;
 
-export default mockExporterNatureOfBusiness;
+export default mockBusinessNatureOfBusiness;


### PR DESCRIPTION
This PR fixes a typo and improves some E2E test coverage.

## Changes
- Rename all instances of `mockExporterNatureOfBusiness` to `mockBusinessNatureOfBusiness`.
- Add missing assertion to "resend confirm email - go back" E2E test.
- Simplify `assertConfirmEmailPageContent` link checking in cypress command.