### PR TITLE
chore(EMS-1721): Various technical improvements

### DIFF
--- a/e2e-tests/constants/dates.js
+++ b/e2e-tests/constants/dates.js
@@ -1,0 +1,20 @@
+/**
+ * DATE_ONE_MINUTE_IN_THE_PAST
+ * Generate a date that is 1 minute in the past.
+ * @returns {Date}
+ */
+export const DATE_ONE_MINUTE_IN_THE_PAST = () => {
+  const now = new Date();
+
+  const MS_PER_MINUTE = 60000;
+
+  const oneMinuteInThePast = new Date(now.getTime() - 1 * MS_PER_MINUTE);
+
+  return oneMinuteInThePast;
+};
+
+const DATES = {
+  DATE_ONE_MINUTE_IN_THE_PAST,
+};
+
+export default DATES;

--- a/e2e-tests/constants/index.js
+++ b/e2e-tests/constants/index.js
@@ -2,6 +2,7 @@ export * from './account';
 export * from './api';
 export * from './application';
 export * from './date-format';
+export * from './dates';
 export * from './examples';
 export * from './field-ids';
 export * from './field-values';

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/link-expired/account-password-reset-link-expired-send-new-link.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/link-expired/account-password-reset-link-expired-send-new-link.spec.js
@@ -3,6 +3,7 @@ import { yourDetailsPage } from '../../../../../pages/insurance/account/create';
 import { signInPage } from '../../../../../pages/insurance/account/sign-in';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import { DATE_ONE_MINUTE_IN_THE_PAST } from '../../../../../../../constants/dates';
 import api from '../../../../../../support/api';
 
 const {
@@ -67,13 +68,10 @@ context('Insurance - Account - Password reset - link expired page - send new lin
        * Update the account's password reset expiry date via the API,
        * so that we can mimic missing the verification period.
        */
-      const now = new Date();
-
-      const milliseconds = 300000;
-      const oneMinuteAgo = new Date(now.setMilliseconds(-milliseconds)).toISOString();
+      const oneMinuteInThePast = DATE_ONE_MINUTE_IN_THE_PAST();
 
       const updateObj = {
-        [PASSWORD_RESET_EXPIRY]: oneMinuteAgo,
+        [PASSWORD_RESET_EXPIRY]: oneMinuteInThePast,
       };
 
       updatedAccount = await api.updateAccount(account.id, updateObj);

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/link-expired/account-password-reset-link-expired.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/link-expired/account-password-reset-link-expired.spec.js
@@ -5,6 +5,7 @@ import { linkExpiredPage } from '../../../../../pages/insurance/account/password
 import { PAGES, BUTTONS } from '../../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import { DATE_ONE_MINUTE_IN_THE_PAST } from '../../../../../../../constants/dates';
 import api from '../../../../../../support/api';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ACCOUNT.PASSWORD_RESET.LINK_EXPIRED;
@@ -74,13 +75,10 @@ context('Insurance - Account - Password reset - link expired page', () => {
        * Update the account's password reset expiry date via the API,
        * so that we can mimic missing the verification period.
        */
-      const now = new Date();
-
-      const milliseconds = 300000;
-      const oneMinuteAgo = new Date(now.setMilliseconds(-milliseconds)).toISOString();
+      const oneMinuteInThePast = DATE_ONE_MINUTE_IN_THE_PAST();
 
       const updateObj = {
-        [PASSWORD_RESET_EXPIRY]: oneMinuteAgo,
+        [PASSWORD_RESET_EXPIRY]: oneMinuteInThePast,
       };
 
       updatedAccount = await api.updateAccount(account.id, updateObj);

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/suspended/link-expired/account-suspended-link-expired.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/suspended/link-expired/account-suspended-link-expired.spec.js
@@ -1,5 +1,6 @@
 import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
+import { DATE_ONE_MINUTE_IN_THE_PAST } from '../../../../../../../constants/dates';
 import { PAGES } from '../../../../../../../content-strings';
 import api from '../../../../../../support/api';
 
@@ -52,13 +53,10 @@ context('Insurance - Account - Suspended - Verify email - Visit with an expired 
        * Update the account's reactivation expiry date via the API,
        * so that we can mimic missing the verification period.
        */
-      const now = new Date();
-
-      const MS_PER_MINUTE = 60000;
-      const oneMinuteAgo = new Date(now.getTime() - 1 * MS_PER_MINUTE);
+      const oneMinuteInThePast = DATE_ONE_MINUTE_IN_THE_PAST();
 
       const updateObj = {
-        [REACTIVATION_EXPIRY]: oneMinuteAgo,
+        [REACTIVATION_EXPIRY]: oneMinuteInThePast,
       };
 
       updatedAccount = await api.updateAccount(account.id, updateObj);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@cypress-audit/lighthouse": "^1.4.2",
         "@cypress-audit/pa11y": "^1.4.2",
         "@keystone-6/auth": "^7.0.0",
-        "@keystone-6/core": "^5.3.0",
+        "@keystone-6/core": "^5.3.1",
         "@keystone-6/fields-document": "^7.0.0",
         "apollo-cache-inmemory": "^1.6.6",
         "apollo-client": "^2.6.10",
@@ -452,43 +452,43 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.345.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.345.0.tgz",
-      "integrity": "sha512-KHpJ7jZq0OGXNIJ+K0U4DcVubroXq92TD7rQi16TU7q8AnjrCoMuJz32QJI+9FEFbjmTIJ/tts9rma0PqR30bw==",
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.350.0.tgz",
+      "integrity": "sha512-46AhBvGWo6TEzlvZieNlZHC2w4NJUJA52KfDUtgr8PmChGgxqzlLBAiOpqbDJ83GR3YB6CNEjXxzN5tmyJKICA==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.345.0",
-        "@aws-sdk/config-resolver": "3.342.0",
-        "@aws-sdk/credential-provider-node": "3.345.0",
-        "@aws-sdk/fetch-http-handler": "3.342.0",
-        "@aws-sdk/hash-node": "3.344.0",
-        "@aws-sdk/invalid-dependency": "3.342.0",
-        "@aws-sdk/middleware-content-length": "3.342.0",
-        "@aws-sdk/middleware-endpoint": "3.344.0",
-        "@aws-sdk/middleware-host-header": "3.342.0",
-        "@aws-sdk/middleware-logger": "3.342.0",
-        "@aws-sdk/middleware-recursion-detection": "3.342.0",
-        "@aws-sdk/middleware-retry": "3.342.0",
-        "@aws-sdk/middleware-serde": "3.342.0",
-        "@aws-sdk/middleware-signing": "3.342.0",
-        "@aws-sdk/middleware-stack": "3.342.0",
-        "@aws-sdk/middleware-user-agent": "3.345.0",
-        "@aws-sdk/node-config-provider": "3.342.0",
-        "@aws-sdk/node-http-handler": "3.344.0",
-        "@aws-sdk/smithy-client": "3.342.0",
-        "@aws-sdk/types": "3.342.0",
-        "@aws-sdk/url-parser": "3.342.0",
+        "@aws-sdk/client-sts": "3.350.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-node": "3.350.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-        "@aws-sdk/util-defaults-mode-node": "3.342.0",
-        "@aws-sdk/util-endpoints": "3.342.0",
-        "@aws-sdk/util-retry": "3.342.0",
-        "@aws-sdk/util-user-agent-browser": "3.345.0",
-        "@aws-sdk/util-user-agent-node": "3.345.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
         "@aws-sdk/util-utf8": "3.310.0",
         "@smithy/protocol-http": "^1.0.1",
         "@smithy/types": "^1.0.0",
@@ -496,6 +496,809 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+      "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.350.0.tgz",
+      "integrity": "sha512-2vpiv6SEjmQGK3ZueGzvTMG6NenjWp0CHjmda71d1Iqr+tZ2UlfC35+3ioU8JP+jiXLL+y9r+SCer3IC8N/i+Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.350.0.tgz",
+      "integrity": "sha512-v3UrWIglg9PPzGXqhyGB/qPZ8ifiGM9r4LV8vve1TpiKsUdf1Khtx1eB8yqjNO0vIsYUF+j1C23QT1qAN2DcEA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sts": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.350.0.tgz",
+      "integrity": "sha512-s8RsJ6upWQgeUt8GdV3j3ZeTS7BQXedk77RhZ7wzvVwAjO9wow4uS7Iyic4kS3Y/6d26s0MO2vP4bR6HW6U6ZQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-node": "3.350.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-sdk-sts": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
+      "integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
+      "integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
+      "integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.350.0.tgz",
+      "integrity": "sha512-mGGU0PpnG0VDNKSuGi083U1egjprrU9/XoRtgf+iYvAKXRR/0XA4pGW5c7zpHY7m4iLhBuRj6N4oxQsH9cMtWg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.350.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.350.0.tgz",
+      "integrity": "sha512-xmqwCFwj/CZPx6AKHNb24Kpr0eHW9VISt9r+SfgH8PaYg5cNyX1pKmMbQCket5ov+WvHEQtOK7aBafak7dhauA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-ini": "3.350.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.350.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
+      "integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.350.0.tgz",
+      "integrity": "sha512-u/3kv+PJeVawzBtWBei+IX1/z50mwhpPe3VrKSTns4CPUw8b5sqIYWkAaw5hxm0td69+xcL98RzIJsEpJc4QSQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.350.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/token-providers": "3.350.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
+      "integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+      "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
+      "integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/hash-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+      "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+      "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+      "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+      "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+      "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+      "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
+      "integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
+      "integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
+      "integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.347.0.tgz",
+      "integrity": "sha512-wJbGN3OE1/daVCrwk49whhIr9E0j1N4gWwN/wi4WuyYIA+5lMUfVp0aGIOvZR+878DxuFz2hQ4XcZVT4K2WvQw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
+      "integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/property-provider": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
+      "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+      "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
+      "integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
+      "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.347.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/token-providers": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.350.0.tgz",
+      "integrity": "sha512-VIfVMV5An1VQQ6bOKQTHPsRFHD3/YRGOPk9lDTVJGOK0G1DIFYd/10ZaLQ86rCWLck2lGhjxsOen2N2n6MtA0A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.350.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/url-parser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
+      "integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
+      "integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.347.0.tgz",
+      "integrity": "sha512-/WUkirizeNAqwVj0zkcrqdQ9pUm1HY5kU+qy7xTR0OebkuJauglkmSTMD+56L1JPunWqHhlwCMVRaz5eaJdSEQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-retry": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+      "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+      "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
+      "integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/fast-xml-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-s3": {
@@ -711,14 +1514,39 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.345.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.345.0.tgz",
-      "integrity": "sha512-cV3oLjy4+OlIfSeNckqEzB9OH4Fb7GPJIb2YECaRAjcEe6FuhfW75dkKfd+whfG+8RNJQRlf1bTxAetCFUUMqA==",
+      "version": "3.351.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.351.0.tgz",
+      "integrity": "sha512-c9XyDUj82ttqQqF8h4Ie7k2Fl3bMh8/yBGEQWIPzWRhfy40m4ChqjilKAcBeoxR/w4Qp3RsdDfLRTLC8sJTpIg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.345.0",
-        "@aws-sdk/property-provider": "3.342.0",
-        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/client-cognito-identity": "3.350.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/property-provider": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
+      "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "optional": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -836,28 +1664,831 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.345.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.345.0.tgz",
-      "integrity": "sha512-rTbc1asHXnVFFiTnQBn90N7rU3ICDaFpsivkzXlo5MEbRRkxswM5QUDm0iO1g4EnGEWTNwTb6T5kwPqg+8GfVw==",
+      "version": "3.351.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.351.0.tgz",
+      "integrity": "sha512-KVfLTVpeDKnOPl0u5w3RJdNz+AtFIOj3dsfpyLkGCV5bHClLN05YFf1ajh93Z5FijuhvDSYuLT1Xr3Ud+AIudQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.345.0",
-        "@aws-sdk/client-sso": "3.345.0",
-        "@aws-sdk/client-sts": "3.345.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.345.0",
-        "@aws-sdk/credential-provider-env": "3.342.0",
-        "@aws-sdk/credential-provider-imds": "3.342.0",
-        "@aws-sdk/credential-provider-ini": "3.345.0",
-        "@aws-sdk/credential-provider-node": "3.345.0",
-        "@aws-sdk/credential-provider-process": "3.342.0",
-        "@aws-sdk/credential-provider-sso": "3.345.0",
-        "@aws-sdk/credential-provider-web-identity": "3.342.0",
-        "@aws-sdk/property-provider": "3.342.0",
-        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/client-cognito-identity": "3.350.0",
+        "@aws-sdk/client-sso": "3.350.0",
+        "@aws-sdk/client-sts": "3.350.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.351.0",
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-ini": "3.350.0",
+        "@aws-sdk/credential-provider-node": "3.350.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.350.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+      "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.350.0.tgz",
+      "integrity": "sha512-2vpiv6SEjmQGK3ZueGzvTMG6NenjWp0CHjmda71d1Iqr+tZ2UlfC35+3ioU8JP+jiXLL+y9r+SCer3IC8N/i+Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.350.0.tgz",
+      "integrity": "sha512-v3UrWIglg9PPzGXqhyGB/qPZ8ifiGM9r4LV8vve1TpiKsUdf1Khtx1eB8yqjNO0vIsYUF+j1C23QT1qAN2DcEA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.350.0.tgz",
+      "integrity": "sha512-s8RsJ6upWQgeUt8GdV3j3ZeTS7BQXedk77RhZ7wzvVwAjO9wow4uS7Iyic4kS3Y/6d26s0MO2vP4bR6HW6U6ZQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-node": "3.350.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-sdk-sts": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
+      "integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
+      "integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
+      "integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.350.0.tgz",
+      "integrity": "sha512-mGGU0PpnG0VDNKSuGi083U1egjprrU9/XoRtgf+iYvAKXRR/0XA4pGW5c7zpHY7m4iLhBuRj6N4oxQsH9cMtWg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.350.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.350.0.tgz",
+      "integrity": "sha512-xmqwCFwj/CZPx6AKHNb24Kpr0eHW9VISt9r+SfgH8PaYg5cNyX1pKmMbQCket5ov+WvHEQtOK7aBafak7dhauA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-ini": "3.350.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.350.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
+      "integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.350.0.tgz",
+      "integrity": "sha512-u/3kv+PJeVawzBtWBei+IX1/z50mwhpPe3VrKSTns4CPUw8b5sqIYWkAaw5hxm0td69+xcL98RzIJsEpJc4QSQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.350.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/token-providers": "3.350.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
+      "integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+      "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
+      "integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/hash-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+      "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+      "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+      "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+      "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+      "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+      "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
+      "integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
+      "integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
+      "integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.347.0.tgz",
+      "integrity": "sha512-wJbGN3OE1/daVCrwk49whhIr9E0j1N4gWwN/wi4WuyYIA+5lMUfVp0aGIOvZR+878DxuFz2hQ4XcZVT4K2WvQw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
+      "integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/property-provider": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
+      "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+      "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
+      "integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
+      "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.347.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.350.0.tgz",
+      "integrity": "sha512-VIfVMV5An1VQQ6bOKQTHPsRFHD3/YRGOPk9lDTVJGOK0G1DIFYd/10ZaLQ86rCWLck2lGhjxsOen2N2n6MtA0A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.350.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/url-parser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
+      "integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
+      "integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.347.0.tgz",
+      "integrity": "sha512-/WUkirizeNAqwVj0zkcrqdQ9pUm1HY5kU+qy7xTR0OebkuJauglkmSTMD+56L1JPunWqHhlwCMVRaz5eaJdSEQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-retry": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+      "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+      "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
+      "integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/fast-xml-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/eventstream-codec": {
@@ -1914,9 +3545,9 @@
       }
     },
     "node_modules/@azure/keyvault-keys": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.7.0.tgz",
-      "integrity": "sha512-HScWdORbRCKi1vdKI6EChe/t/P/zV7jcGZWfj18BOyeensk5d1/Ynfx1t6xfAy5zUIQvAWVU97hXdCznDpULbQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.7.1.tgz",
+      "integrity": "sha512-zfmlZQCw1Yz+aPhgZmWOYBUzaKmfBzR2yceAE4S6hKDl7YZraTguuXmtFbCqjRvpz+pIMKAK25fENay9mFy1hQ==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
@@ -1946,20 +3577,20 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.37.0.tgz",
-      "integrity": "sha512-YNGD/W/tw/5wDWlXOfmrVILaxVsorVLxYU2ovmL1PDvxkdudbQRyGk/76l4emqgDAl/kPQeqyivxjOU6w1YfvQ==",
+      "version": "2.37.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.37.1.tgz",
+      "integrity": "sha512-EoKQISEpIY39Ru1OpWkeFZBcwp6Y0bG81bVmdyy4QJebPPDdVzfm62PSU0XFIRc3bqjZ4PBKBLMYLuo9NZYAow==",
       "dependencies": {
-        "@azure/msal-common": "13.0.0"
+        "@azure/msal-common": "13.1.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.0.0.tgz",
-      "integrity": "sha512-GqCOg5H5bouvLij9NFXFkh+asRRxsPBRwnTDsfK7o0KcxYHJbuidKw8/VXpycahGXNxgtuhqtK/n5he+5NhyEA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.1.0.tgz",
+      "integrity": "sha512-wj+ULrRB0HTuMmtrMjg8j3guCx32GE2BCPbsMCZkHgL1BZetC3o/Su5UJEQMX1HNc9CrIaQNx5WaKWHygYDe0g==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -1973,11 +3604,11 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.17.2.tgz",
-      "integrity": "sha512-l8edYnA2LQj4ue3pjxVz1Qy4HuU5xbcoebfe2bGTRvBL9Q6n2Df47aGftkLIyimD1HxHuA4ZZOe23a/HshoYXw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.17.3.tgz",
+      "integrity": "sha512-slsa+388bQQWnWH1V91KL+zV57rIp/0OQFfF0EmVMY8gnEIkAnpWWFUVBTTMbxEyjEFMk5ZW9xiHvHBcYFHzDw==",
       "dependencies": {
-        "@azure/msal-common": "13.0.0",
+        "@azure/msal-common": "13.1.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -1986,9 +3617,9 @@
       }
     },
     "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.0.0.tgz",
-      "integrity": "sha512-GqCOg5H5bouvLij9NFXFkh+asRRxsPBRwnTDsfK7o0KcxYHJbuidKw8/VXpycahGXNxgtuhqtK/n5he+5NhyEA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.1.0.tgz",
+      "integrity": "sha512-wj+ULrRB0HTuMmtrMjg8j3guCx32GE2BCPbsMCZkHgL1BZetC3o/Su5UJEQMX1HNc9CrIaQNx5WaKWHygYDe0g==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -4161,9 +5792,9 @@
       }
     },
     "node_modules/@keystone-6/core": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@keystone-6/core/-/core-5.3.0.tgz",
-      "integrity": "sha512-s+/82LzEBIxk6w4UQOxC3xZTF71sIG6hzb6JZgKE6jV5XQ1YuEi5K5XweU9+J6qe13FCl5iNCOREeC2stDElVQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@keystone-6/core/-/core-5.3.1.tgz",
+      "integrity": "sha512-l7UYJLGfsTPnwN3zDb1+upuL1ianj0QvJMNJtta8I5v86GZTnX/F8aSuH9NBHyA29zbea5YCrevc73UCn6sIZg==",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
         "@apollo/client": "^3.7.0",
@@ -4192,9 +5823,9 @@
         "@keystone-ui/toast": "^6.0.2",
         "@keystone-ui/tooltip": "^6.0.2",
         "@nodelib/fs.walk": "^1.2.8",
-        "@prisma/client": "4.14.1",
-        "@prisma/internals": "4.14.1",
-        "@prisma/migrate": "4.14.1",
+        "@prisma/client": "4.15.0",
+        "@prisma/internals": "4.15.0",
+        "@prisma/migrate": "4.15.0",
         "@sindresorhus/slugify": "^1.1.2",
         "@types/apollo-upload-client": "17.0.2",
         "@types/bcryptjs": "^2.4.2",
@@ -4242,7 +5873,7 @@
         "node-fetch": "^2.6.7",
         "p-limit": "^2.3.0",
         "pluralize": "^8.0.0",
-        "prisma": "4.14.1",
+        "prisma": "4.15.0",
         "prompts": "^2.4.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4817,12 +6448,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.14.1.tgz",
-      "integrity": "sha512-TZIswkeX1ccsHG/eN2kICzg/csXll0osK3EHu1QKd8VJ3XLcXozbNELKkCNfsCUvKJAwPdDtFCzF+O+raIVldw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.15.0.tgz",
+      "integrity": "sha512-xnROvyABcGiwqRNdrObHVZkD9EjkJYHOmVdlKy1yGgI+XOzvMzJ4tRg3dz1pUlsyhKxXGCnjIQjWW+2ur+YXuw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c"
+        "@prisma/engines-version": "4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944"
       },
       "engines": {
         "node": ">=14.17"
@@ -4840,7 +6471,6 @@
       "version": "4.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.15.0.tgz",
       "integrity": "sha512-dkbPz+gOVlWDBAaOEseSpAUz9NppT38UlwdryPyrwct6OClLirNC7wH+TpAQk5OZp9x59hNnfDz+T7XvL1v0/Q==",
-      "peer": true,
       "dependencies": {
         "@types/debug": "4.1.8",
         "debug": "4.3.4",
@@ -4848,23 +6478,23 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.14.1.tgz",
-      "integrity": "sha512-APqFddPVHYmWNKqc+5J5SqrLFfOghKOLZxobmguDUacxOwdEutLsbXPVhNnpFDmuQWQFbXmrTTPoRrrF6B1MWA==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.15.0.tgz",
+      "integrity": "sha512-FTaOCGs0LL0OW68juZlGxFtYviZa4xdQj/rQEdat2txw0s3Vu/saAPKjNVXfIgUsGXmQ72HPgNr6935/P8FNAA==",
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c.tgz",
-      "integrity": "sha512-3jum8/YSudeSN0zGW5qkpz+wAN2V/NYCQ+BPjvHYDfWatLWlQkqy99toX0GysDeaUoBIJg1vaz2yKqiA3CFcQw=="
+      "version": "4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944.tgz",
+      "integrity": "sha512-sVOig4tjGxxlYaFcXgE71f/rtFhzyYrfyfNFUsxCIEJyVKU9rdOWIlIwQ2NQ7PntvGnn+x0XuFo4OC1jvPJKzg=="
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.14.1.tgz",
-      "integrity": "sha512-4IRZMbeA+5tU+gf15n8oUxGIPqJyF1Gc7DOeP178nvKPNFESp3tWDvzD5vOpVuE0GRM2Mq5WrtiQo5XLD0yQnw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.15.0.tgz",
+      "integrity": "sha512-J5HVpRpLxsw9iDLcwwwxL09DXhERnutMiSwyfgHwCQhTHcETc5++XGZlHZtG4toykO3tploCDynXhJc6Fe/u2A==",
       "dependencies": {
-        "@prisma/debug": "4.14.1",
-        "@prisma/get-platform": "4.14.1",
+        "@prisma/debug": "4.15.0",
+        "@prisma/get-platform": "4.15.0",
         "execa": "5.1.1",
         "find-cache-dir": "3.3.2",
         "fs-extra": "11.1.1",
@@ -4872,7 +6502,7 @@
         "http-proxy-agent": "5.0.0",
         "https-proxy-agent": "5.0.1",
         "kleur": "4.1.5",
-        "node-fetch": "2.6.9",
+        "node-fetch": "2.6.11",
         "p-filter": "2.1.0",
         "p-map": "4.0.0",
         "p-retry": "4.6.2",
@@ -4882,67 +6512,10 @@
         "tempy": "1.0.1"
       }
     },
-    "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.14.1.tgz",
-      "integrity": "sha512-jZjNZimL7FVlSyL78r/w9pSqu2s1y+5JGyi0Ajvq17cBCdDzMONGM76PDKBWjOusRhbZD4xcTQ5kfr9JqM0I2A==",
-      "dependencies": {
-        "@types/debug": "4.1.7",
-        "debug": "4.3.4",
-        "strip-ansi": "6.0.1"
-      }
-    },
-    "node_modules/@prisma/fetch-engine/node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
-    "node_modules/@prisma/fetch-engine/node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@prisma/fetch-engine/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/@prisma/fetch-engine/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/@prisma/fetch-engine/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/@prisma/generator-helper": {
       "version": "4.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.15.0.tgz",
       "integrity": "sha512-JVHNgXr0LrcqXqmFrs+BzxfyRL6cFD5GLTMVWfCLU7kqSJdWuZxfoZW995tg6mOXnBgPTf6Ocv3RY4RLQq8k4g==",
-      "peer": true,
       "dependencies": {
         "@prisma/debug": "4.15.0",
         "@types/cross-spawn": "6.0.2",
@@ -4951,11 +6524,11 @@
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.14.1.tgz",
-      "integrity": "sha512-b5EXlVaW2JDCB3o5lsik9NZwARflOLCINyhDgNaqpGGljcXoUneqAlvm9dZ9YNckXImghV1B19aouVpm1LjPrg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.15.0.tgz",
+      "integrity": "sha512-A7EdfysFDTL6HQmyZ6CLyNGRDz/60shqiJuhQ952cS0irGhi4PhTCy5MbjCvUaXjRBR6cjPp9EDaZ47TZlw5hg==",
       "dependencies": {
-        "@prisma/debug": "4.14.1",
+        "@prisma/debug": "4.15.0",
         "escape-string-regexp": "4.0.0",
         "execa": "5.1.1",
         "fs-jetpack": "5.1.0",
@@ -4964,40 +6537,22 @@
         "strip-ansi": "6.0.1",
         "tempy": "1.0.1",
         "terminal-link": "2.1.1",
-        "ts-pattern": "4.2.2"
-      }
-    },
-    "node_modules/@prisma/get-platform/node_modules/@prisma/debug": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.14.1.tgz",
-      "integrity": "sha512-jZjNZimL7FVlSyL78r/w9pSqu2s1y+5JGyi0Ajvq17cBCdDzMONGM76PDKBWjOusRhbZD4xcTQ5kfr9JqM0I2A==",
-      "dependencies": {
-        "@types/debug": "4.1.7",
-        "debug": "4.3.4",
-        "strip-ansi": "6.0.1"
-      }
-    },
-    "node_modules/@prisma/get-platform/node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dependencies": {
-        "@types/ms": "*"
+        "ts-pattern": "4.3.0"
       }
     },
     "node_modules/@prisma/internals": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.14.1.tgz",
-      "integrity": "sha512-JbT5EhwzYV5VKdPWyGNTvYKI4MBinHF8fDglRtC0mbdYEl8IZNoMK5n5QDO4m8vQKGy10Mn3VcnhsEfO6FbdKw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.15.0.tgz",
+      "integrity": "sha512-bmgn1GX74RfjBRVMV4oJknZJOHmXcO9lh0VbwWKXp1zXvjumQCGeBOmLdzkp4SnvIrpkpXQf9JGbmOTKpVsvRw==",
       "dependencies": {
         "@opentelemetry/api": "1.4.1",
-        "@prisma/debug": "4.14.1",
-        "@prisma/engines": "4.14.1",
-        "@prisma/fetch-engine": "4.14.1",
-        "@prisma/generator-helper": "4.14.1",
-        "@prisma/get-platform": "4.14.1",
-        "@prisma/ni": "4.14.1",
-        "@prisma/prisma-fmt-wasm": "4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c",
+        "@prisma/debug": "4.15.0",
+        "@prisma/engines": "4.15.0",
+        "@prisma/fetch-engine": "4.15.0",
+        "@prisma/generator-helper": "4.15.0",
+        "@prisma/get-platform": "4.15.0",
+        "@prisma/ni": "4.15.0",
+        "@prisma/prisma-fmt-wasm": "4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944",
         "archiver": "5.3.1",
         "arg": "5.0.2",
         "checkpoint-client": "1.1.23",
@@ -5006,7 +6561,7 @@
         "escape-string-regexp": "4.0.0",
         "execa": "5.1.1",
         "find-up": "5.0.0",
-        "fp-ts": "2.14.0",
+        "fp-ts": "2.16.0",
         "fs-extra": "11.1.1",
         "fs-jetpack": "5.1.0",
         "global-dirs": "3.0.1",
@@ -5016,9 +6571,9 @@
         "is-wsl": "2.2.0",
         "kleur": "4.1.5",
         "new-github-issue-url": "0.2.1",
-        "node-fetch": "2.6.9",
+        "node-fetch": "2.6.11",
         "npm-packlist": "5.1.3",
-        "open": "7",
+        "open": "7.4.2",
         "p-map": "4.0.0",
         "prompts": "2.4.2",
         "read-pkg-up": "7.0.1",
@@ -5032,36 +6587,7 @@
         "tempy": "1.0.1",
         "terminal-link": "2.1.1",
         "tmp": "0.2.1",
-        "ts-pattern": "4.2.2"
-      }
-    },
-    "node_modules/@prisma/internals/node_modules/@prisma/debug": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.14.1.tgz",
-      "integrity": "sha512-jZjNZimL7FVlSyL78r/w9pSqu2s1y+5JGyi0Ajvq17cBCdDzMONGM76PDKBWjOusRhbZD4xcTQ5kfr9JqM0I2A==",
-      "dependencies": {
-        "@types/debug": "4.1.7",
-        "debug": "4.3.4",
-        "strip-ansi": "6.0.1"
-      }
-    },
-    "node_modules/@prisma/internals/node_modules/@prisma/generator-helper": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.14.1.tgz",
-      "integrity": "sha512-7mxfM6NTLsUgbmx8t+AQTtOdDuUMG+D4K5QtALQP1A3MD7wZy2O+Np4apbvVJwNUn1286PZWk2DTv4cF7XiK3w==",
-      "dependencies": {
-        "@prisma/debug": "4.14.1",
-        "@types/cross-spawn": "6.0.2",
-        "cross-spawn": "7.0.3",
-        "kleur": "4.1.5"
-      }
-    },
-    "node_modules/@prisma/internals/node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dependencies": {
-        "@types/ms": "*"
+        "ts-pattern": "4.3.0"
       }
     },
     "node_modules/@prisma/internals/node_modules/dotenv": {
@@ -5072,66 +6598,23 @@
         "node": ">=12"
       }
     },
