### PR TITLE
fix(EMS-1729): Account - Sign in - Password as numbers only

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/password-as-number/sign-in-password-as-number.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/password-as-number/sign-in-password-as-number.spec.js
@@ -1,0 +1,63 @@
+import { yourDetailsPage } from '../../../../../pages/insurance/account/create';
+import accountFormFields from '../../../../../partials/insurance/accountFormFields';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
+import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const {
+  START,
+  ACCOUNT: {
+    SIGN_IN: { ROOT: SIGN_IN_ROOT },
+  },
+} = ROUTES;
+
+const {
+  INSURANCE: { ACCOUNT: { SIGN_IN: SIGN_IN_ERROR_MESSAGES } },
+} = ERROR_MESSAGES;
+
+const {
+  ACCOUNT: { PASSWORD },
+} = INSURANCE_FIELD_IDS;
+
+const TOTAL_REQUIRED_FIELDS = 2;
+
+context('Insurance - Account - Sign in - Password entered as only numbers', () => {
+  let url;
+
+  before(() => {
+    cy.deleteAccount();
+
+    cy.navigateToUrl(START);
+
+    cy.submitEligibilityAndStartAccountCreation();
+    cy.completeAndSubmitCreateAccountForm();
+
+    // go back to the create account page
+    cy.go('back');
+
+    // navigate to sign in page
+    yourDetailsPage.signInButtonLink().click();
+
+    url = `${Cypress.config('baseUrl')}${SIGN_IN_ROOT}`;
+
+    cy.url().should('eq', url);
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  describe('When password is entered only as a number', () => {
+    before(() => {
+      cy.verifyAccountEmail();
+    });
+
+    it('should display the relevant validation errors and not go to problem with service', () => {
+      cy.navigateToUrl(url);
+
+      cy.completeAndSubmitSignInAccountForm({ password: 12345, assertRedirectUrl: false });
+
+      cy.submitAndAssertFieldErrors(accountFormFields[PASSWORD], null, 1, TOTAL_REQUIRED_FIELDS, SIGN_IN_ERROR_MESSAGES[PASSWORD].INCORRECT);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/account/sign-in/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/index.test.ts
@@ -287,6 +287,20 @@ describe('controllers/insurance/account/sign-in', () => {
           expect(res.redirect).toHaveBeenCalledWith(`${SUSPENDED_ROOT}?id=${accountSignInResponse.accountId}`);
         });
       });
+
+      describe('when password only contains numbers', () => {
+        it('should call api.keystone.account.signIn with password as a string', async () => {
+          req.body[PASSWORD] = 12345;
+
+          await post(req, res);
+
+          expect(accountSignInSpy).toHaveBeenCalledTimes(1);
+
+          const sanitisedData = sanitiseData(req.body);
+
+          expect(accountSignInSpy).toHaveBeenCalledWith(req.headers.origin, sanitisedData[EMAIL], String(sanitisedData[PASSWORD]));
+        });
+      });
     });
 
     describe('api error handling', () => {

--- a/src/ui/server/controllers/insurance/account/sign-in/index.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/index.ts
@@ -107,7 +107,7 @@ export const post = async (req: Request, res: Response) => {
     const sanitisedData = sanitiseData(req.body);
 
     const email = sanitisedData[EMAIL];
-    const password = sanitisedData[PASSWORD];
+    const password = String(sanitisedData[PASSWORD]);
 
     const urlOrigin = req.headers.origin;
 


### PR DESCRIPTION
# Issue: 
* When password is a number only, it caused service to go to problem with service page

# Changes made:
* Cast password as a string so graphql does not receive only a number
* Added tests