### PR TITLE
feat(EMS-1710): Account sign in - update OTP expiry time

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -399,6 +399,12 @@ var DATE_5_MINUTES_FROM_NOW = () => {
   const future = new Date(now.setMilliseconds(milliseconds));
   return future;
 };
+var DATE_30_MINUTES_FROM_NOW = () => {
+  const now = /* @__PURE__ */ new Date();
+  const minutes = 30;
+  const future = new Date(now.getTime() + minutes * 6e4);
+  return future;
+};
 var ACCOUNT2 = {
   EMAIL: {
     VERIFICATION_EXPIRY: () => {
@@ -430,7 +436,7 @@ var ACCOUNT2 = {
   // One time password
   OTP: {
     DIGITS: 6,
-    VERIFICATION_EXPIRY: DATE_5_MINUTES_FROM_NOW
+    VERIFICATION_EXPIRY: DATE_30_MINUTES_FROM_NOW
   },
   // JSON web token
   JWT: {

--- a/src/api/constants/index.ts
+++ b/src/api/constants/index.ts
@@ -33,6 +33,21 @@ const DATE_5_MINUTES_FROM_NOW = () => {
   return future;
 };
 
+/**
+ * DATE_30_MINUTES_FROM_NOW
+ * Generate a date that is 30 minutes from now
+ * @returns {Date}
+ */
+const DATE_30_MINUTES_FROM_NOW = () => {
+  const now = new Date();
+
+  const minutes = 30;
+
+  const future = new Date(now.getTime() + minutes * 60000);
+
+  return future;
+};
+
 export const ACCOUNT = {
   EMAIL: {
     VERIFICATION_EXPIRY: () => {
@@ -67,7 +82,7 @@ export const ACCOUNT = {
   // One time password
   OTP: {
     DIGITS: 6,
-    VERIFICATION_EXPIRY: DATE_5_MINUTES_FROM_NOW,
+    VERIFICATION_EXPIRY: DATE_30_MINUTES_FROM_NOW,
   },
   // JSON web token
   JWT: {

--- a/src/api/custom-resolvers/mutations/verify-account-sign-in-code.test.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-sign-in-code.test.ts
@@ -1,6 +1,5 @@
 import { getContext } from '@keystone-6/core/context';
 import dotenv from 'dotenv';
-import { subMinutes } from 'date-fns';
 import verifyAccountSignInCode from './verify-account-sign-in-code';
 import create from '../../helpers/create-jwt';
 import { ACCOUNT } from '../../constants';
@@ -184,15 +183,17 @@ describe('custom-resolvers/verify-account-sign-in-code', () => {
       })) as Account;
     });
 
+    const otp = generate.otp();
     test('it should return success=false and expired=true', async () => {
-      const otp = generate.otp();
-
       // add OTP to the account
       const { salt, hash } = otp;
 
-      const today = new Date();
+      const now = new Date();
 
-      const previousTime = subMinutes(today, 6);
+      // update the OTP expiry to be outside of the expiration time
+      const minutes = 31;
+
+      const previousTime = new Date(now.getTime() - minutes * 60000);
 
       // update the account
       const updateResponse = await context.db.Account.updateOne({

--- a/src/api/helpers/generate-otp/index.test.ts
+++ b/src/api/helpers/generate-otp/index.test.ts
@@ -53,8 +53,8 @@ describe('api/helpers/generate-otp', () => {
     // round up (slight millisecond difference in unit tests)
     const rounded = Math.ceil(secondsDifference);
 
-    // 5 minutes
-    const expectedSeconds = 60 * 5;
+    // 30 minutes
+    const expectedSeconds = 60 * 30;
 
     expect(rounded).toEqual(expectedSeconds);
   });


### PR DESCRIPTION
This PR extends the OTP expiration time. This is due to some user/accessibility issues where the OTP/security code would not arrive in an email inbox in time and therefore a user would not be able to sign in to their account.

## Changes

- Create `DATE_30_MINUTES_FROM_NOW` constant.
- Update `OTP.VERIFICATION_EXPIRY` constant.
- Update unit tests.