### PR TITLE
fix(EMS-1698-1743): Account - Sign in - Only create retry attempts if credentials are invalid

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/sign-in-already-blocked/account-sign-in-already-blocked.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/sign-in-already-blocked/account-sign-in-already-blocked.spec.js
@@ -31,7 +31,7 @@ context('Insurance - Account - Sign in - Submitting the form when already blocke
     cy.navigateToUrl(signInUrl);
 
     // force the account to be blocked
-    cy.completeAndSubmitSignInAccountFormMaximumRetries({});
+    cy.completeAndSubmitSignInAccountFormMaximumInvalidRetries({});
 
     cy.navigateToUrl(signInUrl);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/sign-in-retry/account-sign-in-retry-maximum-retries-with-invalid-credentials-suspends-account.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/sign-in-retry/account-sign-in-retry-maximum-retries-with-invalid-credentials-suspends-account.spec.js
@@ -34,7 +34,7 @@ context('Insurance - Account - Sign in - Submitting the form with valid credenti
 
       cy.navigateToUrl(signInUrl);
 
-      cy.completeAndSubmitSignInAccountFormMaximumRetries({
+      cy.completeAndSubmitSignInAccountFormMaximumInvalidRetries({
         password: invalidPassword,
       });
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/sign-in-retry/account-sign-in-retry-maximum-retries-with-invalid-credentials-suspends-account.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/sign-in-retry/account-sign-in-retry-maximum-retries-with-invalid-credentials-suspends-account.spec.js
@@ -1,4 +1,5 @@
 import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
+import mockAccount from '../../../../../../fixtures/account';
 import api from '../../../../../../support/api';
 
 const {
@@ -8,12 +9,14 @@ const {
   },
 } = ROUTES;
 
-context('Insurance - Account - Sign in - Submitting the form with invalid credentials over the maximum threshold in the allowed time period should block the account', () => {
+context('Insurance - Account - Sign in - Submitting the form with valid credentials multiple times should suspend the account', () => {
   const baseUrl = Cypress.config('baseUrl');
   const signInUrl = `${baseUrl}${SIGN_IN_ROOT}`;
   const accountSuspendedUrl = `${baseUrl}${SUSPENDED_ROOT}`;
 
   let account;
+
+  const invalidPassword = `${mockAccount}-invalid`;
 
   before(() => {
     cy.deleteAccount();
@@ -25,13 +28,15 @@ context('Insurance - Account - Sign in - Submitting the form with invalid creden
     cy.assertUrl(signInUrl);
   });
 
-  describe('when attempting sign in multiple times and reaching the maximum retries threshold', () => {
+  describe('when attempting sign in with invalid credentials multiple times and reaching the maximum retries threshold', () => {
     beforeEach(() => {
       cy.saveSession();
 
       cy.navigateToUrl(signInUrl);
 
-      cy.completeAndSubmitSignInAccountFormMaximumRetries({});
+      cy.completeAndSubmitSignInAccountFormMaximumRetries({
+        password: invalidPassword,
+      });
     });
 
     it(`should redirect to ${SUSPENDED_ROOT} with ID query param`, () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/sign-in-retry/account-sign-in-retry-multiple-times-with-valid-credentials.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/sign-in-retry/account-sign-in-retry-multiple-times-with-valid-credentials.spec.js
@@ -29,7 +29,7 @@ context('Insurance - Account - Sign in - Submitting the form with valid credenti
 
       cy.navigateToUrl(signInUrl);
 
-      cy.completeAndSubmitSignInAccountFormMaximumRetries({});
+      cy.completeAndSubmitSignInAccountFormMaximumInvalidRetries({});
     });
 
     it(`should redirect to ${ENTER_CODE}`, () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/sign-in-retry/account-sign-in-retry-multiple-times-with-valid-credentials.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/sign-in-retry/account-sign-in-retry-multiple-times-with-valid-credentials.spec.js
@@ -1,0 +1,74 @@
+import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const {
+  ACCOUNT: {
+    SIGN_IN: { ROOT: SIGN_IN_ROOT, ENTER_CODE },
+  },
+  DASHBOARD,
+} = ROUTES;
+
+context('Insurance - Account - Sign in - Submitting the form with valid credentials multiple times should NOT block the account and allow the user to sign in', () => {
+  const baseUrl = Cypress.config('baseUrl');
+  const signInUrl = `${baseUrl}${SIGN_IN_ROOT}`;
+  const enterCodeUrl = `${baseUrl}${ENTER_CODE}`;
+  const dashboardUrl = `${baseUrl}${DASHBOARD}`;
+
+  before(() => {
+    cy.deleteAccount();
+
+    cy.completeAndSubmitCreateAccountForm({ navigateToAccountCreationPage: true });
+
+    cy.verifyAccountEmail();
+
+    cy.assertUrl(signInUrl);
+  });
+
+  describe('when attempting sign in with valid credentials multiple times - same amount of times as the maximum invalid retries threshold', () => {
+    beforeEach(() => {
+      cy.saveSession();
+
+      cy.navigateToUrl(signInUrl);
+
+      cy.completeAndSubmitSignInAccountFormMaximumRetries({});
+    });
+
+    it(`should redirect to ${ENTER_CODE}`, () => {
+      cy.assertUrl(enterCodeUrl);
+    });
+  });
+
+  describe('when attempting to sign in for an additional time after the same amount of attempts it would take for invalid credential attempts to block an account', () => {
+    before(() => {
+      cy.saveSession();
+
+      cy.navigateToUrl(signInUrl);
+
+      cy.completeAndSubmitSignInAccountForm({ assertRedirectUrl: false });
+    });
+
+    it(`should redirect to ${ENTER_CODE}`, () => {
+      cy.assertUrl(enterCodeUrl);
+    });
+
+    describe('when submitting a valid security code', () => {
+      let validSecurityCode;
+
+      before(() => {
+        cy.saveSession();
+
+        // create and get an OTP for the exporter's account
+        cy.accountAddAndGetOTP().then((securityCode) => {
+          validSecurityCode = securityCode;
+        });
+      });
+
+      it(`should successfully sign the user in and redirect to ${DASHBOARD}`, () => {
+        cy.navigateToUrl(enterCodeUrl);
+
+        cy.completeAndSubmitEnterCodeAccountForm(validSecurityCode);
+
+        cy.url().should('eq', dashboardUrl);
+      });
+    });
+  });
+});

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -54,7 +54,7 @@ Cypress.Commands.add('submitEligibilityAndStartAccountSignIn', require('./insura
 
 Cypress.Commands.add('completeAndSubmitCreateAccountForm', require('./insurance/account/complete-and-submit-create-account-form'));
 Cypress.Commands.add('completeAndSubmitSignInAccountForm', require('./insurance/account/complete-and-submit-sign-in-account-form'));
-Cypress.Commands.add('completeAndSubmitSignInAccountFormMaximumRetries', require('./insurance/account/complete-and-submit-sign-in-account-form-maximum-retries'));
+Cypress.Commands.add('completeAndSubmitSignInAccountFormMaximumInvalidRetries', require('./insurance/account/complete-and-submit-sign-in-account-form-maximum-invalid-retries'));
 Cypress.Commands.add('completeAndSubmitEnterCodeAccountForm', require('./insurance/account/complete-and-submit-enter-code-account-form'));
 
 Cypress.Commands.add('completeAndSubmitPasswordResetForm', require('./insurance/account/complete-and-submit-password-reset-form'));

--- a/e2e-tests/cypress/support/insurance/account/complete-and-submit-sign-in-account-form-maximum-invalid-retries.js
+++ b/e2e-tests/cypress/support/insurance/account/complete-and-submit-sign-in-account-form-maximum-invalid-retries.js
@@ -5,14 +5,14 @@ import { backLink } from '../../../e2e/pages/shared';
 const attemptsToMake = [...Array(ACCOUNT.MAX_AUTH_RETRIES)];
 
 /**
- * completeAndSubmitSignInAccountFormMaximumRetries
+ * completeAndSubmitSignInAccountFormMaximumInvalidRetries
  * Complete and submit the sign in form multiple times,
  * Matching the maximum retries allowed before an account becomes blocked.
  * @param {Object} Object with custom flags
  * - clickBackLinkOnLastAttempt
  * - password
  */
-const completeAndSubmitSignInAccountFormMaximumRetries = ({
+const completeAndSubmitSignInAccountFormMaximumInvalidRetries = ({
   clickBackLinkOnLastAttempt = true,
   password,
 }) => {
@@ -27,4 +27,4 @@ const completeAndSubmitSignInAccountFormMaximumRetries = ({
   });
 };
 
-export default completeAndSubmitSignInAccountFormMaximumRetries;
+export default completeAndSubmitSignInAccountFormMaximumInvalidRetries;

--- a/e2e-tests/cypress/support/insurance/account/complete-and-submit-sign-in-account-form-maximum-retries.js
+++ b/e2e-tests/cypress/support/insurance/account/complete-and-submit-sign-in-account-form-maximum-retries.js
@@ -10,12 +10,14 @@ const attemptsToMake = [...Array(ACCOUNT.MAX_AUTH_RETRIES)];
  * Matching the maximum retries allowed before an account becomes blocked.
  * @param {Object} Object with custom flags
  * - clickBackLinkOnLastAttempt
+ * - password
  */
 const completeAndSubmitSignInAccountFormMaximumRetries = ({
   clickBackLinkOnLastAttempt = true,
+  password,
 }) => {
   attemptsToMake.forEach((item, index) => {
-    completeAndSubmitSignInAccountForm({ assertRedirectUrl: false });
+    completeAndSubmitSignInAccountForm({ assertRedirectUrl: false, password });
 
     const isLastAttempt = index + 1 === attemptsToMake.length;
 

--- a/e2e-tests/cypress/support/insurance/account/create-an-account-and-become-blocked.js
+++ b/e2e-tests/cypress/support/insurance/account/create-an-account-and-become-blocked.js
@@ -31,7 +31,7 @@ const createAnAccountAndBecomeBlocked = ({ startReactivationJourney = false }) =
 
   cy.verifyAccountEmail();
 
-  cy.completeAndSubmitSignInAccountFormMaximumRetries({
+  cy.completeAndSubmitSignInAccountFormMaximumInvalidRetries({
     password: invalidPassword,
   });
 

--- a/e2e-tests/cypress/support/insurance/account/create-an-account-and-become-blocked.js
+++ b/e2e-tests/cypress/support/insurance/account/create-an-account-and-become-blocked.js
@@ -1,5 +1,6 @@
 import { INSURANCE_ROUTES as ROUTES } from '../../../../constants/routes/insurance';
 import { submitButton } from '../../../e2e/pages/shared';
+import mockAccount from '../../../fixtures/account';
 
 const {
   ACCOUNT: {
@@ -11,12 +12,14 @@ const {
 
 const accountSuspendedEmailSentUrl = `${Cypress.config('baseUrl')}${EMAIL_SENT}`;
 
+const invalidPassword = `${mockAccount}-invalid`;
+
 /**
  * createAnAccountAndBecomeBlocked
  * 1) Delete account
  * 2) Complete and submit account creation form
  * 3) Verify the account email
- * 4) Complete and submit sign in form over the maximum threshold
+ * 4) Complete and submit sign in form with invalid credentials over the maximum threshold
  * 5) If startReactivationJourney param is provided: submit the "account suspended" form and check the URL
  * @param {Object} Object with flags on how to complete this flow
  * - startReactivationJourney: Should submit the "account suspended" form, to begin the reactivation journey. Defaults to false.
@@ -28,7 +31,9 @@ const createAnAccountAndBecomeBlocked = ({ startReactivationJourney = false }) =
 
   cy.verifyAccountEmail();
 
-  cy.completeAndSubmitSignInAccountFormMaximumRetries({});
+  cy.completeAndSubmitSignInAccountFormMaximumRetries({
+    password: invalidPassword,
+  });
 
   if (startReactivationJourney) {
     submitButton().click();

--- a/src/api/custom-resolvers/mutations/account-sign-in/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/index.test.ts
@@ -1,4 +1,4 @@
-import { ACCOUNT } from '../../../constants';
+import { ACCOUNT, FIELD_IDS } from '../../../constants';
 import accountSignIn from '.';
 import createAuthenticationRetryEntry from '../../../helpers/create-authentication-retry-entry';
 import generate from '../../../helpers/generate-otp';
@@ -10,6 +10,8 @@ import { Account, AccountSignInResponse, ApplicationRelationship } from '../../.
 import getKeystoneContext from '../../../test-helpers/get-keystone-context';
 
 const context = getKeystoneContext();
+
+const { PASSWORD } = FIELD_IDS.INSURANCE.ACCOUNT;
 
 const { MAX_AUTH_RETRIES } = ACCOUNT;
 
@@ -44,15 +46,9 @@ describe('custom-resolvers/account-sign-in', () => {
     await context.query.AuthenticationRetry.deleteMany({
       where: retries,
     });
-
-    account = await accounts.create(context);
-
-    result = await accountSignIn({}, variables, context);
-
-    account = await accounts.get(context, account.id);
   });
 
-  describe('when the account is found and verified', () => {
+  describe('when the provided password is valid and the account is found and verified', () => {
     beforeEach(async () => {
       await accounts.deleteAll(context);
 
@@ -62,26 +58,52 @@ describe('custom-resolvers/account-sign-in', () => {
       await context.query.AuthenticationRetry.deleteMany({
         where: retries,
       });
+
+      account = await accounts.create(context);
     });
 
     test('it should return the result of accountChecks', async () => {
-      const createdAccount = await accounts.create(context);
-
       result = await accountSignIn({}, variables, context);
 
-      const expected = await accountChecks(context, createdAccount, mockUrlOrigin);
+      const expected = await accountChecks(context, account, mockUrlOrigin);
 
       expect(result).toEqual(expected);
+    });
+
+    test('it should NOT add an authentication retry entry', async () => {
+      retries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
+
+      expect(retries.length).toEqual(0);
+    });
+
+    it('it should NOT mark the account as isBlocked=true', async () => {
+      // get the latest account
+      account = await accounts.get(context, account.id);
+
+      expect(account.isBlocked).toEqual(false);
     });
   });
 
   describe('when the provided password is invalid', () => {
-    beforeEach(() => {
-      variables.password = `${mockPassword}-incorrect`;
+    beforeEach(async () => {
+      await accounts.deleteAll(context);
+
+      // wipe the AuthenticationRetry table so we have a clean slate.
+      retries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
+
+      await context.query.AuthenticationRetry.deleteMany({
+        where: retries,
+      });
+
+      account = await accounts.create(context);
+
+      result = await accountSignIn({}, variables, context);
+
+      variables[PASSWORD] = `${mockPassword}-incorrect`;
     });
 
     afterAll(() => {
-      variables.password = mockPassword;
+      variables[PASSWORD] = mockPassword;
     });
 
     test('it should return success=false', async () => {
@@ -92,20 +114,54 @@ describe('custom-resolvers/account-sign-in', () => {
       expect(result).toEqual(expected);
     });
 
-    test('it should retain the added authentication retry entry', async () => {
-      // wipe the AuthenticationRetry table so we have a clean slate.
-      retries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
-
-      await context.query.AuthenticationRetry.deleteMany({
-        where: retries,
-      });
-
-      await accountSignIn({}, variables, context);
-
+    test('it should add an authentication retry entry', async () => {
       // get the latest retries
       retries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
 
       expect(retries.length).toEqual(1);
+    });
+
+    describe(`when the account has ${MAX_AUTH_RETRIES} entries in the AuthenticationRetry table`, () => {
+      beforeEach(async () => {
+        await accounts.deleteAll(context);
+
+        // create a new account and ensure it is not blocked so that we have a clean slate.
+        account = await accounts.create(context, {
+          ...mockAccount,
+          isBlocked: false,
+        });
+
+        // wipe the AuthenticationRetry table so we have a clean slate.
+        retries = await context.query.AuthenticationRetry.findMany();
+
+        await context.query.AuthenticationRetry.deleteMany({
+          where: retries,
+        });
+
+        // generate an array of promises to create retry entries
+        const entriesToCreate = [...Array(MAX_AUTH_RETRIES)].map(async () => createAuthenticationRetryEntry(context, account.id));
+
+        await Promise.all(entriesToCreate);
+
+        result = await accountSignIn({}, variables, context);
+      });
+
+      test('it should return success=false, isBlocked=true and accountId', async () => {
+        const expected = {
+          success: false,
+          isBlocked: true,
+          accountId: account.id,
+        };
+
+        expect(result).toEqual(expected);
+      });
+
+      test('it should mark the account as isBlocked=true', async () => {
+        // get the latest account
+        account = await accounts.get(context, account.id);
+
+        expect(account.isBlocked).toEqual(true);
+      });
     });
   });
 
@@ -125,7 +181,7 @@ describe('custom-resolvers/account-sign-in', () => {
       result = await accountSignIn({}, variables, context);
     });
 
-    it('should return success=false, isBlocked=true and accountId', async () => {
+    test('it should return success=false, isBlocked=true and accountId', async () => {
       const expected = {
         success: false,
         isBlocked: true,
@@ -133,49 +189,6 @@ describe('custom-resolvers/account-sign-in', () => {
       };
 
       expect(result).toEqual(expected);
-    });
-  });
-
-  describe(`when the account has ${MAX_AUTH_RETRIES} entries in the AuthenticationRetry table`, () => {
-    beforeEach(async () => {
-      // revert the previous account block so we have a clean slate.
-      account = (await context.query.Account.updateOne({
-        where: { id: account.id },
-        data: {
-          isBlocked: false,
-        },
-      })) as Account;
-
-      // wipe the AuthenticationRetry table so we have a clean slate.
-      retries = await context.query.AuthenticationRetry.findMany();
-
-      await context.query.AuthenticationRetry.deleteMany({
-        where: retries,
-      });
-
-      // generate an array of promises to create retry entries
-      const entriesToCreate = [...Array(MAX_AUTH_RETRIES)].map(async () => createAuthenticationRetryEntry(context, account.id));
-
-      await Promise.all(entriesToCreate);
-
-      result = await accountSignIn({}, variables, context);
-    });
-
-    it('should return success=false, isBlocked=true and accountId', async () => {
-      const expected = {
-        success: false,
-        isBlocked: true,
-        accountId: account.id,
-      };
-
-      expect(result).toEqual(expected);
-    });
-
-    it('should mark the account as isBlocked=true', async () => {
-      // get the latest account
-      account = await accounts.get(context, account.id);
-
-      expect(account.isBlocked).toEqual(true);
     });
   });
 

--- a/src/api/custom-resolvers/mutations/account-sign-in/index.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/index.ts
@@ -10,12 +10,16 @@ import { Account, AccountSignInVariables, AccountSignInResponse } from '../../..
 
 /**
  * accountSignIn
- * - Check if the account exists
- * - Check if the account is already blocked
- * - Check if the account needs to be blocked
- * - Get and validate email and password
- * - Generate an OTP, save in the database
- * - Send the user an email with security code
+ * 1) Check if the account exists.
+ * 2) Check if the account is already blocked.
+ * 3) Get and validate email and password.
+ * 4) If the provided credentials are valid:
+ *   4.1) Generate an OTP, save in the database.
+ *   4.2) Send the user an email with security code.
+ *
+ * 5) If the provided credentials are invalid:
+ *   5.1) Create a new retry entry for the account.
+ *   5.2) Check if the account should be blocked. If so, block the account.
  * @param {Object} GraphQL root variables
  * @param {Object} GraphQL variables for the AccountSignIn mutation
  * @param {Object} KeystoneJS context API
@@ -41,16 +45,6 @@ const accountSignIn = async (root: any, variables: AccountSignInVariables, conte
     const { id: accountId } = account;
 
     /**
-     * Create a new retry entry for the account
-     * If this fails, return success=false
-     */
-    const newRetriesEntry = await createAuthenticationRetryEntry(context, accountId);
-
-    if (!newRetriesEntry.success) {
-      return { success: false };
-    }
-
-    /**
      * Check if the account is blocked
      * If so, return isBlocked=false
      */
@@ -60,6 +54,36 @@ const accountSignIn = async (root: any, variables: AccountSignInVariables, conte
       console.info('Unable to sign in account - account is already blocked');
 
       return { success: false, isBlocked: true, accountId };
+    }
+
+    /**
+     * Account is found and verified. We can therefore:
+     * 1) Check if the password matches what is encrypted in the database.
+     * 2) If the password is valid:
+     *   - If the account is unverified, but has a valid has/token, send verification email.
+     *   - If the account is verified, generate an OTP/security code and send via email.
+     * 3) Otherwise, we return a rejection because either:
+     *   - The password is invalid.
+     *   - The email was not sent.
+     */
+    if (isValidAccountPassword(password, account.salt, account.hash)) {
+      console.info('Signing in account - valid credentials provided');
+
+      return accountChecks(context, account, urlOrigin);
+    }
+
+    /**
+     * Provided credentials are invalid.
+     * 1) Create a new retry entry for the account.
+     * 2) Check if the account should be blocked and if so, block the account.
+     */
+
+    console.info('Signing in account - invalid credentials provided');
+
+    const newRetriesEntry = await createAuthenticationRetryEntry(context, accountId);
+
+    if (!newRetriesEntry.success) {
+      return { success: false };
     }
 
     /**
@@ -82,21 +106,6 @@ const accountSignIn = async (root: any, variables: AccountSignInVariables, conte
       return { success: false };
     }
 
-    /**
-     * Account is found and verified. We can therefore:
-     * 1) Check if the password matches what is encrypted in the database.
-     * 2) If the password is valid:
-     *   - If the account is unverified, but has a valid has/token, send verification email.
-     *   - If the account is verified, generate an OTP/security code and send via email.
-     * 3) Otherwise, we return a rejection because either:
-     *   - The password is invalid.
-     *   - The email was not sent.
-     */
-    if (isValidAccountPassword(password, account.salt, account.hash)) {
-      return accountChecks(context, account, urlOrigin);
-    }
-
-    // invalid credentials.
     return { success: false };
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
⚠️ Need this PR merged first https://github.com/UK-Export-Finance/exip/pull/542

This PR fixes an issue where an account sign in attempt would create a retry attempt in the DB regardless off if the sign in credentials were valid or not. We now only create a retry attempt in the DB if the provided credentials are invalid.

## Changes

- Change the ordering of logic in the sign in GQL resolver so that an authentication retry entry is created only after we check if the provided credentials are valid and are deemed to be invalid.
- Improved unit test coverage for the sign in GQL resolver, fixed some typos.
- Updated E2E tests:
  - Rename and update existing E2E tests coverage to test for submitting the sign in form multiple times with invalid credentials and by doing so, the account becomes blocked.
  - `createAnAccountAndBecomeBlocked` command now uses an invalid password.
  - `completeAndSubmitSignInAccountFormMaximumRetries` can now consume a password param.
  - Add E2E test coverage for a user attempting to sign in multiple times with valid credentials, not becoming blocked and are able to sign in successfully
  - Rename `completeAndSubmitSignInAccountFormMaximumRetries` cypress command.


## Other improvements
- Improved documentation in the sign in GQL resolver.
