### PR TITLE
feat/fix(EMS-1688): Account creation - create an application if eligibility answers are available

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/account/account-creation-and-sign-in-with-eligibility-answers.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/account-creation-and-sign-in-with-eligibility-answers.spec.js
@@ -1,0 +1,70 @@
+import dashboardPage from '../../../pages/insurance/dashboard';
+import { ROUTES } from '../../../../../constants';
+
+const { table } = dashboardPage;
+
+const {
+  DASHBOARD,
+  START,
+  ACCOUNT: {
+    SIGN_IN: { ENTER_CODE },
+  },
+} = ROUTES.INSURANCE;
+
+context('Insurance - Account - When answering eligibility answers, creating an account and signing in - should create a new application', () => {
+  let referenceNumber;
+
+  const baseUrl = Cypress.config('baseUrl');
+  const dashboardUrl = `${baseUrl}${DASHBOARD}`;
+  const enterCodeUrl = `${baseUrl}${ENTER_CODE}`;
+
+  before(() => {
+    cy.deleteAccount();
+
+    cy.navigateToUrl(START);
+
+    cy.submitEligibilityAndStartAccountCreation();
+
+    cy.completeAndSubmitCreateAccountForm();
+
+    /**
+     * Clear the session
+     * So that we are mimicking starting a fresh session/browser instance,
+     * when clicking the link in "verify account" email
+     */
+    cy.clearCookie('exip-session');
+
+    cy.verifyAccountEmail();
+
+    cy.completeAndSubmitSignInAccountForm({});
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('after signing in with a valid security code', () => {
+    let validSecurityCode;
+
+    before(() => {
+      cy.navigateToUrl(enterCodeUrl);
+
+      // create and get an OTP for the exporter's account
+      cy.accountAddAndGetOTP().then((securityCode) => {
+        validSecurityCode = securityCode;
+
+        cy.completeAndSubmitEnterCodeAccountForm(validSecurityCode);
+      });
+    });
+
+    it(`should redirect to ${dashboardUrl} and have one application in the table`, () => {
+      cy.url().should('eq', dashboardUrl);
+
+      table.body.rows().should('have.length', 1);
+
+      table.body.firstRow.referenceNumberLink().invoke('text').then((refNumber) => {
+        referenceNumber = refNumber;
+      });
+    });
+  });
+});

--- a/e2e-tests/cypress/support/insurance/account/complete-sign-in-and-go-to-application.js
+++ b/e2e-tests/cypress/support/insurance/account/complete-sign-in-and-go-to-application.js
@@ -16,7 +16,7 @@ const {
  * @return {String} Application reference number
  */
 const completeSignInAndGoToApplication = (email = mockAccount[EMAIL]) => {
-  // complete sign in and go to dashboad
+  // complete sign in and go to dashboard
   completeInsuranceEligibilitySignInAndGoToDashboard(email);
 
   // go to the newly created application

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -3004,7 +3004,7 @@ var send_application_submitted_emails_default = applicationSubmittedEmails;
 var import_exceljs = __toESM(require("exceljs"));
 
 // helpers/replace-character-codes-with-characters/index.ts
-var replaceCharacterCodesWithCharacters = (str) => str.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&quot;/g, '"').replace(/&#x27;/g, "'").replace(/&#x2F;/g, "/").replace(/&#42;/g, "*");
+var replaceCharacterCodesWithCharacters = (str) => str.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&quot;/g, '"').replace(/&#x27;/g, "'").replace(/&#x2F;/g, "/").replace(/&#42;/g, "*").replace(/&amp;/g, "&");
 var replace_character_codes_with_characters_default = replaceCharacterCodesWithCharacters;
 
 // generate-xlsx/map-application-to-XLSX/helpers/xlsx-row/index.ts

--- a/src/ui/server/controllers/insurance/account/create/your-details/index.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/index.ts
@@ -6,7 +6,7 @@ import getUserNameFromSession from '../../../../../helpers/get-user-name-from-se
 import generateValidationErrors from './validation';
 import generateAccountAlreadyExistsValidationErrors from './validation/account-already-exists';
 import saveData from './save-data';
-import { objectHasKeysAndValues } from '../../../../../helpers/object';
+import canCreateAnApplication from '../../../../../helpers/can-create-an-application';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
@@ -135,8 +135,12 @@ export const post = async (req: Request, res: Response) => {
     // store the account ID in local session, for consumption in the next part of the flow.
     req.session.accountIdToConfirm = accountId;
 
-    // if there is eligibility in the session, create application and wipe eligibility answers
-    if (req.session.submittedData && objectHasKeysAndValues(req.session.submittedData.insuranceEligibility)) {
+    /**
+     * If there are eligibility answers in the session:
+     * 1) Create an application
+     * 2) Wipe the eligibility answers in the session.
+     */
+    if (canCreateAnApplication(req.session)) {
       const eligibilityAnswers = sanitiseData(req.session.submittedData.insuranceEligibility);
 
       const application = await api.keystone.application.create(eligibilityAnswers, accountId);

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
@@ -6,7 +6,7 @@ import getUserNameFromSession from '../../../../../helpers/get-user-name-from-se
 import { sanitiseData, sanitiseValue } from '../../../../../helpers/sanitise-data';
 import generateValidationErrors from './validation';
 import securityCodeValidationErrors from './validation/rules/security-code';
-import { objectHasKeysAndValues } from '../../../../../helpers/object';
+import canCreateAnApplication from '../../../../../helpers/can-create-an-application';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
 
@@ -112,8 +112,12 @@ export const post = async (req: Request, res: Response) => {
         expires,
       };
 
-      // if there is eligibility in the session, create application and wipe eligibility answers
-      if (req.session.submittedData && objectHasKeysAndValues(req.session.submittedData.insuranceEligibility)) {
+      /**
+       * If there are eligibility answers in the session:
+       * 1) Create an application
+       * 2) Wipe the eligibility answers in the session.
+       */
+      if (canCreateAnApplication(req.session)) {
         const eligibilityAnswers = sanitiseData(req.session.submittedData.insuranceEligibility);
 
         const application = await api.keystone.application.create(eligibilityAnswers, accountId);

--- a/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.ts
@@ -2,7 +2,7 @@ import { PAGES } from '../../../../content-strings';
 import { ROUTES, TEMPLATES } from '../../../../constants';
 import corePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
-import { objectHasKeysAndValues } from '../../../../helpers/object';
+import canCreateAnApplication from '../../../../helpers/can-create-an-application';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import api from '../../../../api';
 import { Request, Response } from '../../../../../types';
@@ -27,8 +27,12 @@ export const get = (req: Request, res: Response) =>
 
 export const post = async (req: Request, res: Response) => {
   try {
-    // if user is logged in, create application.
-    if (req.session.user && req.session.submittedData && objectHasKeysAndValues(req.session.submittedData.insuranceEligibility)) {
+    /**
+     * If the user is signed in and there are eligibility answers in the session:
+     * 1) Create an application
+     * 2) Wipe the eligibility answers in the session.
+     */
+    if (req.session.user && canCreateAnApplication(req.session)) {
       const eligibilityAnswers = sanitiseData(req.session.submittedData.insuranceEligibility);
 
       const application = await api.keystone.application.create(eligibilityAnswers, req.session.user.id);

--- a/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.ts
@@ -2,6 +2,7 @@ import { PAGES } from '../../../../content-strings';
 import { ROUTES, TEMPLATES } from '../../../../constants';
 import corePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import { objectHasKeysAndValues } from '../../../../helpers/object';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import api from '../../../../api';
 import { Request, Response } from '../../../../../types';
@@ -27,9 +28,9 @@ export const get = (req: Request, res: Response) =>
 export const post = async (req: Request, res: Response) => {
   try {
     // if user is logged in, create application.
-    const eligibilityAnswers = sanitiseData(req.session.submittedData.insuranceEligibility);
+    if (req.session.user && req.session.submittedData && objectHasKeysAndValues(req.session.submittedData.insuranceEligibility)) {
+      const eligibilityAnswers = sanitiseData(req.session.submittedData.insuranceEligibility);
 
-    if (req.session.user && eligibilityAnswers) {
       const application = await api.keystone.application.create(eligibilityAnswers, req.session.user.id);
 
       if (!application) {

--- a/src/ui/server/helpers/can-create-an-application/index.test.ts
+++ b/src/ui/server/helpers/can-create-an-application/index.test.ts
@@ -1,0 +1,34 @@
+import canCreateAnApplication from '.';
+import mockEligibility from '../../test-mocks/mock-eligibility';
+
+describe('server/helpers/can-create-an-application', () => {
+  describe('when session.submittedData.insuranceEligibility has answers', () => {
+    it('should return true', () => {
+      const mockSession = {
+        submittedData: {
+          insuranceEligibility: mockEligibility,
+          quoteEligibility: {},
+        },
+      };
+
+      const result = canCreateAnApplication(mockSession);
+
+      expect(result).toEqual(true);
+    });
+  });
+
+  describe('when session.submittedData.insuranceEligibility does NOT have answers', () => {
+    it('should return false', () => {
+      const mockSession = {
+        submittedData: {
+          insuranceEligibility: {},
+          quoteEligibility: {},
+        },
+      };
+
+      const result = canCreateAnApplication(mockSession);
+
+      expect(result).toEqual(false);
+    });
+  });
+});

--- a/src/ui/server/helpers/can-create-an-application/index.ts
+++ b/src/ui/server/helpers/can-create-an-application/index.ts
@@ -1,0 +1,19 @@
+import { objectHasKeysAndValues } from '../object';
+import { RequestSession } from '../../../types';
+
+/**
+ * canCreateAnApplication
+ * Check if there are eligibility answers in the session.
+ * If so, return true
+ * @param {Express.Request.session} Express request session
+ * @returns {Boolean}
+ */
+const canCreateAnApplication = (session: RequestSession) => {
+  if (session.submittedData && objectHasKeysAndValues(session.submittedData.insuranceEligibility)) {
+    return true;
+  }
+
+  return false;
+};
+
+export default canCreateAnApplication;

--- a/src/ui/server/test-mocks/mock-application.ts
+++ b/src/ui/server/test-mocks/mock-application.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import { add, addMonths } from 'date-fns';
 import { APPLICATION, FIELD_VALUES } from '../constants';
+import mockEligibility from './mock-eligibility';
 import mockAccount from './mock-account';
 import mockCountries from './mock-countries';
 import mockCurrencies from './mock-currencies';
@@ -123,16 +124,8 @@ const mockApplication = {
   submissionType: 'Manual Inclusion Application',
   submissionDate: new Date().toISOString(),
   eligibility: {
+    ...mockEligibility,
     id: 'clav8by1g0000kgoq5a2afr1z',
-    buyerCountry: mockCountries[0],
-    hasMinimumUkGoodsOrServices: true,
-    validExporterLocation: true,
-    hasCompaniesHouseNumber: true,
-    otherPartiesInvolved: false,
-    paidByLetterOfCredit: false,
-    needPreCreditPeriodCover: false,
-    wantCoverOverMaxAmount: false,
-    wantCoverOverMaxPeriod: false,
   },
   status: APPLICATION.STATUS.DRAFT,
   owner: mockOwner,

--- a/src/ui/server/test-mocks/mock-eligibility.ts
+++ b/src/ui/server/test-mocks/mock-eligibility.ts
@@ -1,0 +1,15 @@
+import mockCountries from './mock-countries';
+
+const mockEligibility = {
+  buyerCountry: mockCountries[0],
+  hasMinimumUkGoodsOrServices: true,
+  validExporterLocation: true,
+  hasCompaniesHouseNumber: true,
+  otherPartiesInvolved: false,
+  paidByLetterOfCredit: false,
+  needPreCreditPeriodCover: false,
+  wantCoverOverMaxAmount: false,
+  wantCoverOverMaxPeriod: false,
+};
+
+export default mockEligibility;


### PR DESCRIPTION
This PR updates the POST controller for "account creation - your details" so that if eligibility answers are in the session, we create an application associated to the account.

This fixes an issue/enhances the UX where if a user verifies an account via email link, the eligibility session answers are lost because a new session has started.

## Changes

- Update "your details" POST controller to call the API to create an application if eligibility answers are available.
- Add E2E test coverage.

## Other improvements

- Create a new helper function `canCreateAnApplication`, since we would otherwise have the same conditional statment in 3 places.
- Add more documentation.
- Extract `eligibility` test mocks into its own directory.
- Fixed a typo.