-    "node_modules/@prisma/internals/node_modules/fp-ts": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.14.0.tgz",
-      "integrity": "sha512-QLagLSYAgMA00pZzUzeksH/78Sd14y7+Gc2A8Yaja3/IpGOFMdm/gYBuDMxYqLsJ58iT5lz+bJb953RAeFfp1A=="
-    },
-    "node_modules/@prisma/internals/node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@prisma/internals/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/@prisma/internals/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/@prisma/internals/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/@prisma/migrate": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/migrate/-/migrate-4.14.1.tgz",
-      "integrity": "sha512-W5nHkDUJSfci0oZUvEKkPm746ZjVBcpuQOmfT8kg3GUq6Yj+2cKKgu29u9Iz6cAEi1BaQVjzsELCTBN4L7CdbQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/migrate/-/migrate-4.15.0.tgz",
+      "integrity": "sha512-rT8gS1Xfbz//QVc6RMm3XchuQr7uV48BKEe15B2WRpBxR6/3EX0olhrFEJMyV+P2Q5BfnSxTKXQQKhBmAgvUzA==",
       "dependencies": {
-        "@prisma/debug": "4.14.1",
-        "@prisma/get-platform": "4.14.1",
+        "@prisma/debug": "4.15.0",
+        "@prisma/get-platform": "4.15.0",
         "@sindresorhus/slugify": "1.1.2",
         "execa": "5.1.1",
-        "fp-ts": "2.14.0",
+        "fp-ts": "2.16.0",
         "get-stdin": "8.0.0",
         "has-yarn": "2.1.0",
         "indent-string": "4.0.0",
         "kleur": "4.1.5",
         "log-update": "4.0.0",
         "mariadb": "3.1.1",
-        "mongoose": "6.10.5",
+        "mongoose": "6.11.1",
         "mssql": "9.1.1",
         "ora": "5.4.1",
         "pg": "8.10.0",
@@ -5139,45 +6622,22 @@
         "prompts": "2.4.2",
         "strip-ansi": "6.0.1",
         "strip-indent": "3.0.0",
-        "ts-pattern": "4.2.2"
+        "ts-pattern": "4.3.0"
       },
       "peerDependencies": {
         "@prisma/generator-helper": "*",
         "@prisma/internals": "*"
       }
     },
