### PR TITLE
fix(EMS-1554): Page not found - Missing wording

### DIFF
--- a/e2e-tests/content-strings/pages/index.js
+++ b/e2e-tests/content-strings/pages/index.js
@@ -1,7 +1,7 @@
 import QUOTE_PAGES from './quote';
 import INSURANCE_PAGES from './insurance';
 import { LINKS } from '../links';
-import { CONTACT_DETAILS } from '../../constants';
+import { CONTACT_DETAILS, ROUTES } from '../../constants';
 import { CUSTOMER_SERVICE_CONTACT_DETAILS } from '../contact';
 
 const BUYER_COUNTRY = {
@@ -182,7 +182,8 @@ const PAGE_NOT_FOUND_PAGE = {
     TEXT: 'If the web address is correct or you selected a link or button, you can',
     LINK: {
       TEXT: 'contact us',
-      HREF: '#',
+      QUOTE_HREF: ROUTES.CONTACT_US,
+      INSURANCE_HREF: ROUTES.INSURANCE.CONTACT_US,
     },
     OUTRO: 'if you still need help.',
   },

--- a/e2e-tests/cypress/e2e/journeys/insurance/page-not-found.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/page-not-found.spec.js
@@ -1,4 +1,3 @@
-import { pageNotFoundPage } from '../../pages';
 import { PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 
@@ -30,22 +29,8 @@ context('Insurance - page not found', () => {
       cy.navigateToUrl(invalidUrl);
     });
 
-    it('renders `typed` and `pasted` text', () => {
-      cy.checkText(pageNotFoundPage.typedAddress(), CONTENT_STRINGS.TYPED_ADDRESS);
-
-      cy.checkText(pageNotFoundPage.pastedAddress(), CONTENT_STRINGS.PASTED_ADDRESS);
-    });
-
-    it('renders contact text and link', () => {
-      cy.checkText(pageNotFoundPage.contact1(), CONTENT_STRINGS.CONTACT.TEXT);
-
-      cy.checkText(pageNotFoundPage.contact2(), CONTENT_STRINGS.CONTACT.LINK.TEXT);
-
-      cy.checkText(pageNotFoundPage.contact3(), CONTENT_STRINGS.CONTACT.OUTRO);
-
-      cy.checkText(pageNotFoundPage.contactLink(), CONTENT_STRINGS.CONTACT.LINK.TEXT);
-
-      pageNotFoundPage.contactLink().should('have.attr', 'href', CONTENT_STRINGS.CONTACT.LINK.HREF);
+    it('renders `typed` and `pasted` text and contact text and link for insurance contact us', () => {
+      cy.checkPageNotFoundPageText({});
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/page-not-found.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/page-not-found.spec.js
@@ -1,4 +1,3 @@
-import { pageNotFoundPage } from '../pages';
 import partials from '../partials';
 import { PAGES, PRODUCT } from '../../../content-strings';
 
@@ -39,9 +38,7 @@ context('404 Page not found', () => {
     });
   });
 
-  it('renders `typed` and `pasted` text', () => {
-    cy.checkText(pageNotFoundPage.typedAddress(), CONTENT_STRINGS.TYPED_ADDRESS);
-
-    cy.checkText(pageNotFoundPage.pastedAddress(), CONTENT_STRINGS.PASTED_ADDRESS);
+  it('renders `typed` and `pasted` text and contact text and link for quote contact us', () => {
+    cy.checkPageNotFoundPageText({ isInsurancePage: false });
   });
 });

--- a/e2e-tests/cypress/support/check-page-not-found-page-text.js
+++ b/e2e-tests/cypress/support/check-page-not-found-page-text.js
@@ -1,0 +1,24 @@
+import { pageNotFoundPage } from '../e2e/pages';
+import { PAGES } from '../../content-strings';
+
+const CONTENT_STRINGS = PAGES.PAGE_NOT_FOUND_PAGE;
+
+const checkPageNotFoundPageText = ({ isInsurancePage = true }) => {
+  cy.checkText(pageNotFoundPage.typedAddress(), CONTENT_STRINGS.TYPED_ADDRESS);
+
+  cy.checkText(pageNotFoundPage.pastedAddress(), CONTENT_STRINGS.PASTED_ADDRESS);
+
+  cy.checkText(pageNotFoundPage.contact1(), CONTENT_STRINGS.CONTACT.TEXT);
+
+  cy.checkText(pageNotFoundPage.contact2(), CONTENT_STRINGS.CONTACT.LINK.TEXT);
+
+  cy.checkText(pageNotFoundPage.contact3(), CONTENT_STRINGS.CONTACT.OUTRO);
+
+  if (isInsurancePage) {
+    cy.checkLink(pageNotFoundPage.contactLink(), CONTENT_STRINGS.CONTACT.LINK.INSURANCE_HREF, CONTENT_STRINGS.CONTACT.LINK.TEXT);
+  } else {
+    cy.checkLink(pageNotFoundPage.contactLink(), CONTENT_STRINGS.CONTACT.LINK.QUOTE_HREF, CONTENT_STRINGS.CONTACT.LINK.TEXT);
+  }
+};
+
+export default checkPageNotFoundPageText;

--- a/e2e-tests/cypress/support/check-page-not-found-page-text.js
+++ b/e2e-tests/cypress/support/check-page-not-found-page-text.js
@@ -3,6 +3,12 @@ import { PAGES } from '../../content-strings';
 
 const CONTENT_STRINGS = PAGES.PAGE_NOT_FOUND_PAGE;
 
+/**
+ * checkPageNotFoundPageText
+ * checks the text and links on page not found page
+ * if insurance page, checks that href points to insurance contact us
+ * @param {Object} params isInsurancePage
+ */
 const checkPageNotFoundPageText = ({ isInsurancePage = true }) => {
   cy.checkText(pageNotFoundPage.typedAddress(), CONTENT_STRINGS.TYPED_ADDRESS);
 

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -35,6 +35,8 @@ Cypress.Commands.add('checkCookiesConsentBannerIsNotVisible', analytics.checkCoo
 Cypress.Commands.add('checkCookiesConsentBannerIsVisible', analytics.checkCookiesConsentBannerIsVisible);
 Cypress.Commands.add('checkCookiesConsentBannerDoesNotExist', analytics.checkCookiesConsentBannerDoesNotExist);
 
+Cypress.Commands.add('checkPageNotFoundPageText', require('./check-page-not-found-page-text'));
+
 Cypress.Commands.add('checkHeaderServiceNameAndHref', require('./check-header-service-name-href'));
 Cypress.Commands.add('checkFooterLinks', require('./check-footer-links'));
 

--- a/src/ui/server/content-strings/pages/index.ts
+++ b/src/ui/server/content-strings/pages/index.ts
@@ -1,7 +1,7 @@
 import INSURANCE_PAGES from './insurance';
 import QUOTE_PAGES from './quote';
 import { LINKS } from '../links';
-import { CONTACT_DETAILS } from '../../constants';
+import { CONTACT_DETAILS, ROUTES } from '../../constants';
 import { CUSTOMER_SERVICE_CONTACT_DETAILS } from '../contact';
 
 const BUYER_COUNTRY = {
@@ -183,7 +183,8 @@ const PAGE_NOT_FOUND_PAGE = {
     TEXT: 'If the web address is correct or you selected a link or button, you can',
     LINK: {
       TEXT: 'contact us',
-      HREF: '#',
+      QUOTE_HREF: ROUTES.CONTACT_US,
+      INSURANCE_HREF: ROUTES.INSURANCE.CONTACT_US,
     },
     OUTRO: 'if you still need help.',
   },

--- a/src/ui/templates/insurance/page-not-found.njk
+++ b/src/ui/templates/insurance/page-not-found.njk
@@ -12,7 +12,7 @@
   <p class="govuk-body" data-cy="pasted-address">{{ CONTENT_STRINGS.PASTED_ADDRESS }}</p>
 
   {% set contactLinkHtml %}
-    <a class="govuk-link govuk-link--no-visited-state" href="{{ CONTENT_STRINGS.CONTACT.LINK.HREF }}" data-cy="contact-link">{{ CONTENT_STRINGS.CONTACT.LINK.TEXT }}</a>
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ CONTENT_STRINGS.CONTACT.LINK.INSURANCE_HREF }}" data-cy="contact-link">{{ CONTENT_STRINGS.CONTACT.LINK.TEXT }}</a>
   {% endset %}
 
   <div class="govuk-grid-row">

--- a/src/ui/templates/page-not-found.njk
+++ b/src/ui/templates/page-not-found.njk
@@ -11,4 +11,9 @@
   <p class="govuk-body" data-cy="typed-address">{{ CONTENT_STRINGS.TYPED_ADDRESS }}</p>
   <p class="govuk-body" data-cy="pasted-address">{{ CONTENT_STRINGS.PASTED_ADDRESS }}</p>
 
+  {% set contactLinkHtml %}
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ CONTENT_STRINGS.CONTACT.LINK.QUOTE_HREF }}" data-cy="contact-link">{{ CONTENT_STRINGS.CONTACT.LINK.TEXT }}</a>
+  {% endset %}
+
+  <span data-cy="contact-1">{{ CONTENT_STRINGS.CONTACT.TEXT }}</span> <span data-cy="contact-2">{{ contactLinkHtml | safe }}</span> <span data-cy="contact-3">{{ CONTENT_STRINGS.CONTACT.OUTRO }}</span>
 {% endblock %}


### PR DESCRIPTION
# Issue:
* Page not found page for quote/root had missing contact us text

# Changes made:
* Added to PAGE_CONTENT_STRINGS so there is a HREF for quote and insurance
* Added missing text to page not found
* Refactored tests with shared function