### PR TITLE
feat(EMS-1689): Application submission - XLSX - add exporter contact details

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/account-password-reset.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/account-password-reset.spec.js
@@ -28,6 +28,8 @@ context('Insurance - Account - Password reset page - As an Exporter, I want to r
   let url;
 
   before(() => {
+    cy.deleteAccount();
+
     cy.completeAndSubmitCreateAccountForm({ navigateToAccountCreationPage: true });
 
     // go back to create account page

--- a/e2e-tests/cypress/e2e/journeys/insurance/application-submission/submit-an-application-single-policy-type-different-contact-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/application-submission/submit-an-application-single-policy-type-different-contact-details.spec.js
@@ -1,0 +1,38 @@
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+
+const {
+  ROOT: INSURANCE_ROOT,
+  APPLICATION_SUBMITTED,
+} = INSURANCE_ROUTES;
+
+context('Insurance - submit an application with different contact details in the `your business - contact details` form', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.createAccount({});
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.completeSignInAndSubmitAnApplication({
+      exporterHasTradedWithBuyer: false,
+      hasAntiBriberyCodeOfConduct: false,
+      exportingWithCodeOfConduct: false,
+      useDifferentContactEmail: true,
+    }).then((refNumber) => {
+      referenceNumber = refNumber;
+    });
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  it(`should successfully submit the application and redirect to ${APPLICATION_SUBMITTED}`, () => {
+    url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${APPLICATION_SUBMITTED}`;
+
+    cy.url().should('eq', url);
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-and-exports-multiple-policy-type.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-and-exports-multiple-policy-type.spec.js
@@ -59,7 +59,7 @@ context('Insurance - Change your answers - Policy and exports - multiple contrac
   before(() => {
     cy.completeSignInAndGoToApplication().then((refNumber) => {
       referenceNumber = refNumber;
-      cy.completePrepareApplicationMultiplePolicyType();
+      cy.completePrepareApplicationMultiplePolicyType({});
 
       task.link().click();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-type-change-multiple-to-single-policy-type-summary-list.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-type-change-multiple-to-single-policy-type-summary-list.spec.js
@@ -49,7 +49,7 @@ context('Insurance - Change your answers - Policy and exports - Change multiple 
   before(() => {
     cy.completeSignInAndGoToApplication().then((refNumber) => {
       referenceNumber = refNumber;
-      cy.completePrepareApplicationMultiplePolicyType();
+      cy.completePrepareApplicationMultiplePolicyType({});
 
       task.link().click();
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/policy-and-exports/summary-list/check-your-answers-policy-and-exports-multiple-summary-list.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/policy-and-exports/summary-list/check-your-answers-policy-and-exports-multiple-summary-list.spec.js
@@ -39,7 +39,7 @@ context('Insurance - Check your answers - Policy and exports - Multiple contract
   before(() => {
     cy.completeSignInAndGoToApplication().then((refNumber) => {
       referenceNumber = refNumber;
-      cy.completePrepareApplicationMultiplePolicyType();
+      cy.completePrepareApplicationMultiplePolicyType({});
 
       task.link().click();
 

--- a/e2e-tests/cypress/support/insurance/complete-and-submit-your-contact-form.js
+++ b/e2e-tests/cypress/support/insurance/complete-and-submit-your-contact-form.js
@@ -20,13 +20,30 @@ const {
 
 const businessContactDetails = application.EXPORTER_BUSINESS[BUSINESS_CONTACT_DETAIL];
 
+/**
+ * completeAndSubmitYourContact
+ * Runs through the exporter contact details form in the "your business" section
+ * @param {Object} Object with flags on how to complete specific parts of the application
+ * firstName: First name to submit in the form, defaults to test data.
+ * lastName: Last name to submit in the form, defaults to test data.
+ * - useDifferentContactEmail: Should submit a different email address in the "exporter contact" details form.
+ */
 const completeAndSubmitYourContact = ({
   firstName = businessContactDetails[FIRST_NAME],
   lastName = businessContactDetails[LAST_NAME],
+  useDifferentContactEmail = false,
 }) => {
   cy.keyboardInput(yourContactPage.field(FIRST_NAME).input(), firstName);
   cy.keyboardInput(yourContactPage.field(LAST_NAME).input(), lastName);
-  cy.keyboardInput(yourContactPage.field(EMAIL).input(), businessContactDetails[EMAIL]);
+
+  let email = businessContactDetails[EMAIL];
+
+  if (useDifferentContactEmail) {
+    email = Cypress.env('GOV_NOTIFY_EMAIL_RECIPIENT_2');
+  }
+
+  cy.keyboardInput(yourContactPage.field(EMAIL).input(), email);
+
   cy.keyboardInput(yourContactPage.field(POSITION).input(), businessContactDetails[POSITION]);
 
   submitButton().click();

--- a/e2e-tests/cypress/support/insurance/complete-prepare-your-application-section-multiple.js
+++ b/e2e-tests/cypress/support/insurance/complete-prepare-your-application-section-multiple.js
@@ -7,12 +7,12 @@ const { taskList } = partials.insurancePartials;
 const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
 /**
- * completePrepareYourApplicationSectionMultiple
+ * completePrepareApplicationMultiplePolicyType
  * Runs through the full prepare your application journey for multiple policy type
  * @param {Object} Object with flags on how to complete specific parts of the application
  * - useDifferentContactEmail: Should submit a different email address in the "exporter contact" details form.
  */
-const completePrepareYourApplicationSectionMultiple = ({ useDifferentContactEmail }) => {
+const completePrepareApplicationMultiplePolicyType = ({ useDifferentContactEmail }) => {
   task.link().click();
 
   cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
@@ -35,4 +35,4 @@ const completePrepareYourApplicationSectionMultiple = ({ useDifferentContactEmai
   submitButton().click();
 };
 
-export default completePrepareYourApplicationSectionMultiple;
+export default completePrepareApplicationMultiplePolicyType;

--- a/e2e-tests/cypress/support/insurance/complete-prepare-your-application-section-multiple.js
+++ b/e2e-tests/cypress/support/insurance/complete-prepare-your-application-section-multiple.js
@@ -6,8 +6,13 @@ const { taskList } = partials.insurancePartials;
 
 const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
-// runs through the full prepare your application journey for multiple policy type
-export default () => {
+/**
+ * completePrepareYourApplicationSectionMultiple
+ * Runs through the full prepare your application journey for multiple policy type
+ * @param {Object} Object with flags on how to complete specific parts of the application
+ * - useDifferentContactEmail: Should submit a different email address in the "exporter contact" details form.
+ */
+const completePrepareYourApplicationSectionMultiple = ({ useDifferentContactEmail }) => {
   task.link().click();
 
   cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
@@ -17,7 +22,7 @@ export default () => {
   submitButton().click();
 
   cy.completeAndSubmitCompanyDetails();
-  cy.completeAndSubmitYourContact({});
+  cy.completeAndSubmitYourContact({ useDifferentContactEmail });
   cy.completeAndSubmitNatureOfYourBusiness();
   cy.completeAndSubmitTurnoverForm();
   cy.completeAndSubmitBrokerForm({});
@@ -29,3 +34,5 @@ export default () => {
 
   submitButton().click();
 };
+
+export default completePrepareYourApplicationSectionMultiple;

--- a/e2e-tests/cypress/support/insurance/complete-prepare-your-application-section-single.js
+++ b/e2e-tests/cypress/support/insurance/complete-prepare-your-application-section-single.js
@@ -7,12 +7,14 @@ const { taskList } = partials.insurancePartials;
 const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
 /**
- * completePrepareApplicationSinglePolicyType
+ * completePrepareYourApplicationSectionSingle
  * Runs through the full prepare your application journey for a single policy type
  * @param {Object} Object with flags on how to complete specific parts of the application
  * - exporterHasTradedWithBuyer: Should submit "yes" to "have traded with buyer before" in the "working with buyer" form. Defaults to "yes".
+ * - usingBroker: Should submit "yes" or "no" to "using a broker". Defaults to "no".
+ * - useDifferentContactEmail: Should submit a different email address in the "exporter contact" details form.
  */
-export default ({ exporterHasTradedWithBuyer, usingBroker }) => {
+const completePrepareYourApplicationSectionSingle = ({ exporterHasTradedWithBuyer, usingBroker, useDifferentContactEmail }) => {
   task.link().click();
 
   cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
@@ -22,7 +24,7 @@ export default ({ exporterHasTradedWithBuyer, usingBroker }) => {
   submitButton().click();
 
   cy.completeAndSubmitCompanyDetails();
-  cy.completeAndSubmitYourContact({});
+  cy.completeAndSubmitYourContact({ useDifferentContactEmail });
   cy.completeAndSubmitNatureOfYourBusiness();
   cy.completeAndSubmitTurnoverForm();
   cy.completeAndSubmitBrokerForm({ usingBroker });
@@ -34,3 +36,5 @@ export default ({ exporterHasTradedWithBuyer, usingBroker }) => {
 
   submitButton().click();
 };
+
+export default completePrepareYourApplicationSectionSingle;

--- a/e2e-tests/cypress/support/insurance/complete-sign-in-and-submit-an-application.js
+++ b/e2e-tests/cypress/support/insurance/complete-sign-in-and-submit-an-application.js
@@ -8,6 +8,8 @@ import completeSignInAndGoToApplication from './account/complete-sign-in-and-go-
  * 3) Complete and submit all declarations forms
  * 4) Get and return the application reference number from the URL for consumption in the tests
  * @param {Object} Object with flags on how to complete specific parts of the application
+ * - policyType: Type of policy. Defaults to "single"
+ * - useDifferentContactEmail: Should submit a different email address in the "exporter contact" details form.
  * - exporterHasTradedWithBuyer: Should submit "yes" to "have traded with buyer before" in the "working with buyer" form. Defaults to "yes".
  * - hasAntiBriberyCodeOfConduct: Should submit "yes" in the "have a code of conduct" form. Defaults to "yes".
  * - exportingWithCodeOfConduct: Should submit "yes" in the "exporting with code of conduct" form. Defaults to "yes".
@@ -15,6 +17,7 @@ import completeSignInAndGoToApplication from './account/complete-sign-in-and-go-
  */
 const completeSignInAndSubmitAnApplication = ({
   policyType = APPLICATION.POLICY_TYPE.SINGLE,
+  useDifferentContactEmail,
   exporterHasTradedWithBuyer,
   hasAntiBriberyCodeOfConduct,
   exportingWithCodeOfConduct,
@@ -22,9 +25,9 @@ const completeSignInAndSubmitAnApplication = ({
   completeSignInAndGoToApplication();
 
   if (policyType === APPLICATION.POLICY_TYPE.MULTIPLE) {
-    cy.completePrepareApplicationMultiplePolicyType({ exporterHasTradedWithBuyer });
+    cy.completePrepareApplicationMultiplePolicyType({ exporterHasTradedWithBuyer, useDifferentContactEmail });
   } else {
-    cy.completePrepareApplicationSinglePolicyType({ exporterHasTradedWithBuyer });
+    cy.completePrepareApplicationSinglePolicyType({ exporterHasTradedWithBuyer, useDifferentContactEmail });
   }
 
   cy.completeAndSubmitCheckYourAnswers();

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -325,11 +325,25 @@ var {
     BROKER: { USING_BROKER }
   }
 } = insurance_default;
-var TITLE_ROW_INDEXES = (application2) => {
-  if (!application2) {
-    return {};
-  }
+var XLSX_ROW_INDEXES = (application2) => {
   const { policyAndExport, broker } = application2;
+  const TITLES = {
+    HEADER: 1,
+    EXPORTER_CONTACT_DETAILS: 9,
+    KEY_INFORMATION: 14,
+    POLICY_AND_EXPORT: 20,
+    EXPORTER_BUSINESS: 30,
+    BUYER: 49,
+    ELIGIBILITY: 59
+  };
+  const INDEXES = {
+    TITLES,
+    COMPANY_ADDRESS: 34,
+    COMPANY_SIC_CODES: 37,
+    BROKER_ADDRESS: 45,
+    BUYER_ADDRESS: 50,
+    BUYER_CONTACT_DETAILS: 53
+  };
   const policyType = policyAndExport[POLICY_TYPE2];
   let isMultiplePolicy = false;
   let isUsingBroker = false;
@@ -339,28 +353,23 @@ var TITLE_ROW_INDEXES = (application2) => {
   if (broker[USING_BROKER] === ANSWERS.YES) {
     isUsingBroker = true;
   }
-  let EXPORTER_BUSINESS3 = 25;
-  let BUYER = 44;
-  let ELIGIBILITY = 54;
   if (isMultiplePolicy) {
-    EXPORTER_BUSINESS3 += 1;
-    BUYER += 1;
-    ELIGIBILITY += 1;
+    TITLES.EXPORTER_BUSINESS += 1;
+    TITLES.BUYER += 1;
+    TITLES.ELIGIBILITY += 1;
+    INDEXES.COMPANY_ADDRESS += 1;
+    INDEXES.COMPANY_SIC_CODES += 1;
+    INDEXES.BROKER_ADDRESS += 1;
+    INDEXES.BUYER_ADDRESS += 1;
+    INDEXES.BUYER_CONTACT_DETAILS += 1;
   }
   if (isUsingBroker) {
-    BUYER += 3;
-    ELIGIBILITY += 3;
+    TITLES.BUYER += 3;
+    TITLES.ELIGIBILITY += 3;
   }
-  return {
-    HEADER: 1,
-    KEY_INFORMATION: 9,
-    POLICY_AND_EXPORT: 15,
-    EXPORTER_BUSINESS: EXPORTER_BUSINESS3,
-    BUYER,
-    ELIGIBILITY
-  };
+  return INDEXES;
 };
-var XLSX_CONFIG = (application2) => ({
+var XLSX_CONFIG = {
   KEY: {
     ID: "field",
     COPY: "Field"
@@ -376,16 +385,8 @@ var XLSX_CONFIG = (application2) => ({
   FONT_SIZE: {
     DEFAULT: 11,
     TITLE: 14
-  },
-  ROW_INDEXES: {
-    COMPANY_ADDRESS: 30,
-    COMPANY_SIC_CODES: 33,
-    BROKER_ADDRESS: 45,
-    BUYER_ADDRESS: 50,
-    BUYER_CONTACT_DETAILS: 53
-  },
-  TITLE_ROW_INDEXES: TITLE_ROW_INDEXES(application2)
-});
+  }
+};
 
 // constants/index.ts
 import_dotenv.default.config();
@@ -3158,7 +3159,7 @@ var replaceCharacterCodesWithCharacters = (str) => str.replace(/&lt;/g, "<").rep
 var replace_character_codes_with_characters_default = replaceCharacterCodesWithCharacters;
 
 // generate-xlsx/map-application-to-XLSX/helpers/xlsx-row/index.ts
-var { KEY, VALUE } = XLSX_CONFIG();
+var { KEY, VALUE } = XLSX_CONFIG;
 var xlsxRow = (fieldName, answer) => {
   const value = answer || answer === 0 ? answer : "";
   const cleanValue = replace_character_codes_with_characters_default(String(value));
@@ -3530,6 +3531,7 @@ var {
 var XLSX = {
   SECTION_TITLES: {
     KEY_INFORMATION: "Key information",
+    EXPORTER_CONTACT_DETAILS: "Exporter contact details",
     POLICY_AND_EXPORT: "Type of policy and exports",
     EXPORTER_BUSINESS: "About your business",
     BUYER: "Your buyer",
@@ -3539,6 +3541,11 @@ var XLSX = {
     [FIRST_NAME]: "Applicant first name",
     [LAST_NAME]: "Applicant last name",
     APPLICANT_EMAIL_ADDRESS: "Applicant email address",
+    EXPORTER_CONTACT: {
+      [FIRST_NAME]: "Exporter first name",
+      [LAST_NAME]: "Exporter last name",
+      EXPORTER_CONTACT_EMAIL: "Exporter email address"
+    },
     [CONTRACT_COMPLETION_DATE]: "Date expected for contract to complete",
     [EXPORTER_COMPANY_NAME]: "Exporter company name",
     [EXPORTER_COMPANY_ADDRESS]: "Exporter registered office address",
@@ -3581,10 +3588,32 @@ var mapKeyInformation = (application2) => {
 };
 var map_key_information_default = mapKeyInformation;
 
+// generate-xlsx/map-application-to-XLSX/map-exporter-contact-details/index.ts
+var {
+  ACCOUNT: { FIRST_NAME: FIRST_NAME3, LAST_NAME: LAST_NAME3, EMAIL: EMAIL5 }
+} = insurance_default;
+var {
+  SECTION_TITLES: { EXPORTER_CONTACT_DETAILS },
+  FIELDS: FIELDS3
+} = XLSX;
+var mapExporterContactDetails = (application2) => {
+  const {
+    business: { businessContactDetail }
+  } = application2;
+  const mapped = [
+    xlsx_row_default(EXPORTER_CONTACT_DETAILS),
+    xlsx_row_default(FIELDS3.EXPORTER_CONTACT[FIRST_NAME3], businessContactDetail[FIRST_NAME3]),
+    xlsx_row_default(FIELDS3.EXPORTER_CONTACT[LAST_NAME3], businessContactDetail[LAST_NAME3]),
+    xlsx_row_default(FIELDS3.EXPORTER_CONTACT.EXPORTER_CONTACT_EMAIL, businessContactDetail[EMAIL5])
+  ];
+  return mapped;
+};
+var map_exporter_contact_details_default = mapExporterContactDetails;
+
 // generate-xlsx/map-application-to-XLSX/map-secondary-key-information/index.ts
 var {
   SECTION_TITLES: { KEY_INFORMATION },
-  FIELDS: FIELDS3
+  FIELDS: FIELDS4
 } = XLSX;
 var CONTENT_STRINGS = {
   ...POLICY_AND_EXPORTS_FIELDS
@@ -3604,9 +3633,9 @@ var mapSecondaryKeyInformation = (application2) => {
   const { policyAndExport } = application2;
   const mapped = [
     xlsx_row_default(KEY_INFORMATION),
-    xlsx_row_default(FIELDS3[EXPORTER_COMPANY_NAME2], application2.company[EXPORTER_COMPANY_NAME2]),
-    xlsx_row_default(FIELDS3[COUNTRY2], application2.buyer[COUNTRY2].name),
-    xlsx_row_default(FIELDS3[BUYER_COMPANY_NAME2], application2.buyer[BUYER_COMPANY_NAME2]),
+    xlsx_row_default(FIELDS4[EXPORTER_COMPANY_NAME2], application2.company[EXPORTER_COMPANY_NAME2]),
+    xlsx_row_default(FIELDS4[COUNTRY2], application2.buyer[COUNTRY2].name),
+    xlsx_row_default(FIELDS4[BUYER_COMPANY_NAME2], application2.buyer[BUYER_COMPANY_NAME2]),
     xlsx_row_default(String(CONTENT_STRINGS[POLICY_TYPE3].SUMMARY?.TITLE), policyAndExport[POLICY_TYPE3])
   ];
   return mapped;
@@ -3724,7 +3753,7 @@ var {
   YOUR_COMPANY: { TRADING_NAME: TRADING_NAME2, TRADING_ADDRESS: TRADING_ADDRESS2, WEBSITE: WEBSITE3, PHONE_NUMBER: PHONE_NUMBER3 },
   NATURE_OF_YOUR_BUSINESS: { GOODS_OR_SERVICES: GOODS_OR_SERVICES3, YEARS_EXPORTING: YEARS_EXPORTING3, EMPLOYEES_UK: EMPLOYEES_UK3, EMPLOYEES_INTERNATIONAL: EMPLOYEES_INTERNATIONAL3 },
   TURNOVER: { ESTIMATED_ANNUAL_TURNOVER: ESTIMATED_ANNUAL_TURNOVER3, PERCENTAGE_TURNOVER: PERCENTAGE_TURNOVER2 },
-  BROKER: { USING_BROKER: USING_BROKER4, NAME: BROKER_NAME2, ADDRESS_LINE_1: ADDRESS_LINE_12, ADDRESS_LINE_2, TOWN, COUNTY, POSTCODE, EMAIL: EMAIL5 }
+  BROKER: { USING_BROKER: USING_BROKER4, NAME: BROKER_NAME2, ADDRESS_LINE_1: ADDRESS_LINE_12, ADDRESS_LINE_2, TOWN, COUNTY, POSTCODE, EMAIL: EMAIL6 }
 } = business_default;
 var mapSicCodes2 = (sicCodes) => {
   let mapped = "";
@@ -3746,7 +3775,7 @@ var mapBroker = (application2) => {
       ...mapped,
       xlsx_row_default(XLSX.FIELDS[BROKER_NAME2], broker[BROKER_NAME2]),
       xlsx_row_default(XLSX.FIELDS[ADDRESS_LINE_12], `${addressAnswer.lineOneAndTwo}${addressAnswer.other}`),
-      xlsx_row_default(XLSX.FIELDS[EMAIL5], broker[EMAIL5])
+      xlsx_row_default(XLSX.FIELDS[EMAIL6], broker[EMAIL6])
     ];
   }
   return mapped;
@@ -3786,7 +3815,7 @@ var CONTENT_STRINGS4 = {
   ...YOUR_BUYER_FIELDS.WORKING_WITH_BUYER
 };
 var {
-  COMPANY_OR_ORGANISATION: { NAME: NAME2, ADDRESS, COUNTRY: COUNTRY3, REGISTRATION_NUMBER, WEBSITE: WEBSITE4, FIRST_NAME: FIRST_NAME3, LAST_NAME: LAST_NAME3, POSITION, EMAIL: EMAIL6, CAN_CONTACT_BUYER },
+  COMPANY_OR_ORGANISATION: { NAME: NAME2, ADDRESS, COUNTRY: COUNTRY3, REGISTRATION_NUMBER, WEBSITE: WEBSITE4, FIRST_NAME: FIRST_NAME4, LAST_NAME: LAST_NAME4, POSITION, EMAIL: EMAIL7, CAN_CONTACT_BUYER },
   WORKING_WITH_BUYER: { CONNECTED_WITH_BUYER, TRADED_WITH_BUYER }
 } = your_buyer_default;
 var mapBuyer = (application2) => {
@@ -3797,7 +3826,7 @@ var mapBuyer = (application2) => {
     xlsx_row_default(String(CONTENT_STRINGS4[ADDRESS].SUMMARY?.TITLE), `${buyer[ADDRESS]} ${xlsx_new_line_default}${buyer[COUNTRY3].name}`),
     xlsx_row_default(XLSX.FIELDS[REGISTRATION_NUMBER], buyer[REGISTRATION_NUMBER]),
     xlsx_row_default(String(CONTENT_STRINGS4[WEBSITE4].SUMMARY?.TITLE), buyer[WEBSITE4]),
-    xlsx_row_default(XLSX.FIELDS[FIRST_NAME3], `${buyer[FIRST_NAME3]} ${buyer[LAST_NAME3]} ${xlsx_new_line_default}${buyer[POSITION]} ${xlsx_new_line_default}${buyer[EMAIL6]}`),
+    xlsx_row_default(XLSX.FIELDS[FIRST_NAME4], `${buyer[FIRST_NAME4]} ${buyer[LAST_NAME4]} ${xlsx_new_line_default}${buyer[POSITION]} ${xlsx_new_line_default}${buyer[EMAIL7]}`),
     xlsx_row_default(String(CONTENT_STRINGS4[CAN_CONTACT_BUYER].SUMMARY?.TITLE), buyer[CAN_CONTACT_BUYER]),
     xlsx_row_default(String(CONTENT_STRINGS4[CONNECTED_WITH_BUYER].SUMMARY?.TITLE), buyer[CONNECTED_WITH_BUYER]),
     xlsx_row_default(String(CONTENT_STRINGS4[TRADED_WITH_BUYER].SUMMARY?.TITLE), buyer[TRADED_WITH_BUYER])
@@ -3854,6 +3883,8 @@ var mapApplicationToXLSX = (application2) => {
     const mapped = [
       ...map_key_information_default(application2),
       xlsx_row_seperator_default,
+      ...map_exporter_contact_details_default(application2),
+      xlsx_row_seperator_default,
       ...map_secondary_key_information_default(application2),
       xlsx_row_seperator_default,
       ...map_policy_and_export_default(application2),
@@ -3873,7 +3904,7 @@ var mapApplicationToXLSX = (application2) => {
 var map_application_to_XLSX_default = mapApplicationToXLSX;
 
 // generate-xlsx/header-columns/index.ts
-var { KEY: KEY2, VALUE: VALUE2, COLUMN_WIDTH } = XLSX_CONFIG();
+var { KEY: KEY2, VALUE: VALUE2, COLUMN_WIDTH } = XLSX_CONFIG;
 var XLSX_HEADER_COLUMNS = [
   { key: KEY2.ID, header: KEY2.COPY, width: COLUMN_WIDTH },
   { key: VALUE2.ID, header: VALUE2.COPY, width: COLUMN_WIDTH }
@@ -3881,22 +3912,23 @@ var XLSX_HEADER_COLUMNS = [
 var header_columns_default = XLSX_HEADER_COLUMNS;
 
 // generate-xlsx/styled-columns/index.ts
-var { ADDITIONAL_COLUMN_HEIGHT, LARGE_ADDITIONAL_COLUMN_HEIGHT, ADDITIONAL_TITLE_COLUMN_HEIGHT, ROW_INDEXES, FONT_SIZE } = XLSX_CONFIG();
-var worksheetRowHeights = (titleRowIndexes, worksheet) => {
+var { LARGE_ADDITIONAL_COLUMN_HEIGHT, ADDITIONAL_TITLE_COLUMN_HEIGHT, FONT_SIZE } = XLSX_CONFIG;
+var worksheetRowHeights = (titleRowIndexes, rowIndexes, worksheet) => {
   const modifiedWorksheet = worksheet;
-  modifiedWorksheet.getRow(ROW_INDEXES.COMPANY_ADDRESS).height = LARGE_ADDITIONAL_COLUMN_HEIGHT;
-  modifiedWorksheet.getRow(ROW_INDEXES.COMPANY_SIC_CODES).height = ADDITIONAL_COLUMN_HEIGHT;
-  modifiedWorksheet.getRow(ROW_INDEXES.BROKER_ADDRESS).height = LARGE_ADDITIONAL_COLUMN_HEIGHT;
-  modifiedWorksheet.getRow(ROW_INDEXES.BUYER_ADDRESS).height = LARGE_ADDITIONAL_COLUMN_HEIGHT;
-  modifiedWorksheet.getRow(ROW_INDEXES.BUYER_CONTACT_DETAILS).height = LARGE_ADDITIONAL_COLUMN_HEIGHT;
-  Object.values(titleRowIndexes).forEach((rowIndex) => {
+  titleRowIndexes.forEach((rowIndex) => {
     modifiedWorksheet.getRow(rowIndex).height = ADDITIONAL_TITLE_COLUMN_HEIGHT;
+  });
+  rowIndexes.forEach((rowIndex) => {
+    modifiedWorksheet.getRow(rowIndex).height = LARGE_ADDITIONAL_COLUMN_HEIGHT;
   });
   return modifiedWorksheet;
 };
 var styledColumns = (application2, worksheet) => {
   let modifiedWorksheet = worksheet;
-  const TITLE_INDEXES = Object.values(XLSX_CONFIG(application2).TITLE_ROW_INDEXES);
+  const INDEXES = XLSX_ROW_INDEXES(application2);
+  const { TITLES, ...ROWS } = INDEXES;
+  const TITLE_INDEXES = Object.values(TITLES);
+  const ROW_INDEXES = Object.values(ROWS);
   modifiedWorksheet.eachRow((row, rowNumber) => {
     row.eachCell((cell, colNumber) => {
       const modifiedRow = row;
@@ -3911,7 +3943,7 @@ var styledColumns = (application2, worksheet) => {
       };
     });
   });
-  modifiedWorksheet = worksheetRowHeights(TITLE_INDEXES, modifiedWorksheet);
+  modifiedWorksheet = worksheetRowHeights(TITLE_INDEXES, ROW_INDEXES, modifiedWorksheet);
   return modifiedWorksheet;
 };
 var styled_columns_default = styledColumns;

--- a/src/api/constants/XLSX-CONFIG/index.test.ts
+++ b/src/api/constants/XLSX-CONFIG/index.test.ts
@@ -1,4 +1,4 @@
-import { XLSX_CONFIG, TITLE_ROW_INDEXES } from '.';
+import { XLSX_CONFIG, XLSX_ROW_INDEXES } from '.';
 import FIELD_IDS from '../field-ids/insurance';
 import { APPLICATION } from '../application';
 import { ANSWERS } from '../answers';
@@ -16,7 +16,7 @@ const {
 describe('api/constants/XLSX-CONFIG', () => {
   describe('XLSX_CONFIG', () => {
     it('should return a config for XLSX', () => {
-      const result = XLSX_CONFIG();
+      const result = XLSX_CONFIG;
 
       const expected = {
         KEY: {
@@ -35,39 +35,13 @@ describe('api/constants/XLSX-CONFIG', () => {
           DEFAULT: 11,
           TITLE: 14,
         },
-        ROW_INDEXES: {
-          COMPANY_ADDRESS: 30,
-          COMPANY_SIC_CODES: 33,
-          BROKER_ADDRESS: 45,
-          BUYER_ADDRESS: 50,
-          BUYER_CONTACT_DETAILS: 53,
-        },
-        TITLE_ROW_INDEXES: TITLE_ROW_INDEXES(),
       };
 
       expect(result).toEqual(expected);
     });
-
-    describe('when an application is passed', () => {
-      it('should return TITLE_ROW_INDEXES with the application', () => {
-        const result = XLSX_CONFIG(mockApplication);
-
-        const expected = TITLE_ROW_INDEXES(mockApplication);
-
-        expect(result.TITLE_ROW_INDEXES).toEqual(expected);
-      });
-    });
   });
 
-  describe('TITLE_ROW_INDEXES', () => {
-    describe('when no application is passed', () => {
-      it('should return an empty object', () => {
-        const result = TITLE_ROW_INDEXES();
-
-        expect(result).toEqual({});
-      });
-    });
-
+  describe('XLSX_ROW_INDEXES', () => {
     describe(APPLICATION.POLICY_TYPE.SINGLE, () => {
       const application = {
         ...mockApplication,
@@ -84,15 +58,23 @@ describe('api/constants/XLSX-CONFIG', () => {
             [USING_BROKER]: ANSWERS.YES,
           };
 
-          const result = TITLE_ROW_INDEXES(application);
+          const result = XLSX_ROW_INDEXES(application);
 
           const expected = {
-            HEADER: 1,
-            KEY_INFORMATION: 9,
-            POLICY_AND_EXPORT: 15,
-            EXPORTER_BUSINESS: 25,
-            BUYER: 47,
-            ELIGIBILITY: 57,
+            TITLES: {
+              HEADER: 1,
+              EXPORTER_CONTACT_DETAILS: 9,
+              KEY_INFORMATION: 14,
+              POLICY_AND_EXPORT: 20,
+              EXPORTER_BUSINESS: 30,
+              BUYER: 52,
+              ELIGIBILITY: 62,
+            },
+            COMPANY_ADDRESS: 34,
+            COMPANY_SIC_CODES: 37,
+            BROKER_ADDRESS: 45,
+            BUYER_ADDRESS: 50,
+            BUYER_CONTACT_DETAILS: 53,
           };
 
           expect(result).toEqual(expected);
@@ -106,15 +88,23 @@ describe('api/constants/XLSX-CONFIG', () => {
             [USING_BROKER]: ANSWERS.NO,
           };
 
-          const result = TITLE_ROW_INDEXES(application);
+          const result = XLSX_ROW_INDEXES(application);
 
           const expected = {
-            HEADER: 1,
-            KEY_INFORMATION: 9,
-            POLICY_AND_EXPORT: 15,
-            EXPORTER_BUSINESS: 25,
-            BUYER: 44,
-            ELIGIBILITY: 54,
+            TITLES: {
+              HEADER: 1,
+              EXPORTER_CONTACT_DETAILS: 9,
+              KEY_INFORMATION: 14,
+              POLICY_AND_EXPORT: 20,
+              EXPORTER_BUSINESS: 30,
+              BUYER: 49,
+              ELIGIBILITY: 59,
+            },
+            COMPANY_ADDRESS: 34,
+            COMPANY_SIC_CODES: 37,
+            BROKER_ADDRESS: 45,
+            BUYER_ADDRESS: 50,
+            BUYER_CONTACT_DETAILS: 53,
           };
 
           expect(result).toEqual(expected);
@@ -138,15 +128,23 @@ describe('api/constants/XLSX-CONFIG', () => {
             [USING_BROKER]: ANSWERS.YES,
           };
 
-          const result = TITLE_ROW_INDEXES(application);
+          const result = XLSX_ROW_INDEXES(application);
 
           const expected = {
-            HEADER: 1,
-            KEY_INFORMATION: 9,
-            POLICY_AND_EXPORT: 15,
-            EXPORTER_BUSINESS: 26,
-            BUYER: 48,
-            ELIGIBILITY: 58,
+            TITLES: {
+              HEADER: 1,
+              EXPORTER_CONTACT_DETAILS: 9,
+              KEY_INFORMATION: 14,
+              POLICY_AND_EXPORT: 20,
+              EXPORTER_BUSINESS: 31,
+              BUYER: 53,
+              ELIGIBILITY: 63,
+            },
+            COMPANY_ADDRESS: 35,
+            COMPANY_SIC_CODES: 38,
+            BROKER_ADDRESS: 46,
+            BUYER_ADDRESS: 51,
+            BUYER_CONTACT_DETAILS: 54,
           };
 
           expect(result).toEqual(expected);
@@ -160,15 +158,23 @@ describe('api/constants/XLSX-CONFIG', () => {
             [USING_BROKER]: ANSWERS.NO,
           };
 
-          const result = TITLE_ROW_INDEXES(application);
+          const result = XLSX_ROW_INDEXES(application);
 
           const expected = {
-            HEADER: 1,
-            KEY_INFORMATION: 9,
-            POLICY_AND_EXPORT: 15,
-            EXPORTER_BUSINESS: 26,
-            BUYER: 45,
-            ELIGIBILITY: 55,
+            TITLES: {
+              HEADER: 1,
+              EXPORTER_CONTACT_DETAILS: 9,
+              KEY_INFORMATION: 14,
+              POLICY_AND_EXPORT: 20,
+              EXPORTER_BUSINESS: 31,
+              BUYER: 50,
+              ELIGIBILITY: 60,
+            },
+            COMPANY_ADDRESS: 35,
+            COMPANY_SIC_CODES: 38,
+            BROKER_ADDRESS: 46,
+            BUYER_ADDRESS: 51,
+            BUYER_CONTACT_DETAILS: 54,
           };
 
           expect(result).toEqual(expected);

--- a/src/api/constants/XLSX-CONFIG/index.ts
+++ b/src/api/constants/XLSX-CONFIG/index.ts
@@ -1,7 +1,7 @@
 import FIELD_IDS from '../field-ids/insurance';
 import { isMultiPolicyType } from '../../helpers/policy-type';
 import { ANSWERS } from '../answers';
-import { Application } from '../../types';
+import { Application, XLSXTitleRowIndexes, XLSXRowIndexes } from '../../types';
 
 const {
   POLICY_AND_EXPORTS: {
@@ -13,19 +13,35 @@ const {
 } = FIELD_IDS;
 
 /**
- * TITLE_ROW_INDEXES
- * Generate title row indexes for XLSX.
+ * XLSX_ROW_INDEXES
+ * Generate row indexes for XLSX.
  * Depending on the submitted application data, the rows can be different:
  * - If the policy type is multiple - the XLSX's "Policy and exports” section has 1 additional row.
  * - If "using a broker" is true - the XLSX's “About your business“ section has 3 additional rows.
  * @returns {Object}
  */
-export const TITLE_ROW_INDEXES = (application?: Application): object => {
-  if (!application) {
-    return {};
-  }
-
+export const XLSX_ROW_INDEXES = (application: Application): XLSXRowIndexes => {
   const { policyAndExport, broker } = application;
+
+  const TITLES = {
+    HEADER: 1,
+    EXPORTER_CONTACT_DETAILS: 9,
+    KEY_INFORMATION: 14,
+    POLICY_AND_EXPORT: 20,
+    EXPORTER_BUSINESS: 30,
+    BUYER: 49,
+    ELIGIBILITY: 59,
+  } as XLSXTitleRowIndexes;
+
+  const INDEXES = {
+    TITLES,
+    COMPANY_ADDRESS: 34,
+    COMPANY_SIC_CODES: 37,
+    BROKER_ADDRESS: 45,
+    BUYER_ADDRESS: 50,
+    BUYER_CONTACT_DETAILS: 53,
+  } as XLSXRowIndexes;
+
   const policyType = policyAndExport[POLICY_TYPE];
 
   let isMultiplePolicy = false;
@@ -39,29 +55,24 @@ export const TITLE_ROW_INDEXES = (application?: Application): object => {
     isUsingBroker = true;
   }
 
-  let EXPORTER_BUSINESS = 25;
-  let BUYER = 44;
-  let ELIGIBILITY = 54;
-
   if (isMultiplePolicy) {
-    EXPORTER_BUSINESS += 1;
-    BUYER += 1;
-    ELIGIBILITY += 1;
+    TITLES.EXPORTER_BUSINESS += 1;
+    TITLES.BUYER += 1;
+    TITLES.ELIGIBILITY += 1;
+
+    INDEXES.COMPANY_ADDRESS += 1;
+    INDEXES.COMPANY_SIC_CODES += 1;
+    INDEXES.BROKER_ADDRESS += 1;
+    INDEXES.BUYER_ADDRESS += 1;
+    INDEXES.BUYER_CONTACT_DETAILS += 1;
   }
 
   if (isUsingBroker) {
-    BUYER += 3;
-    ELIGIBILITY += 3;
+    TITLES.BUYER += 3;
+    TITLES.ELIGIBILITY += 3;
   }
 
-  return {
-    HEADER: 1,
-    KEY_INFORMATION: 9,
-    POLICY_AND_EXPORT: 15,
-    EXPORTER_BUSINESS,
-    BUYER,
-    ELIGIBILITY,
-  };
+  return INDEXES;
 };
 
 /**
@@ -69,7 +80,7 @@ export const TITLE_ROW_INDEXES = (application?: Application): object => {
  * Generate XLSX config.
  * @returns {Object}
  */
-export const XLSX_CONFIG = (application?: Application) => ({
+export const XLSX_CONFIG = {
   KEY: {
     ID: 'field',
     COPY: 'Field',
@@ -86,14 +97,6 @@ export const XLSX_CONFIG = (application?: Application) => ({
     DEFAULT: 11,
     TITLE: 14,
   },
-  ROW_INDEXES: {
-    COMPANY_ADDRESS: 30,
-    COMPANY_SIC_CODES: 33,
-    BROKER_ADDRESS: 45,
-    BUYER_ADDRESS: 50,
-    BUYER_CONTACT_DETAILS: 53,
-  },
-  TITLE_ROW_INDEXES: TITLE_ROW_INDEXES(application),
-});
+};
 
 export default XLSX_CONFIG;

--- a/src/api/content-strings/XLSX.ts
+++ b/src/api/content-strings/XLSX.ts
@@ -26,6 +26,7 @@ const {
 export const XLSX = {
   SECTION_TITLES: {
     KEY_INFORMATION: 'Key information',
+    EXPORTER_CONTACT_DETAILS: 'Exporter contact details',
     POLICY_AND_EXPORT: 'Type of policy and exports',
     EXPORTER_BUSINESS: 'About your business',
     BUYER: 'Your buyer',
@@ -35,6 +36,11 @@ export const XLSX = {
     [FIRST_NAME]: 'Applicant first name',
     [LAST_NAME]: 'Applicant last name',
     APPLICANT_EMAIL_ADDRESS: 'Applicant email address',
+    EXPORTER_CONTACT: {
+      [FIRST_NAME]: 'Exporter first name',
+      [LAST_NAME]: 'Exporter last name',
+      EXPORTER_CONTACT_EMAIL: 'Exporter email address',
+    },
     [CONTRACT_COMPLETION_DATE]: 'Date expected for contract to complete',
     [EXPORTER_COMPANY_NAME]: 'Exporter company name',
     [EXPORTER_COMPANY_ADDRESS]: 'Exporter registered office address',

--- a/src/api/generate-xlsx/header-columns/index.test.ts
+++ b/src/api/generate-xlsx/header-columns/index.test.ts
@@ -1,7 +1,7 @@
 import XLSX_HEADER_COLUMNS from '.';
 import { XLSX_CONFIG } from '../../constants';
 
-const { KEY, VALUE, COLUMN_WIDTH } = XLSX_CONFIG();
+const { KEY, VALUE, COLUMN_WIDTH } = XLSX_CONFIG;
 
 describe('api/generate-xlsx/header-columns', () => {
   it('should return an array of header columns', () => {

--- a/src/api/generate-xlsx/header-columns/index.ts
+++ b/src/api/generate-xlsx/header-columns/index.ts
@@ -1,6 +1,6 @@
 import { XLSX_CONFIG } from '../../constants';
 
-const { KEY, VALUE, COLUMN_WIDTH } = XLSX_CONFIG();
+const { KEY, VALUE, COLUMN_WIDTH } = XLSX_CONFIG;
 
 /**
  * XLSX_HEADER_COLUMNS

--- a/src/api/generate-xlsx/map-application-to-XLSX/helpers/xlsx-row/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/helpers/xlsx-row/index.test.ts
@@ -2,7 +2,7 @@ import xlsxRow from '.';
 import { XLSX_CONFIG } from '../../../../constants';
 import replaceCharacterCodesWithCharacters from '../../../../helpers/replace-character-codes-with-characters';
 
-const { KEY, VALUE } = XLSX_CONFIG();
+const { KEY, VALUE } = XLSX_CONFIG;
 
 describe('api/generate-xlsx/map-application-to-xlsx/helpers/xlsx-row', () => {
   const mockFieldName = 'Field A';

--- a/src/api/generate-xlsx/map-application-to-XLSX/helpers/xlsx-row/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/helpers/xlsx-row/index.ts
@@ -1,7 +1,7 @@
 import { XLSX_CONFIG } from '../../../../constants';
 import replaceCharacterCodesWithCharacters from '../../../../helpers/replace-character-codes-with-characters';
 
-const { KEY, VALUE } = XLSX_CONFIG();
+const { KEY, VALUE } = XLSX_CONFIG;
 
 /**
  * xlsxRow

--- a/src/api/generate-xlsx/map-application-to-XLSX/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/index.test.ts
@@ -1,6 +1,7 @@
 import mapApplicationToXLSX from '.';
 import ROW_SEPERATOR from './helpers/xlsx-row-seperator';
 import mapKeyInformation from './map-key-information';
+import mapExporterContactDetails from './map-exporter-contact-details';
 import mapSecondaryKeyInformation from './map-secondary-key-information';
 import mapPolicyAndExport from './map-policy-and-export';
 import mapExporter from './map-exporter';
@@ -14,6 +15,10 @@ describe('api/generate-xlsx/map-application-to-xlsx/index', () => {
 
     const expected = [
       ...mapKeyInformation(mockApplication),
+
+      ROW_SEPERATOR,
+
+      ...mapExporterContactDetails(mockApplication),
 
       ROW_SEPERATOR,
 

--- a/src/api/generate-xlsx/map-application-to-XLSX/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/index.ts
@@ -1,5 +1,6 @@
 import ROW_SEPERATOR from './helpers/xlsx-row-seperator';
 import mapKeyInformation from './map-key-information';
+import mapExporterContactDetails from './map-exporter-contact-details';
 import mapSecondaryKeyInformation from './map-secondary-key-information';
 import mapPolicyAndExport from './map-policy-and-export';
 import mapExporter from './map-exporter';
@@ -17,6 +18,10 @@ const mapApplicationToXLSX = (application: Application) => {
   try {
     const mapped = [
       ...mapKeyInformation(application),
+
+      ROW_SEPERATOR,
+
+      ...mapExporterContactDetails(application),
 
       ROW_SEPERATOR,
 

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-exporter-contact-details/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-exporter-contact-details/index.test.ts
@@ -1,0 +1,33 @@
+import mapBuyer from '.';
+import INSURANCE_FIELD_IDS from '../../../constants/field-ids/insurance';
+import { XLSX } from '../../../content-strings';
+import xlsxRow from '../helpers/xlsx-row';
+import { mockApplication } from '../../../test-mocks';
+
+const {
+  ACCOUNT: { FIRST_NAME, LAST_NAME, EMAIL },
+} = INSURANCE_FIELD_IDS;
+
+const {
+  SECTION_TITLES: { EXPORTER_CONTACT_DETAILS },
+  FIELDS,
+} = XLSX;
+
+describe('api/generate-xlsx/map-application-to-xlsx/map-exporter-contact-details', () => {
+  it('should return an array of mapped eporter contact details', () => {
+    const result = mapBuyer(mockApplication);
+
+    const {
+      business: { businessContactDetail },
+    } = mockApplication;
+
+    const expected = [
+      xlsxRow(EXPORTER_CONTACT_DETAILS),
+      xlsxRow(FIELDS.EXPORTER_CONTACT[FIRST_NAME], businessContactDetail[FIRST_NAME]),
+      xlsxRow(FIELDS.EXPORTER_CONTACT[LAST_NAME], businessContactDetail[LAST_NAME]),
+      xlsxRow(FIELDS.EXPORTER_CONTACT.EXPORTER_CONTACT_EMAIL, businessContactDetail[EMAIL]),
+    ];
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-exporter-contact-details/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-exporter-contact-details/index.ts
@@ -1,0 +1,36 @@
+import INSURANCE_FIELD_IDS from '../../../constants/field-ids/insurance';
+import { XLSX } from '../../../content-strings';
+import xlsxRow from '../helpers/xlsx-row';
+import { Application } from '../../../types';
+
+const {
+  ACCOUNT: { FIRST_NAME, LAST_NAME, EMAIL },
+} = INSURANCE_FIELD_IDS;
+
+const {
+  SECTION_TITLES: { EXPORTER_CONTACT_DETAILS },
+  FIELDS,
+} = XLSX;
+
+/**
+ * mapExporterContactDetails
+ * Map an application's exporter contact details fields into an array of objects for XLSX generation
+ * @param {Object} Application
+ * @returns {Array} Array of objects for XLSX generation
+ */
+const mapExporterContactDetails = (application: Application) => {
+  const {
+    business: { businessContactDetail },
+  } = application;
+
+  const mapped = [
+    xlsxRow(EXPORTER_CONTACT_DETAILS),
+    xlsxRow(FIELDS.EXPORTER_CONTACT[FIRST_NAME], businessContactDetail[FIRST_NAME]),
+    xlsxRow(FIELDS.EXPORTER_CONTACT[LAST_NAME], businessContactDetail[LAST_NAME]),
+    xlsxRow(FIELDS.EXPORTER_CONTACT.EXPORTER_CONTACT_EMAIL, businessContactDetail[EMAIL]),
+  ];
+
+  return mapped;
+};
+
+export default mapExporterContactDetails;

--- a/src/api/generate-xlsx/styled-columns/index.test.ts
+++ b/src/api/generate-xlsx/styled-columns/index.test.ts
@@ -2,10 +2,10 @@ import ExcelJS from 'exceljs';
 import styledColumns, { worksheetRowHeights } from '.';
 import HEADER_COLUMNS from '../header-columns';
 import mapApplicationToXLSX from '../map-application-to-XLSX';
-import { XLSX_CONFIG } from '../../constants';
+import { XLSX_CONFIG, XLSX_ROW_INDEXES } from '../../constants';
 import { mockApplication } from '../../test-mocks';
 
-const { ROW_INDEXES, ADDITIONAL_COLUMN_HEIGHT, LARGE_ADDITIONAL_COLUMN_HEIGHT, FONT_SIZE } = XLSX_CONFIG();
+const { LARGE_ADDITIONAL_COLUMN_HEIGHT, ADDITIONAL_TITLE_COLUMN_HEIGHT, FONT_SIZE } = XLSX_CONFIG;
 
 describe('api/generate-xlsx/styled-columns/index', () => {
   const workbook = new ExcelJS.Workbook();
@@ -14,7 +14,12 @@ describe('api/generate-xlsx/styled-columns/index', () => {
 
   worksheet.columns = HEADER_COLUMNS;
 
-  const TITLE_INDEXES = Object.values(XLSX_CONFIG(mockApplication).TITLE_ROW_INDEXES);
+  const INDEXES = XLSX_ROW_INDEXES(mockApplication);
+
+  const { TITLES, ...ROWS } = INDEXES;
+
+  const TITLE_INDEXES = Object.values(TITLES);
+  const ROW_INDEXES = Object.values(ROWS);
 
   describe('styledColumns', () => {
     it('should add custom `alignment` and font size properties to each column', () => {
@@ -78,22 +83,19 @@ describe('api/generate-xlsx/styled-columns/index', () => {
         worksheet.addRow(row);
       });
 
-      const result = worksheetRowHeights(TITLE_INDEXES, worksheet);
+      const result = worksheetRowHeights(TITLE_INDEXES, ROW_INDEXES, worksheet);
 
-      const row1 = result.getRow(ROW_INDEXES.COMPANY_ADDRESS);
-      expect(row1.height).toEqual(LARGE_ADDITIONAL_COLUMN_HEIGHT);
+      TITLE_INDEXES.forEach((rowIndex) => {
+        const row = result.getRow(rowIndex);
 
-      const row2 = result.getRow(ROW_INDEXES.COMPANY_SIC_CODES);
-      expect(row2.height).toEqual(ADDITIONAL_COLUMN_HEIGHT);
+        expect(row.height).toEqual(ADDITIONAL_TITLE_COLUMN_HEIGHT);
+      });
 
-      const row3 = result.getRow(ROW_INDEXES.BROKER_ADDRESS);
-      expect(row3.height).toEqual(LARGE_ADDITIONAL_COLUMN_HEIGHT);
+      ROW_INDEXES.forEach((rowIndex) => {
+        const row = result.getRow(rowIndex);
 
-      const row4 = result.getRow(ROW_INDEXES.BUYER_ADDRESS);
-      expect(row4.height).toEqual(LARGE_ADDITIONAL_COLUMN_HEIGHT);
-
-      const row5 = result.getRow(ROW_INDEXES.BUYER_CONTACT_DETAILS);
-      expect(row5.height).toEqual(LARGE_ADDITIONAL_COLUMN_HEIGHT);
+        expect(row.height).toEqual(LARGE_ADDITIONAL_COLUMN_HEIGHT);
+      });
     });
   });
 });

--- a/src/api/generate-xlsx/styled-columns/index.ts
+++ b/src/api/generate-xlsx/styled-columns/index.ts
@@ -1,8 +1,8 @@
 import { Row, Worksheet } from 'exceljs';
-import { XLSX_CONFIG } from '../../constants';
+import { XLSX_CONFIG, XLSX_ROW_INDEXES } from '../../constants';
 import { Application } from '../../types';
 
-const { ADDITIONAL_COLUMN_HEIGHT, LARGE_ADDITIONAL_COLUMN_HEIGHT, ADDITIONAL_TITLE_COLUMN_HEIGHT, ROW_INDEXES, FONT_SIZE } = XLSX_CONFIG();
+const { LARGE_ADDITIONAL_COLUMN_HEIGHT, ADDITIONAL_TITLE_COLUMN_HEIGHT, FONT_SIZE } = XLSX_CONFIG;
 
 /**
  * worksheetRowHeights
@@ -11,17 +11,15 @@ const { ADDITIONAL_COLUMN_HEIGHT, LARGE_ADDITIONAL_COLUMN_HEIGHT, ADDITIONAL_TIT
  * @param {ExcelJS.Worksheet} ExcelJS worksheet
  * @returns {ExcelJS.Worksheet} ExcelJS worksheet
  */
-export const worksheetRowHeights = (titleRowIndexes: Array<number>, worksheet: Worksheet) => {
+export const worksheetRowHeights = (titleRowIndexes: Array<number>, rowIndexes: Array<number>, worksheet: Worksheet) => {
   const modifiedWorksheet = worksheet;
 
-  modifiedWorksheet.getRow(ROW_INDEXES.COMPANY_ADDRESS).height = LARGE_ADDITIONAL_COLUMN_HEIGHT;
-  modifiedWorksheet.getRow(ROW_INDEXES.COMPANY_SIC_CODES).height = ADDITIONAL_COLUMN_HEIGHT;
-  modifiedWorksheet.getRow(ROW_INDEXES.BROKER_ADDRESS).height = LARGE_ADDITIONAL_COLUMN_HEIGHT;
-  modifiedWorksheet.getRow(ROW_INDEXES.BUYER_ADDRESS).height = LARGE_ADDITIONAL_COLUMN_HEIGHT;
-  modifiedWorksheet.getRow(ROW_INDEXES.BUYER_CONTACT_DETAILS).height = LARGE_ADDITIONAL_COLUMN_HEIGHT;
-
-  Object.values(titleRowIndexes).forEach((rowIndex) => {
+  titleRowIndexes.forEach((rowIndex) => {
     modifiedWorksheet.getRow(rowIndex).height = ADDITIONAL_TITLE_COLUMN_HEIGHT;
+  });
+
+  rowIndexes.forEach((rowIndex) => {
+    modifiedWorksheet.getRow(rowIndex).height = LARGE_ADDITIONAL_COLUMN_HEIGHT;
   });
 
   return modifiedWorksheet;
@@ -37,7 +35,12 @@ export const worksheetRowHeights = (titleRowIndexes: Array<number>, worksheet: W
 const styledColumns = (application: Application, worksheet: Worksheet) => {
   let modifiedWorksheet = worksheet;
 
-  const TITLE_INDEXES = Object.values(XLSX_CONFIG(application).TITLE_ROW_INDEXES);
+  const INDEXES = XLSX_ROW_INDEXES(application);
+
+  const { TITLES, ...ROWS } = INDEXES;
+
+  const TITLE_INDEXES = Object.values(TITLES);
+  const ROW_INDEXES = Object.values(ROWS);
 
   modifiedWorksheet.eachRow((row: Row, rowNumber: number) => {
     row.eachCell((cell, colNumber) => {
@@ -57,7 +60,7 @@ const styledColumns = (application: Application, worksheet: Worksheet) => {
     });
   });
 
-  modifiedWorksheet = worksheetRowHeights(TITLE_INDEXES, modifiedWorksheet);
+  modifiedWorksheet = worksheetRowHeights(TITLE_INDEXES, ROW_INDEXES, modifiedWorksheet);
 
   return modifiedWorksheet;
 };

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -397,6 +397,25 @@ interface IndustrySector {
   ukefIndustryName: string;
 }
 
+interface XLSXTitleRowIndexes {
+  HEADER: number;
+  KEY_INFORMATION: number;
+  EXPORTER_CONTACT_DETAILS?: number;
+  POLICY_AND_EXPORT: number;
+  EXPORTER_BUSINESS: number;
+  BUYER: number;
+  ELIGIBILITY: number;
+}
+
+interface XLSXRowIndexes {
+  TITLES: XLSXTitleRowIndexes;
+  COMPANY_ADDRESS: number;
+  COMPANY_SIC_CODES: number;
+  BROKER_ADDRESS: number;
+  BUYER_ADDRESS: number;
+  BUYER_CONTACT_DETAILS: number;
+}
+
 export {
   Account,
   AccountCreationVariables,
@@ -445,6 +464,8 @@ export {
   SubmitApplicationVariables,
   SuccessResponse,
   UpdateCompanyAndCompanyAddressVariables,
+  XLSXTitleRowIndexes,
+  XLSXRowIndexes,
   VerifyEmailAddressVariables,
   VerifyEmailAddressResponse,
   VerifyAccountPasswordResetTokenVariables,


### PR DESCRIPTION
This PR updates the XLSX generation mapping to include exporter contact details (reagrdless of if they are the same as the application owner).

## Changes

Update various cypress command (including `completeAndSubmitYourContact`) to accept `useDifferentContactEmail` flag/argument.
- Refactor `XLSX_CONFIG` constants so that:
  - `ROW_INDEXES` are seperated from the config - otherwise becomes messy and we have to pass application to the config, when the config doesn't actually require any data.
  - Returns both `TITLES` indexes and non-title indexes.
- Add exporter contact details mapping.

## Other improvements

- Add E2E test coverage for submitting a single policy with different contact details.
- Added some missing documentation to some E2E commands.
- Simplify `styledColumns`.
- Add TS types for the `ROW_INDEXES`.