-    "node_modules/@prisma/migrate/node_modules/@prisma/debug": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.14.1.tgz",
-      "integrity": "sha512-jZjNZimL7FVlSyL78r/w9pSqu2s1y+5JGyi0Ajvq17cBCdDzMONGM76PDKBWjOusRhbZD4xcTQ5kfr9JqM0I2A==",
-      "dependencies": {
-        "@types/debug": "4.1.7",
-        "debug": "4.3.4",
-        "strip-ansi": "6.0.1"
-      }
-    },
-    "node_modules/@prisma/migrate/node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
-    "node_modules/@prisma/migrate/node_modules/fp-ts": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.14.0.tgz",
-      "integrity": "sha512-QLagLSYAgMA00pZzUzeksH/78Sd14y7+Gc2A8Yaja3/IpGOFMdm/gYBuDMxYqLsJ58iT5lz+bJb953RAeFfp1A=="
-    },
     "node_modules/@prisma/ni": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/ni/-/ni-4.14.1.tgz",
-      "integrity": "sha512-71ep1GT2k5il/hnLBuGpw81UzcBX5yON2XxOlQ3JknlvOQKkdDRM3If9UgJUrJxx7BHBzieZK02PIKbFVEuqmg=="
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/ni/-/ni-4.15.0.tgz",
+      "integrity": "sha512-kuVzvCbndl2GGoCFufQ5jzSPUaKMF6rp6OmSpFF8z9gflJlPLahtWqIcyKJ8sPaFrkhTlXXsyEX37mY98H1FZg=="
     },
     "node_modules/@prisma/prisma-fmt-wasm": {
-      "version": "4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c.tgz",
-      "integrity": "sha512-qvxi6xbUb4wcawvLju0t2soGBPGs13L6HVmJrZG+RGaDDuJn9qzDAdZl97YdyFgn4jN6VMJeSqXt3yTWKkaaUw=="
+      "version": "4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944.tgz",
+      "integrity": "sha512-1vuW5Cp6DnZpSmmM3dRsJ7do3LncJVkBAV9wwqGSLANDUNWDPfJwC7enN/YY3rnwkEVXMxzkTEbtYGA55blDLw=="
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -5631,7 +7091,6 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
       "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
-      "peer": true,
       "dependencies": {
         "@types/ms": "*"
       }
@@ -14192,11 +15651,11 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mongodb": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.14.0.tgz",
-      "integrity": "sha512-coGKkWXIBczZPr284tYKFLg+KbGPPLlSbdgfKAb6QqCFt5bo5VFZ50O3FFzsw4rnkqjwT6D8Qcoo9nshYKM7Mg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.16.0.tgz",
+      "integrity": "sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==",
       "dependencies": {
-        "bson": "^4.7.0",
+        "bson": "^4.7.2",
         "mongodb-connection-string-url": "^2.5.4",
         "socks": "^2.7.1"
       },
@@ -14218,13 +15677,13 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "6.10.5",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.10.5.tgz",
-      "integrity": "sha512-y4HL4/9EySec7L0gJ+pCm9heLSF45uIIvRS4fSeAFWDfe4vXW1vRZJwTz7OGkra3ZoSfRnFTo9bNZkuggDVlVA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.11.1.tgz",
+      "integrity": "sha512-AvQ8C5ZGF6GcsQhoRg/i7pbNZpb96qLGU5ICBllckp7qMOxcfUF1nA6JstZw841BqRcE6myZ/mx9CluEESaw5Q==",
       "dependencies": {
-        "bson": "^4.7.0",
+        "bson": "^4.7.2",
         "kareem": "2.5.1",
-        "mongodb": "4.14.0",
+        "mongodb": "4.16.0",
         "mpath": "0.9.0",
         "mquery": "4.0.3",
         "ms": "2.1.3",
@@ -15580,12 +17039,12 @@
       "dev": true
     },
     "node_modules/prisma": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.14.1.tgz",
-      "integrity": "sha512-z6hxzTMYqT9SIKlzD08dhzsLUpxjFKKsLpp5/kBDnSqiOjtUyyl/dC5tzxLcOa3jkEHQ8+RpB/fE3w8bgNP51g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.15.0.tgz",
+      "integrity": "sha512-iKZZpobPl48gTcSZVawLMQ3lEy6BnXwtoMj7hluoGFYu2kQ6F9LBuBrUyF95zRVnNo8/3KzLXJXJ5TEnLSJFiA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.14.1"
+        "@prisma/engines": "4.15.0"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -17883,9 +19342,9 @@
       "dev": true
     },
     "node_modules/ts-pattern": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-4.2.2.tgz",
