### PR TITLE
fix(EMS-1701): Account suspension - fix issue where retries check would include irrelevant retries

### DIFF
--- a/e2e-tests/constants/account.js
+++ b/e2e-tests/constants/account.js
@@ -1,3 +1,3 @@
 export const ACCOUNT = {
-  MAX_PASSWORD_RESET_TRIES: 6,
+  MAX_AUTH_RETRIES: 6,
 };

--- a/e2e-tests/cypress/support/insurance/account/complete-and-submit-password-reset-form-maximum-retries.js
+++ b/e2e-tests/cypress/support/insurance/account/complete-and-submit-password-reset-form-maximum-retries.js
@@ -2,7 +2,7 @@ import { ACCOUNT } from '../../../../constants/account';
 import completeAndSubmitPasswordResetForm from './complete-and-submit-password-reset-form';
 import { backLink } from '../../../e2e/pages/shared';
 
-const attemptsToMake = [...Array(ACCOUNT.MAX_PASSWORD_RESET_TRIES)];
+const attemptsToMake = [...Array(ACCOUNT.MAX_AUTH_RETRIES)];
 
 /**
  * completeAndSubmitPasswordResetFormMaximumRetries

--- a/e2e-tests/cypress/support/insurance/account/complete-and-submit-sign-in-account-form-maximum-retries.js
+++ b/e2e-tests/cypress/support/insurance/account/complete-and-submit-sign-in-account-form-maximum-retries.js
@@ -2,7 +2,7 @@ import { ACCOUNT } from '../../../../constants/account';
 import completeAndSubmitSignInAccountForm from './complete-and-submit-sign-in-account-form';
 import { backLink } from '../../../e2e/pages/shared';
 
-const attemptsToMake = [...Array(ACCOUNT.MAX_PASSWORD_RESET_TRIES)];
+const attemptsToMake = [...Array(ACCOUNT.MAX_AUTH_RETRIES)];
 
 /**
  * completeAndSubmitSignInAccountFormMaximumRetries

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -467,11 +467,11 @@ var ACCOUNT2 = {
   },
   MAX_PASSWORD_RESET_TRIES: 6,
   /**
-   * MAX_PASSWORD_RESET_TRIES_TIMEFRAME
+   * MAX_AUTH_RETRIES_TIMEFRAME
    * Generate a date that is 24 hours ago from now
    * To be safe, we use time rather than subtracting a day.
    */
