### PR TITLE
fix(EMS-1589): Name fields rendering previously submitted special characters incorrectly

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/dashboard/dashboard-populated-application.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/dashboard/dashboard-populated-application.spec.js
@@ -70,7 +70,7 @@ context('Insurance - Dashboard - populated application', () => {
       task.link().click();
 
       // complete and submit the form
-      cy.completeAndSubmitCompanyOrOrganisationForm();
+      cy.completeAndSubmitCompanyOrOrganisationForm({});
     });
 
     beforeEach(() => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-dashboard.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-dashboard.spec.js
@@ -1,0 +1,50 @@
+import { FIELD_IDS } from '../../../../../constants';
+import partials from '../../../partials';
+import dashboardPage from '../../../pages/insurance/dashboard';
+import mockApplication from '../../../../fixtures/application';
+import mockNameWithSpecialCharacters from '../../../../fixtures/name-with-special-characters';
+
+const {
+  INSURANCE: {
+    YOUR_BUYER: {
+      COMPANY_OR_ORGANISATION: { NAME: BUYER_NAME },
+    },
+  },
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const nameWithSpecialCharacters = mockNameWithSpecialCharacters(mockApplication.BUYER[BUYER_NAME]);
+
+context('Insurance - Name fields - Dashboard fields should render special characters without character codes after submission', () => {
+  let referenceNumber;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication().then((refNumber) => {
+      referenceNumber = refNumber;
+
+      taskList.prepareApplication.tasks.buyer.link().click();
+
+      cy.completeAndSubmitCompanyOrOrganisationForm({
+        buyerName: nameWithSpecialCharacters,
+      });
+
+      partials.header.navigation.applications().click();
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  it('should alkds kasl', () => {
+    cy.checkText(
+      dashboardPage.table.body.firstRow.buyerName(),
+      nameWithSpecialCharacters,
+    );
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-dashboard.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-dashboard.spec.js
@@ -41,7 +41,7 @@ context('Insurance - Name fields - Dashboard fields should render special charac
     cy.deleteApplication(referenceNumber);
   });
 
-  it('should alkds kasl', () => {
+  it("should render special characters in the dashboard's buyer name field", () => {
     cy.checkText(
       dashboardPage.table.body.firstRow.buyerName(),
       nameWithSpecialCharacters,

--- a/e2e-tests/cypress/e2e/journeys/insurance/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-header-and-page-fields.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-header-and-page-fields.spec.js
@@ -1,12 +1,13 @@
-import { FIELD_IDS, ROUTES } from '../../../../constants';
-import { enterCodePage } from '../../pages/insurance/account/sign-in';
-import { yourContactPage } from '../../pages/your-business';
-import { companyOrOrganisationPage } from '../../pages/insurance/your-buyer';
-import { submitButton, backLink } from '../../pages/shared';
-import dashboardPage from '../../pages/insurance/dashboard';
-import partials from '../../partials';
-import mockAccount from '../../../fixtures/account';
-import mockApplication from '../../../fixtures/application';
+import { FIELD_IDS, ROUTES } from '../../../../../constants';
+import { enterCodePage } from '../../../pages/insurance/account/sign-in';
+import { yourContactPage } from '../../../pages/your-business';
+import { companyOrOrganisationPage } from '../../../pages/insurance/your-buyer';
+import { submitButton, backLink } from '../../../pages/shared';
+import dashboardPage from '../../../pages/insurance/dashboard';
+import partials from '../../../partials';
+import mockAccount from '../../../../fixtures/account';
+import mockApplication from '../../../../fixtures/application';
+import mockNameWithSpecialCharacters from '../../../../fixtures/name-with-special-characters';
 
 const {
   INSURANCE: {
@@ -27,17 +28,13 @@ const {
   },
 } = partials.insurancePartials;
 
-const specialCharacters = '<>"\'/*&';
-
-const mockNameWithSpecialCharacters = (name) => `${name}${specialCharacters}`;
-
 const mockAccountSpecialCharacters = {
   ...mockAccount,
   [FIRST_NAME]: mockNameWithSpecialCharacters(mockAccount[FIRST_NAME]),
   [LAST_NAME]: mockNameWithSpecialCharacters(mockAccount[LAST_NAME]),
 };
 
-context('Insurance - Name fields - should render special characters after submission', () => {
+context('Insurance - Name fields - Header and page fields should render special characters without character codes after submission', () => {
   const baseUrl = Cypress.config('baseUrl');
   let referenceNumber;
   let allSectionsUrl;
@@ -45,6 +42,8 @@ context('Insurance - Name fields - should render special characters after submis
   const dashboardUrl = `${baseUrl}${DASHBOARD}`;
 
   before(() => {
+    cy.deleteAccount();
+
     cy.createAccount({
       ...mockAccountSpecialCharacters,
       nameFirst: mockAccountSpecialCharacters[FIRST_NAME],

--- a/e2e-tests/cypress/e2e/journeys/insurance/submitted-name-fields-with-special-characters-render-correctly.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/submitted-name-fields-with-special-characters-render-correctly.spec.js
@@ -1,0 +1,157 @@
+import { FIELD_IDS, ROUTES } from '../../../../constants';
+import { enterCodePage } from '../../pages/insurance/account/sign-in';
+import { yourContactPage } from '../../pages/your-business';
+import { companyOrOrganisationPage } from '../../pages/insurance/your-buyer';
+import { submitButton, backLink } from '../../pages/shared';
+import dashboardPage from '../../pages/insurance/dashboard';
+import partials from '../../partials';
+import mockAccount from '../../../fixtures/account';
+import mockApplication from '../../../fixtures/application';
+
+const {
+  INSURANCE: {
+    ACCOUNT: { FIRST_NAME, LAST_NAME, SECURITY_CODE },
+    YOUR_BUYER: {
+      COMPANY_OR_ORGANISATION: { NAME: BUYER_NAME, FIRST_NAME: BUYER_CONTACT_FIRST_NAME, LAST_NAME: BUYER_CONTACT_LAST_NAME },
+    },
+  },
+} = FIELD_IDS;
+
+const {
+  INSURANCE: { ROOT, DASHBOARD, ALL_SECTIONS },
+} = ROUTES;
+
+const {
+  taskList: {
+    prepareApplication: { tasks },
+  },
+} = partials.insurancePartials;
+
+const specialCharacters = '<>"\'/*&';
+
+const mockNameWithSpecialCharacters = (name) => `${name}${specialCharacters}`;
+
+const mockAccountSpecialCharacters = {
+  ...mockAccount,
+  [FIRST_NAME]: mockNameWithSpecialCharacters(mockAccount[FIRST_NAME]),
+  [LAST_NAME]: mockNameWithSpecialCharacters(mockAccount[LAST_NAME]),
+};
+
+context('Insurance - TODO.....', () => {
+  const baseUrl = Cypress.config('baseUrl');
+  let referenceNumber;
+  let allSectionsUrl;
+
+  const dashboardUrl = `${baseUrl}${DASHBOARD}`;
+
+  before(() => {
+    cy.createAccount({
+      ...mockAccountSpecialCharacters,
+      nameFirst: mockAccountSpecialCharacters[FIRST_NAME],
+      nameLast: mockAccountSpecialCharacters[LAST_NAME],
+    }).then((verifyAccountUrl) => {
+      // verify the account by navigating to the "verify account" page
+      cy.navigateToUrl(verifyAccountUrl);
+
+      // sign in to the account. Behind the scenes, an application is created at this point.
+      cy.completeAndSubmitSignInAccountForm({});
+
+      // get the OTP security code
+      cy.accountAddAndGetOTP(mockAccount.emailAddress).then((securityCode) => {
+        cy.keyboardInput(enterCodePage[SECURITY_CODE].input(), securityCode);
+
+        // submit the OTP security code
+        submitButton().click();
+      });
+    });
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(dashboardUrl);
+
+    dashboardPage.startNewApplication().click();
+
+    cy.submitInsuranceEligibilityAnswersFromBuyerCountryHappyPath();
+
+    cy.getReferenceNumber().then((refNumber) => {
+      referenceNumber = refNumber;
+
+      allSectionsUrl = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+    });
+  });
+
+  it("should render special characters in the header's user name/'manage account' link", () => {
+    const expected = `${mockAccountSpecialCharacters[FIRST_NAME]} ${mockAccountSpecialCharacters[LAST_NAME]}`;
+
+    cy.checkText(
+      partials.header.navigation.manageAccount(),
+      expected,
+    );
+  });
+
+  describe("'your business - contact details' page", () => {
+    describe('when submitting a name with special characters and going back to the page', () => {
+      beforeEach(() => {
+        cy.navigateToUrl(allSectionsUrl);
+
+        tasks.business.link().click();
+
+        cy.completeAndSubmitCompanyDetails();
+
+        cy.completeAndSubmitYourContact({
+          [FIRST_NAME]: mockAccountSpecialCharacters[FIRST_NAME],
+          [LAST_NAME]: mockAccountSpecialCharacters[LAST_NAME],
+        });
+
+        backLink().click();
+      });
+
+      it("should render special characters in the contact's first and last name fields", () => {
+        const firstNameField = yourContactPage.field(FIRST_NAME);
+
+        cy.checkValue(firstNameField, mockAccountSpecialCharacters[FIRST_NAME]);
+
+        const lastNameField = yourContactPage.field(FIRST_NAME);
+
+        cy.checkValue(lastNameField, mockAccountSpecialCharacters[FIRST_NAME]);
+      });
+    });
+  });
+
+  describe("'your buyer - company or organisation' page", () => {
+    describe('when submitting name fields with special characters and going back to the page', () => {
+      const nameWithSpecialCharacters = mockNameWithSpecialCharacters(mockApplication.BUYER[BUYER_NAME]);
+
+      beforeEach(() => {
+        cy.navigateToUrl(allSectionsUrl);
+
+        tasks.buyer.link().click();
+
+        cy.completeAndSubmitCompanyOrOrganisationForm({
+          buyerName: nameWithSpecialCharacters,
+          firstName: nameWithSpecialCharacters,
+          lastName: nameWithSpecialCharacters,
+        });
+
+        backLink().click();
+      });
+
+      it('should render special characters in the comapny/organisation name field', () => {
+        const buyerNameField = companyOrOrganisationPage[BUYER_NAME];
+        cy.checkValue(buyerNameField, nameWithSpecialCharacters);
+
+        const buyerFirstNameField = companyOrOrganisationPage[BUYER_CONTACT_FIRST_NAME];
+        cy.checkValue(buyerFirstNameField, nameWithSpecialCharacters);
+
+        const buyerLasttNameField = companyOrOrganisationPage[BUYER_CONTACT_LAST_NAME];
+        cy.checkValue(buyerLasttNameField, nameWithSpecialCharacters);
+      });
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/submitted-name-fields-with-special-characters-render-correctly.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/submitted-name-fields-with-special-characters-render-correctly.spec.js
@@ -37,7 +37,7 @@ const mockAccountSpecialCharacters = {
   [LAST_NAME]: mockNameWithSpecialCharacters(mockAccount[LAST_NAME]),
 };
 
-context('Insurance - TODO.....', () => {
+context('Insurance - Name fields - should render special characters after submission', () => {
   const baseUrl = Cypress.config('baseUrl');
   let referenceNumber;
   let allSectionsUrl;

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
@@ -62,7 +62,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
@@ -62,7 +62,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/save-and-back.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Your business - Broker page - Save and back', () => {
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
 
@@ -99,7 +99,7 @@ context('Insurance - Your business - Broker page - Save and back', () => {
       // submit company details form
       submitButton().click();
       // your contact page submit
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       // submit nature of business form
       submitButton().click();
       // submit turnover form
@@ -147,7 +147,7 @@ context('Insurance - Your business - Broker page - Save and back', () => {
         // submit company details form
         submitButton().click();
         // your contact page submit
-        cy.acompleteAndSubmitYourContact({});
+        cy.completeAndSubmitYourContact({});
         // submit nature of business form
         submitButton().click();
         // submit turnover form
@@ -186,7 +186,7 @@ context('Insurance - Your business - Broker page - Save and back', () => {
         // submit company details form
         submitButton().click();
         // your contact page submit
-        cy.acompleteAndSubmitYourContact({});
+        cy.completeAndSubmitYourContact({});
         // submit nature of business form
         submitButton().click();
         // submit turnover form

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/save-and-back.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Your business - Broker page - Save and back', () => {
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
 
@@ -99,7 +99,7 @@ context('Insurance - Your business - Broker page - Save and back', () => {
       // submit company details form
       submitButton().click();
       // your contact page submit
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       // submit nature of business form
       submitButton().click();
       // submit turnover form
@@ -147,7 +147,7 @@ context('Insurance - Your business - Broker page - Save and back', () => {
         // submit company details form
         submitButton().click();
         // your contact page submit
-        cy.completeAndSubmitYourContact();
+        cy.acompleteAndSubmitYourContact({});
         // submit nature of business form
         submitButton().click();
         // submit turnover form
@@ -186,7 +186,7 @@ context('Insurance - Your business - Broker page - Save and back', () => {
         // submit company details form
         submitButton().click();
         // your contact page submit
-        cy.completeAndSubmitYourContact();
+        cy.acompleteAndSubmitYourContact({});
         // submit nature of business form
         submitButton().click();
         // submit turnover form

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/are-you-using-a-broker-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/are-you-using-a-broker-answer-no.spec.js
@@ -34,7 +34,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/are-you-using-a-broker-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/are-you-using-a-broker-answer-no.spec.js
@@ -34,7 +34,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-all-required-fields.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-all-required-fields.spec.js
@@ -27,7 +27,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-all-required-fields.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-all-required-fields.spec.js
@@ -27,7 +27,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-no-required-fields.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-no-required-fields.spec.js
@@ -39,7 +39,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-no-required-fields.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-no-required-fields.spec.js
@@ -39,7 +39,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/broker-postcode-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/broker-postcode-validation.spec.js
@@ -48,7 +48,7 @@ context('Insurance - Your business - Broker Page - Validation - Postcode', () =>
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/broker-postcode-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/validation/broker-postcode-validation.spec.js
@@ -48,7 +48,7 @@ context('Insurance - Your business - Broker Page - Validation - Postcode', () =>
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-broker.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-broker.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Your business - Change your answers - Broker - As an export
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-broker.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-broker.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Your business - Change your answers - Broker - As an export
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
@@ -53,7 +53,7 @@ context('Insurance - Your business - Change your answers - Company details - As 
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
@@ -53,7 +53,7 @@ context('Insurance - Your business - Change your answers - Company details - As 
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-contact.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-contact.spec.js
@@ -38,7 +38,7 @@ context('Insurance - Your business - Change your answers - Contact- As an export
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-contact.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-contact.spec.js
@@ -38,7 +38,7 @@ context('Insurance - Your business - Change your answers - Contact- As an export
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-nature-of-your-business.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-nature-of-your-business.spec.js
@@ -42,7 +42,7 @@ context('Insurance - Your business - Change your answers - Nature of your busine
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-nature-of-your-business.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-nature-of-your-business.spec.js
@@ -42,7 +42,7 @@ context('Insurance - Your business - Change your answers - Nature of your busine
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
@@ -36,7 +36,7 @@ context('Insurance - Your business - Change your answers - Turnover - As an expo
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
@@ -36,7 +36,7 @@ context('Insurance - Your business - Change your answers - Turnover - As an expo
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/check-your-answers/check-your-answers-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/check-your-answers/check-your-answers-page.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Your Business - Check your answers - As an exporter, I want
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/check-your-answers/check-your-answers-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/check-your-answers/check-your-answers-page.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Your Business - Check your answers - As an exporter, I want
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
@@ -68,7 +68,7 @@ context('Insurance - Your business - Check your answers - Summary list - your bu
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
@@ -68,7 +68,7 @@ context('Insurance - Your business - Check your answers - Summary list - your bu
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/contact/your-contact-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/contact/your-contact-page.spec.js
@@ -156,7 +156,7 @@ context('Insurance - Your business - Contact page - As an Exporter I want to ent
     it(`should redirect to ${NATURE_OF_BUSINESS}`, () => {
       cy.navigateToUrl(url);
 
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
 
       cy.url().should('eq', natureOfBusinessUrl);
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/contact/your-contact-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/contact/your-contact-page.spec.js
@@ -156,7 +156,7 @@ context('Insurance - Your business - Contact page - As an Exporter I want to ent
     it(`should redirect to ${NATURE_OF_BUSINESS}`, () => {
       cy.navigateToUrl(url);
 
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
 
       cy.url().should('eq', natureOfBusinessUrl);
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/nature-of-business-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/nature-of-business-page.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Your business - Nature of your business page - As an Export
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
 
       natureOfBusinessUrl = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/nature-of-business-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/nature-of-business-page.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Your business - Nature of your business page - As an Export
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
 
       natureOfBusinessUrl = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/save-and-back.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Your business - Nature of your business page - Save and bac
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS}`;
 
@@ -95,7 +95,7 @@ context('Insurance - Your business - Nature of your business page - Save and bac
       // company details submit
       submitButton().click();
       // your contact page submit
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
 
       natureOfBusiness[GOODS_OR_SERVICES].input().should('have.value', application.EXPORTER_BUSINESS[GOODS_OR_SERVICES]);
       natureOfBusiness[YEARS_EXPORTING].input().should('have.value', '');
@@ -130,7 +130,7 @@ context('Insurance - Your business - Nature of your business page - Save and bac
       // company details submit
       submitButton().click();
       // your contact page submit
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
 
       natureOfBusiness[GOODS_OR_SERVICES].input().should('have.value', application.EXPORTER_BUSINESS[GOODS_OR_SERVICES]);
       natureOfBusiness[YEARS_EXPORTING].input().should('have.value', application.EXPORTER_BUSINESS[YEARS_EXPORTING]);

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/save-and-back.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Your business - Nature of your business page - Save and bac
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS}`;
 
@@ -95,7 +95,7 @@ context('Insurance - Your business - Nature of your business page - Save and bac
       // company details submit
       submitButton().click();
       // your contact page submit
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
 
       natureOfBusiness[GOODS_OR_SERVICES].input().should('have.value', application.EXPORTER_BUSINESS[GOODS_OR_SERVICES]);
       natureOfBusiness[YEARS_EXPORTING].input().should('have.value', '');
@@ -130,7 +130,7 @@ context('Insurance - Your business - Nature of your business page - Save and bac
       // company details submit
       submitButton().click();
       // your contact page submit
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
 
       natureOfBusiness[GOODS_OR_SERVICES].input().should('have.value', application.EXPORTER_BUSINESS[GOODS_OR_SERVICES]);
       natureOfBusiness[YEARS_EXPORTING].input().should('have.value', application.EXPORTER_BUSINESS[YEARS_EXPORTING]);

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
@@ -28,7 +28,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
 
       url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.NATURE_OF_BUSINESS}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
@@ -28,7 +28,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
 
       url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.NATURE_OF_BUSINESS}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
@@ -30,7 +30,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
 
       url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.NATURE_OF_BUSINESS}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
@@ -30,7 +30,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
 
       url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.NATURE_OF_BUSINESS}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
@@ -30,7 +30,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
 
       url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.NATURE_OF_BUSINESS}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
@@ -30,7 +30,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
 
       url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.NATURE_OF_BUSINESS}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/save-and-back.spec.js
@@ -35,7 +35,7 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${TURNOVER}`;
@@ -92,7 +92,7 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
       // submit company details form
       submitButton().click();
       // your contact page submit
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       // submit nature of business form
       submitButton().click();
 
@@ -126,7 +126,7 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
       // submit company details form
       submitButton().click();
       // your contact page submit
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       // submit nature of business form
       submitButton().click();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/save-and-back.spec.js
@@ -35,7 +35,7 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${TURNOVER}`;
@@ -92,7 +92,7 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
       // submit company details form
       submitButton().click();
       // your contact page submit
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       // submit nature of business form
       submitButton().click();
 
@@ -126,7 +126,7 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
       // submit company details form
       submitButton().click();
       // your contact page submit
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       // submit nature of business form
       submitButton().click();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-financial-year-end.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-financial-year-end.spec.js
@@ -38,7 +38,7 @@ context(`Insurance - Your business - Turnover page - when ${fieldId} exists`, ()
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${TURNOVER}`;

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-financial-year-end.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-financial-year-end.spec.js
@@ -38,7 +38,7 @@ context(`Insurance - Your business - Turnover page - when ${fieldId} exists`, ()
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${TURNOVER}`;

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-page.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Your business - Turnover page - As an Exporter I want to en
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${TURNOVER}`;

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-page.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Your business - Turnover page - As an Exporter I want to en
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${TURNOVER}`;

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
@@ -36,7 +36,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
 
       url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.TURNOVER}`;

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
@@ -36,7 +36,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
 
       url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.TURNOVER}`;

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
@@ -36,7 +36,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.completeAndSubmitYourContact();
+      cy.acompleteAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
 
       url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.TURNOVER}`;

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
@@ -36,7 +36,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
       task.link().click();
 
       cy.completeAndSubmitCompanyDetails();
-      cy.acompleteAndSubmitYourContact({});
+      cy.completeAndSubmitYourContact({});
       cy.completeAndSubmitNatureOfYourBusiness();
 
       url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.TURNOVER}`;

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/change-your-answers/change-your-answers-change-company-or-organisation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/change-your-answers/change-your-answers-change-company-or-organisation.spec.js
@@ -53,7 +53,7 @@ context('Insurance - Your buyer - Change your answers - Company or organisation 
 
       task.link().click();
 
-      cy.completeAndSubmitCompanyOrOrganisationForm();
+      cy.completeAndSubmitCompanyOrOrganisationForm({});
       cy.completeAndSubmitWorkingWithBuyerForm({});
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer.spec.js
@@ -40,7 +40,7 @@ context('Insurance - Your buyer - Change your answers - Company or organisation 
 
       task.link().click();
 
-      cy.completeAndSubmitCompanyOrOrganisationForm();
+      cy.completeAndSubmitCompanyOrOrganisationForm({});
       cy.completeAndSubmitWorkingWithBuyerForm({});
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/check-your-answers/check-your-answers-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/check-your-answers/check-your-answers-page.spec.js
@@ -33,7 +33,7 @@ context('Insurance - Your buyer - Check your answers - As an exporter, I want to
 
       task.link().click();
 
-      cy.completeAndSubmitCompanyOrOrganisationForm();
+      cy.completeAndSubmitCompanyOrOrganisationForm({});
       cy.completeAndSubmitWorkingWithBuyerForm({});
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Your buyer - Check your answers - Summary list - your buyer
 
       task.link().click();
 
-      cy.completeAndSubmitCompanyOrOrganisationForm();
+      cy.completeAndSubmitCompanyOrOrganisationForm({});
       cy.completeAndSubmitWorkingWithBuyerForm({});
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/company-or-organisation/company-or-organisation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/company-or-organisation/company-or-organisation.spec.js
@@ -210,7 +210,7 @@ context('Insurance - Your Buyer - Company or organisation page - As an exporter,
       it(`should redirect to ${WORKING_WITH_BUYER} page`, () => {
         cy.navigateToUrl(url);
 
-        cy.completeAndSubmitCompanyOrOrganisationForm();
+        cy.completeAndSubmitCompanyOrOrganisationForm({});
 
         cy.url().should('eq', workingWithBuyerUrl);
       });

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/working-with-buyer/save-and-back.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/working-with-buyer/save-and-back.spec.js
@@ -35,7 +35,7 @@ context('Insurance - Your buyer - Working with buyer - Save and back', () => {
 
       task.link().click();
 
-      cy.completeAndSubmitCompanyOrOrganisationForm();
+      cy.completeAndSubmitCompanyOrOrganisationForm({});
 
       url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${WORKING_WITH_BUYER}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/working-with-buyer/validation/working-with-buyer-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/working-with-buyer/validation/working-with-buyer-validation.spec.js
@@ -40,7 +40,7 @@ context('Insurance - Your Buyer - Working with buyer page - form validation', ()
 
       task.link().click();
 
-      cy.completeAndSubmitCompanyOrOrganisationForm();
+      cy.completeAndSubmitCompanyOrOrganisationForm({});
 
       url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${WORKING_WITH_BUYER}`;
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/working-with-buyer/working-with-buyer.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/working-with-buyer/working-with-buyer.spec.js
@@ -36,7 +36,7 @@ context('Insurance - Your Buyer - Working with buyer page - As an exporter, I wa
 
       task.link().click();
 
-      cy.completeAndSubmitCompanyOrOrganisationForm();
+      cy.completeAndSubmitCompanyOrOrganisationForm({});
 
       url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${WORKING_WITH_BUYER}`;
       checkYourAnswersUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/cypress/e2e/pages/insurance/dashboard/index.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/dashboard/index.js
@@ -23,6 +23,7 @@ const dashboardPage = {
       }),
       firstRow: {
         referenceNumberLink: () => cy.get('table tbody tr').first().find('td a'),
+        buyerName: () => cy.get('table tbody tr').first().find('td').eq(4),
       },
       lastRow: {
         referenceNumberLink: () => cy.get('table tbody tr').last().find('td a'),

--- a/e2e-tests/cypress/fixtures/application.js
+++ b/e2e-tests/cypress/fixtures/application.js
@@ -173,7 +173,7 @@ const application = {
       [ACCOUNT_FIRST_NAME]: 'Bob',
       [ACCOUNT_LAST_NAME]: 'Smith',
       [ACCOUNT_EMAIL]: Cypress.env('GOV_NOTIFY_EMAIL_RECIPIENT_1'),
-      [CONTACT_POSITION]: 'EO',
+      [CONTACT_POSITION]: 'CEO',
     },
   },
   EXPORTER_BROKER: {

--- a/e2e-tests/cypress/fixtures/name-with-special-characters.js
+++ b/e2e-tests/cypress/fixtures/name-with-special-characters.js
@@ -1,0 +1,5 @@
+const SPECIAL_CHARACTERS = '<>"\'/*&';
+
+const mockNameWithSpecialCharacters = (name) => `${name}${SPECIAL_CHARACTERS}`;
+
+export default mockNameWithSpecialCharacters;

--- a/e2e-tests/cypress/support/insurance/complete-and-submit-your-contact-form.js
+++ b/e2e-tests/cypress/support/insurance/complete-and-submit-your-contact-form.js
@@ -20,11 +20,16 @@ const {
 
 const businessContactDetails = application.EXPORTER_BUSINESS[BUSINESS_CONTACT_DETAIL];
 
-export default () => {
-  cy.keyboardInput(yourContactPage.field(FIRST_NAME).input(), businessContactDetails[FIRST_NAME]);
-  cy.keyboardInput(yourContactPage.field(LAST_NAME).input(), businessContactDetails[LAST_NAME]);
+const completeAndSubmitYourContact = ({
+  firstName = businessContactDetails[FIRST_NAME],
+  lastName = businessContactDetails[LAST_NAME],
+}) => {
+  cy.keyboardInput(yourContactPage.field(FIRST_NAME).input(), firstName);
+  cy.keyboardInput(yourContactPage.field(LAST_NAME).input(), lastName);
   cy.keyboardInput(yourContactPage.field(EMAIL).input(), businessContactDetails[EMAIL]);
   cy.keyboardInput(yourContactPage.field(POSITION).input(), businessContactDetails[POSITION]);
 
   submitButton().click();
 };
+
+export default completeAndSubmitYourContact;

--- a/e2e-tests/cypress/support/insurance/complete-prepare-your-application-section-multiple.js
+++ b/e2e-tests/cypress/support/insurance/complete-prepare-your-application-section-multiple.js
@@ -17,14 +17,14 @@ export default () => {
   submitButton().click();
 
   cy.completeAndSubmitCompanyDetails();
-  cy.completeAndSubmitYourContact();
+  cy.acompleteAndSubmitYourContact({});
   cy.completeAndSubmitNatureOfYourBusiness();
   cy.completeAndSubmitTurnoverForm();
   cy.completeAndSubmitBrokerForm();
 
   submitButton().click();
 
-  cy.completeAndSubmitCompanyOrOrganisationForm();
+  cy.completeAndSubmitCompanyOrOrganisationForm({});
   cy.completeAndSubmitWorkingWithBuyerForm({});
 
   submitButton().click();

--- a/e2e-tests/cypress/support/insurance/complete-prepare-your-application-section-multiple.js
+++ b/e2e-tests/cypress/support/insurance/complete-prepare-your-application-section-multiple.js
@@ -17,7 +17,7 @@ export default () => {
   submitButton().click();
 
   cy.completeAndSubmitCompanyDetails();
-  cy.acompleteAndSubmitYourContact({});
+  cy.completeAndSubmitYourContact({});
   cy.completeAndSubmitNatureOfYourBusiness();
   cy.completeAndSubmitTurnoverForm();
   cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/support/insurance/complete-prepare-your-application-section-single.js
+++ b/e2e-tests/cypress/support/insurance/complete-prepare-your-application-section-single.js
@@ -22,14 +22,14 @@ export default ({ exporterHasTradedWithBuyer }) => {
   submitButton().click();
 
   cy.completeAndSubmitCompanyDetails();
-  cy.completeAndSubmitYourContact();
+  cy.acompleteAndSubmitYourContact({});
   cy.completeAndSubmitNatureOfYourBusiness();
   cy.completeAndSubmitTurnoverForm();
   cy.completeAndSubmitBrokerForm();
 
   submitButton().click();
 
-  cy.completeAndSubmitCompanyOrOrganisationForm();
+  cy.completeAndSubmitCompanyOrOrganisationForm({});
   cy.completeAndSubmitWorkingWithBuyerForm({ exporterHasTradedWithBuyer });
 
   submitButton().click();

--- a/e2e-tests/cypress/support/insurance/complete-prepare-your-application-section-single.js
+++ b/e2e-tests/cypress/support/insurance/complete-prepare-your-application-section-single.js
@@ -22,7 +22,7 @@ export default ({ exporterHasTradedWithBuyer }) => {
   submitButton().click();
 
   cy.completeAndSubmitCompanyDetails();
-  cy.acompleteAndSubmitYourContact({});
+  cy.completeAndSubmitYourContact({});
   cy.completeAndSubmitNatureOfYourBusiness();
   cy.completeAndSubmitTurnoverForm();
   cy.completeAndSubmitBrokerForm();

--- a/e2e-tests/cypress/support/insurance/your-buyer/complete-and-submit-company-or-organisation-form.js
+++ b/e2e-tests/cypress/support/insurance/your-buyer/complete-and-submit-company-or-organisation-form.js
@@ -22,13 +22,17 @@ const {
 const { BUYER } = application;
 const countryToSelect = mockCountries[0].isoCode;
 
-export default () => {
-  cy.keyboardInput(companyOrOrganisationPage[NAME].input(), BUYER[NAME]);
+const completeAndSubmitCompanyOrOrganisationForm = ({
+  buyerName = BUYER[NAME],
+  firstName = BUYER[FIRST_NAME],
+  lastName = BUYER[LAST_NAME],
+}) => {
+  cy.keyboardInput(companyOrOrganisationPage[NAME].input(), buyerName);
   cy.keyboardInput(companyOrOrganisationPage[ADDRESS].input(), BUYER[ADDRESS]);
   cy.keyboardInput(companyOrOrganisationPage[REGISTRATION_NUMBER].input(), BUYER[REGISTRATION_NUMBER]);
   cy.keyboardInput(companyOrOrganisationPage[WEBSITE].input(), BUYER[WEBSITE]);
-  cy.keyboardInput(companyOrOrganisationPage[FIRST_NAME].input(), BUYER[FIRST_NAME]);
-  cy.keyboardInput(companyOrOrganisationPage[LAST_NAME].input(), BUYER[LAST_NAME]);
+  cy.keyboardInput(companyOrOrganisationPage[FIRST_NAME].input(), firstName);
+  cy.keyboardInput(companyOrOrganisationPage[LAST_NAME].input(), lastName);
   cy.keyboardInput(companyOrOrganisationPage[POSITION].input(), BUYER[POSITION]);
   cy.keyboardInput(companyOrOrganisationPage[EMAIL].input(), BUYER[EMAIL]);
   companyOrOrganisationPage[CAN_CONTACT_BUYER].yesRadioInput().click();
@@ -38,3 +42,5 @@ export default () => {
   cy.wait(10000); // eslint-disable-line cypress/no-unnecessary-waiting
   submitButton().click();
 };
+
+export default completeAndSubmitCompanyOrOrganisationForm;

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -3004,7 +3004,7 @@ var send_application_submitted_emails_default = applicationSubmittedEmails;
 var import_exceljs = __toESM(require("exceljs"));
 
 // helpers/replace-character-codes-with-characters/index.ts
-var replaceCharacterCodesWithCharacters = (str) => str.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&quot;/g, '"').replace(/&#x27;/g, "'").replace(/&#x2F;/g, "/").replace(/&#42;/g, "*");
+var replaceCharacterCodesWithCharacters = (str) => str.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&quot;/g, '"').replace(/&#x27;/g, "'").replace(/&#x2F;/g, "/").replace(/&#42;/g, "*").replace(/&amp;/g, "&");
 var replace_character_codes_with_characters_default = replaceCharacterCodesWithCharacters;
 
 // generate-xlsx/map-application-to-XLSX/helpers/xlsx-row/index.ts

--- a/src/ui/server/controllers/insurance/application-submitted/index.test.ts
+++ b/src/ui/server/controllers/insurance/application-submitted/index.test.ts
@@ -3,6 +3,7 @@ import { PAGES } from '../../../content-strings';
 import { ROUTES, TEMPLATES, APPLICATION } from '../../../constants';
 import insuranceCorePageVariables from '../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../helpers/mappings/map-application-to-form-fields';
 import { Request, Response } from '../../../../types';
 import { mockReq, mockRes, mockApplication } from '../../../test-mocks';
 
@@ -40,7 +41,7 @@ describe('controllers/insurance/application-submitted', () => {
           BACK_LINK: req.headers.referer,
         }),
         userName: getUserNameFromSession(req.session.user),
-        application: res.locals.application,
+        application: mapApplicationToFormFields(res.locals.application),
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);

--- a/src/ui/server/controllers/insurance/application-submitted/index.ts
+++ b/src/ui/server/controllers/insurance/application-submitted/index.ts
@@ -2,6 +2,7 @@ import { ROUTES, TEMPLATES, APPLICATION } from '../../../constants';
 import { PAGES } from '../../../content-strings';
 import insuranceCorePageVariables from '../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../helpers/mappings/map-application-to-form-fields';
 import { Request, Response } from '../../../../types';
 
 const {
@@ -36,6 +37,6 @@ export const get = (req: Request, res: Response) => {
       BACK_LINK: req.headers.referer,
     }),
     userName: getUserNameFromSession(req.session.user),
-    application,
+    application: mapApplicationToFormFields(res.locals.application),
   });
 };

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.test.ts
@@ -4,6 +4,7 @@ import { DECLARATIONS_FIELDS } from '../../../../../content-strings/fields/insur
 import { FIELD_IDS, FIELD_VALUES, ROUTES, TEMPLATES } from '../../../../../constants';
 import singleInputPageVariables from '../../../../../helpers/page-variables/single-input/insurance';
 import getUserNameFromSession from '../../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../../helpers/mappings/map-application-to-form-fields';
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import save from '../../save-data';
 import { Request, Response } from '../../../../../../types';
@@ -69,7 +70,7 @@ describe('controllers/insurance/declarations/anti-bribery/code-of-conduct', () =
         ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer }),
         ...pageVariables(mockApplication.referenceNumber),
         userName: getUserNameFromSession(req.session.user),
-        application: res.locals.application,
+        application: mapApplicationToFormFields(res.locals.application),
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.ts
@@ -3,6 +3,7 @@ import { DECLARATIONS_FIELDS } from '../../../../../content-strings/fields/insur
 import { FIELD_IDS, FIELD_VALUES, ROUTES, TEMPLATES } from '../../../../../constants';
 import singleInputPageVariables from '../../../../../helpers/page-variables/single-input/insurance';
 import getUserNameFromSession from '../../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../../helpers/mappings/map-application-to-form-fields';
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import save from '../../save-data';
 import { Request, Response } from '../../../../../../types';
@@ -57,7 +58,7 @@ export const get = (req: Request, res: Response) => {
     ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer }),
     ...pageVariables(refNumber),
     userName: getUserNameFromSession(req.session.user),
-    application: res.locals.application,
+    application: mapApplicationToFormFields(res.locals.application),
   });
 };
 

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/exporting-with-code-of-conduct/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/exporting-with-code-of-conduct/index.test.ts
@@ -4,6 +4,7 @@ import { DECLARATIONS_FIELDS } from '../../../../../content-strings/fields/insur
 import { FIELD_IDS, FIELD_VALUES, ROUTES, TEMPLATES } from '../../../../../constants';
 import singleInputPageVariables from '../../../../../helpers/page-variables/single-input/insurance';
 import getUserNameFromSession from '../../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../../helpers/mappings/map-application-to-form-fields';
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import save from '../../save-data';
 import { Request, Response } from '../../../../../../types';
@@ -69,7 +70,7 @@ describe('controllers/insurance/declarations/anti-bribery/exporting-with-acode-o
         ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer }),
         ...pageVariables(mockApplication.referenceNumber),
         userName: getUserNameFromSession(req.session.user),
-        application: res.locals.application,
+        application: mapApplicationToFormFields(res.locals.application),
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/exporting-with-code-of-conduct/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/exporting-with-code-of-conduct/index.ts
@@ -3,6 +3,7 @@ import { DECLARATIONS_FIELDS } from '../../../../../content-strings/fields/insur
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../../constants';
 import singleInputPageVariables from '../../../../../helpers/page-variables/single-input/insurance';
 import getUserNameFromSession from '../../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../../helpers/mappings/map-application-to-form-fields';
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import save from '../../save-data';
 import { Request, Response } from '../../../../../../types';
@@ -57,7 +58,7 @@ export const get = (req: Request, res: Response) => {
     ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer }),
     ...pageVariables(refNumber),
     userName: getUserNameFromSession(req.session.user),
-    application: res.locals.application,
+    application: mapApplicationToFormFields(res.locals.application),
   });
 };
 

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/index.test.ts
@@ -5,6 +5,7 @@ import { DECLARATIONS_FIELDS as FIELDS } from '../../../../content-strings/field
 import api from '../../../../api';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import keystoneDocumentRendererConfig from '../../../../helpers/keystone-document-renderer-config';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
@@ -83,7 +84,7 @@ describe('controllers/insurance/declarations/anti-bribery', () => {
         userName: getUserNameFromSession(req.session.user),
         documentContent: mockDeclarations.antiBribery.content.document,
         documentConfig: keystoneDocumentRendererConfig(),
-        application: res.locals.application,
+        application: mapApplicationToFormFields(res.locals.application),
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/index.ts
@@ -4,6 +4,7 @@ import { DECLARATIONS_FIELDS as FIELDS } from '../../../../content-strings/field
 import api from '../../../../api';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import keystoneDocumentRendererConfig from '../../../../helpers/keystone-document-renderer-config';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
@@ -64,7 +65,7 @@ export const get = async (req: Request, res: Response) => {
       userName: getUserNameFromSession(req.session.user),
       documentContent: antiBriberyContent.content.document,
       documentConfig: keystoneDocumentRendererConfig(),
-      application,
+      application: mapApplicationToFormFields(res.locals.application),
     });
   } catch (err) {
     console.error("Error getting declarations - anti-bribery and rendering 'anti-bribery' page ", { err });

--- a/src/ui/server/controllers/insurance/declarations/confidentiality/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/confidentiality/index.test.ts
@@ -4,6 +4,7 @@ import { FIELD_IDS, TEMPLATES, ROUTES } from '../../../../constants';
 import { DECLARATIONS_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance/declarations';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
@@ -73,7 +74,7 @@ describe('controllers/insurance/declarations/confidentiality', () => {
         ...pageVariables(mockApplication.referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         CONFIDENTIALITY_CONTENT,
-        application: res.locals.application,
+        application: mapApplicationToFormFields(res.locals.application),
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);

--- a/src/ui/server/controllers/insurance/declarations/confidentiality/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/confidentiality/index.ts
@@ -3,6 +3,7 @@ import { FIELD_IDS, TEMPLATES, ROUTES } from '../../../../constants';
 import { DECLARATIONS_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance/declarations';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
@@ -61,7 +62,7 @@ export const get = async (req: Request, res: Response) => {
     ...pageVariables(refNumber),
     userName: getUserNameFromSession(req.session.user),
     CONFIDENTIALITY_CONTENT,
-    application,
+    application: mapApplicationToFormFields(res.locals.application),
   });
 };
 

--- a/src/ui/server/controllers/insurance/declarations/confirmation-and-acknowledgements/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/confirmation-and-acknowledgements/index.test.ts
@@ -5,6 +5,7 @@ import { DECLARATIONS_FIELDS as FIELDS } from '../../../../content-strings/field
 import api from '../../../../api';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import keystoneDocumentRendererConfig from '../../../../helpers/keystone-document-renderer-config';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
@@ -81,7 +82,7 @@ describe('controllers/insurance/declarations/confirmation-and-acknowledgements',
         userName: getUserNameFromSession(req.session.user),
         documentContent: mockDeclarations.confirmationAndAcknowledgement.content.document,
         documentConfig: keystoneDocumentRendererConfig(),
-        application: res.locals.application,
+        application: mapApplicationToFormFields(res.locals.application),
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);

--- a/src/ui/server/controllers/insurance/declarations/confirmation-and-acknowledgements/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/confirmation-and-acknowledgements/index.ts
@@ -4,6 +4,7 @@ import { DECLARATIONS_FIELDS as FIELDS } from '../../../../content-strings/field
 import api from '../../../../api';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import keystoneDocumentRendererConfig from '../../../../helpers/keystone-document-renderer-config';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
@@ -62,7 +63,7 @@ export const get = async (req: Request, res: Response) => {
       userName: getUserNameFromSession(req.session.user),
       documentContent: declarationContent.content.document,
       documentConfig: keystoneDocumentRendererConfig(),
-      application,
+      application: mapApplicationToFormFields(res.locals.application),
     });
   } catch (err) {
     console.error("Error getting declarations - confirmation and acknowledgements and rendering 'confirmation and acknowledgements' page ", { err });

--- a/src/ui/server/controllers/insurance/declarations/how-your-data-will-be-used/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/how-your-data-will-be-used/index.test.ts
@@ -5,6 +5,7 @@ import { DECLARATIONS_FIELDS as FIELDS } from '../../../../content-strings/field
 import api from '../../../../api';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import keystoneDocumentRendererConfig from '../../../../helpers/keystone-document-renderer-config';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
@@ -84,7 +85,7 @@ describe('controllers/insurance/declarations/how-your-data-will-be-used', () => 
         userName: getUserNameFromSession(req.session.user),
         documentContent: mockDeclarations.howDataWillBeUsed.content.document,
         documentConfig: keystoneDocumentRendererConfig(),
-        application: res.locals.application,
+        application: mapApplicationToFormFields(res.locals.application),
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);

--- a/src/ui/server/controllers/insurance/declarations/how-your-data-will-be-used/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/how-your-data-will-be-used/index.ts
@@ -4,6 +4,7 @@ import { DECLARATIONS_FIELDS as FIELDS } from '../../../../content-strings/field
 import api from '../../../../api';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import keystoneDocumentRendererConfig from '../../../../helpers/keystone-document-renderer-config';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
@@ -65,7 +66,7 @@ export const get = async (req: Request, res: Response) => {
       userName: getUserNameFromSession(req.session.user),
       documentContent: declarationContent.content.document,
       documentConfig: keystoneDocumentRendererConfig(),
-      application,
+      application: mapApplicationToFormFields(res.locals.application),
     });
   } catch (err) {
     console.error("Error getting declarations - how data will be used and rendering 'how data will be used' page ", { err });

--- a/src/ui/server/controllers/insurance/policy-and-export/check-your-answers/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/check-your-answers/index.test.ts
@@ -5,6 +5,7 @@ import { POLICY_AND_EXPORTS_FIELDS as FIELDS } from '../../../../content-strings
 import api from '../../../../api';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import { policyAndExportSummaryList } from '../../../../helpers/summary-lists/policy-and-export';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes, mockApplication, mockCountries, mockCurrencies } from '../../../../test-mocks';
@@ -86,7 +87,7 @@ describe('controllers/insurance/policy-and-export/check-your-answers', () => {
         }),
         ...pageVariables(refNumber),
         userName: getUserNameFromSession(req.session.user),
-        application: res.locals.application,
+        application: mapApplicationToFormFields(res.locals.application),
         SUMMARY_LIST: policyAndExportSummaryList(mockApplication.policyAndExport, mockApplication.referenceNumber, mockCountries, mockCurrencies),
       };
 

--- a/src/ui/server/controllers/insurance/policy-and-export/check-your-answers/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/check-your-answers/index.ts
@@ -5,6 +5,7 @@ import api from '../../../../api';
 import { isPopulatedArray } from '../../../../helpers/array';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import { policyAndExportSummaryList } from '../../../../helpers/summary-lists/policy-and-export';
 import { Request, Response } from '../../../../../types';
 
@@ -59,7 +60,7 @@ export const get = async (req: Request, res: Response) => {
       }),
       ...pageVariables(refNumber),
       userName: getUserNameFromSession(req.session.user),
-      application,
+      application: mapApplicationToFormFields(res.locals.application),
       SUMMARY_LIST: summaryList,
     });
   } catch (err) {

--- a/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.test.ts
@@ -4,6 +4,7 @@ import { PAGES } from '../../../../content-strings';
 import { POLICY_AND_EXPORTS_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save';
 import { Request, Response } from '../../../../../types';
@@ -68,7 +69,7 @@ describe('controllers/insurance/policy-and-export/type-of-policy', () => {
         }),
         ...pageVariables(refNumber),
         userName: getUserNameFromSession(req.session.user),
-        application: res.locals.application,
+        application: mapApplicationToFormFields(res.locals.application),
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);

--- a/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.ts
@@ -3,6 +3,7 @@ import { PAGES } from '../../../../content-strings';
 import { POLICY_AND_EXPORTS_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import { objectHasKeysAndValues } from '../../../../helpers/object';
 import generateValidationErrors from './validation';
 import { isMultiPolicyType, isSinglePolicyType } from '../../../../helpers/policy-type';
@@ -48,7 +49,7 @@ export const get = (req: Request, res: Response) => {
     }),
     ...pageVariables(refNumber),
     userName: getUserNameFromSession(req.session.user),
-    application,
+    application: mapApplicationToFormFields(res.locals.application),
   });
 };
 

--- a/src/ui/server/helpers/get-user-name-from-session/index.test.ts
+++ b/src/ui/server/helpers/get-user-name-from-session/index.test.ts
@@ -1,5 +1,6 @@
 import getUserNameFromSession from '.';
 import ACCOUNT_FIELD_IDS from '../../constants/field-ids/insurance/account';
+import replaceCharacterCodesWithCharacters from '../replace-character-codes-with-characters';
 import { mockAccount } from '../../test-mocks';
 
 const { FIRST_NAME, LAST_NAME } = ACCOUNT_FIELD_IDS;
@@ -8,7 +9,10 @@ describe('server/helpers/get-user-name-from-session', () => {
   it("should return a users's full anme", () => {
     const result = getUserNameFromSession(mockAccount);
 
-    const expected = `${mockAccount[FIRST_NAME]} ${mockAccount[LAST_NAME]}`;
+    const firstName = replaceCharacterCodesWithCharacters(mockAccount[FIRST_NAME]);
+    const lastName = replaceCharacterCodesWithCharacters(mockAccount[LAST_NAME]);
+
+    const expected = `${firstName} ${lastName}`;
 
     expect(result).toEqual(expected);
   });

--- a/src/ui/server/helpers/get-user-name-from-session/index.ts
+++ b/src/ui/server/helpers/get-user-name-from-session/index.ts
@@ -1,4 +1,5 @@
 import ACCOUNT_FIELD_IDS from '../../constants/field-ids/insurance/account';
+import replaceCharacterCodesWithCharacters from '../replace-character-codes-with-characters';
 import { RequestSessionUser } from '../../../types';
 
 const { FIRST_NAME, LAST_NAME } = ACCOUNT_FIELD_IDS;
@@ -11,7 +12,10 @@ const { FIRST_NAME, LAST_NAME } = ACCOUNT_FIELD_IDS;
  */
 const getUserNameFromSession = (userSession?: RequestSessionUser) => {
   if (userSession) {
-    return `${userSession[FIRST_NAME]} ${userSession[LAST_NAME]}`;
+    const firstName = replaceCharacterCodesWithCharacters(userSession[FIRST_NAME]);
+    const lastName = replaceCharacterCodesWithCharacters(userSession[LAST_NAME]);
+
+    return `${firstName} ${lastName}`;
   }
 
   return null;

--- a/src/ui/server/helpers/mappings/map-application-to-form-fields/index.test.ts
+++ b/src/ui/server/helpers/mappings/map-application-to-form-fields/index.test.ts
@@ -38,7 +38,7 @@ describe('server/helpers/mappings/map-application-to-form-fields', () => {
     expect(result).toEqual(expected);
   });
 
-  describe(`when an application has policyAndExport${REQUESTED_START_DATE} field`, () => {
+  describe(`when an application has policyAndExport.${REQUESTED_START_DATE} field`, () => {
     it('should return additional date fields from the timestamp', () => {
       const timestamp = mockApplication.policyAndExport[REQUESTED_START_DATE];
 
@@ -78,7 +78,7 @@ describe('server/helpers/mappings/map-application-to-form-fields', () => {
     });
   });
 
-  describe(`when an application has policyAndExport${CONTRACT_COMPLETION_DATE} field`, () => {
+  describe(`when an application has policyAndExport.${CONTRACT_COMPLETION_DATE} field`, () => {
     it('should return additional date fields from the timestamp', () => {
       const timestamp = mockApplication.policyAndExport[CONTRACT_COMPLETION_DATE];
 

--- a/src/ui/server/helpers/mappings/map-application-to-form-fields/index.test.ts
+++ b/src/ui/server/helpers/mappings/map-application-to-form-fields/index.test.ts
@@ -1,5 +1,6 @@
 import mapApplicationToFormFields from '.';
 import { FIELD_IDS } from '../../../constants';
+import mapNameFields from '../map-name-fields';
 import formatDate from '../../date/format-date';
 import getDateFieldsFromTimestamp from '../../date/get-date-fields-from-timestamp';
 import { mockApplication } from '../../../test-mocks';
@@ -32,7 +33,9 @@ describe('server/helpers/mappings/map-application-to-form-fields', () => {
 
     const result = mapApplicationToFormFields(simpleApplication);
 
-    expect(result).toEqual(simpleApplication);
+    const expected = mapNameFields(simpleApplication);
+
+    expect(result).toEqual(expected);
   });
 
   describe(`when an application has policyAndExport${REQUESTED_START_DATE} field`, () => {
@@ -41,14 +44,14 @@ describe('server/helpers/mappings/map-application-to-form-fields', () => {
 
       const result = mapApplicationToFormFields(mockApplication);
 
-      const expected = {
+      const expected = mapNameFields({
         ...mockApplication,
         [SUBMISSION_DEADLINE]: formatDate(mockApplication[SUBMISSION_DEADLINE]),
         policyAndExport: {
           ...mockApplication.policyAndExport,
           ...getDateFieldsFromTimestamp(timestamp, REQUESTED_START_DATE),
         },
-      };
+      });
 
       expect(result).toEqual(expected);
     });
@@ -58,7 +61,7 @@ describe('server/helpers/mappings/map-application-to-form-fields', () => {
     it('should return the relevant business fields', () => {
       const result = mapApplicationToFormFields(mockApplication);
 
-      const expected = {
+      const expected = mapNameFields({
         ...mockApplication,
         [SUBMISSION_DEADLINE]: formatDate(mockApplication[SUBMISSION_DEADLINE]),
         business: {
@@ -69,7 +72,7 @@ describe('server/helpers/mappings/map-application-to-form-fields', () => {
           [PERCENTAGE_TURNOVER]: transformNumberToString(mockApplication.business[PERCENTAGE_TURNOVER]),
           [ESTIMATED_ANNUAL_TURNOVER]: transformNumberToString(mockApplication.business[ESTIMATED_ANNUAL_TURNOVER]),
         },
-      };
+      });
 
       expect(result).toEqual(expected);
     });
@@ -81,14 +84,14 @@ describe('server/helpers/mappings/map-application-to-form-fields', () => {
 
       const result = mapApplicationToFormFields(mockApplication);
 
-      const expected = {
+      const expected = mapNameFields({
         ...mockApplication,
         [SUBMISSION_DEADLINE]: formatDate(mockApplication[SUBMISSION_DEADLINE]),
         policyAndExport: {
           ...mockApplication.policyAndExport,
           ...getDateFieldsFromTimestamp(timestamp, CONTRACT_COMPLETION_DATE),
         },
-      };
+      });
 
       expect(result).toEqual(expected);
     });
@@ -98,24 +101,15 @@ describe('server/helpers/mappings/map-application-to-form-fields', () => {
     it('should return mapped date field', () => {
       const result = mapApplicationToFormFields(mockApplication);
 
-      const expected = {
+      const expected = mapNameFields({
         ...mockApplication,
         company: {
           ...mockApplication.company,
           [FINANCIAL_YEAR_END_DATE]: mapFinancialYearEndDate(mockApplication.company[FINANCIAL_YEAR_END_DATE]),
         },
-      };
+      });
 
       expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when an application is not passed', () => {
-    it('should return an empty object', () => {
-      // @ts-ignore
-      const result = mapApplicationToFormFields();
-
-      expect(result).toEqual({});
     });
   });
 

--- a/src/ui/server/helpers/mappings/map-application-to-form-fields/index.ts
+++ b/src/ui/server/helpers/mappings/map-application-to-form-fields/index.ts
@@ -1,5 +1,7 @@
 import { Application } from '../../../../types';
 import { FIELD_IDS } from '../../../constants';
+import { objectHasKeysAndValues } from '../../object';
+import mapNameFields from '../map-name-fields';
 import formatDate from '../../date/format-date';
 import getDateFieldsFromTimestamp from '../../date/get-date-fields-from-timestamp';
 import mapFinancialYearEndDate from '../map-financial-year-end-date';
@@ -26,8 +28,8 @@ const {
  * @returns {Object} Mapped application for UI form fields.
  */
 const mapApplicationToFormFields = (application: Application): object => {
-  if (application && Object.keys(application)) {
-    const mapped = application;
+  if (objectHasKeysAndValues(application)) {
+    const mapped = mapNameFields(application);
 
     if (mapped[SUBMISSION_DEADLINE]) {
       mapped[SUBMISSION_DEADLINE] = formatDate(application[SUBMISSION_DEADLINE]);

--- a/src/ui/server/helpers/mappings/map-application-to-form-fields/index.ts
+++ b/src/ui/server/helpers/mappings/map-application-to-form-fields/index.ts
@@ -27,8 +27,8 @@ const {
  * @param {Object} Application
  * @returns {Object} Mapped application for UI form fields.
  */
-const mapApplicationToFormFields = (application: Application): object => {
-  if (objectHasKeysAndValues(application)) {
+const mapApplicationToFormFields = (application?: Application): object => {
+  if (application && objectHasKeysAndValues(application)) {
     const mapped = mapNameFields(application);
 
     if (mapped[SUBMISSION_DEADLINE]) {

--- a/src/ui/server/helpers/mappings/map-applications/index.test.ts
+++ b/src/ui/server/helpers/mappings/map-applications/index.test.ts
@@ -1,6 +1,7 @@
 import mapApplications, { mapApplication } from '.';
 import { DEFAULT } from '../../../content-strings';
 import formatDate from '../../date/format-date';
+import replaceCharacterCodesWithCharacters from '../../replace-character-codes-with-characters';
 import mapInsuredFor from './map-insured-for';
 import { mockApplication, mockApplications } from '../../../test-mocks';
 
@@ -16,7 +17,7 @@ describe('server/helpers/mappings/map-applications', () => {
         lastUpdated: formatDate(new Date(updatedAt)),
         referenceNumber,
         buyerLocation: buyer?.country?.name || DEFAULT.EMPTY,
-        buyerName: buyer.companyOrOrganisationName || DEFAULT.EMPTY,
+        buyerName: replaceCharacterCodesWithCharacters(buyer.companyOrOrganisationName),
         insuredFor: mapInsuredFor(mockApplication),
       };
 

--- a/src/ui/server/helpers/mappings/map-applications/index.ts
+++ b/src/ui/server/helpers/mappings/map-applications/index.ts
@@ -18,7 +18,7 @@ export const mapApplication = (application: Application) => {
     lastUpdated: formatDate(new Date(updatedAt)),
     referenceNumber,
     buyerLocation: buyer?.country?.name || DEFAULT.EMPTY,
-    buyerName: buyer.companyOrOrganisationName ? replaceCharacterCodesWithCharacters(buyer.companyOrOrganisationName) : DEFAULT.EMPTY,
+    buyerName: replaceCharacterCodesWithCharacters(buyer.companyOrOrganisationName) || DEFAULT.EMPTY,
     insuredFor: mapInsuredFor(application),
   };
 

--- a/src/ui/server/helpers/mappings/map-applications/index.ts
+++ b/src/ui/server/helpers/mappings/map-applications/index.ts
@@ -1,5 +1,6 @@
 import { DEFAULT } from '../../../content-strings';
 import formatDate from '../../date/format-date';
+import replaceCharacterCodesWithCharacters from '../../replace-character-codes-with-characters';
 import mapInsuredFor from './map-insured-for';
 import { Application } from '../../../../types';
 
@@ -17,7 +18,7 @@ export const mapApplication = (application: Application) => {
     lastUpdated: formatDate(new Date(updatedAt)),
     referenceNumber,
     buyerLocation: buyer?.country?.name || DEFAULT.EMPTY,
-    buyerName: buyer.companyOrOrganisationName || DEFAULT.EMPTY,
+    buyerName: buyer.companyOrOrganisationName ? replaceCharacterCodesWithCharacters(buyer.companyOrOrganisationName) : DEFAULT.EMPTY,
     insuredFor: mapInsuredFor(application),
   };
 

--- a/src/ui/server/helpers/mappings/map-name-fields/index.test.ts
+++ b/src/ui/server/helpers/mappings/map-name-fields/index.test.ts
@@ -1,0 +1,85 @@
+import mapNameFields from '.';
+import INSURANCE_FIELD_IDS from '../../../constants/field-ids/insurance';
+import replaceCharacterCodesWithCharacters from '../../replace-character-codes-with-characters';
+import { mockApplication } from '../../../test-mocks';
+
+const {
+  ACCOUNT: { FIRST_NAME, LAST_NAME },
+  YOUR_BUYER: {
+    COMPANY_OR_ORGANISATION: { NAME: BUYER_NAME, FIRST_NAME: BUYER_CONTACT_FIRST_NAME, LAST_NAME: BUYER_CONTACT_LAST_NAME },
+  },
+} = INSURANCE_FIELD_IDS;
+
+const characterCodes = '&lt;&gt;&quot;&#x27;&#x2F;&#42;&amp';
+
+const mockStringWithCharacterCodes = String.raw`mock${characterCodes}`;
+
+const mockApplicationWithCharcterCodes = {
+  ...mockApplication,
+  business: {
+    ...mockApplication.business,
+    businessContactDetail: {
+      ...mockApplication.business.businessContactDetail,
+      [FIRST_NAME]: mockStringWithCharacterCodes,
+      [LAST_NAME]: mockStringWithCharacterCodes,
+    },
+  },
+  buyer: {
+    ...mockApplication.buyer,
+    [BUYER_NAME]: mockStringWithCharacterCodes,
+    [BUYER_CONTACT_FIRST_NAME]: mockStringWithCharacterCodes,
+    [BUYER_CONTACT_LAST_NAME]: mockStringWithCharacterCodes,
+  },
+};
+
+describe('server/helpers/mappings/map-name-fields', () => {
+  it(`should replace character codes in businessContactDetail.${FIRST_NAME}`, () => {
+    const result = mapNameFields(mockApplicationWithCharcterCodes);
+
+    const fieldValue = mockApplicationWithCharcterCodes.business.businessContactDetail[FIRST_NAME];
+
+    const expected = replaceCharacterCodesWithCharacters(fieldValue);
+
+    expect(result.business.businessContactDetail[FIRST_NAME]).toEqual(expected);
+  });
+
+  it(`should replace character codes in businessContactDetail.${LAST_NAME}`, () => {
+    const result = mapNameFields(mockApplicationWithCharcterCodes);
+
+    const fieldValue = mockApplicationWithCharcterCodes.business.businessContactDetail[LAST_NAME];
+
+    const expected = replaceCharacterCodesWithCharacters(fieldValue);
+
+    expect(result.business.businessContactDetail[LAST_NAME]).toEqual(expected);
+  });
+
+  it(`should replace character codes in buyer.${BUYER_NAME}`, () => {
+    const result = mapNameFields(mockApplicationWithCharcterCodes);
+
+    const fieldValue = mockApplicationWithCharcterCodes.buyer[BUYER_NAME];
+
+    const expected = replaceCharacterCodesWithCharacters(fieldValue);
+
+    expect(result.buyer[BUYER_NAME]).toEqual(expected);
+  });
+
+  it(`should replace character codes in buyer.${BUYER_CONTACT_FIRST_NAME}`, () => {
+    const result = mapNameFields(mockApplicationWithCharcterCodes);
+
+    const fieldValue = mockApplicationWithCharcterCodes.buyer[BUYER_CONTACT_FIRST_NAME];
+
+    const expected = replaceCharacterCodesWithCharacters(fieldValue);
+
+    expect(result.buyer[BUYER_CONTACT_FIRST_NAME]).toEqual(expected);
+  });
+
+  it(`should replace character codes in buyer.${BUYER_CONTACT_LAST_NAME}`, () => {
+    const result = mapNameFields(mockApplicationWithCharcterCodes);
+
+    const fieldValue = mockApplicationWithCharcterCodes.buyer[BUYER_CONTACT_LAST_NAME];
+
+    const expected = replaceCharacterCodesWithCharacters(fieldValue);
+
+    expect(result.buyer[BUYER_CONTACT_LAST_NAME]).toEqual(expected);
+  });
+});

--- a/src/ui/server/helpers/mappings/map-name-fields/index.ts
+++ b/src/ui/server/helpers/mappings/map-name-fields/index.ts
@@ -1,0 +1,54 @@
+import INSURANCE_FIELD_IDS from '../../../constants/field-ids/insurance';
+import replaceCharacterCodesWithCharacters from '../../replace-character-codes-with-characters';
+import { Application } from '../../../../types';
+
+const {
+  ACCOUNT: { FIRST_NAME, LAST_NAME },
+  YOUR_BUYER: {
+    COMPANY_OR_ORGANISATION: { NAME: BUYER_NAME, FIRST_NAME: BUYER_CONTACT_FIRST_NAME, LAST_NAME: BUYER_CONTACT_LAST_NAME },
+  },
+} = INSURANCE_FIELD_IDS;
+
+/**
+ * mapNameFields
+ * Replace character codes in name fields with characters
+ * @param {Object} Application
+ * @returns {Object} Application with name field characters
+ */
+const mapNameFields = (application: Application): Application => {
+  const { business, buyer } = application;
+
+  if (business && business.businessContactDetail[FIRST_NAME]) {
+    const fieldValue = business.businessContactDetail[FIRST_NAME];
+
+    business.businessContactDetail[FIRST_NAME] = replaceCharacterCodesWithCharacters(fieldValue);
+  }
+
+  if (business && business.businessContactDetail[LAST_NAME]) {
+    const fieldValue = business.businessContactDetail[LAST_NAME];
+
+    business.businessContactDetail[LAST_NAME] = replaceCharacterCodesWithCharacters(fieldValue);
+  }
+
+  if (buyer && buyer[BUYER_NAME]) {
+    const fieldValue = buyer[BUYER_NAME];
+
+    buyer[BUYER_NAME] = replaceCharacterCodesWithCharacters(fieldValue);
+  }
+
+  if (buyer && buyer[BUYER_CONTACT_FIRST_NAME]) {
+    const fieldValue = buyer[BUYER_CONTACT_FIRST_NAME];
+
+    buyer[BUYER_CONTACT_FIRST_NAME] = replaceCharacterCodesWithCharacters(fieldValue);
+  }
+
+  if (buyer && buyer[BUYER_CONTACT_LAST_NAME]) {
+    const fieldValue = buyer[BUYER_CONTACT_LAST_NAME];
+
+    buyer[BUYER_CONTACT_LAST_NAME] = replaceCharacterCodesWithCharacters(fieldValue);
+  }
+
+  return application;
+};
+
+export default mapNameFields;

--- a/src/ui/server/helpers/replace-character-codes-with-characters/index.test.ts
+++ b/src/ui/server/helpers/replace-character-codes-with-characters/index.test.ts
@@ -1,0 +1,59 @@
+import replaceCharacterCodesWithCharacters from '.';
+
+describe('server/helpers/replace-character-codes-with-characters', () => {
+  it('should replace `lower than` character codes', () => {
+    const result = replaceCharacterCodesWithCharacters('&lt;test&lt;');
+
+    const expected = '<test<';
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should replace `greater than` character codes', () => {
+    const result = replaceCharacterCodesWithCharacters('&gt;test&gt;');
+
+    const expected = '>test>';
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should replace quote character codes', () => {
+    const result = replaceCharacterCodesWithCharacters('&quot;test&quot;');
+
+    const expected = '"test"';
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should replace apostrophe character codes', () => {
+    const result = replaceCharacterCodesWithCharacters('&#x27;test&#x27;');
+
+    const expected = "'test'";
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should replace forward slash character codes', () => {
+    const result = replaceCharacterCodesWithCharacters('&#x2F;test&#x2F;');
+
+    const expected = '/test/';
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should replace star character codes', () => {
+    const result = replaceCharacterCodesWithCharacters('&#42;&#42;');
+
+    const expected = '**';
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should replace ampersand character codes', () => {
+    const result = replaceCharacterCodesWithCharacters('&amp;test&amp;');
+
+    const expected = '&test&';
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/ui/server/helpers/replace-character-codes-with-characters/index.test.ts
+++ b/src/ui/server/helpers/replace-character-codes-with-characters/index.test.ts
@@ -56,4 +56,12 @@ describe('server/helpers/replace-character-codes-with-characters', () => {
 
     expect(result).toEqual(expected);
   });
+
+  describe('when no value is passed', () => {
+    it('should return null', () => {
+      const result = replaceCharacterCodesWithCharacters();
+
+      expect(result).toEqual(null);
+    });
+  });
 });

--- a/src/ui/server/helpers/replace-character-codes-with-characters/index.ts
+++ b/src/ui/server/helpers/replace-character-codes-with-characters/index.ts
@@ -1,0 +1,17 @@
+/**
+ * replaceCharacterCodesWithCharacters
+ * Replace certain character codes with characters
+ * @param {String}
+ * @returns {String}
+ */
+const replaceCharacterCodesWithCharacters = (str: string): string =>
+  str
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/g, "'")
+    .replace(/&#x2F;/g, '/')
+    .replace(/&#42;/g, '*')
+    .replace(/&amp;/g, '&');
+
+export default replaceCharacterCodesWithCharacters;

--- a/src/ui/server/helpers/replace-character-codes-with-characters/index.ts
+++ b/src/ui/server/helpers/replace-character-codes-with-characters/index.ts
@@ -2,16 +2,21 @@
  * replaceCharacterCodesWithCharacters
  * Replace certain character codes with characters
  * @param {String}
- * @returns {String}
+ * @returns {String | null}
  */
-const replaceCharacterCodesWithCharacters = (str: string): string =>
-  str
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#x27;/g, "'")
-    .replace(/&#x2F;/g, '/')
-    .replace(/&#42;/g, '*')
-    .replace(/&amp;/g, '&');
+const replaceCharacterCodesWithCharacters = (str?: string): string | null => {
+  if (str && typeof str === 'string') {
+    return str
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;/g, "'")
+      .replace(/&#x2F;/g, '/')
+      .replace(/&#42;/g, '*')
+      .replace(/&amp;/g, '&');
+  }
+
+  return null;
+};
 
 export default replaceCharacterCodesWithCharacters;

--- a/src/ui/server/helpers/summary-lists/generate-summary-list-rows/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/generate-summary-list-rows/index.test.ts
@@ -1,6 +1,7 @@
 import generateSummaryListRows, { generateItemText } from '.';
 import getKeyText from '../get-key-text';
 import { LINKS } from '../../../content-strings';
+import replaceCharacterCodesWithCharacters from '../../replace-character-codes-with-characters';
 import { generateFields } from '../quote-summary-list';
 import mapQuoteToContent from '../../data-content-mappings/map-quote-to-content';
 import { mockQuote } from '../../../test-mocks';
@@ -60,7 +61,7 @@ describe('server/helpers/summary-lists/generate-summary-list-rows', () => {
         const mapped = {
           ...initObj,
           value: {
-            text: field.value,
+            text: replaceCharacterCodesWithCharacters(field.value),
             html: field.value,
             classes: `${field.id}-value`,
           },

--- a/src/ui/server/helpers/summary-lists/generate-summary-list-rows/index.ts
+++ b/src/ui/server/helpers/summary-lists/generate-summary-list-rows/index.ts
@@ -1,4 +1,5 @@
 import { LINKS } from '../../../content-strings';
+import replaceCharacterCodesWithCharacters from '../../replace-character-codes-with-characters';
 import { SummaryListItemData, SummaryListItem } from '../../../../types';
 
 /**
@@ -39,7 +40,7 @@ const generateSummaryListRows = (fields: Array<SummaryListItemData>, whiteText?:
         classes: `${field.id}-key govuk-!-width-one-half`,
       },
       value: {
-        text: field.value,
+        text: replaceCharacterCodesWithCharacters(field.value),
         html: field.value,
         classes: `${field.id}-value`,
       },


### PR DESCRIPTION
This PR fixes an issue where if a name field contained certain special characters and is saved in the DB - when revisiting the field in the UI, the special characters would render as character codes, instead of the originally submitted values/chracters. 

This was because before calling the API, we encode/sanitise some specific special characters.

## Changes
- Create new helper function in the UI: `replaceCharacterCodesWithCharacters`.
- Create a new mapping function, `mapNameFields`. This function calls `replaceCharacterCodesWithCharacters` on specific "name" fields.
- Update `mapApplicationToFormFields` mapping function  to call `mapNameFields`.
- Update `getUserNameFromSession` helper function to use `replaceCharacterCodesWithCharacters`. Meaning, the name displayed in the header of all pages, will display special characters correctly.
- Update all GET controllers that consume an application, to consume the application with `mapApplicationToFormFields` mappings instead of a raw application.
- Update `mapApplications` function to replace character codes for the `buyerName` field.
- Update `generateSummaryListRows` function to replace character codes for any row's value.
- Add E2E test coverage for entering and rendering name values with special characters, for the fields that specifically replace character codes with characters.

## Other improvements
- Update some cypress commands to accept object params:
  - `mapApplicationToFormFields`
  - `completeAndSubmitYourContact`
  - `completeAndSubmitCompanyOrOrganisationForm`
- Remove unnecessary UI unit test.
- Fixed a typo in an E2E fixture.