-      "integrity": "sha512-qzJMo2pbkUJWusRH5o8xR+xogn6RmvViyUgwBFTtRENLse470clCGjHDf6haWGZ1AOmk8XkEohUoBW8Uut6Scg=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-4.3.0.tgz",
+      "integrity": "sha512-pefrkcd4lmIVR0LA49Imjf9DYLK8vtWhqBPA3Ya1ir8xCW0O2yjL9dsCVvI7pCodLC5q7smNpEtDR2yVulQxOg=="
     },
     "node_modules/ts-toolbelt": {
       "version": "9.6.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@cypress-audit/lighthouse": "^1.4.2",
     "@cypress-audit/pa11y": "^1.4.2",
     "@keystone-6/auth": "^7.0.0",
-    "@keystone-6/core": "^5.3.0",
+    "@keystone-6/core": "^5.3.1",
     "@keystone-6/fields-document": "^7.0.0",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -2116,9 +2116,6 @@ var sendEmailConfirmEmailAddressMutation = async (root, variables, context) => {
 };
 var send_email_confirm_email_address_default2 = sendEmailConfirmEmailAddressMutation;
 
-// custom-resolvers/mutations/account-sign-in/index.ts
-var import_date_fns5 = require("date-fns");
-
 // helpers/get-password-hash/index.ts
 var import_crypto3 = __toESM(require("crypto"));
 var { ENCRYPTION: ENCRYPTION3 } = ACCOUNT2;
@@ -2147,68 +2144,6 @@ var isValidAccountPassword = (password2, salt, hash) => {
   return false;
 };
 var is_valid_account_password_default = isValidAccountPassword;
-
-// helpers/generate-otp/index.ts
-var import_crypto4 = __toESM(require("crypto"));
-var import_otplib = require("otplib");
-var { ENCRYPTION: ENCRYPTION4, OTP } = ACCOUNT2;
-var {
-  RANDOM_BYTES_SIZE: RANDOM_BYTES_SIZE2,
-  STRING_TYPE: STRING_TYPE4,
-  PBKDF2: { ITERATIONS: ITERATIONS4, DIGEST_ALGORITHM: DIGEST_ALGORITHM4 },
-  OTP: {
-    PBKDF2: { KEY_LENGTH: KEY_LENGTH4 }
-  }
-} = ENCRYPTION4;
-var generateOtp = () => {
-  try {
-    console.info("Generating OTP");
-    const salt = import_crypto4.default.randomBytes(RANDOM_BYTES_SIZE2).toString(STRING_TYPE4);
-    import_otplib.authenticator.options = { digits: OTP.DIGITS };
-    const securityCode = import_otplib.authenticator.generate(salt);
-    const hash = import_crypto4.default.pbkdf2Sync(securityCode, salt, ITERATIONS4, KEY_LENGTH4, DIGEST_ALGORITHM4).toString(STRING_TYPE4);
-    const expiry = OTP.VERIFICATION_EXPIRY();
-    return {
-      securityCode,
-      salt,
-      hash,
-      expiry
-    };
-  } catch (err) {
-    console.error(err);
-    throw new Error(`Error generating OTP ${err}`);
-  }
-};
-var generate = {
-  otp: generateOtp
-};
-var generate_otp_default = generate;
-
-// helpers/generate-otp-and-update-account/index.ts
-var generateOTPAndUpdateAccount = async (context, accountId) => {
-  try {
-    console.info("Adding OTP to an account");
-    const otp = generate_otp_default.otp();
-    const { securityCode, salt, hash, expiry } = otp;
-    const accountUpdate = {
-      otpSalt: salt,
-      otpHash: hash,
-      otpExpiry: expiry
-    };
-    await context.db.Account.updateOne({
-      where: { id: accountId },
-      data: accountUpdate
-    });
-    return {
-      success: true,
-      securityCode
-    };
-  } catch (err) {
-    console.error(err);
-    throw new Error(`Adding OTP to an account ${err}`);
-  }
-};
-var generate_otp_and_update_account_default = generateOTPAndUpdateAccount;
 
 // helpers/create-authentication-retry-entry/index.ts
 var createAuthenticationRetryEntry = async (context, accountId) => {
@@ -2287,8 +2222,118 @@ var blockAccount = async (context, accountId) => {
 };
 var block_account_default = blockAccount;
 
-// custom-resolvers/mutations/account-sign-in/index.ts
+// custom-resolvers/mutations/account-sign-in/account-checks/index.ts
+var import_date_fns5 = require("date-fns");
+
+// helpers/generate-otp/index.ts
+var import_crypto4 = __toESM(require("crypto"));
+var import_otplib = require("otplib");
+var { ENCRYPTION: ENCRYPTION4, OTP } = ACCOUNT2;
+var {
+  RANDOM_BYTES_SIZE: RANDOM_BYTES_SIZE2,
+  STRING_TYPE: STRING_TYPE4,
+  PBKDF2: { ITERATIONS: ITERATIONS4, DIGEST_ALGORITHM: DIGEST_ALGORITHM4 },
+  OTP: {
+    PBKDF2: { KEY_LENGTH: KEY_LENGTH4 }
+  }
+} = ENCRYPTION4;
+var generateOtp = () => {
+  try {
+    console.info("Generating OTP");
+    const salt = import_crypto4.default.randomBytes(RANDOM_BYTES_SIZE2).toString(STRING_TYPE4);
+    import_otplib.authenticator.options = { digits: OTP.DIGITS };
+    const securityCode = import_otplib.authenticator.generate(salt);
+    const hash = import_crypto4.default.pbkdf2Sync(securityCode, salt, ITERATIONS4, KEY_LENGTH4, DIGEST_ALGORITHM4).toString(STRING_TYPE4);
+    const expiry = OTP.VERIFICATION_EXPIRY();
+    return {
+      securityCode,
+      salt,
+      hash,
+      expiry
+    };
+  } catch (err) {
+    console.error(err);
+    throw new Error(`Error generating OTP ${err}`);
+  }
+};
+var generate = {
+  otp: generateOtp
+};
+var generate_otp_default = generate;
+
+// helpers/generate-otp-and-update-account/index.ts
+var generateOTPAndUpdateAccount = async (context, accountId) => {
+  try {
+    console.info("Adding OTP to an account");
+    const otp = generate_otp_default.otp();
+    const { securityCode, salt, hash, expiry } = otp;
+    const accountUpdate = {
+      otpSalt: salt,
+      otpHash: hash,
+      otpExpiry: expiry
+    };
+    await context.db.Account.updateOne({
+      where: { id: accountId },
+      data: accountUpdate
+    });
+    return {
+      success: true,
+      securityCode
+    };
+  } catch (err) {
+    console.error(err);
+    throw new Error(`Adding OTP to an account ${err}`);
+  }
+};
+var generate_otp_and_update_account_default = generateOTPAndUpdateAccount;
+
+// custom-resolvers/mutations/account-sign-in/account-checks/index.ts
 var { EMAIL: EMAIL2 } = ACCOUNT2;
+var accountChecks = async (context, account, urlOrigin) => {
+  const { id: accountId, email } = account;
+  if (!account.isVerified) {
+    console.info("Unable to sign in account - account has not been verified yet");
+    const now = /* @__PURE__ */ new Date();
+    const verificationHasExpired = (0, import_date_fns5.isAfter)(now, account.verificationExpiry);
+    if (account.verificationHash && !verificationHasExpired) {
+      console.info("Account has an unexpired verification token - resetting verification expiry");
+      const accountUpdate = {
+        verificationExpiry: EMAIL2.VERIFICATION_EXPIRY()
+      };
+      await context.db.Account.updateOne({
+        where: { id: accountId },
+        data: accountUpdate
+      });
+      console.info("Account has an unexpired verification token - sending verification email");
+      const emailResponse2 = await send_email_confirm_email_address_default.send(context, urlOrigin, accountId);
+      if (emailResponse2.success) {
+        return {
+          success: false,
+          resentVerificationEmail: true,
+          accountId
+        };
+      }
+      return { success: false, accountId };
+    }
+    console.info("Unable to sign in account - account has not been verified");
+    return { success: false };
+  }
+  const { securityCode } = await generate_otp_and_update_account_default(context, accountId);
+  const name = get_full_name_string_default(account);
+  const emailResponse = await emails_default.securityCodeEmail(email, name, securityCode);
+  if (emailResponse.success) {
+    return {
+      ...emailResponse,
+      accountId
+    };
+  }
+  return {
+    success: false
+  };
+};
+var account_checks_default = accountChecks;
+
+// custom-resolvers/mutations/account-sign-in/index.ts
 var accountSignIn = async (root, variables, context) => {
   try {
     console.info("Signing in account");
@@ -2322,45 +2367,7 @@ var accountSignIn = async (root, variables, context) => {
       return { success: false };
     }
     if (is_valid_account_password_default(password2, account.salt, account.hash)) {
-      if (!account.isVerified) {
-        console.info("Unable to sign in account - account has not been verified yet");
-        const now = /* @__PURE__ */ new Date();
-        const verificationHasExpired = (0, import_date_fns5.isAfter)(now, account.verificationExpiry);
-        if (account.verificationHash && !verificationHasExpired) {
-          console.info("Account has an unexpired verification token - resetting verification expiry");
-          const accountUpdate = {
-            verificationExpiry: EMAIL2.VERIFICATION_EXPIRY()
-          };
-          await context.db.Account.updateOne({
-            where: { id: accountId },
-            data: accountUpdate
-          });
-          console.info("Account has an unexpired verification token - sending verification email");
-          const emailResponse2 = await send_email_confirm_email_address_default.send(context, urlOrigin, accountId);
-          if (emailResponse2.success) {
-            return {
-              success: false,
-              resentVerificationEmail: true,
-              accountId
-            };
-          }
-          return { success: false, accountId };
-        }
-        console.info("Unable to sign in account - account has not been verified");
-        return { success: false };
-      }
-      const { securityCode } = await generate_otp_and_update_account_default(context, accountId);
-      const name = get_full_name_string_default(account);
-      const emailResponse = await emails_default.securityCodeEmail(email, name, securityCode);
-      if (emailResponse.success) {
-        return {
-          ...emailResponse,
-          accountId
-        };
-      }
-      return {
-        success: false
-      };
+      return account_checks_default(context, account, urlOrigin);
     }
     return { success: false };
   } catch (err) {
@@ -2888,7 +2895,7 @@ var updateCompanyAndCompanyAddress = async (root, variables, context) => {
         where: oldSicCodes
       });
     }
-    if (mappedSicCodes && mappedSicCodes.length) {
+    if (mappedSicCodes?.length) {
       await context.db.CompanySicCode.createMany({
         data: mappedSicCodes
       });

--- a/src/api/constants/index.ts
+++ b/src/api/constants/index.ts
@@ -70,6 +70,21 @@ const DATE_30_MINUTES_FROM_NOW = () => {
   return future;
 };
 
+/**
+ * DATE_ONE_MINUTE_IN_THE_PAST
+ * Generate a date that is 1 minute in the past.
+ * @returns {Date}
+ */
+export const DATE_ONE_MINUTE_IN_THE_PAST = () => {
+  const now = new Date();
+
+  const MS_PER_MINUTE = 60000;
+
+  const oneMinuteInThePast = new Date(now.getTime() - 1 * MS_PER_MINUTE);
+
+  return oneMinuteInThePast;
+};
+
 export const ACCOUNT = {
   EMAIL: {
     VERIFICATION_EXPIRY: DATE_24_HOURS_FROM_NOW,

--- a/src/api/custom-resolvers/mutations/account-password-reset/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-password-reset/index.test.ts
@@ -4,18 +4,10 @@ import * as PrismaModule from '.prisma/client'; // eslint-disable-line import/no
 import accountPasswordReset from '.';
 import createAuthenticationEntry from '../../../helpers/create-authentication-entry';
 import createAuthenticationRetryEntry from '../../../helpers/create-authentication-retry-entry';
-import baseConfig from '../../../keystone';
-import { ACCOUNT } from '../../../constants';
+import { ACCOUNT, DATE_ONE_MINUTE_IN_THE_PAST } from '../../../constants';
 import { mockAccount } from '../../../test-mocks';
 import { Account, AccountPasswordResetVariables, ApplicationRelationship, SuccessResponse } from '../../../types';
 import { Context } from '.keystone/types'; // eslint-disable-line
-
-const dbUrl = String(process.env.DATABASE_URL);
-const config = { ...baseConfig, db: { ...baseConfig.db, url: dbUrl } };
-
-dotenv.config();
-
-const context = getContext(config, PrismaModule) as Context;
 
 const { ENCRYPTION } = ACCOUNT;
 
@@ -198,16 +190,13 @@ describe('custom-resolvers/account-password-reset', () => {
 
   describe("when the account's password reset expiry is in the past", () => {
     beforeEach(async () => {
-      const now = new Date();
-
-      const milliseconds = 300000;
-      const oneMinuteAgo = new Date(now.setMilliseconds(-milliseconds)).toISOString();
+      const oneMinuteInThePast = DATE_ONE_MINUTE_IN_THE_PAST();
 
       account = (await context.query.Account.updateOne({
         where: { id: account.id },
         data: {
           passwordResetHash: mockAccount.passwordResetHash,
-          passwordResetExpiry: oneMinuteAgo,
+          passwordResetExpiry: oneMinuteInThePast,
         },
       })) as Account;
     });

--- a/src/api/custom-resolvers/mutations/account-password-reset/index.ts
+++ b/src/api/custom-resolvers/mutations/account-password-reset/index.ts
@@ -19,7 +19,7 @@ const accountPasswordReset = async (root: any, variables: AccountPasswordResetVa
      * Get the account the token is associated with.
      * If no account is found, return success=false
      */
-    const account = await getAccountByField(context, FIELD_IDS.INSURANCE.ACCOUNT.PASSWORD_RESET_HASH, token) as Account;
+    const account = (await getAccountByField(context, FIELD_IDS.INSURANCE.ACCOUNT.PASSWORD_RESET_HASH, token)) as Account;
 
     if (!account) {
       console.info('Unable to reset account password - account does not exist');

--- a/src/api/custom-resolvers/mutations/account-password-reset/index.ts
+++ b/src/api/custom-resolvers/mutations/account-password-reset/index.ts
@@ -19,7 +19,7 @@ const accountPasswordReset = async (root: any, variables: AccountPasswordResetVa
      * Get the account the token is associated with.
      * If no account is found, return success=false
      */
-    const account = await getAccountByField(context, FIELD_IDS.INSURANCE.ACCOUNT.PASSWORD_RESET_HASH, token);
+    const account = await getAccountByField(context, FIELD_IDS.INSURANCE.ACCOUNT.PASSWORD_RESET_HASH, token) as Account;
 
     if (!account) {
       console.info('Unable to reset account password - account does not exist');
@@ -31,7 +31,7 @@ const accountPasswordReset = async (root: any, variables: AccountPasswordResetVa
      * Check if the account is blocked
      * If so, return success=false
      */
-    const { isBlocked } = account as Account;
+    const { isBlocked } = account;
 
     if (isBlocked) {
       console.info('Unable to reset account password - account is blocked');

--- a/src/api/custom-resolvers/mutations/account-sign-in/account-checks/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/account-checks/index.test.ts
@@ -19,7 +19,7 @@ dotenv.config();
 
 const context = getContext(config, PrismaModule) as Context;
 
-const { EMAIL, MAX_AUTH_RETRIES } = ACCOUNT;
+const { EMAIL } = ACCOUNT;
 
 describe('custom-resolvers/account-sign-in/account-checks', () => {
   let account: Account;
@@ -215,7 +215,9 @@ describe('custom-resolvers/account-sign-in/account-checks', () => {
       } catch (err) {
         expect(securityCodeEmailSpy).toHaveBeenCalledTimes(1);
 
-        const expected = new Error(`Validating password or sending email for account sign in (accountChecks contexttaaccount) mockUrlOriginmockSendEmailResponse}`);
+        const expected = new Error(
+          `Validating password or sending email for account sign in (accountChecks contexttaaccount) mockUrlOriginmockSendEmailResponse}`,
+        );
         expect(err).toEqual(expected);
       }
     });

--- a/src/api/custom-resolvers/mutations/account-sign-in/account-checks/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/account-checks/index.test.ts
@@ -1,0 +1,223 @@
+import { getContext } from '@keystone-6/core/context';
+import dotenv from 'dotenv';
+import * as PrismaModule from '.prisma/client'; // eslint-disable-line import/no-extraneous-dependencies
+import { ACCOUNT, DATE_ONE_MINUTE_IN_THE_PAST } from '../../../../constants';
+import accountChecks from '.';
+import baseConfig from '../../../../keystone';
+import confirmEmailAddressEmail from '../../../../helpers/send-email-confirm-email-address';
+import generate from '../../../../helpers/generate-otp';
+import getFullNameString from '../../../../helpers/get-full-name-string';
+import sendEmail from '../../../../emails';
+import { mockAccount, mockOTP, mockSendEmailResponse, mockUrlOrigin } from '../../../../test-mocks';
+import { Account, AccountSignInResponse, ApplicationRelationship } from '../../../../types';
+import { Context } from '.keystone/types'; // eslint-disable-line
+
+const dbUrl = String(process.env.DATABASE_URL);
+const config = { ...baseConfig, db: { ...baseConfig.db, url: dbUrl } };
+
+dotenv.config();
+
+const context = getContext(config, PrismaModule) as Context;
+
+const { EMAIL, MAX_AUTH_RETRIES } = ACCOUNT;
+
+describe('custom-resolvers/account-sign-in/account-checks', () => {
+  let account: Account;
+  let retries: Array<ApplicationRelationship>;
+
+  jest.mock('../../../../emails');
+  jest.mock('../../../../helpers/generate-otp');
+
+  generate.otp = () => mockOTP;
+
+  let sendConfirmEmailAddressEmailSpy = jest.fn();
+  let securityCodeEmailSpy = jest.fn();
+
+  const mockPassword = String(process.env.MOCK_ACCOUNT_PASSWORD);
+
+  const variables = {
+    urlOrigin: mockUrlOrigin,
+    email: mockAccount.email,
+    password: mockPassword,
+  };
+
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  let result: AccountSignInResponse;
+
+  beforeAll(async () => {
+    // wipe the account table so we have a clean slate.
+    const accounts = await context.query.Account.findMany();
+
+    await context.query.Account.deleteMany({
+      where: accounts,
+    });
+
+    // wipe the AuthenticationRetry table so we have a clean slate.
+    retries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
+
+    await context.query.AuthenticationRetry.deleteMany({
+      where: retries,
+    });
+
+    // create an account
+    account = (await context.query.Account.createOne({
+      data: mockAccount,
+      query: 'id',
+    })) as Account;
+
+    jest.resetAllMocks();
+
+    securityCodeEmailSpy = jest.fn(() => Promise.resolve(mockSendEmailResponse));
+    sendEmail.securityCodeEmail = securityCodeEmailSpy;
+
+    result = await accountChecks(context, account, mockUrlOrigin);
+
+    account = (await context.query.Account.findOne({
+      where: { id: account.id },
+      query: 'id firstName lastName email otpSalt otpHash otpExpiry verificationExpiry',
+    })) as Account;
+  });
+
+  describe('when the provided password is valid', () => {
+    test('it should generate an OTP and save to the account', () => {
+      expect(account.otpSalt).toEqual(mockOTP.salt);
+      expect(account.otpHash).toEqual(mockOTP.hash);
+      expect(new Date(account.otpExpiry)).toEqual(mockOTP.expiry);
+    });
+
+    test('it should call sendEmail.securityCodeEmail', () => {
+      const { email } = account;
+
+      const name = getFullNameString(account);
+
+      expect(securityCodeEmailSpy).toHaveBeenCalledTimes(1);
+      expect(securityCodeEmailSpy).toHaveBeenCalledWith(email, name, mockOTP.securityCode);
+    });
+
+    test('it should return the email response and accountId', () => {
+      const expected = {
+        ...mockSendEmailResponse,
+        accountId: account.id,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when account is not verified, but has a verificationHash and verificationExpiry has not expired', () => {
+    beforeEach(async () => {
+      jest.resetAllMocks();
+
+      sendConfirmEmailAddressEmailSpy = jest.fn(() => Promise.resolve(mockSendEmailResponse));
+      confirmEmailAddressEmail.send = sendConfirmEmailAddressEmailSpy;
+
+      await context.query.Account.updateOne({
+        where: { id: account.id },
+        data: {
+          isVerified: false,
+          isBlocked: false,
+          verificationHash: mockAccount.verificationHash,
+        },
+      });
+
+      result = await accountChecks(context, account, mockUrlOrigin);
+    });
+
+    describe('verificationExpiry', () => {
+      let updatedAccount: Account;
+      let newExpiryDay: number;
+
+      beforeEach(async () => {
+        updatedAccount = (await context.query.Account.findOne({
+          where: { id: account.id },
+          query: 'verificationExpiry',
+        })) as Account;
+
+        newExpiryDay = new Date(updatedAccount.verificationExpiry).getDate();
+      });
+
+      test('it should be reset and have a new day vale', async () => {
+        const expectedExpiryDay = new Date(EMAIL.VERIFICATION_EXPIRY()).getDate();
+
+        expect(newExpiryDay).toEqual(expectedExpiryDay);
+      });
+
+      test('the account`s verificationExpiry should NOT have have the same day as the previous verificationExpiry', async () => {
+        const originalExpiryDay = new Date(account.verificationExpiry).getDay();
+
+        expect(newExpiryDay).not.toEqual(originalExpiryDay);
+      });
+    });
+
+    test('it should call confirmEmailAddressEmail.send', async () => {
+      expect(sendConfirmEmailAddressEmailSpy).toHaveBeenCalledTimes(1);
+      expect(sendConfirmEmailAddressEmailSpy).toHaveBeenCalledWith(context, variables.urlOrigin, account.id);
+    });
+
+    test('it should return success=false, accountId and resentVerificationEmail=true', async () => {
+      const expected = {
+        success: false,
+        resentVerificationEmail: true,
+        accountId: account.id,
+      };
+
+      expect(result).toEqual(expected);
+    });
+
+    describe('when the verificationExpiry is after now', () => {
+      beforeEach(async () => {
+        jest.resetAllMocks();
+
+        // wipe the AuthenticationRetry table so we have a clean slate.
+        retries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
+
+        await context.query.AuthenticationRetry.deleteMany({
+          where: retries,
+        });
+
+        const oneMinuteInThePast = DATE_ONE_MINUTE_IN_THE_PAST();
+
+        await context.query.Account.updateOne({
+          where: { id: account.id },
+          data: {
+            verificationExpiry: oneMinuteInThePast,
+          },
+        });
+      });
+
+      test('it should NOT call confirmEmailAddressEmail.send', async () => {
+        await accountChecks(context, account, mockUrlOrigin);
+
+        expect(sendConfirmEmailAddressEmailSpy).toHaveBeenCalledTimes(0);
+      });
+
+      test('it should return success=false', async () => {
+        result = await accountChecks(context, account, mockUrlOrigin);
+
+        const expected = { success: false };
+
+        expect(result).toEqual(expected);
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      sendEmail.securityCodeEmail = jest.fn(() => Promise.reject(mockSendEmailResponse));
+    });
+
+    test('should throw an error', async () => {
+      try {
+        await accountChecks(context, account, mockUrlOrigin);
+      } catch (err) {
+        expect(securityCodeEmailSpy).toHaveBeenCalledTimes(1);
+
+        const expected = new Error(`Validating password or sending email for account sign in (accountChecks contexttaaccount) mockUrlOriginmockSendEmailResponse}`);
+        expect(err).toEqual(expected);
+      }
+    });
+  });
+});

--- a/src/api/custom-resolvers/mutations/account-sign-in/account-checks/index.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/account-checks/index.ts
@@ -1,0 +1,96 @@
+import { Context } from '.keystone/types'; // eslint-disable-line
+import { isAfter } from 'date-fns';
+import { ACCOUNT } from '../../../../constants';
+import confirmEmailAddressEmail from '../../../../helpers/send-email-confirm-email-address';
+import generateOTPAndUpdateAccount from '../../../../helpers/generate-otp-and-update-account';
+import getFullNameString from '../../../../helpers/get-full-name-string';
+import sendEmail from '../../../../emails';
+import { Account } from '../../../../types';
+
+const { EMAIL } = ACCOUNT;
+
+/**
+ * accountChecks
+ * Assuming that a provided password is valid, check if the account:
+ * 1) Is unverified.
+ * 2) Has a verification hash/token.
+ * 3) Has a verification hash/token that has not expired.
+ *
+ * If so, this means that the user has not verified their email address. We can therefore:
+ * 1) Reset the account's verification expiry.
+ * 2) Re-send the verification link email that was sent during account creation.
+ * 
+ * Otherwise, the account is verified. We can therefore:
+ * 1) Generate an OTP
+ * 2) Update the account
+ * 3) Send an email with the OTP
+ * 
+ * @param {Object} KeystoneJS context API
+ * @param {Object} Account
+ * @param {String} URL origin
+ * @returns {Object} Object with success flag
+ */
+const accountChecks = async (context: Context, account: Account, urlOrigin: string) => {
+  const { id: accountId, email } = account;
+
+  if (!account.isVerified) {
+    console.info('Unable to sign in account - account has not been verified yet');
+
+    const now = new Date();
+
+    const verificationHasExpired = isAfter(now, account.verificationExpiry);
+
+    if (account.verificationHash && !verificationHasExpired) {
+      console.info('Account has an unexpired verification token - resetting verification expiry');
+
+      const accountUpdate = {
+        verificationExpiry: EMAIL.VERIFICATION_EXPIRY(),
+      };
+
+      (await context.db.Account.updateOne({
+        where: { id: accountId },
+        data: accountUpdate,
+      })) as Account;
+
+      console.info('Account has an unexpired verification token - sending verification email');
+
+      const emailResponse = await confirmEmailAddressEmail.send(context, urlOrigin, accountId);
+
+      if (emailResponse.success) {
+        return {
+          success: false,
+          resentVerificationEmail: true,
+          accountId,
+        };
+      }
+
+      return { success: false, accountId };
+    }
+
+    // reject
+    console.info('Unable to sign in account - account has not been verified');
+
+    return { success: false };
+  }
+
+  // generate OTP and update the account
+  const { securityCode } = await generateOTPAndUpdateAccount(context, accountId);
+
+  // send "security code" email.
+  const name = getFullNameString(account);
+
+  const emailResponse = await sendEmail.securityCodeEmail(email, name, securityCode);
+
+  if (emailResponse.success) {
+    return {
+      ...emailResponse,
+      accountId,
+    };
+  }
+
+  return {
+    success: false,
+  };
+};
+
+export default accountChecks;

--- a/src/api/custom-resolvers/mutations/account-sign-in/account-checks/index.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/account-checks/index.ts
@@ -19,12 +19,12 @@ const { EMAIL } = ACCOUNT;
  * If so, this means that the user has not verified their email address. We can therefore:
  * 1) Reset the account's verification expiry.
  * 2) Re-send the verification link email that was sent during account creation.
- * 
+ *
  * Otherwise, the account is verified. We can therefore:
  * 1) Generate an OTP
  * 2) Update the account
  * 3) Send an email with the OTP
- * 
+ *
  * @param {Object} KeystoneJS context API
  * @param {Object} Account
  * @param {String} URL origin

--- a/src/api/custom-resolvers/mutations/account-sign-in/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/index.test.ts
@@ -1,7 +1,7 @@
 import { getContext } from '@keystone-6/core/context';
 import dotenv from 'dotenv';
 import * as PrismaModule from '.prisma/client'; // eslint-disable-line import/no-extraneous-dependencies
-import { ACCOUNT } from '../../../constants';
+import { ACCOUNT, DATE_ONE_MINUTE_IN_THE_PAST } from '../../../constants';
 import accountSignIn from '.';
 import baseConfig from '../../../keystone';
 import createAuthenticationRetryEntry from '../../../helpers/create-authentication-retry-entry';
@@ -179,15 +179,12 @@ describe('custom-resolvers/account-sign-in', () => {
           where: retries,
         });
 
-        const now = new Date();
-
-        const milliseconds = 300000;
-        const oneMinuteAgo = new Date(now.setMilliseconds(-milliseconds)).toISOString();
+        const oneMinuteInThePast = DATE_ONE_MINUTE_IN_THE_PAST();
 
         await context.query.Account.updateOne({
           where: { id: account.id },
           data: {
-            verificationExpiry: oneMinuteAgo,
+            verificationExpiry: oneMinuteInThePast,
           },
         });
       });

--- a/src/api/custom-resolvers/mutations/account-sign-in/index.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/index.ts
@@ -100,7 +100,8 @@ const accountSignIn = async (root: any, variables: AccountSignInVariables, conte
     return { success: false };
   } catch (err) {
     console.error(err);
-    throw new Error(`Validating password or sending email for account sign in (accountSignIn mutation) ${err}`);
+
+    throw new Error(`Signing in account (accountSignIn mutation) ${err}`);
   }
 };
 

--- a/src/api/custom-resolvers/mutations/account-sign-in/index.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/index.ts
@@ -28,7 +28,7 @@ const accountSignIn = async (root: any, variables: AccountSignInVariables, conte
     const { urlOrigin, email, password } = variables;
 
     // Get the account the email is associated with.
-    const accountData = await getAccountByField(context, FIELD_IDS.INSURANCE.ACCOUNT.EMAIL, email) as Account;
+    const accountData = (await getAccountByField(context, FIELD_IDS.INSURANCE.ACCOUNT.EMAIL, email)) as Account;
 
     if (!accountData) {
       console.info('Unable to validate account - no account found');

--- a/src/api/custom-resolvers/mutations/account-sign-in/index.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/index.ts
@@ -1,18 +1,12 @@
 import { Context } from '.keystone/types'; // eslint-disable-line
-import { isAfter } from 'date-fns';
-import { ACCOUNT, FIELD_IDS } from '../../../constants';
+import { FIELD_IDS } from '../../../constants';
 import getAccountByField from '../../../helpers/get-account-by-field';
-import confirmEmailAddressEmail from '../../../helpers/send-email-confirm-email-address';
 import isValidAccountPassword from '../../../helpers/is-valid-account-password';
-import generateOTPAndUpdateAccount from '../../../helpers/generate-otp-and-update-account';
-import getFullNameString from '../../../helpers/get-full-name-string';
 import createAuthenticationRetryEntry from '../../../helpers/create-authentication-retry-entry';
 import shouldBlockAccount from '../../../helpers/should-block-account';
 import blockAccount from '../../../helpers/block-account';
-import sendEmail from '../../../emails';
+import accountChecks from './account-checks';
 import { Account, AccountSignInVariables, AccountSignInResponse } from '../../../types';
-
-const { EMAIL } = ACCOUNT;
 
 /**
  * accountSignIn
@@ -34,7 +28,7 @@ const accountSignIn = async (root: any, variables: AccountSignInVariables, conte
     const { urlOrigin, email, password } = variables;
 
     // Get the account the email is associated with.
-    const accountData = await getAccountByField(context, FIELD_IDS.INSURANCE.ACCOUNT.EMAIL, email);
+    const accountData = await getAccountByField(context, FIELD_IDS.INSURANCE.ACCOUNT.EMAIL, email) as Account;
 
     if (!accountData) {
       console.info('Unable to validate account - no account found');
@@ -42,7 +36,7 @@ const accountSignIn = async (root: any, variables: AccountSignInVariables, conte
       return { success: false };
     }
 
-    const account = accountData as Account;
+    const account = accountData;
 
     const { id: accountId } = account;
 
@@ -60,7 +54,7 @@ const accountSignIn = async (root: any, variables: AccountSignInVariables, conte
      * Check if the account is blocked
      * If so, return isBlocked=false
      */
-    const { isBlocked } = account as Account;
+    const { isBlocked } = account;
 
     if (isBlocked) {
       console.info('Unable to sign in account - account is already blocked');
@@ -90,7 +84,7 @@ const accountSignIn = async (root: any, variables: AccountSignInVariables, conte
 
     /**
      * Account is found and verified. We can therefore:
-     * 1) Check if the password is matches what is encrypted in the database.
+     * 1) Check if the password matches what is encrypted in the database.
      * 2) If the password is valid:
      *   - If the account is unverified, but has a valid has/token, send verification email.
      *   - If the account is verified, generate an OTP/security code and send via email.
@@ -99,75 +93,7 @@ const accountSignIn = async (root: any, variables: AccountSignInVariables, conte
      *   - The email was not sent.
      */
     if (isValidAccountPassword(password, account.salt, account.hash)) {
-      /**
-       * Check if the account:
-       * 1) Is unverified.
-       * 2) Has a verification hash/token.
-       * 3) Has a verification hash/token that has not expired.
-       *
-       * This means that the user has not verified their email address.
-       * We can therefore:
-       * 1) Reset the account's verification expiry.
-       * 2) Re-send the verification link email that was sent during account creation.
-       */
-      if (!account.isVerified) {
-        console.info('Unable to sign in account - account has not been verified yet');
-
-        const now = new Date();
-
-        const verificationHasExpired = isAfter(now, account.verificationExpiry);
-
-        if (account.verificationHash && !verificationHasExpired) {
-          console.info('Account has an unexpired verification token - resetting verification expiry');
-
-          const accountUpdate = {
-            verificationExpiry: EMAIL.VERIFICATION_EXPIRY(),
-          };
-
-          (await context.db.Account.updateOne({
-            where: { id: accountId },
-            data: accountUpdate,
-          })) as Account;
-
-          console.info('Account has an unexpired verification token - sending verification email');
-
-          const emailResponse = await confirmEmailAddressEmail.send(context, urlOrigin, accountId);
-
-          if (emailResponse.success) {
-            return {
-              success: false,
-              resentVerificationEmail: true,
-              accountId,
-            };
-          }
-
-          return { success: false, accountId };
-        }
-
-        // reject
-        console.info('Unable to sign in account - account has not been verified');
-
-        return { success: false };
-      }
-
-      // generate OTP and update the account
-      const { securityCode } = await generateOTPAndUpdateAccount(context, accountId);
-
-      // send "security code" email.
-      const name = getFullNameString(account);
-
-      const emailResponse = await sendEmail.securityCodeEmail(email, name, securityCode);
-
-      if (emailResponse.success) {
-        return {
-          ...emailResponse,
-          accountId,
-        };
-      }
-
-      return {
-        success: false,
-      };
+      return accountChecks(context, account, urlOrigin);
     }
 
     // invalid credentials.

--- a/src/api/custom-resolvers/mutations/send-email-reactivate-account-link/index.ts
+++ b/src/api/custom-resolvers/mutations/send-email-reactivate-account-link/index.ts
@@ -38,7 +38,7 @@ const sendEmailReactivateAccountLink = async (
      * Get the account
      * If an account does not exist, return success=false
      */
-    const account = (await getAccountById(context, accountId)) as Account;
+    const account = (await getAccountById(context, accountId));
 
     if (!account) {
       console.info('Unable to check account and send reactivate account email/link - no account found');

--- a/src/api/custom-resolvers/mutations/send-email-reactivate-account-link/index.ts
+++ b/src/api/custom-resolvers/mutations/send-email-reactivate-account-link/index.ts
@@ -38,7 +38,7 @@ const sendEmailReactivateAccountLink = async (
      * Get the account
      * If an account does not exist, return success=false
      */
-    const account = (await getAccountById(context, accountId));
+    const account = await getAccountById(context, accountId);
 
     if (!account) {
       console.info('Unable to check account and send reactivate account email/link - no account found');

--- a/src/api/custom-resolvers/mutations/submit-application/index.test.ts
+++ b/src/api/custom-resolvers/mutations/submit-application/index.test.ts
@@ -6,7 +6,7 @@ import baseConfig from '../../../keystone';
 import submitApplication from '.';
 import generate from '../../../generate-xlsx';
 import applicationSubmittedEmails from '../../../emails/send-application-submitted-emails';
-import { APPLICATION } from '../../../constants';
+import { APPLICATION, DATE_ONE_MINUTE_IN_THE_PAST } from '../../../constants';
 import getPopulatedApplication from '../../../helpers/get-populated-application';
 import { createFullApplication } from '../../../test-helpers';
 import { mockSendEmailResponse } from '../../../test-mocks';
@@ -149,9 +149,7 @@ describe('custom-resolvers/submit-application', () => {
     it('should return success=false', async () => {
       // create a new application so we can set submission deadline in the past
 
-      // 1 minute ago
-      const milliseconds = 300000;
-      const oneMinuteAgo = new Date(now.setMilliseconds(-milliseconds)).toISOString();
+      const oneMinuteInThePast = DATE_ONE_MINUTE_IN_THE_PAST();
 
       const newApplication = (await context.query.Application.createOne({
         query: 'id',
@@ -162,7 +160,7 @@ describe('custom-resolvers/submit-application', () => {
       await context.query.Application.updateOne({
         where: { id: newApplication.id },
         data: {
-          submissionDeadline: oneMinuteAgo,
+          submissionDeadline: oneMinuteInThePast,
         },
       });
 

--- a/src/api/custom-resolvers/mutations/update-company-and-company-address/index.ts
+++ b/src/api/custom-resolvers/mutations/update-company-and-company-address/index.ts
@@ -40,7 +40,7 @@ const updateCompanyAndCompanyAddress = async (
     }
 
     // if there are sic codes to be added
-    if (mappedSicCodes && mappedSicCodes.length) {
+    if (mappedSicCodes?.length) {
       await context.db.CompanySicCode.createMany({
         data: mappedSicCodes,
       });

--- a/src/api/custom-resolvers/mutations/verify-account-reactivation-token/index.test.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-reactivation-token/index.test.ts
@@ -5,7 +5,8 @@ import crypto from 'crypto';
 import baseConfig from '../../../keystone';
 import verifyAccountReactivationToken from '.';
 import createAuthenticationRetryEntry from '../../../helpers/create-authentication-retry-entry';
-import { ACCOUNT, FIELD_IDS } from '../../../constants';
+import { ACCOUNT, FIELD_IDS, DATE_ONE_MINUTE_IN_THE_PAST } from '../../../constants';
+import accounts from '../../../test-helpers/accounts';
 import { mockAccount } from '../../../test-mocks';
 import { Account, SuccessResponse, VerifyAccountReactivationTokenVariables } from '../../../types';
 import { Context } from '.keystone/types'; // eslint-disable-line
@@ -137,19 +138,16 @@ describe('custom-resolvers/verify-account-reactivation-token', () => {
 
   describe(`when the ${REACTIVATION_EXPIRY} has expired`, () => {
     test('it should return success=false and expired=true', async () => {
-      const now = new Date();
+      const oneMinuteInThePast = DATE_ONE_MINUTE_IN_THE_PAST();
 
-      const MS_PER_MINUTE = 60000;
-      const oneMinuteAgo = new Date(now.getTime() - 1 * MS_PER_MINUTE);
+      const accountBlockedAndReactivationExpired = {
+        ...mockAccount,
+        reactivationHash,
+        [IS_BLOCKED]: true,
+        [REACTIVATION_EXPIRY]: oneMinuteInThePast,
+      };
 
-      account = (await context.query.Account.createOne({
-        data: {
-          ...mockAccount,
-          reactivationHash,
-          [REACTIVATION_EXPIRY]: oneMinuteAgo,
-          [IS_BLOCKED]: true,
-        },
-      })) as Account;
+      account = await accounts.create(context, accountBlockedAndReactivationExpired);
 
       result = await verifyAccountReactivationToken({}, variables, context);
 

--- a/src/api/package-lock.json
+++ b/src/api/package-lock.json
@@ -15,7 +15,7 @@
         "@babel/preset-typescript": "^7.21.5",
         "@graphql-tools/schema": "^9.0.19",
         "@keystone-6/auth": "^7.0.0",
-        "@keystone-6/core": "^5.3.0",
+        "@keystone-6/core": "^5.3.1",
         "@keystone-6/fields-document": "^8.0.0",
         "axios": "^1.4.0",
         "date-fns": "^2.30.0",
@@ -492,43 +492,43 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.345.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.345.0.tgz",
-      "integrity": "sha512-KHpJ7jZq0OGXNIJ+K0U4DcVubroXq92TD7rQi16TU7q8AnjrCoMuJz32QJI+9FEFbjmTIJ/tts9rma0PqR30bw==",
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.350.0.tgz",
+      "integrity": "sha512-46AhBvGWo6TEzlvZieNlZHC2w4NJUJA52KfDUtgr8PmChGgxqzlLBAiOpqbDJ83GR3YB6CNEjXxzN5tmyJKICA==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.345.0",
-        "@aws-sdk/config-resolver": "3.342.0",
-        "@aws-sdk/credential-provider-node": "3.345.0",
-        "@aws-sdk/fetch-http-handler": "3.342.0",
-        "@aws-sdk/hash-node": "3.344.0",
-        "@aws-sdk/invalid-dependency": "3.342.0",
-        "@aws-sdk/middleware-content-length": "3.342.0",
-        "@aws-sdk/middleware-endpoint": "3.344.0",
-        "@aws-sdk/middleware-host-header": "3.342.0",
-        "@aws-sdk/middleware-logger": "3.342.0",
-        "@aws-sdk/middleware-recursion-detection": "3.342.0",
-        "@aws-sdk/middleware-retry": "3.342.0",
-        "@aws-sdk/middleware-serde": "3.342.0",
-        "@aws-sdk/middleware-signing": "3.342.0",
-        "@aws-sdk/middleware-stack": "3.342.0",
-        "@aws-sdk/middleware-user-agent": "3.345.0",
-        "@aws-sdk/node-config-provider": "3.342.0",
-        "@aws-sdk/node-http-handler": "3.344.0",
-        "@aws-sdk/smithy-client": "3.342.0",
-        "@aws-sdk/types": "3.342.0",
-        "@aws-sdk/url-parser": "3.342.0",
+        "@aws-sdk/client-sts": "3.350.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-node": "3.350.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.342.0",
-        "@aws-sdk/util-defaults-mode-node": "3.342.0",
-        "@aws-sdk/util-endpoints": "3.342.0",
-        "@aws-sdk/util-retry": "3.342.0",
-        "@aws-sdk/util-user-agent-browser": "3.345.0",
-        "@aws-sdk/util-user-agent-node": "3.345.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
         "@aws-sdk/util-utf8": "3.310.0",
         "@smithy/protocol-http": "^1.0.1",
         "@smithy/types": "^1.0.0",
@@ -536,6 +536,809 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+      "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.350.0.tgz",
+      "integrity": "sha512-2vpiv6SEjmQGK3ZueGzvTMG6NenjWp0CHjmda71d1Iqr+tZ2UlfC35+3ioU8JP+jiXLL+y9r+SCer3IC8N/i+Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.350.0.tgz",
+      "integrity": "sha512-v3UrWIglg9PPzGXqhyGB/qPZ8ifiGM9r4LV8vve1TpiKsUdf1Khtx1eB8yqjNO0vIsYUF+j1C23QT1qAN2DcEA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sts": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.350.0.tgz",
+      "integrity": "sha512-s8RsJ6upWQgeUt8GdV3j3ZeTS7BQXedk77RhZ7wzvVwAjO9wow4uS7Iyic4kS3Y/6d26s0MO2vP4bR6HW6U6ZQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-node": "3.350.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-sdk-sts": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
+      "integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
+      "integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
+      "integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.350.0.tgz",
+      "integrity": "sha512-mGGU0PpnG0VDNKSuGi083U1egjprrU9/XoRtgf+iYvAKXRR/0XA4pGW5c7zpHY7m4iLhBuRj6N4oxQsH9cMtWg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.350.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.350.0.tgz",
+      "integrity": "sha512-xmqwCFwj/CZPx6AKHNb24Kpr0eHW9VISt9r+SfgH8PaYg5cNyX1pKmMbQCket5ov+WvHEQtOK7aBafak7dhauA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-ini": "3.350.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.350.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
+      "integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.350.0.tgz",
+      "integrity": "sha512-u/3kv+PJeVawzBtWBei+IX1/z50mwhpPe3VrKSTns4CPUw8b5sqIYWkAaw5hxm0td69+xcL98RzIJsEpJc4QSQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.350.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/token-providers": "3.350.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
+      "integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+      "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
+      "integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/hash-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+      "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+      "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+      "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+      "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+      "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+      "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
+      "integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
+      "integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
+      "integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.347.0.tgz",
+      "integrity": "sha512-wJbGN3OE1/daVCrwk49whhIr9E0j1N4gWwN/wi4WuyYIA+5lMUfVp0aGIOvZR+878DxuFz2hQ4XcZVT4K2WvQw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
+      "integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/property-provider": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
+      "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+      "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
+      "integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
+      "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.347.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/token-providers": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.350.0.tgz",
+      "integrity": "sha512-VIfVMV5An1VQQ6bOKQTHPsRFHD3/YRGOPk9lDTVJGOK0G1DIFYd/10ZaLQ86rCWLck2lGhjxsOen2N2n6MtA0A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.350.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/url-parser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
+      "integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
+      "integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.347.0.tgz",
+      "integrity": "sha512-/WUkirizeNAqwVj0zkcrqdQ9pUm1HY5kU+qy7xTR0OebkuJauglkmSTMD+56L1JPunWqHhlwCMVRaz5eaJdSEQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-retry": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+      "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+      "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
+      "integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/fast-xml-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-s3": {
@@ -751,14 +1554,39 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.345.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.345.0.tgz",
-      "integrity": "sha512-cV3oLjy4+OlIfSeNckqEzB9OH4Fb7GPJIb2YECaRAjcEe6FuhfW75dkKfd+whfG+8RNJQRlf1bTxAetCFUUMqA==",
+      "version": "3.351.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.351.0.tgz",
+      "integrity": "sha512-c9XyDUj82ttqQqF8h4Ie7k2Fl3bMh8/yBGEQWIPzWRhfy40m4ChqjilKAcBeoxR/w4Qp3RsdDfLRTLC8sJTpIg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.345.0",
-        "@aws-sdk/property-provider": "3.342.0",
-        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/client-cognito-identity": "3.350.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/property-provider": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
+      "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "optional": true,
+      "dependencies": {
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -876,28 +1704,831 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.345.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.345.0.tgz",
-      "integrity": "sha512-rTbc1asHXnVFFiTnQBn90N7rU3ICDaFpsivkzXlo5MEbRRkxswM5QUDm0iO1g4EnGEWTNwTb6T5kwPqg+8GfVw==",
+      "version": "3.351.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.351.0.tgz",
+      "integrity": "sha512-KVfLTVpeDKnOPl0u5w3RJdNz+AtFIOj3dsfpyLkGCV5bHClLN05YFf1ajh93Z5FijuhvDSYuLT1Xr3Ud+AIudQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.345.0",
-        "@aws-sdk/client-sso": "3.345.0",
-        "@aws-sdk/client-sts": "3.345.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.345.0",
-        "@aws-sdk/credential-provider-env": "3.342.0",
-        "@aws-sdk/credential-provider-imds": "3.342.0",
-        "@aws-sdk/credential-provider-ini": "3.345.0",
-        "@aws-sdk/credential-provider-node": "3.345.0",
-        "@aws-sdk/credential-provider-process": "3.342.0",
-        "@aws-sdk/credential-provider-sso": "3.345.0",
-        "@aws-sdk/credential-provider-web-identity": "3.342.0",
-        "@aws-sdk/property-provider": "3.342.0",
-        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/client-cognito-identity": "3.350.0",
+        "@aws-sdk/client-sso": "3.350.0",
+        "@aws-sdk/client-sts": "3.350.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.351.0",
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-ini": "3.350.0",
+        "@aws-sdk/credential-provider-node": "3.350.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.350.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+      "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.350.0.tgz",
+      "integrity": "sha512-2vpiv6SEjmQGK3ZueGzvTMG6NenjWp0CHjmda71d1Iqr+tZ2UlfC35+3ioU8JP+jiXLL+y9r+SCer3IC8N/i+Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.350.0.tgz",
+      "integrity": "sha512-v3UrWIglg9PPzGXqhyGB/qPZ8ifiGM9r4LV8vve1TpiKsUdf1Khtx1eB8yqjNO0vIsYUF+j1C23QT1qAN2DcEA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.350.0.tgz",
+      "integrity": "sha512-s8RsJ6upWQgeUt8GdV3j3ZeTS7BQXedk77RhZ7wzvVwAjO9wow4uS7Iyic4kS3Y/6d26s0MO2vP4bR6HW6U6ZQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-node": "3.350.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-sdk-sts": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
+      "integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
+      "integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
+      "integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.350.0.tgz",
+      "integrity": "sha512-mGGU0PpnG0VDNKSuGi083U1egjprrU9/XoRtgf+iYvAKXRR/0XA4pGW5c7zpHY7m4iLhBuRj6N4oxQsH9cMtWg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.350.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.350.0.tgz",
+      "integrity": "sha512-xmqwCFwj/CZPx6AKHNb24Kpr0eHW9VISt9r+SfgH8PaYg5cNyX1pKmMbQCket5ov+WvHEQtOK7aBafak7dhauA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-ini": "3.350.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.350.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
+      "integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.350.0.tgz",
+      "integrity": "sha512-u/3kv+PJeVawzBtWBei+IX1/z50mwhpPe3VrKSTns4CPUw8b5sqIYWkAaw5hxm0td69+xcL98RzIJsEpJc4QSQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.350.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/token-providers": "3.350.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
+      "integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+      "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
+      "integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/hash-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+      "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+      "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+      "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+      "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+      "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+      "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
+      "integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
+      "integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
+      "integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.347.0.tgz",
+      "integrity": "sha512-wJbGN3OE1/daVCrwk49whhIr9E0j1N4gWwN/wi4WuyYIA+5lMUfVp0aGIOvZR+878DxuFz2hQ4XcZVT4K2WvQw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
+      "integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/property-provider": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
+      "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+      "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
+      "integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
+      "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.347.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.350.0.tgz",
+      "integrity": "sha512-VIfVMV5An1VQQ6bOKQTHPsRFHD3/YRGOPk9lDTVJGOK0G1DIFYd/10ZaLQ86rCWLck2lGhjxsOen2N2n6MtA0A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.350.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/url-parser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
+      "integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
+      "integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.347.0.tgz",
+      "integrity": "sha512-/WUkirizeNAqwVj0zkcrqdQ9pUm1HY5kU+qy7xTR0OebkuJauglkmSTMD+56L1JPunWqHhlwCMVRaz5eaJdSEQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-retry": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+      "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+      "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
+      "integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/fast-xml-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/eventstream-codec": {
@@ -1973,9 +3604,9 @@
       }
     },
     "node_modules/@azure/keyvault-keys": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.7.0.tgz",
-      "integrity": "sha512-HScWdORbRCKi1vdKI6EChe/t/P/zV7jcGZWfj18BOyeensk5d1/Ynfx1t6xfAy5zUIQvAWVU97hXdCznDpULbQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.7.1.tgz",
+      "integrity": "sha512-zfmlZQCw1Yz+aPhgZmWOYBUzaKmfBzR2yceAE4S6hKDl7YZraTguuXmtFbCqjRvpz+pIMKAK25fENay9mFy1hQ==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
@@ -2005,20 +3636,20 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.37.0.tgz",
-      "integrity": "sha512-YNGD/W/tw/5wDWlXOfmrVILaxVsorVLxYU2ovmL1PDvxkdudbQRyGk/76l4emqgDAl/kPQeqyivxjOU6w1YfvQ==",
+      "version": "2.37.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.37.1.tgz",
+      "integrity": "sha512-EoKQISEpIY39Ru1OpWkeFZBcwp6Y0bG81bVmdyy4QJebPPDdVzfm62PSU0XFIRc3bqjZ4PBKBLMYLuo9NZYAow==",
       "dependencies": {
-        "@azure/msal-common": "13.0.0"
+        "@azure/msal-common": "13.1.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.0.0.tgz",
-      "integrity": "sha512-GqCOg5H5bouvLij9NFXFkh+asRRxsPBRwnTDsfK7o0KcxYHJbuidKw8/VXpycahGXNxgtuhqtK/n5he+5NhyEA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.1.0.tgz",
+      "integrity": "sha512-wj+ULrRB0HTuMmtrMjg8j3guCx32GE2BCPbsMCZkHgL1BZetC3o/Su5UJEQMX1HNc9CrIaQNx5WaKWHygYDe0g==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -2032,11 +3663,11 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.17.2.tgz",
-      "integrity": "sha512-l8edYnA2LQj4ue3pjxVz1Qy4HuU5xbcoebfe2bGTRvBL9Q6n2Df47aGftkLIyimD1HxHuA4ZZOe23a/HshoYXw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.17.3.tgz",
+      "integrity": "sha512-slsa+388bQQWnWH1V91KL+zV57rIp/0OQFfF0EmVMY8gnEIkAnpWWFUVBTTMbxEyjEFMk5ZW9xiHvHBcYFHzDw==",
       "dependencies": {
-        "@azure/msal-common": "13.0.0",
+        "@azure/msal-common": "13.1.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -2045,9 +3676,9 @@
       }
     },
     "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.0.0.tgz",
-      "integrity": "sha512-GqCOg5H5bouvLij9NFXFkh+asRRxsPBRwnTDsfK7o0KcxYHJbuidKw8/VXpycahGXNxgtuhqtK/n5he+5NhyEA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.1.0.tgz",
+      "integrity": "sha512-wj+ULrRB0HTuMmtrMjg8j3guCx32GE2BCPbsMCZkHgL1BZetC3o/Su5UJEQMX1HNc9CrIaQNx5WaKWHygYDe0g==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -5354,9 +6985,9 @@
       }
     },
     "node_modules/@keystone-6/core": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@keystone-6/core/-/core-5.3.0.tgz",
-      "integrity": "sha512-s+/82LzEBIxk6w4UQOxC3xZTF71sIG6hzb6JZgKE6jV5XQ1YuEi5K5XweU9+J6qe13FCl5iNCOREeC2stDElVQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@keystone-6/core/-/core-5.3.1.tgz",
+      "integrity": "sha512-l7UYJLGfsTPnwN3zDb1+upuL1ianj0QvJMNJtta8I5v86GZTnX/F8aSuH9NBHyA29zbea5YCrevc73UCn6sIZg==",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
         "@apollo/client": "^3.7.0",
@@ -5385,9 +7016,9 @@
         "@keystone-ui/toast": "^6.0.2",
         "@keystone-ui/tooltip": "^6.0.2",
         "@nodelib/fs.walk": "^1.2.8",
-        "@prisma/client": "4.14.1",
-        "@prisma/internals": "4.14.1",
-        "@prisma/migrate": "4.14.1",
+        "@prisma/client": "4.15.0",
+        "@prisma/internals": "4.15.0",
+        "@prisma/migrate": "4.15.0",
         "@sindresorhus/slugify": "^1.1.2",
         "@types/apollo-upload-client": "17.0.2",
         "@types/bcryptjs": "^2.4.2",
@@ -5435,7 +7066,7 @@
         "node-fetch": "^2.6.7",
         "p-limit": "^2.3.0",
         "pluralize": "^8.0.0",
-        "prisma": "4.14.1",
+        "prisma": "4.15.0",
         "prompts": "^2.4.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -6021,12 +7652,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.14.1.tgz",
-      "integrity": "sha512-TZIswkeX1ccsHG/eN2kICzg/csXll0osK3EHu1QKd8VJ3XLcXozbNELKkCNfsCUvKJAwPdDtFCzF+O+raIVldw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.15.0.tgz",
+      "integrity": "sha512-xnROvyABcGiwqRNdrObHVZkD9EjkJYHOmVdlKy1yGgI+XOzvMzJ4tRg3dz1pUlsyhKxXGCnjIQjWW+2ur+YXuw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c"
+        "@prisma/engines-version": "4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944"
       },
       "engines": {
         "node": ">=14.17"
@@ -6044,7 +7675,6 @@
       "version": "4.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.15.0.tgz",
       "integrity": "sha512-dkbPz+gOVlWDBAaOEseSpAUz9NppT38UlwdryPyrwct6OClLirNC7wH+TpAQk5OZp9x59hNnfDz+T7XvL1v0/Q==",
-      "peer": true,
       "dependencies": {
         "@types/debug": "4.1.8",
         "debug": "4.3.4",
@@ -6052,23 +7682,23 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.14.1.tgz",
-      "integrity": "sha512-APqFddPVHYmWNKqc+5J5SqrLFfOghKOLZxobmguDUacxOwdEutLsbXPVhNnpFDmuQWQFbXmrTTPoRrrF6B1MWA==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.15.0.tgz",
+      "integrity": "sha512-FTaOCGs0LL0OW68juZlGxFtYviZa4xdQj/rQEdat2txw0s3Vu/saAPKjNVXfIgUsGXmQ72HPgNr6935/P8FNAA==",
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c.tgz",
-      "integrity": "sha512-3jum8/YSudeSN0zGW5qkpz+wAN2V/NYCQ+BPjvHYDfWatLWlQkqy99toX0GysDeaUoBIJg1vaz2yKqiA3CFcQw=="
+      "version": "4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944.tgz",
+      "integrity": "sha512-sVOig4tjGxxlYaFcXgE71f/rtFhzyYrfyfNFUsxCIEJyVKU9rdOWIlIwQ2NQ7PntvGnn+x0XuFo4OC1jvPJKzg=="
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.14.1.tgz",
-      "integrity": "sha512-4IRZMbeA+5tU+gf15n8oUxGIPqJyF1Gc7DOeP178nvKPNFESp3tWDvzD5vOpVuE0GRM2Mq5WrtiQo5XLD0yQnw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-4.15.0.tgz",
+      "integrity": "sha512-J5HVpRpLxsw9iDLcwwwxL09DXhERnutMiSwyfgHwCQhTHcETc5++XGZlHZtG4toykO3tploCDynXhJc6Fe/u2A==",
       "dependencies": {
-        "@prisma/debug": "4.14.1",
-        "@prisma/get-platform": "4.14.1",
+        "@prisma/debug": "4.15.0",
+        "@prisma/get-platform": "4.15.0",
         "execa": "5.1.1",
         "find-cache-dir": "3.3.2",
         "fs-extra": "11.1.1",
@@ -6076,7 +7706,7 @@
         "http-proxy-agent": "5.0.0",
         "https-proxy-agent": "5.0.1",
         "kleur": "4.1.5",
-        "node-fetch": "2.6.9",
+        "node-fetch": "2.6.11",
         "p-filter": "2.1.0",
         "p-map": "4.0.0",
         "p-retry": "4.6.2",
@@ -6086,67 +7716,10 @@
         "tempy": "1.0.1"
       }
     },
-    "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.14.1.tgz",
-      "integrity": "sha512-jZjNZimL7FVlSyL78r/w9pSqu2s1y+5JGyi0Ajvq17cBCdDzMONGM76PDKBWjOusRhbZD4xcTQ5kfr9JqM0I2A==",
-      "dependencies": {
-        "@types/debug": "4.1.7",
-        "debug": "4.3.4",
-        "strip-ansi": "6.0.1"
-      }
-    },
-    "node_modules/@prisma/fetch-engine/node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
-    "node_modules/@prisma/fetch-engine/node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@prisma/fetch-engine/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/@prisma/fetch-engine/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/@prisma/fetch-engine/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/@prisma/generator-helper": {
       "version": "4.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.15.0.tgz",
       "integrity": "sha512-JVHNgXr0LrcqXqmFrs+BzxfyRL6cFD5GLTMVWfCLU7kqSJdWuZxfoZW995tg6mOXnBgPTf6Ocv3RY4RLQq8k4g==",
-      "peer": true,
       "dependencies": {
         "@prisma/debug": "4.15.0",
         "@types/cross-spawn": "6.0.2",
@@ -6155,11 +7728,11 @@
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.14.1.tgz",
-      "integrity": "sha512-b5EXlVaW2JDCB3o5lsik9NZwARflOLCINyhDgNaqpGGljcXoUneqAlvm9dZ9YNckXImghV1B19aouVpm1LjPrg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-4.15.0.tgz",
+      "integrity": "sha512-A7EdfysFDTL6HQmyZ6CLyNGRDz/60shqiJuhQ952cS0irGhi4PhTCy5MbjCvUaXjRBR6cjPp9EDaZ47TZlw5hg==",
       "dependencies": {
-        "@prisma/debug": "4.14.1",
+        "@prisma/debug": "4.15.0",
         "escape-string-regexp": "4.0.0",
         "execa": "5.1.1",
         "fs-jetpack": "5.1.0",
@@ -6168,40 +7741,22 @@
         "strip-ansi": "6.0.1",
         "tempy": "1.0.1",
         "terminal-link": "2.1.1",
-        "ts-pattern": "4.2.2"
-      }
-    },
-    "node_modules/@prisma/get-platform/node_modules/@prisma/debug": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.14.1.tgz",
-      "integrity": "sha512-jZjNZimL7FVlSyL78r/w9pSqu2s1y+5JGyi0Ajvq17cBCdDzMONGM76PDKBWjOusRhbZD4xcTQ5kfr9JqM0I2A==",
-      "dependencies": {
-        "@types/debug": "4.1.7",
-        "debug": "4.3.4",
-        "strip-ansi": "6.0.1"
-      }
-    },
-    "node_modules/@prisma/get-platform/node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dependencies": {
-        "@types/ms": "*"
+        "ts-pattern": "4.3.0"
       }
     },
     "node_modules/@prisma/internals": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.14.1.tgz",
-      "integrity": "sha512-JbT5EhwzYV5VKdPWyGNTvYKI4MBinHF8fDglRtC0mbdYEl8IZNoMK5n5QDO4m8vQKGy10Mn3VcnhsEfO6FbdKw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-4.15.0.tgz",
+      "integrity": "sha512-bmgn1GX74RfjBRVMV4oJknZJOHmXcO9lh0VbwWKXp1zXvjumQCGeBOmLdzkp4SnvIrpkpXQf9JGbmOTKpVsvRw==",
       "dependencies": {
         "@opentelemetry/api": "1.4.1",
-        "@prisma/debug": "4.14.1",
-        "@prisma/engines": "4.14.1",
-        "@prisma/fetch-engine": "4.14.1",
-        "@prisma/generator-helper": "4.14.1",
-        "@prisma/get-platform": "4.14.1",
-        "@prisma/ni": "4.14.1",
-        "@prisma/prisma-fmt-wasm": "4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c",
+        "@prisma/debug": "4.15.0",
+        "@prisma/engines": "4.15.0",
+        "@prisma/fetch-engine": "4.15.0",
+        "@prisma/generator-helper": "4.15.0",
+        "@prisma/get-platform": "4.15.0",
+        "@prisma/ni": "4.15.0",
+        "@prisma/prisma-fmt-wasm": "4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944",
         "archiver": "5.3.1",
         "arg": "5.0.2",
         "checkpoint-client": "1.1.23",
@@ -6210,7 +7765,7 @@
         "escape-string-regexp": "4.0.0",
         "execa": "5.1.1",
         "find-up": "5.0.0",
-        "fp-ts": "2.14.0",
+        "fp-ts": "2.16.0",
         "fs-extra": "11.1.1",
         "fs-jetpack": "5.1.0",
         "global-dirs": "3.0.1",
@@ -6220,9 +7775,9 @@
         "is-wsl": "2.2.0",
         "kleur": "4.1.5",
         "new-github-issue-url": "0.2.1",
-        "node-fetch": "2.6.9",
+        "node-fetch": "2.6.11",
         "npm-packlist": "5.1.3",
-        "open": "7",
+        "open": "7.4.2",
         "p-map": "4.0.0",
         "prompts": "2.4.2",
         "read-pkg-up": "7.0.1",
@@ -6236,36 +7791,7 @@
         "tempy": "1.0.1",
         "terminal-link": "2.1.1",
         "tmp": "0.2.1",
-        "ts-pattern": "4.2.2"
-      }
-    },
-    "node_modules/@prisma/internals/node_modules/@prisma/debug": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.14.1.tgz",
-      "integrity": "sha512-jZjNZimL7FVlSyL78r/w9pSqu2s1y+5JGyi0Ajvq17cBCdDzMONGM76PDKBWjOusRhbZD4xcTQ5kfr9JqM0I2A==",
-      "dependencies": {
-        "@types/debug": "4.1.7",
-        "debug": "4.3.4",
-        "strip-ansi": "6.0.1"
-      }
-    },
-    "node_modules/@prisma/internals/node_modules/@prisma/generator-helper": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-4.14.1.tgz",
-      "integrity": "sha512-7mxfM6NTLsUgbmx8t+AQTtOdDuUMG+D4K5QtALQP1A3MD7wZy2O+Np4apbvVJwNUn1286PZWk2DTv4cF7XiK3w==",
-      "dependencies": {
-        "@prisma/debug": "4.14.1",
-        "@types/cross-spawn": "6.0.2",
-        "cross-spawn": "7.0.3",
-        "kleur": "4.1.5"
-      }
-    },
-    "node_modules/@prisma/internals/node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dependencies": {
-        "@types/ms": "*"
+        "ts-pattern": "4.3.0"
       }
     },
     "node_modules/@prisma/internals/node_modules/dotenv": {
@@ -6276,66 +7802,23 @@
         "node": ">=12"
       }
     },
-    "node_modules/@prisma/internals/node_modules/fp-ts": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.14.0.tgz",
-      "integrity": "sha512-QLagLSYAgMA00pZzUzeksH/78Sd14y7+Gc2A8Yaja3/IpGOFMdm/gYBuDMxYqLsJ58iT5lz+bJb953RAeFfp1A=="
-    },
-    "node_modules/@prisma/internals/node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@prisma/internals/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/@prisma/internals/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/@prisma/internals/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/@prisma/migrate": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/migrate/-/migrate-4.14.1.tgz",
-      "integrity": "sha512-W5nHkDUJSfci0oZUvEKkPm746ZjVBcpuQOmfT8kg3GUq6Yj+2cKKgu29u9Iz6cAEi1BaQVjzsELCTBN4L7CdbQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/migrate/-/migrate-4.15.0.tgz",
+      "integrity": "sha512-rT8gS1Xfbz//QVc6RMm3XchuQr7uV48BKEe15B2WRpBxR6/3EX0olhrFEJMyV+P2Q5BfnSxTKXQQKhBmAgvUzA==",
       "dependencies": {
-        "@prisma/debug": "4.14.1",
-        "@prisma/get-platform": "4.14.1",
+        "@prisma/debug": "4.15.0",
+        "@prisma/get-platform": "4.15.0",
         "@sindresorhus/slugify": "1.1.2",
         "execa": "5.1.1",
-        "fp-ts": "2.14.0",
+        "fp-ts": "2.16.0",
         "get-stdin": "8.0.0",
         "has-yarn": "2.1.0",
         "indent-string": "4.0.0",
         "kleur": "4.1.5",
         "log-update": "4.0.0",
         "mariadb": "3.1.1",
-        "mongoose": "6.10.5",
+        "mongoose": "6.11.1",
         "mssql": "9.1.1",
         "ora": "5.4.1",
         "pg": "8.10.0",
@@ -6343,45 +7826,22 @@
         "prompts": "2.4.2",
         "strip-ansi": "6.0.1",
         "strip-indent": "3.0.0",
-        "ts-pattern": "4.2.2"
+        "ts-pattern": "4.3.0"
       },
       "peerDependencies": {
         "@prisma/generator-helper": "*",
         "@prisma/internals": "*"
       }
     },
-    "node_modules/@prisma/migrate/node_modules/@prisma/debug": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-4.14.1.tgz",
-      "integrity": "sha512-jZjNZimL7FVlSyL78r/w9pSqu2s1y+5JGyi0Ajvq17cBCdDzMONGM76PDKBWjOusRhbZD4xcTQ5kfr9JqM0I2A==",
-      "dependencies": {
-        "@types/debug": "4.1.7",
-        "debug": "4.3.4",
-        "strip-ansi": "6.0.1"
-      }
-    },
-    "node_modules/@prisma/migrate/node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
-    "node_modules/@prisma/migrate/node_modules/fp-ts": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.14.0.tgz",
-      "integrity": "sha512-QLagLSYAgMA00pZzUzeksH/78Sd14y7+Gc2A8Yaja3/IpGOFMdm/gYBuDMxYqLsJ58iT5lz+bJb953RAeFfp1A=="
-    },
     "node_modules/@prisma/ni": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@prisma/ni/-/ni-4.14.1.tgz",
-      "integrity": "sha512-71ep1GT2k5il/hnLBuGpw81UzcBX5yON2XxOlQ3JknlvOQKkdDRM3If9UgJUrJxx7BHBzieZK02PIKbFVEuqmg=="
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/ni/-/ni-4.15.0.tgz",
+      "integrity": "sha512-kuVzvCbndl2GGoCFufQ5jzSPUaKMF6rp6OmSpFF8z9gflJlPLahtWqIcyKJ8sPaFrkhTlXXsyEX37mY98H1FZg=="
     },
     "node_modules/@prisma/prisma-fmt-wasm": {
-      "version": "4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c.tgz",
-      "integrity": "sha512-qvxi6xbUb4wcawvLju0t2soGBPGs13L6HVmJrZG+RGaDDuJn9qzDAdZl97YdyFgn4jN6VMJeSqXt3yTWKkaaUw=="
+      "version": "4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.15.0-28.8fbc245156db7124f997f4cecdd8d1219e360944.tgz",
+      "integrity": "sha512-1vuW5Cp6DnZpSmmM3dRsJ7do3LncJVkBAV9wwqGSLANDUNWDPfJwC7enN/YY3rnwkEVXMxzkTEbtYGA55blDLw=="
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -6654,7 +8114,6 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
       "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
-      "peer": true,
       "dependencies": {
         "@types/ms": "*"
       }
@@ -14966,11 +16425,11 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.14.0.tgz",
-      "integrity": "sha512-coGKkWXIBczZPr284tYKFLg+KbGPPLlSbdgfKAb6QqCFt5bo5VFZ50O3FFzsw4rnkqjwT6D8Qcoo9nshYKM7Mg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.16.0.tgz",
+      "integrity": "sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==",
       "dependencies": {
-        "bson": "^4.7.0",
+        "bson": "^4.7.2",
         "mongodb-connection-string-url": "^2.5.4",
         "socks": "^2.7.1"
       },
@@ -14992,13 +16451,13 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "6.10.5",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.10.5.tgz",
-      "integrity": "sha512-y4HL4/9EySec7L0gJ+pCm9heLSF45uIIvRS4fSeAFWDfe4vXW1vRZJwTz7OGkra3ZoSfRnFTo9bNZkuggDVlVA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.11.1.tgz",
+      "integrity": "sha512-AvQ8C5ZGF6GcsQhoRg/i7pbNZpb96qLGU5ICBllckp7qMOxcfUF1nA6JstZw841BqRcE6myZ/mx9CluEESaw5Q==",
       "dependencies": {
-        "bson": "^4.7.0",
+        "bson": "^4.7.2",
         "kareem": "2.5.1",
-        "mongodb": "4.14.0",
+        "mongodb": "4.16.0",
         "mpath": "0.9.0",
         "mquery": "4.0.3",
         "ms": "2.1.3",
@@ -16224,12 +17683,12 @@
       "dev": true
     },
     "node_modules/prisma": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.14.1.tgz",
-      "integrity": "sha512-z6hxzTMYqT9SIKlzD08dhzsLUpxjFKKsLpp5/kBDnSqiOjtUyyl/dC5tzxLcOa3jkEHQ8+RpB/fE3w8bgNP51g==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.15.0.tgz",
+      "integrity": "sha512-iKZZpobPl48gTcSZVawLMQ3lEy6BnXwtoMj7hluoGFYu2kQ6F9LBuBrUyF95zRVnNo8/3KzLXJXJ5TEnLSJFiA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.14.1"
+        "@prisma/engines": "4.15.0"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -18172,9 +19631,9 @@
       }
     },
     "node_modules/ts-pattern": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-4.2.2.tgz",
-      "integrity": "sha512-qzJMo2pbkUJWusRH5o8xR+xogn6RmvViyUgwBFTtRENLse470clCGjHDf6haWGZ1AOmk8XkEohUoBW8Uut6Scg=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-4.3.0.tgz",
+      "integrity": "sha512-pefrkcd4lmIVR0LA49Imjf9DYLK8vtWhqBPA3Ya1ir8xCW0O2yjL9dsCVvI7pCodLC5q7smNpEtDR2yVulQxOg=="
     },
     "node_modules/ts-toolbelt": {
       "version": "9.6.0",

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -32,7 +32,7 @@
     "@babel/preset-typescript": "^7.21.5",
     "@graphql-tools/schema": "^9.0.19",
     "@keystone-6/auth": "^7.0.0",
-    "@keystone-6/core": "^5.3.0",
+    "@keystone-6/core": "^5.3.1",
     "@keystone-6/fields-document": "^8.0.0",
     "axios": "^1.4.0",
     "date-fns": "^2.30.0",

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -337,7 +337,7 @@ interface VerifyAccountSignInCodeResponse extends SuccessResponse {
   sessionIdentifier?: string;
 }
 
-interface VerifyAccountSesssionVariables {
+interface VerifyAccountSessionVariables {
   token: string;
 }
 
@@ -472,7 +472,7 @@ export {
   VerifyAccountPasswordResetTokenVariables,
   VerifyAccountSignInCodeVariables,
   VerifyAccountSignInCodeResponse,
-  VerifyAccountSesssionVariables,
+  VerifyAccountSessionVariables,
   VerifyAccountReactivationTokenVariables,
   VerifyAccountReactivationTokenResponse,
 };

--- a/src/ui/server/constants/dates.ts
+++ b/src/ui/server/constants/dates.ts
@@ -1,0 +1,20 @@
+/**
+ * DATE_ONE_MINUTE_IN_THE_PAST
+ * Generate a date that is 1 minute in the past.
+ * @returns {Date}
+ */
+export const DATE_ONE_MINUTE_IN_THE_PAST = () => {
+  const now = new Date();
+
+  const MS_PER_MINUTE = 60000;
+
+  const oneMinuteInThePast = new Date(now.getTime() - 1 * MS_PER_MINUTE);
+
+  return oneMinuteInThePast;
+};
+
+const DATES = {
+  DATE_ONE_MINUTE_IN_THE_PAST,
+};
+
+export default DATES;

--- a/src/ui/server/constants/index.ts
+++ b/src/ui/server/constants/index.ts
@@ -3,6 +3,7 @@ export * from './account';
 export * from './application';
 export * from './currencies';
 export * from './date-format';
+export * from './dates';
 export * from './field-ids';
 export * from './field-values';
 export * from './percentages-of-cover';

--- a/src/ui/server/helpers/can-submit-application/index.test.ts
+++ b/src/ui/server/helpers/can-submit-application/index.test.ts
@@ -1,5 +1,6 @@
 import canSubmitApplication from '.';
 import { APPLICATION } from '../../constants';
+import { DATE_ONE_MINUTE_IN_THE_PAST } from '../../constants/dates';
 import { mockApplication } from '../../test-mocks';
 
 describe('server/helpers/can-submit-application', () => {
@@ -36,15 +37,11 @@ describe('server/helpers/can-submit-application', () => {
   });
 
   describe("when the date is NOT before the application's submission deadline", () => {
-    const now = new Date();
-
-    // 1 minute ago
-    const milliseconds = 300000;
-    const oneMinuteAgo = new Date(now.setMilliseconds(-milliseconds)).toISOString();
+    const oneMinuteInThePast = DATE_ONE_MINUTE_IN_THE_PAST();
 
     const mockApplicationDeadlinePassed = {
       ...mockApplication,
-      submissionDeadline: oneMinuteAgo,
+      submissionDeadline: String(oneMinuteInThePast),
     };
 
     it('should return false', () => {

--- a/src/ui/server/middleware/insurance/user-session/index.test.ts
+++ b/src/ui/server/middleware/insurance/user-session/index.test.ts
@@ -1,5 +1,6 @@
 import userSessionMiddleware from '.';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
+import { DATE_ONE_MINUTE_IN_THE_PAST } from '../../../constants/dates';
 import { mockReq, mockRes, mockAccount } from '../../../test-mocks';
 import { Next, Request, Response } from '../../../../types';
 
@@ -36,11 +37,11 @@ describe('middleware/insurance/user-session', () => {
 
   describe('when the current time is past req.session.user.expires', () => {
     beforeEach(() => {
-      const oneMinuteAgo = new Date(Date.now() - 1000 * 60).toISOString();
+      const oneMinuteInThePast = DATE_ONE_MINUTE_IN_THE_PAST();
 
       req.session.user = {
         ...mockAccount,
-        expires: String(oneMinuteAgo),
+        expires: oneMinuteInThePast.toISOString(),
       };
 
       next = nextSpy;


### PR DESCRIPTION
This PR cleans up and improves various parts of the API, UI E2E tests.

## Changes
- Use a new constant `DATE_ONE_MINUTE_IN_THE_PAST` in some E2E tests instead the tests having their own definitions of "one minute in the past".
- Update various API GQL resolver unit tests to use a new `DATE_ONE_MINUTE_IN_THE_PAST` constant, same as E2E tests.
- Update the UI's "can submit application" helper function unit test to use a new `DATE_ONE_MINUTE_IN_THE_PAST` constant, same as API and E2E tests.
- Resolve some code smells reported by SonarCloud (https://sonarcloud.io/project/issues?id=UK-Export-Finance_exip&pullRequest=540&resolved=false&types=CODE_SMELL):
  - Split out some logic from the account sign in GQL resolver into a new function, `accountChecks`.
  - Remove some uncessary type wrappings.
  - Simplify a `mappedSicCodes` condition.
- Bump `keystone-6/core` package.