-  MAX_PASSWORD_RESET_TRIES_TIMEFRAME: DATE_24_HOURS_IN_THE_PAST()
+  MAX_AUTH_RETRIES_TIMEFRAME: DATE_24_HOURS_IN_THE_PAST()
 };
 var EMAIL_TEMPLATE_IDS = {
   ACCOUNT: {
@@ -2241,7 +2241,7 @@ var create_authentication_retry_entry_default = createAuthenticationRetryEntry;
 
 // helpers/should-block-account/index.ts
 var import_date_fns4 = require("date-fns");
-var { MAX_PASSWORD_RESET_TRIES, MAX_PASSWORD_RESET_TRIES_TIMEFRAME } = ACCOUNT2;
+var { MAX_PASSWORD_RESET_TRIES, MAX_AUTH_RETRIES_TIMEFRAME } = ACCOUNT2;
 var shouldBlockAccount = async (context, accountId) => {
   console.info(`Checking account ${accountId} authentication retries`);
   try {
@@ -2250,7 +2250,7 @@ var shouldBlockAccount = async (context, accountId) => {
     const retriesInTimeframe = [];
     retries.forEach((retry) => {
       const retryDate = retry.createdAt;
-      const isWithinLast24Hours = (0, import_date_fns4.isAfter)(retryDate, MAX_PASSWORD_RESET_TRIES_TIMEFRAME) && (0, import_date_fns4.isBefore)(retryDate, now);
+      const isWithinLast24Hours = (0, import_date_fns4.isAfter)(retryDate, MAX_AUTH_RETRIES_TIMEFRAME) && (0, import_date_fns4.isBefore)(retryDate, now);
       if (isWithinLast24Hours) {
         retriesInTimeframe.push(retry.id);
       }

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -404,6 +404,12 @@ var DATE_24_HOURS_FROM_NOW = () => {
   const tomorrow = new Date(now.setDate(day + 1));
   return tomorrow;
 };
+var DATE_24_HOURS_IN_THE_PAST = () => {
+  const now = /* @__PURE__ */ new Date();
+  const day = now.getDate();
+  const yesterday = new Date(now.setDate(day - 1));
+  return yesterday;
+};
 var DATE_30_MINUTES_FROM_NOW = () => {
   const now = /* @__PURE__ */ new Date();
   const minutes = 30;
@@ -465,7 +471,7 @@ var ACCOUNT2 = {
    * Generate a date that is 24 hours ago from now
    * To be safe, we use time rather than subtracting a day.
    */
-  MAX_PASSWORD_RESET_TRIES_TIMEFRAME: (/* @__PURE__ */ new Date()).setDate((/* @__PURE__ */ new Date()).getDate() - 1)
+  MAX_PASSWORD_RESET_TRIES_TIMEFRAME: DATE_24_HOURS_IN_THE_PAST()
 };
 var EMAIL_TEMPLATE_IDS = {
   ACCOUNT: {
@@ -2243,11 +2249,8 @@ var shouldBlockAccount = async (context, accountId) => {
     const now = /* @__PURE__ */ new Date();
     const retriesInTimeframe = [];
     retries.forEach((retry) => {
-      const retryDate = new Date(retry.createdAt);
-      const isWithinLast24Hours = (0, import_date_fns4.isWithinInterval)(retryDate, {
-        start: MAX_PASSWORD_RESET_TRIES_TIMEFRAME,
-        end: now
-      });
+      const retryDate = retry.createdAt;
+      const isWithinLast24Hours = (0, import_date_fns4.isAfter)(retryDate, MAX_PASSWORD_RESET_TRIES_TIMEFRAME) && (0, import_date_fns4.isBefore)(retryDate, now);
       if (isWithinLast24Hours) {
         retriesInTimeframe.push(retry.id);
       }

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -465,7 +465,7 @@ var ACCOUNT2 = {
       return future;
     }
   },
-  MAX_PASSWORD_RESET_TRIES: 6,
+  MAX_AUTH_RETRIES: 6,
   /**
    * MAX_AUTH_RETRIES_TIMEFRAME
    * Generate a date that is 24 hours ago from now
@@ -2241,7 +2241,7 @@ var create_authentication_retry_entry_default = createAuthenticationRetryEntry;
 
 // helpers/should-block-account/index.ts
 var import_date_fns4 = require("date-fns");
-var { MAX_PASSWORD_RESET_TRIES, MAX_AUTH_RETRIES_TIMEFRAME } = ACCOUNT2;
+var { MAX_AUTH_RETRIES, MAX_AUTH_RETRIES_TIMEFRAME } = ACCOUNT2;
 var shouldBlockAccount = async (context, accountId) => {
   console.info(`Checking account ${accountId} authentication retries`);
   try {
@@ -2255,7 +2255,7 @@ var shouldBlockAccount = async (context, accountId) => {
         retriesInTimeframe.push(retry.id);
       }
     });
-    if (retriesInTimeframe.length >= MAX_PASSWORD_RESET_TRIES) {
+    if (retriesInTimeframe.length >= MAX_AUTH_RETRIES) {
       console.info(`Account ${accountId} authentication retries exceeds the threshold`);
       return true;
     }

--- a/src/api/constants/index.test.ts
+++ b/src/api/constants/index.test.ts
@@ -61,9 +61,9 @@ describe('constants/index', () => {
       });
     });
 
-    describe('MAX_PASSWORD_RESET_TRIES', () => {
+    describe('MAX_AUTH_RETRIES', () => {
       it('should have the correct value', () => {
-        const result = ACCOUNT.MAX_PASSWORD_RESET_TRIES;
+        const result = ACCOUNT.MAX_AUTH_RETRIES;
 
         expect(result).toEqual(6);
       });

--- a/src/api/constants/index.test.ts
+++ b/src/api/constants/index.test.ts
@@ -1,5 +1,5 @@
 import { ACCOUNT } from '.';
-import { get30minutesFromNow, getTomorrowDay } from '../helpers/date';
+import { get30minutesFromNow, getTomorrowDay, getYesterdayDay } from '../helpers/date';
 
 describe('constants/index', () => {
   describe('ACCOUNT', () => {
@@ -29,9 +29,11 @@ describe('constants/index', () => {
 
     describe('OTP', () => {
       describe('DIGITS', () => {
-        const result = ACCOUNT.OTP.DIGITS;
+        it('should have the correct value', () => {
+          const result = ACCOUNT.OTP.DIGITS;
 
-        expect(result).toEqual(6);
+          expect(result).toEqual(6);
+        });
       });
 
       describe('VERIFICATION_EXPIRY', () => {
@@ -54,6 +56,26 @@ describe('constants/index', () => {
         const resultDay = new Date(result).getDate();
 
         const expectedDay = getTomorrowDay();
+
+        expect(resultDay).toEqual(expectedDay);
+      });
+    });
+
+    describe('MAX_PASSWORD_RESET_TRIES', () => {
+      it('should have the correct value', () => {
+        const result = ACCOUNT.MAX_PASSWORD_RESET_TRIES;
+
+        expect(result).toEqual(6);
+      });
+    });
+
+    describe('MAX_PASSWORD_RESET_TRIES_TIMEFRAME', () => {
+      it('should have a day of yesterday', () => {
+        const result = ACCOUNT.MAX_PASSWORD_RESET_TRIES_TIMEFRAME;
+
+        const resultDay = new Date(result).getDate();
+
+        const expectedDay = getYesterdayDay();
 
         expect(resultDay).toEqual(expectedDay);
       });

--- a/src/api/constants/index.test.ts
+++ b/src/api/constants/index.test.ts
@@ -69,9 +69,9 @@ describe('constants/index', () => {
       });
     });
 
-    describe('MAX_PASSWORD_RESET_TRIES_TIMEFRAME', () => {
+    describe('MAX_AUTH_RETRIES_TIMEFRAME', () => {
       it('should have a day of yesterday', () => {
-        const result = ACCOUNT.MAX_PASSWORD_RESET_TRIES_TIMEFRAME;
+        const result = ACCOUNT.MAX_AUTH_RETRIES_TIMEFRAME;
 
         const resultDay = new Date(result).getDate();
 

--- a/src/api/constants/index.ts
+++ b/src/api/constants/index.ts
@@ -124,11 +124,11 @@ export const ACCOUNT = {
   },
   MAX_PASSWORD_RESET_TRIES: 6,
   /**
-   * MAX_PASSWORD_RESET_TRIES_TIMEFRAME
+   * MAX_AUTH_RETRIES_TIMEFRAME
    * Generate a date that is 24 hours ago from now
    * To be safe, we use time rather than subtracting a day.
    */
-  MAX_PASSWORD_RESET_TRIES_TIMEFRAME: DATE_24_HOURS_IN_THE_PAST(),
+  MAX_AUTH_RETRIES_TIMEFRAME: DATE_24_HOURS_IN_THE_PAST(),
 };
 
 export const EMAIL_TEMPLATE_IDS = {

--- a/src/api/constants/index.ts
+++ b/src/api/constants/index.ts
@@ -24,7 +24,7 @@ export const EXTERNAL_API_ENDPOINTS = {
  * Generate a date that is 24 hours from now
  * @returns {Date}
  */
-const DATE_24_HOURS_FROM_NOW = () => {
+export const DATE_24_HOURS_FROM_NOW = () => {
   const now = new Date();
 
   const day = now.getDate();
@@ -33,6 +33,22 @@ const DATE_24_HOURS_FROM_NOW = () => {
   const tomorrow = new Date(now.setDate(day + 1));
 
   return tomorrow;
+};
+
+/**
+ * DATE_24_HOURS_IN_THE_PAST
+ * Generate a date that is 24 hours in the past
+ * @returns {Date}
+ */
+export const DATE_24_HOURS_IN_THE_PAST = () => {
+  const now = new Date();
+
+  const day = now.getDate();
+
+  // subtract 1 day from the current day.
+  const yesterday = new Date(now.setDate(day - 1));
+
+  return yesterday;
 };
 
 /**
@@ -112,7 +128,7 @@ export const ACCOUNT = {
    * Generate a date that is 24 hours ago from now
    * To be safe, we use time rather than subtracting a day.
    */
-  MAX_PASSWORD_RESET_TRIES_TIMEFRAME: new Date().setDate(new Date().getDate() - 1),
+  MAX_PASSWORD_RESET_TRIES_TIMEFRAME: DATE_24_HOURS_IN_THE_PAST(),
 };
 
 export const EMAIL_TEMPLATE_IDS = {

--- a/src/api/constants/index.ts
+++ b/src/api/constants/index.ts
@@ -122,7 +122,7 @@ export const ACCOUNT = {
       return future;
     },
   },
-  MAX_PASSWORD_RESET_TRIES: 6,
+  MAX_AUTH_RETRIES: 6,
   /**
    * MAX_AUTH_RETRIES_TIMEFRAME
    * Generate a date that is 24 hours ago from now

--- a/src/api/custom-resolvers/mutations/account-sign-in.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in.test.ts
@@ -20,7 +20,7 @@ dotenv.config();
 
 const context = getContext(config, PrismaModule) as Context;
 
-const { EMAIL, MAX_PASSWORD_RESET_TRIES } = ACCOUNT;
+const { EMAIL, MAX_AUTH_RETRIES } = ACCOUNT;
 
 describe('custom-resolvers/account-sign-in', () => {
   let account: Account;
@@ -259,7 +259,7 @@ describe('custom-resolvers/account-sign-in', () => {
     });
   });
 
-  describe(`when the account has ${MAX_PASSWORD_RESET_TRIES} entries in the AuthenticationRetry table`, () => {
+  describe(`when the account has ${MAX_AUTH_RETRIES} entries in the AuthenticationRetry table`, () => {
     beforeEach(async () => {
       // revert the previous account block so we have a clean slate.
       account = (await context.query.Account.updateOne({
@@ -277,7 +277,7 @@ describe('custom-resolvers/account-sign-in', () => {
       });
 
       // generate an array of promises to create retry entries
-      const entriesToCreate = [...Array(MAX_PASSWORD_RESET_TRIES)].map(async () => createAuthenticationRetryEntry(context, account.id));
+      const entriesToCreate = [...Array(MAX_AUTH_RETRIES)].map(async () => createAuthenticationRetryEntry(context, account.id));
 
       await Promise.all(entriesToCreate);
 

--- a/src/api/custom-resolvers/mutations/send-email-password-reset-link.test.ts
+++ b/src/api/custom-resolvers/mutations/send-email-password-reset-link.test.ts
@@ -25,7 +25,7 @@ const {
       PBKDF2: { KEY_LENGTH },
     },
   },
-  MAX_PASSWORD_RESET_TRIES,
+  MAX_AUTH_RETRIES,
 } = ACCOUNT;
 
 describe('custom-resolvers/send-email-password-reset-link', () => {
@@ -177,7 +177,7 @@ describe('custom-resolvers/send-email-password-reset-link', () => {
     });
   });
 
-  describe(`when the account has ${MAX_PASSWORD_RESET_TRIES} entries in the AuthenticationRetry table`, () => {
+  describe(`when the account has ${MAX_AUTH_RETRIES} entries in the AuthenticationRetry table`, () => {
     beforeEach(async () => {
       // wipe the AuthenticationRetry table so we have a clean slate.
       const retries = await context.query.AuthenticationRetry.findMany();
@@ -187,7 +187,7 @@ describe('custom-resolvers/send-email-password-reset-link', () => {
       });
 
       // generate an array of promises to create retry entries
-      const entriesToCreate = [...Array(MAX_PASSWORD_RESET_TRIES)].map(async () => createAuthenticationRetryEntry(context, account.id));
+      const entriesToCreate = [...Array(MAX_AUTH_RETRIES)].map(async () => createAuthenticationRetryEntry(context, account.id));
 
       await Promise.all(entriesToCreate);
 

--- a/src/api/custom-resolvers/mutations/send-email-password-reset-link.ts
+++ b/src/api/custom-resolvers/mutations/send-email-password-reset-link.ts
@@ -21,7 +21,7 @@ const {
 
 /**
  * sendEmailPasswordResetLink
- * If an account has not reached the MAX_PASSWORD_RESET_TRIES threshold,
+ * If an account has not reached the MAX_AUTH_RETRIES threshold,
  * Generate a password reset hash, update account and send a link to the account via email.
  * Otherwise, block the account
  * Or return success=false if the account is not found.

--- a/src/api/helpers/date/index.test.ts
+++ b/src/api/helpers/date/index.test.ts
@@ -1,4 +1,4 @@
-import { get30minutesFromNow, getTomorrowDay } from '.';
+import { get30minutesFromNow, getTomorrowDay, getYesterdayDay } from '.';
 
 describe('api/helpers/date', () => {
   describe('get30minutesFromNow', () => {
@@ -26,6 +26,18 @@ describe('api/helpers/date', () => {
       const now = new Date();
 
       const expected = new Date(now.setDate(now.getDate() + 1)).getDate();
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('getYesterdayDay', () => {
+    it('should return the day of yesterday', () => {
+      const result = getYesterdayDay();
+
+      const now = new Date();
+
+      const expected = new Date(now.setDate(now.getDate() - 1)).getDate();
 
       expect(result).toEqual(expected);
     });

--- a/src/api/helpers/date/index.ts
+++ b/src/api/helpers/date/index.ts
@@ -29,3 +29,16 @@ export const getTomorrowDay = (): number => {
 
   return result;
 };
+
+/**
+ * getYesterdayDay
+ * Get 1 day before now and return the day
+ * @returns {Integer} 1 day before toda
+ */
+export const getYesterdayDay = (): number => {
+  const now = new Date();
+
+  const result = new Date(now.setDate(now.getDate() - 1)).getDate();
+
+  return result;
+};

--- a/src/api/helpers/should-block-account/index.test.ts
+++ b/src/api/helpers/should-block-account/index.test.ts
@@ -16,7 +16,7 @@ dotenv.config();
 
 const context = getContext(config, PrismaModule) as Context;
 
-const { MAX_PASSWORD_RESET_TRIES, MAX_AUTH_RETRIES_TIMEFRAME } = ACCOUNT;
+const { MAX_AUTH_RETRIES, MAX_AUTH_RETRIES_TIMEFRAME } = ACCOUNT;
 
 describe('helpers/should-block-account', () => {
   let account: Account;
@@ -37,7 +37,7 @@ describe('helpers/should-block-account', () => {
     })) as Account;
   });
 
-  describe(`when the account has ${MAX_PASSWORD_RESET_TRIES} entries in the AuthenticationRetry table that are within MAX_AUTH_RETRIES_TIMEFRAME`, () => {
+  describe(`when the account has ${MAX_AUTH_RETRIES} entries in the AuthenticationRetry table that are within MAX_AUTH_RETRIES_TIMEFRAME`, () => {
     beforeEach(async () => {
       // wipe the AuthenticationRetry table so we have a clean slate.
       retries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
@@ -47,7 +47,7 @@ describe('helpers/should-block-account', () => {
       });
 
       // generate an array of promises to create retry entries
-      const entriesToCreate = [...Array(MAX_PASSWORD_RESET_TRIES)].map(async () => createAuthenticationRetryEntry(context, account.id));
+      const entriesToCreate = [...Array(MAX_AUTH_RETRIES)].map(async () => createAuthenticationRetryEntry(context, account.id));
 
       await Promise.all(entriesToCreate);
 
@@ -61,7 +61,7 @@ describe('helpers/should-block-account', () => {
     });
   });
 
-  describe(`when the account does NOT have ${MAX_PASSWORD_RESET_TRIES} entries in the AuthenticationRetry table`, () => {
+  describe(`when the account does NOT have ${MAX_AUTH_RETRIES} entries in the AuthenticationRetry table`, () => {
     beforeEach(async () => {
       // delete the last retry entry
       const lastRetry = retries[retries.length - 1];
@@ -80,7 +80,7 @@ describe('helpers/should-block-account', () => {
     });
   });
 
-  describe(`when the account has ${MAX_PASSWORD_RESET_TRIES} entries in the AuthenticationRetry table that are outside of the timeframe`, () => {
+  describe(`when the account has ${MAX_AUTH_RETRIES} entries in the AuthenticationRetry table that are outside of the timeframe`, () => {
     beforeEach(async () => {
       // wipe the AuthenticationRetry table so we have a clean slate.
       retries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
@@ -98,7 +98,7 @@ describe('helpers/should-block-account', () => {
       const currentDay = timeframe.getDate();
       const oneDayOutsideOfTimeframe = new Date(oneHourOutsideOfTimeframe.setDate(currentDay - 1));
 
-      const retryEntries = Array(MAX_PASSWORD_RESET_TRIES).fill({
+      const retryEntries = Array(MAX_AUTH_RETRIES).fill({
         createdAt: oneDayOutsideOfTimeframe,
       });
 

--- a/src/api/helpers/should-block-account/index.test.ts
+++ b/src/api/helpers/should-block-account/index.test.ts
@@ -16,7 +16,7 @@ dotenv.config();
 
 const context = getContext(config, PrismaModule) as Context;
 
-const { MAX_PASSWORD_RESET_TRIES, MAX_PASSWORD_RESET_TRIES_TIMEFRAME } = ACCOUNT;
+const { MAX_PASSWORD_RESET_TRIES, MAX_AUTH_RETRIES_TIMEFRAME } = ACCOUNT;
 
 describe('helpers/should-block-account', () => {
   let account: Account;
@@ -37,7 +37,7 @@ describe('helpers/should-block-account', () => {
     })) as Account;
   });
 
-  describe(`when the account has ${MAX_PASSWORD_RESET_TRIES} entries in the AuthenticationRetry table that are within MAX_PASSWORD_RESET_TRIES_TIMEFRAME`, () => {
+  describe(`when the account has ${MAX_PASSWORD_RESET_TRIES} entries in the AuthenticationRetry table that are within MAX_AUTH_RETRIES_TIMEFRAME`, () => {
     beforeEach(async () => {
       // wipe the AuthenticationRetry table so we have a clean slate.
       retries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
@@ -89,7 +89,7 @@ describe('helpers/should-block-account', () => {
         where: retries,
       });
 
-      const timeframe = new Date(MAX_PASSWORD_RESET_TRIES_TIMEFRAME);
+      const timeframe = new Date(MAX_AUTH_RETRIES_TIMEFRAME);
 
       const currentHours = timeframe.getHours();
 

--- a/src/api/helpers/should-block-account/index.ts
+++ b/src/api/helpers/should-block-account/index.ts
@@ -3,12 +3,12 @@ import { isAfter, isBefore } from 'date-fns';
 import { ACCOUNT } from '../../constants';
 import getAuthenticationRetriesByAccountId from '../get-authentication-retries-by-account-id';
 
-const { MAX_PASSWORD_RESET_TRIES, MAX_PASSWORD_RESET_TRIES_TIMEFRAME } = ACCOUNT;
+const { MAX_PASSWORD_RESET_TRIES, MAX_AUTH_RETRIES_TIMEFRAME } = ACCOUNT;
 
 /**
  * shouldBlockAccount
  * Check an accounts authentication retries
- * If there are total of MAX_PASSWORD_RESET_TRIES in less than MAX_PASSWORD_RESET_TRIES_TIMEFRAME,
+ * If there are total of MAX_PASSWORD_RESET_TRIES in less than MAX_AUTH_RETRIES_TIMEFRAME,
  * Return a flag indicating that the account should be blocked.
  * @param {Object} KeystoneJS context API
  * @param {String} Account ID
@@ -27,7 +27,7 @@ const shouldBlockAccount = async (context: Context, accountId: string): Promise<
 
     /**
      * Get retries that are within 24 hours:
-     * 1) Retry date is after 24 hours from now (MAX_PASSWORD_RESET_TRIES_TIMEFRAME)
+     * 1) Retry date is after 24 hours from now (MAX_AUTH_RETRIES_TIMEFRAME)
      * 2) Retry date is before the current time
      */
     const retriesInTimeframe = [] as Array<string>;
@@ -35,7 +35,7 @@ const shouldBlockAccount = async (context: Context, accountId: string): Promise<
     retries.forEach((retry) => {
       const retryDate = retry.createdAt;
 
-      const isWithinLast24Hours = isAfter(retryDate, MAX_PASSWORD_RESET_TRIES_TIMEFRAME) && isBefore(retryDate, now);
+      const isWithinLast24Hours = isAfter(retryDate, MAX_AUTH_RETRIES_TIMEFRAME) && isBefore(retryDate, now);
 
       if (isWithinLast24Hours) {
         retriesInTimeframe.push(retry.id);
@@ -44,7 +44,7 @@ const shouldBlockAccount = async (context: Context, accountId: string): Promise<
 
     /**
      * Check if the retries breach the threshold:
-     * - total of MAX_PASSWORD_RESET_TRIES in less than MAX_PASSWORD_RESET_TRIES_TIMEFRAME
+     * - total of MAX_PASSWORD_RESET_TRIES in less than MAX_AUTH_RETRIES_TIMEFRAME
      */
     if (retriesInTimeframe.length >= MAX_PASSWORD_RESET_TRIES) {
       console.info(`Account ${accountId} authentication retries exceeds the threshold`);

--- a/src/api/helpers/should-block-account/index.ts
+++ b/src/api/helpers/should-block-account/index.ts
@@ -3,12 +3,12 @@ import { isAfter, isBefore } from 'date-fns';
 import { ACCOUNT } from '../../constants';
 import getAuthenticationRetriesByAccountId from '../get-authentication-retries-by-account-id';
 
-const { MAX_PASSWORD_RESET_TRIES, MAX_AUTH_RETRIES_TIMEFRAME } = ACCOUNT;
+const { MAX_AUTH_RETRIES, MAX_AUTH_RETRIES_TIMEFRAME } = ACCOUNT;
 
 /**
  * shouldBlockAccount
  * Check an accounts authentication retries
- * If there are total of MAX_PASSWORD_RESET_TRIES in less than MAX_AUTH_RETRIES_TIMEFRAME,
+ * If there are total of MAX_AUTH_RETRIES in less than MAX_AUTH_RETRIES_TIMEFRAME,
  * Return a flag indicating that the account should be blocked.
  * @param {Object} KeystoneJS context API
  * @param {String} Account ID
@@ -44,9 +44,9 @@ const shouldBlockAccount = async (context: Context, accountId: string): Promise<
 
     /**
      * Check if the retries breach the threshold:
-     * - total of MAX_PASSWORD_RESET_TRIES in less than MAX_AUTH_RETRIES_TIMEFRAME
+     * - total of MAX_AUTH_RETRIES in less than MAX_AUTH_RETRIES_TIMEFRAME
      */
-    if (retriesInTimeframe.length >= MAX_PASSWORD_RESET_TRIES) {
+    if (retriesInTimeframe.length >= MAX_AUTH_RETRIES) {
       console.info(`Account ${accountId} authentication retries exceeds the threshold`);
 
       return true;


### PR DESCRIPTION
This PR fixes an issue where the `shouldBlockAccount` check would include auth retry attempts would include attempts outside of `MAX_AUTH_RETRIES_TIMEFRAME`.


## Changes
- Create new API constant helper, `DATE_24_HOURS_IN_THE_PAST`.
- Create new API date helper, `getYesterdayDay`. This is used for unit tests.
- Update API `shouldBlockAccount` helper function to use `isAfter` and `isBefore` date-fns functions instead of `isWithinInterval`.

## Other improvements
- Rename some API constants since they are not specific to password reset.
  - `MAX_PASSWORD_RESET_TRIES` is now `MAX_AUTH_RETRIES`.
  - `MAX_PASSWORD_RESET_TRIES_TIMEFRAME` is now `MAX_AUTH_RETRIES_TIMEFRAME`.