### PR TITLE
fix(EMS-1736): Quote - Tell us about your policy - fix "percentage of cover" population issue

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy-validation.spec.js
@@ -171,8 +171,8 @@ context('Tell us about the multi policy you need - form validation', () => {
     });
   });
 
-  describe('with any validation error', () => {
-    it('should render submitted values', () => {
+  describe('with `currency` and `max amount owed` fields have been submitted and `percentage of cover` is not provided', () => {
+    it('should render the submitted values for the `currency` and `max amount owed` fields', () => {
       tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].input().select('GBP');
       tellUsAboutYourPolicyPage[FIELD_IDS.MAX_AMOUNT_OWED].input().clear().type('10');
 
@@ -182,6 +182,18 @@ context('Tell us about the multi policy you need - form validation', () => {
 
       tellUsAboutYourPolicyPage[FIELD_IDS.MAX_AMOUNT_OWED].input()
         .should('have.attr', 'value', '10');
+    });
+  });
+
+  describe('with the `percentage of cover` field has been submitted and other fields are not provided', () => {
+    it('should render the submitted values for the `percentage of cover` field', () => {
+      tellUsAboutYourPolicyPage[FIELD_IDS.MAX_AMOUNT_OWED].input().clear();
+
+      tellUsAboutYourPolicyPage[FIELD_IDS.PERCENTAGE_OF_COVER].input().select('85');
+
+      tellUsAboutYourPolicyPage.submitButton().click();
+
+      tellUsAboutYourPolicyPage[FIELD_IDS.PERCENTAGE_OF_COVER].inputOptionSelected().contains('85');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy-validation.spec.js
@@ -189,11 +189,13 @@ context('Tell us about the multi policy you need - form validation', () => {
     it('should render the submitted values for the `percentage of cover` field', () => {
       tellUsAboutYourPolicyPage[FIELD_IDS.MAX_AMOUNT_OWED].input().clear();
 
-      tellUsAboutYourPolicyPage[FIELD_IDS.PERCENTAGE_OF_COVER].input().select('85');
+      const field = tellUsAboutYourPolicyPage[FIELD_IDS.PERCENTAGE_OF_COVER];
+
+      field.input().select('85');
 
       tellUsAboutYourPolicyPage.submitButton().click();
 
-      tellUsAboutYourPolicyPage[FIELD_IDS.PERCENTAGE_OF_COVER].inputOptionSelected().contains('85');
+      field.inputOptionSelected().contains('85');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy-validation.spec.js
@@ -158,11 +158,13 @@ context('Tell us about the policy you need page - form validation', () => {
     it('should render the submitted values for the `percentage of cover` field', () => {
       tellUsAboutYourPolicyPage[FIELD_IDS.CONTRACT_VALUE].input().clear();
 
-      tellUsAboutYourPolicyPage[FIELD_IDS.PERCENTAGE_OF_COVER].input().select('90');
+      const field = tellUsAboutYourPolicyPage[FIELD_IDS.PERCENTAGE_OF_COVER];
+
+      field.input().select('90');
 
       tellUsAboutYourPolicyPage.submitButton().click();
 
-      tellUsAboutYourPolicyPage[FIELD_IDS.PERCENTAGE_OF_COVER].inputOptionSelected().contains('90');
+      field.inputOptionSelected().contains('90');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy-validation.spec.js
@@ -140,8 +140,8 @@ context('Tell us about the policy you need page - form validation', () => {
     });
   });
 
-  describe('with any validation error', () => {
-    it('should render submitted values', () => {
+  describe('with `currency` and `contract value` fields have been submitted and `percentage of cover` is not provided', () => {
+    it('should render the submitted values for `currency` and `contract value` fields', () => {
       tellUsAboutYourPolicyPage[FIELD_IDS.CURRENCY].input().select('GBP');
       tellUsAboutYourPolicyPage[FIELD_IDS.CONTRACT_VALUE].input().clear().type('10');
 
@@ -151,6 +151,18 @@ context('Tell us about the policy you need page - form validation', () => {
 
       tellUsAboutYourPolicyPage[FIELD_IDS.CONTRACT_VALUE].input()
         .should('have.attr', 'value', '10');
+    });
+  });
+
+  describe('with the `perecntage of cover` field has been submitted and other fields are not provided', () => {
+    it('should render the submitted values for the `percentage of cover` field', () => {
+      tellUsAboutYourPolicyPage[FIELD_IDS.CONTRACT_VALUE].input().clear();
+
+      tellUsAboutYourPolicyPage[FIELD_IDS.PERCENTAGE_OF_COVER].input().select('90');
+
+      tellUsAboutYourPolicyPage.submitButton().click();
+
+      tellUsAboutYourPolicyPage[FIELD_IDS.PERCENTAGE_OF_COVER].inputOptionSelected().contains('90');
     });
   });
 });

--- a/e2e-tests/cypress/e2e/pages/quote/tellUsAboutYourPolicy.js
+++ b/e2e-tests/cypress/e2e/pages/quote/tellUsAboutYourPolicy.js
@@ -29,6 +29,7 @@ const tellUsAboutYourPolicyPage = {
     hint: () => cy.get(`[data-cy="${FIELD_IDS.PERCENTAGE_OF_COVER}-hint"]`),
     input: () => cy.get(`[data-cy="${FIELD_IDS.PERCENTAGE_OF_COVER}-input"]`),
     inputOption: () => cy.get(`[data-cy="${FIELD_IDS.PERCENTAGE_OF_COVER}-input"] option`),
+    inputOptionSelected: () => cy.get(`[data-cy="${FIELD_IDS.PERCENTAGE_OF_COVER}-input"]`).find(':selected'),
     errorMessage: () => cy.get(`[data-cy="${FIELD_IDS.PERCENTAGE_OF_COVER}-error-message"]`),
   },
   [FIELD_IDS.CREDIT_PERIOD]: {

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
@@ -424,7 +424,9 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
         it('should render template with mapped submitted percentage', async () => {
           await post(req, res);
 
-          const mappedPercentageOfCoverWithSelected = mapPercentageOfCover(PERCENTAGES_OF_COVER, req.body[PERCENTAGE_OF_COVER]);
+          const submittedPercentageOfCover = Number(req.body[PERCENTAGE_OF_COVER]);
+
+          const mappedPercentageOfCoverWithSelected = mapPercentageOfCover(PERCENTAGES_OF_COVER, submittedPercentageOfCover);
 
           expect(res.render).toHaveBeenCalledWith(TEMPLATES.QUOTE.TELL_US_ABOUT_YOUR_POLICY, {
             ...generatePageVariables(req.session.submittedData[POLICY_TYPE]),

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.ts
@@ -161,7 +161,7 @@ const post = async (req: Request, res: Response) => {
 
     // map percentage of cover drop down options
     let mappedPercentageOfCover = [];
-    const submittedPercentageOfCover = req.body[PERCENTAGE_OF_COVER];
+    const submittedPercentageOfCover = Number(req.body[PERCENTAGE_OF_COVER]);
 
     if (submittedPercentageOfCover) {
       mappedPercentageOfCover = mapPercentageOfCover(PERCENTAGES_OF_COVER, submittedPercentageOfCover);


### PR DESCRIPTION
This PR fixes an issue where the "percentage of cover" field in the "tell us about your policy" form would not be populated with a submitted answer when other fields have validation errors.

## Changes
- Wrap the submitted percentage of cover value in `Number()`, as per other instances of the percentage of cover mapping.
- Add E2E test coverage for both single and multiple contract policy types.
- Add more details to the the existing E2E test coverage descriptions.