### PR TITLE
feat(EMS-1742): Cookies saved page

### DIFF
--- a/e2e-tests/constants/routes/index.js
+++ b/e2e-tests/constants/routes/index.js
@@ -5,6 +5,8 @@ export const ROUTES = {
   ROOT: '/',
   ACCESSIBILITY_STATEMENT: '/accessibility-statement',
   COOKIES: '/cookies',
+  COOKIES_CONSENT: '/cookies-consent',
+  COOKIES_SAVED: '/cookies/saved',
   CONTACT_US: '/contact-us',
   PROBLEM_WITH_SERVICE: '/problem-with-service',
   QUOTE: QUOTE_ROUTES,

--- a/e2e-tests/constants/routes/insurance/index.js
+++ b/e2e-tests/constants/routes/insurance/index.js
@@ -47,6 +47,7 @@ export const INSURANCE_ROUTES = {
   FEEDBACK_SENT: `${INSURANCE_ROOT}/feedback-sent`,
   ACCESSIBILITY_STATEMENT: `${INSURANCE_ROOT}/accessibility-statement`,
   COOKIES: `${INSURANCE_ROOT}/cookies`,
+  COOKIES_SAVED: `${INSURANCE_ROOT}/cookies/saved`,
   COOKIES_CONSENT: `${INSURANCE_ROOT}/cookies-consent`,
   CONTACT_US: `${INSURANCE_ROOT}/contact-us`,
   PROBLEM_WITH_SERVICE: `${INSURANCE_ROOT}/problem-with-service`,

--- a/e2e-tests/content-strings/buttons.js
+++ b/e2e-tests/content-strings/buttons.js
@@ -7,6 +7,7 @@ export const BUTTONS = {
   CONTINUE_TO_SIGN_IN: 'Continue to sign in',
   REACTIVATE_ACCOUNT: 'Reactivate account',
   RETURN_TO_EXISTING_APPLICATION: 'Return to my existing application',
+  RETURN_TO_SERVICE: 'Return to service',
   SAVE_CHANGES: 'Save changes',
   SAVE_AND_BACK: 'Save and back to all sections',
   SEARCH: 'Search',

--- a/e2e-tests/content-strings/pages/index.js
+++ b/e2e-tests/content-strings/pages/index.js
@@ -169,6 +169,11 @@ const COOKIES_PAGE = {
   },
 };
 
+const COOKIES_SAVED_PAGE = {
+  PAGE_TITLE: 'Your cookie preferences have been saved',
+  BODY: 'You can change your preferences at any time.',
+};
+
 const NEED_TO_START_AGAIN_PAGE = {
   PAGE_TITLE: 'You need to start again',
   REASON: 'This is because you have not yet answered all the eligibility questions.',
@@ -226,6 +231,7 @@ const PAGES = {
   CANNOT_APPLY,
   ACCESSIBILITY_STATEMENT_PAGE,
   COOKIES_PAGE,
+  COOKIES_SAVED_PAGE,
   NEED_TO_START_AGAIN_PAGE,
   PAGE_NOT_FOUND_PAGE,
   PROBLEM_WITH_SERVICE_PAGE,

--- a/e2e-tests/cypress/e2e/journeys/insurance/cookies-saved-visit-directly-when-signed-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/cookies-saved-visit-directly-when-signed-in.spec.js
@@ -1,0 +1,39 @@
+import { FIELD_IDS, ROUTES } from '../../../../constants';
+import { cookiesPage, cookiesSavedPage } from '../../pages';
+import { submitButton } from '../../pages/shared';
+
+const {
+  INSURANCE: { COOKIES, DASHBOARD },
+} = ROUTES;
+
+context('Cookies saved page - Insurance - visit the page directly as a signed in user and submit the cookies form', () => {
+  let referenceNumber;
+  const baseUrl = Cypress.config('baseUrl');
+  const dashboardUrl = `${baseUrl}${DASHBOARD}`;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication().then((refNumber) => {
+      referenceNumber = refNumber;
+
+      cy.navigateToUrl(COOKIES);
+
+      cookiesPage[FIELD_IDS.OPTIONAL_COOKIES].acceptInput().click();
+
+      submitButton().click();
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  it(`should redirect to the ${DASHBOARD} when clicking 'return to service' link button link`, () => {
+    cookiesSavedPage.returnToServiceLinkButton().click();
+
+    cy.assertUrl(dashboardUrl);
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/cookies-saved.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/cookies-saved.spec.js
@@ -1,0 +1,59 @@
+import { FIELD_IDS, ROUTES } from '../../../../constants';
+import { cookiesPage, cookiesSavedPage } from '../../pages';
+import partials from '../../partials';
+import { submitButton } from '../../pages/shared';
+import { PAGES, BUTTONS } from '../../../../content-strings';
+
+const CONTENT_STRINGS = PAGES.COOKIES_SAVED_PAGE;
+
+const {
+  INSURANCE: { COOKIES, COOKIES_SAVED, START },
+} = ROUTES;
+
+context('Cookies saved page - Insurance', () => {
+  const baseUrl = Cypress.config('baseUrl');
+  const url = `${baseUrl}${COOKIES_SAVED}`;
+  const insuranceStartUrl = `${baseUrl}${START}`;
+
+  beforeEach(() => {
+    cy.login();
+
+    cy.navigateToUrl(insuranceStartUrl);
+
+    partials.footer.supportLinks.cookies().click();
+
+    cy.saveSession();
+
+    cookiesPage[FIELD_IDS.OPTIONAL_COOKIES].acceptInput().click();
+
+    submitButton().click();
+
+    cy.assertUrl(url);
+  });
+
+  it('renders core page elements', () => {
+    cy.corePageChecks({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: COOKIES_SAVED,
+      backLink: COOKIES,
+      assertSubmitButton: false,
+      assertAuthenticatedHeader: false,
+      isInsurancePage: true,
+      assertCookies: false,
+    });
+  });
+
+  it('renders body copy', () => {
+    cy.checkText(cookiesSavedPage.body(), CONTENT_STRINGS.BODY);
+  });
+
+  it('renders a `return to service` button link', () => {
+    const expectedUrl = insuranceStartUrl;
+
+    cy.checkLink(
+      cookiesSavedPage.returnToServiceLinkButton(),
+      expectedUrl,
+      BUTTONS.RETURN_TO_SERVICE,
+    );
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/cookies.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/cookies.spec.js
@@ -1,5 +1,5 @@
 import { inlineErrorMessage, submitButton } from '../../pages/shared';
-import { cookiesPage } from '../../pages';
+import { cookiesPage, cookiesSavedPage } from '../../pages';
 import partials from '../../partials';
 import {
   BUTTONS, ERROR_MESSAGES, FIELDS, PAGES,
@@ -8,15 +8,28 @@ import { FIELD_IDS, ROUTES } from '../../../../constants';
 
 const CONTENT_STRINGS = PAGES.COOKIES_PAGE;
 
+const {
+  INSURANCE: {
+    COOKIES,
+    COOKIES_SAVED,
+    START,
+    ACCOUNT: {
+      SIGN_IN: { ROOT: SIGN_IN_ROOT },
+    },
+  },
+} = ROUTES;
+
 context('Cookies page - Insurance', () => {
-  const url = ROUTES.INSURANCE.COOKIES;
+  const baseUrl = Cypress.config('baseUrl');
+  const url = `${baseUrl}${COOKIES}`;
+  const insuranceStartUrl = `${baseUrl}${START}`;
 
   beforeEach(() => {
-    cy.navigateToUrl(ROUTES.INSURANCE.START);
+    cy.navigateToUrl(START);
 
     partials.footer.supportLinks.cookies().click();
 
-    cy.assertUrl(`${Cypress.config('baseUrl')}${url}`);
+    cy.assertUrl(`${baseUrl}${url}`);
 
     cy.saveSession();
   });
@@ -26,8 +39,8 @@ context('Cookies page - Insurance', () => {
 
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
-      currentHref: url,
-      backLink: ROUTES.INSURANCE.START,
+      currentHref: COOKIES,
+      backLink: START,
       submitButtonCopy: BUTTONS.SAVE_CHANGES,
       assertAuthenticatedHeader: false,
       isInsurancePage: true,
@@ -192,20 +205,22 @@ context('Cookies page - Insurance', () => {
           submitButton().click();
         });
 
-        it(`should redirect to ${url}`, () => {
-          cy.assertUrl(`${Cypress.config('baseUrl')}${url}`);
+        it(`should redirect to ${COOKIES_SAVED}`, () => {
+          cy.assertUrl(`${baseUrl}${COOKIES_SAVED}`);
         });
 
-        it('should render a success message with correct content and `go back` link', () => {
-          cy.checkText(cookiesPage.successBanner.heading(), CONTENT_STRINGS.SUCCESS_BANNER.HEADING);
+        it(`should redirect to ${COOKIES_SAVED}`, () => {
+          cy.assertUrl(`${baseUrl}${COOKIES_SAVED}`);
+        });
 
-          cy.checkText(cookiesPage.successBanner.body(), CONTENT_STRINGS.SUCCESS_BANNER.BODY);
+        it('should render a link button with the URL that was visited prior to submitting an answer in the cookies page', () => {
+          const expectedUrl = insuranceStartUrl;
 
-          cookiesPage.successBanner.goBackLink().should('exist');
-          cy.checkText(cookiesPage.successBanner.goBackLink(), CONTENT_STRINGS.SUCCESS_BANNER.GO_BACK);
-
-          const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.START}`;
-          cookiesPage.successBanner.goBackLink().should('have.attr', 'href', expectedUrl);
+          cy.checkLink(
+            cookiesSavedPage.returnToServiceLinkButton(),
+            expectedUrl,
+            BUTTONS.RETURN_TO_SERVICE,
+          );
         });
 
         it('should NOT render the cookie consent banner', () => {
@@ -229,20 +244,22 @@ context('Cookies page - Insurance', () => {
           submitButton().click();
         });
 
-        it(`should redirect to ${url}`, () => {
-          cy.assertUrl(`${Cypress.config('baseUrl')}${url}`);
+        it(`should redirect to ${COOKIES_SAVED}`, () => {
+          cy.assertUrl(`${baseUrl}${COOKIES_SAVED}`);
         });
 
-        it('should render a success message with correct content and `go back` link', () => {
-          cy.checkText(cookiesPage.successBanner.heading(), CONTENT_STRINGS.SUCCESS_BANNER.HEADING);
+        it(`should redirect to ${COOKIES_SAVED}`, () => {
+          cy.assertUrl(`${baseUrl}${COOKIES_SAVED}`);
+        });
 
-          cy.checkText(cookiesPage.successBanner.body(), CONTENT_STRINGS.SUCCESS_BANNER.BODY);
+        it('should render a link button with the URL that was visited prior to submitting an answer in the cookies page', () => {
+          const expectedUrl = insuranceStartUrl;
 
-          cookiesPage.successBanner.goBackLink().should('exist');
-          cy.checkText(cookiesPage.successBanner.goBackLink(), CONTENT_STRINGS.SUCCESS_BANNER.GO_BACK);
-
-          const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.START}`;
-          cookiesPage.successBanner.goBackLink().should('have.attr', 'href', expectedUrl);
+          cy.checkLink(
+            cookiesSavedPage.returnToServiceLinkButton(),
+            expectedUrl,
+            BUTTONS.RETURN_TO_SERVICE,
+          );
         });
 
         it('should NOT render the cookie consent banner', () => {
@@ -260,7 +277,7 @@ context('Cookies page - Insurance', () => {
 
       describe('when a user navigates to the cookies page directly via URL and optional cookies are submitted as `accept`', () => {
         beforeEach(() => {
-          cy.saveSession();
+          cy.clearCookie('exip-session');
 
           cy.navigateToUrl(url);
 
@@ -268,18 +285,20 @@ context('Cookies page - Insurance', () => {
           submitButton().click();
         });
 
-        it('should render a success message with correct content and no `go back` link', () => {
-          cy.checkText(cookiesPage.successBanner.heading(), CONTENT_STRINGS.SUCCESS_BANNER.HEADING);
+        it(`should render a link button with the URL to ${SIGN_IN_ROOT}`, () => {
+          const expectedUrl = SIGN_IN_ROOT;
 
-          cy.checkText(cookiesPage.successBanner.body(), CONTENT_STRINGS.SUCCESS_BANNER.BODY);
-
-          cookiesPage.successBanner.goBackLink().should('not.exist');
+          cy.checkLink(
+            cookiesSavedPage.returnToServiceLinkButton(),
+            expectedUrl,
+            BUTTONS.RETURN_TO_SERVICE,
+          );
         });
       });
 
       describe('when a user navigates to the cookies page directly via URL and optional cookies are submitted as `reject`', () => {
         beforeEach(() => {
-          cy.saveSession();
+          cy.clearCookie('exip-session');
 
           cy.navigateToUrl(url);
 
@@ -287,12 +306,14 @@ context('Cookies page - Insurance', () => {
           submitButton().click();
         });
 
-        it('should render a success message with correct content and no `go back` link', () => {
-          cy.checkText(cookiesPage.successBanner.heading(), CONTENT_STRINGS.SUCCESS_BANNER.HEADING);
+        it(`should render a link button with the URL to ${SIGN_IN_ROOT}`, () => {
+          const expectedUrl = SIGN_IN_ROOT;
 
-          cy.checkText(cookiesPage.successBanner.body(), CONTENT_STRINGS.SUCCESS_BANNER.BODY);
-
-          cookiesPage.successBanner.goBackLink().should('not.exist');
+          cy.checkLink(
+            cookiesSavedPage.returnToServiceLinkButton(),
+            expectedUrl,
+            BUTTONS.RETURN_TO_SERVICE,
+          );
         });
       });
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/cookies.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/cookies.spec.js
@@ -21,7 +21,7 @@ const {
 
 context('Cookies page - Insurance', () => {
   const baseUrl = Cypress.config('baseUrl');
-  const url = `${baseUrl}${COOKIES}`;
+  const url = COOKIES;
   const insuranceStartUrl = `${baseUrl}${START}`;
 
   beforeEach(() => {

--- a/e2e-tests/cypress/e2e/journeys/quote/cookies-saved.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/cookies-saved.spec.js
@@ -1,0 +1,59 @@
+import { FIELD_IDS, ROUTES } from '../../../../constants';
+import { cookiesPage, cookiesSavedPage } from '../../pages';
+import partials from '../../partials';
+import { submitButton } from '../../pages/shared';
+import { PAGES, BUTTONS } from '../../../../content-strings';
+
+const CONTENT_STRINGS = PAGES.COOKIES_SAVED_PAGE;
+
+const {
+  COOKIES,
+  COOKIES_SAVED,
+  QUOTE: { BUYER_COUNTRY },
+} = ROUTES;
+
+context('Cookies saved page - Quote', () => {
+  const baseUrl = Cypress.config('baseUrl');
+  const url = `${baseUrl}${COOKIES_SAVED}`;
+  const buyerCountryUrl = `${baseUrl}${BUYER_COUNTRY}`;
+
+  beforeEach(() => {
+    cy.login();
+
+    partials.footer.supportLinks.cookies().click();
+
+    cy.saveSession();
+
+    cookiesPage[FIELD_IDS.OPTIONAL_COOKIES].acceptInput().click();
+
+    submitButton().click();
+
+    cy.assertUrl(url);
+  });
+
+  it('renders core page elements', () => {
+    cy.corePageChecks({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: COOKIES_SAVED,
+      backLink: COOKIES,
+      assertSubmitButton: false,
+      assertAuthenticatedHeader: false,
+      isInsurancePage: false,
+      assertCookies: false,
+    });
+  });
+
+  it('renders body copy', () => {
+    cy.checkText(cookiesSavedPage.body(), CONTENT_STRINGS.BODY);
+  });
+
+  it('renders a `return to service` button link', () => {
+    const expectedUrl = buyerCountryUrl;
+
+    cy.checkLink(
+      cookiesSavedPage.returnToServiceLinkButton(),
+      expectedUrl,
+      BUTTONS.RETURN_TO_SERVICE,
+    );
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/quote/cookies.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/cookies.spec.js
@@ -1,5 +1,5 @@
 import { inlineErrorMessage, submitButton } from '../../pages/shared';
-import { cookiesPage } from '../../pages';
+import { cookiesPage, cookiesSavedPage } from '../../pages';
 import partials from '../../partials';
 import {
   BUTTONS, ERROR_MESSAGES, FIELDS, PAGES,
@@ -8,15 +8,28 @@ import { FIELD_IDS, ROUTES } from '../../../../constants';
 
 const CONTENT_STRINGS = PAGES.COOKIES_PAGE;
 
+const {
+  COOKIES,
+  COOKIES_SAVED,
+  QUOTE: { BUYER_COUNTRY },
+  INSURANCE: {
+    ACCOUNT: {
+      SIGN_IN: { ROOT: SIGN_IN_ROOT },
+    },
+  },
+} = ROUTES;
+
 context('Cookies page - Quote', () => {
-  const url = ROUTES.COOKIES;
+  const baseUrl = Cypress.config('baseUrl');
+  const url = COOKIES;
+  const buyerCountryUrl = `${baseUrl}${BUYER_COUNTRY}`;
 
   beforeEach(() => {
     cy.login();
 
     partials.footer.supportLinks.cookies().click();
 
-    cy.assertUrl(`${Cypress.config('baseUrl')}${url}`);
+    cy.assertUrl(`${baseUrl}${url}`);
 
     cy.saveSession();
   });
@@ -26,8 +39,8 @@ context('Cookies page - Quote', () => {
 
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
-      currentHref: ROUTES.COOKIES,
-      backLink: ROUTES.QUOTE.BUYER_COUNTRY,
+      currentHref: COOKIES,
+      backLink: BUYER_COUNTRY,
       submitButtonCopy: BUTTONS.SAVE_CHANGES,
       assertAuthenticatedHeader: false,
       isInsurancePage: false,
@@ -188,24 +201,26 @@ context('Cookies page - Quote', () => {
         beforeEach(() => {
           cy.saveSession();
 
+          cy.navigateToUrl(BUYER_COUNTRY);
+
+          partials.footer.supportLinks.cookies().click();
+
           cookiesPage[FIELD_IDS.OPTIONAL_COOKIES].acceptInput().click();
           submitButton().click();
         });
 
-        it(`should redirect to ${ROUTES.COOKIES}`, () => {
-          cy.assertUrl(`${Cypress.config('baseUrl')}${ROUTES.COOKIES}`);
+        it(`should redirect to ${COOKIES_SAVED}`, () => {
+          cy.assertUrl(`${baseUrl}${COOKIES_SAVED}`);
         });
 
-        it('should render a success message with correct content and `go back` link', () => {
-          cy.checkText(cookiesPage.successBanner.heading(), CONTENT_STRINGS.SUCCESS_BANNER.HEADING);
+        it('should render a link button with the URL that was visited prior to submitting an answer in the cookies page', () => {
+          const expectedUrl = buyerCountryUrl;
 
-          cy.checkText(cookiesPage.successBanner.body(), CONTENT_STRINGS.SUCCESS_BANNER.BODY);
-
-          cookiesPage.successBanner.goBackLink().should('exist');
-          cy.checkText(cookiesPage.successBanner.goBackLink(), CONTENT_STRINGS.SUCCESS_BANNER.GO_BACK);
-
-          const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.BUYER_COUNTRY}`;
-          cookiesPage.successBanner.goBackLink().should('have.attr', 'href', expectedUrl);
+          cy.checkLink(
+            cookiesSavedPage.returnToServiceLinkButton(),
+            expectedUrl,
+            BUTTONS.RETURN_TO_SERVICE,
+          );
         });
 
         it('should NOT render the cookie consent banner', () => {
@@ -225,24 +240,26 @@ context('Cookies page - Quote', () => {
         beforeEach(() => {
           cy.saveSession();
 
+          cy.navigateToUrl(BUYER_COUNTRY);
+
+          partials.footer.supportLinks.cookies().click();
+
           cookiesPage[FIELD_IDS.OPTIONAL_COOKIES].rejectInput().click();
           submitButton().click();
         });
 
-        it(`should redirect to ${ROUTES.COOKIES}`, () => {
-          cy.assertUrl(`${Cypress.config('baseUrl')}${ROUTES.COOKIES}`);
+        it(`should redirect to ${COOKIES_SAVED}`, () => {
+          cy.assertUrl(`${baseUrl}${COOKIES_SAVED}`);
         });
 
-        it('should render a success message with correct content and `go back` link', () => {
-          cy.checkText(cookiesPage.successBanner.heading(), CONTENT_STRINGS.SUCCESS_BANNER.HEADING);
+        it('should render a link button with the URL that was visited prior to submitting an answer in the cookies page', () => {
+          const expectedUrl = buyerCountryUrl;
 
-          cy.checkText(cookiesPage.successBanner.body(), CONTENT_STRINGS.SUCCESS_BANNER.BODY);
-
-          cookiesPage.successBanner.goBackLink().should('exist');
-          cy.checkText(cookiesPage.successBanner.goBackLink(), CONTENT_STRINGS.SUCCESS_BANNER.GO_BACK);
-
-          const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.BUYER_COUNTRY}`;
-          cookiesPage.successBanner.goBackLink().should('have.attr', 'href', expectedUrl);
+          cy.checkLink(
+            cookiesSavedPage.returnToServiceLinkButton(),
+            expectedUrl,
+            BUTTONS.RETURN_TO_SERVICE,
+          );
         });
 
         it('should NOT render the cookie consent banner', () => {
@@ -260,39 +277,43 @@ context('Cookies page - Quote', () => {
 
       describe('when a user navigates to the cookies page directly via URL and optional cookies are submitted as `accept`', () => {
         beforeEach(() => {
-          cy.saveSession();
+          cy.clearCookie('exip-session');
 
-          cy.navigateToUrl(ROUTES.COOKIES);
+          cy.navigateToUrl(COOKIES);
 
           cookiesPage[FIELD_IDS.OPTIONAL_COOKIES].acceptInput().click();
           submitButton().click();
         });
 
-        it('should render a success message with correct content and no `go back` link', () => {
-          cy.checkText(cookiesPage.successBanner.heading(), CONTENT_STRINGS.SUCCESS_BANNER.HEADING);
+        it(`should render a link button with the URL to ${SIGN_IN_ROOT}`, () => {
+          const expectedUrl = SIGN_IN_ROOT;
 
-          cy.checkText(cookiesPage.successBanner.body(), CONTENT_STRINGS.SUCCESS_BANNER.BODY);
-
-          cookiesPage.successBanner.goBackLink().should('not.exist');
+          cy.checkLink(
+            cookiesSavedPage.returnToServiceLinkButton(),
+            expectedUrl,
+            BUTTONS.RETURN_TO_SERVICE,
+          );
         });
       });
 
       describe('when a user navigates to the cookies page directly via URL and optional cookies are submitted as `reject`', () => {
         beforeEach(() => {
-          cy.saveSession();
+          cy.clearCookie('exip-session');
 
-          cy.navigateToUrl(ROUTES.COOKIES);
+          cy.navigateToUrl(COOKIES);
 
-          cookiesPage[FIELD_IDS.OPTIONAL_COOKIES].rejectInput().click();
+          cookiesPage[FIELD_IDS.OPTIONAL_COOKIES].acceptInput().click();
           submitButton().click();
         });
 
-        it('should render a success message with correct content and no `go back` link', () => {
-          cy.checkText(cookiesPage.successBanner.heading(), CONTENT_STRINGS.SUCCESS_BANNER.HEADING);
+        it(`should render a link button with the URL to ${SIGN_IN_ROOT}`, () => {
+          const expectedUrl = SIGN_IN_ROOT;
 
-          cy.checkText(cookiesPage.successBanner.body(), CONTENT_STRINGS.SUCCESS_BANNER.BODY);
-
-          cookiesPage.successBanner.goBackLink().should('not.exist');
+          cy.checkLink(
+            cookiesSavedPage.returnToServiceLinkButton(),
+            expectedUrl,
+            BUTTONS.RETURN_TO_SERVICE,
+          );
         });
       });
     });

--- a/e2e-tests/cypress/e2e/pages/cookies-saved.js
+++ b/e2e-tests/cypress/e2e/pages/cookies-saved.js
@@ -1,0 +1,4 @@
+export const cookiesSavedPage = {
+  body: () => cy.get('[data-cy="body"]'),
+  returnToServiceLinkButton: () => cy.get('[data-cy="return-to-service-link-button"]'),
+};

--- a/e2e-tests/cypress/e2e/pages/cookies.js
+++ b/e2e-tests/cypress/e2e/pages/cookies.js
@@ -43,9 +43,4 @@ export const cookiesPage = {
     errorMessage: () => cy.get(`[data-cy="${FIELD_IDS.OPTIONAL_COOKIES}-error-message"]`),
     submitButton: () => cy.get('[data-cy="submit-button"]'),
   },
-  successBanner: {
-    heading: () => cy.get('[data-cy="success-message-heading"]'),
-    body: () => cy.get('[data-cy="success-message-body"]'),
-    goBackLink: () => cy.get('[data-cy="success-message-go-back-link"]'),
-  },
 };

--- a/e2e-tests/cypress/e2e/pages/index.js
+++ b/e2e-tests/cypress/e2e/pages/index.js
@@ -3,6 +3,7 @@ import insurancePages from './insurance';
 
 export * from './accessibility-statement';
 export * from './cookies';
+export * from './cookies-saved';
 export * from './contact-us';
 export * from './pageNotFound';
 

--- a/src/ui/server/constants/routes/index.ts
+++ b/src/ui/server/constants/routes/index.ts
@@ -6,6 +6,7 @@ export const ROUTES = {
   ACCESSIBILITY_STATEMENT: '/accessibility-statement',
   COOKIES: '/cookies',
   COOKIES_CONSENT: '/cookies-consent',
+  COOKIES_SAVED: '/cookies/saved',
   CONTACT_US: '/contact-us',
   PROBLEM_WITH_SERVICE: '/problem-with-service',
   QUOTE: QUOTE_ROUTES,

--- a/src/ui/server/constants/routes/insurance/index.ts
+++ b/src/ui/server/constants/routes/insurance/index.ts
@@ -48,6 +48,7 @@ export const INSURANCE_ROUTES = {
   FEEDBACK_SENT: `${INSURANCE_ROOT}/feedback-sent`,
   ACCESSIBILITY_STATEMENT: `${INSURANCE_ROOT}/accessibility-statement`,
   COOKIES: `${INSURANCE_ROOT}/cookies`,
+  COOKIES_SAVED: `${INSURANCE_ROOT}/cookies/saved`,
   COOKIES_CONSENT: `${INSURANCE_ROOT}/cookies-consent`,
   CONTACT_US: `${INSURANCE_ROOT}/contact-us`,
   PROBLEM_WITH_SERVICE: `${INSURANCE_ROOT}/problem-with-service`,

--- a/src/ui/server/constants/templates/index.ts
+++ b/src/ui/server/constants/templates/index.ts
@@ -5,6 +5,7 @@ import { SHARED_PAGES } from './shared-pages';
 export const TEMPLATES = {
   ACCESSIBILITY_STATEMENT: 'accessibility-statement.njk',
   COOKIES: 'cookies.njk',
+  COOKIES_SAVED: 'cookies-saved.njk',
   PROBLEM_WITH_SERVICE: 'problem-with-service.njk',
   CANNOT_APPLY: 'cannot-apply.njk',
   CONTACT_US: 'contact-us.njk',

--- a/src/ui/server/content-strings/buttons.ts
+++ b/src/ui/server/content-strings/buttons.ts
@@ -7,6 +7,7 @@ export const BUTTONS = {
   CONTINUE_TO_SIGN_IN: 'Continue to sign in',
   REACTIVATE_ACCOUNT: 'Reactivate account',
   RETURN_TO_EXISTING_APPLICATION: 'Return to my existing application',
+  RETURN_TO_SERVICE: 'Return to service',
   SAVE_CHANGES: 'Save changes',
   SAVE_AND_BACK: 'Save and back to all sections',
   SEARCH: 'Search',

--- a/src/ui/server/content-strings/pages/index.ts
+++ b/src/ui/server/content-strings/pages/index.ts
@@ -163,11 +163,11 @@ const COOKIES_PAGE = {
       },
     ],
   },
-  SUCCESS_BANNER: {
-    HEADING: 'Your cookie settings were saved',
-    BODY: 'Government services may set additional cookies and, if so, will have their own cookie policy and banner.',
-    GO_BACK: 'Go back to the page you were looking at',
-  },
+};
+
+const COOKIES_SAVED_PAGE = {
+  PAGE_TITLE: 'Your cookie preferences have been saved',
+  BODY: 'You can change your preferences at any time.',
 };
 
 const NEED_TO_START_AGAIN_PAGE = {
@@ -226,6 +226,7 @@ export const PAGES = {
   UK_GOODS_OR_SERVICES,
   CANNOT_APPLY,
   COOKIES_PAGE,
+  COOKIES_SAVED_PAGE,
   ACCESSIBILITY_STATEMENT_PAGE,
   NEED_TO_START_AGAIN_PAGE,
   PAGE_NOT_FOUND_PAGE,

--- a/src/ui/server/controllers/root/cookies/index.ts
+++ b/src/ui/server/controllers/root/cookies/index.ts
@@ -10,6 +10,11 @@ const FIELD_ID = FIELD_IDS.OPTIONAL_COOKIES;
 
 const { COOKIES_SAVED, INSURANCE } = ROUTES;
 
+/**
+ * PAGE_VARIABLES
+ * Page fields and content
+ * @returns {Object} Page variables
+ */
 export const PAGE_VARIABLES = {
   FIELD_ID,
   PAGE_CONTENT_STRINGS: PAGES.COOKIES_PAGE,
@@ -17,7 +22,20 @@ export const PAGE_VARIABLES = {
 
 export const TEMPLATE = TEMPLATES.COOKIES;
 
+/**
+ * get
+ * Render the Cookies page
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.render} Cookies page
+ */
 export const get = (req: Request, res: Response) => {
+  /**
+   * Add the previous URL to the session.
+   * This is required for consumption in the "cookies saved" page,
+   * so that we can render a button with the original URL the user was on,
+   * prior to visiting the cookies page and changing answers.
+   */
   if (req.headers.referer) {
     req.session.returnToServiceUrl = req.headers.referer;
   }
@@ -30,6 +48,13 @@ export const get = (req: Request, res: Response) => {
   });
 };
 
+/**
+ * post
+ * Check the cookies page for validation errors and if successful, redirect to the cookies saved page.
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.redirect} Cookies page with validation errors or the Cookies saved page
+ */
 export const post = (req: Request, res: Response) => {
   const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES[FIELD_ID]);
 

--- a/src/ui/server/controllers/root/cookies/index.ts
+++ b/src/ui/server/controllers/root/cookies/index.ts
@@ -3,9 +3,12 @@ import { FIELD_IDS, ROUTES, TEMPLATES, SECURE_OPTION_COOKIE } from '../../../con
 import singleInputPageVariables from '../../../helpers/page-variables/single-input';
 import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
 import generateValidationErrors from '../../../shared-validation/yes-no-radios-form';
+import isInsuranceRoute from '../../../helpers/is-insurance-route';
 import { Request, Response } from '../../../../types';
 
 const FIELD_ID = FIELD_IDS.OPTIONAL_COOKIES;
+
+const { COOKIES_SAVED, INSURANCE } = ROUTES;
 
 export const PAGE_VARIABLES = {
   FIELD_ID,
@@ -15,8 +18,9 @@ export const PAGE_VARIABLES = {
 export const TEMPLATE = TEMPLATES.COOKIES;
 
 export const get = (req: Request, res: Response) => {
-  // store the previous URL so that we can use this in the POST res.render.
-  req.flash('previousUrl', req.headers.referer);
+  if (req.headers.referer) {
+    req.session.returnToServiceUrl = req.headers.referer;
+  }
 
   return res.render(TEMPLATE, {
     userName: getUserNameFromSession(req.session.user),
@@ -29,32 +33,18 @@ export const get = (req: Request, res: Response) => {
 export const post = (req: Request, res: Response) => {
   const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES[FIELD_ID]);
 
-  let backLink = req.headers.referer;
-
   if (validationErrors) {
     return res.render(TEMPLATE, {
       userName: getUserNameFromSession(req.session.user),
       ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer, ORIGINAL_URL: req.originalUrl }),
       FIELD: FIELDS[FIELD_IDS.OPTIONAL_COOKIES],
-      BACK_LINK: req.headers.referer,
       validationErrors,
     });
   }
 
-  const previousUrl = req.flash('previousUrl');
-
-  const showSuccessMessageGoBackLink = previousUrl && previousUrl.length && !previousUrl.includes(ROUTES.COOKIES);
-
-  if (previousUrl) {
-    backLink = previousUrl[previousUrl.length - 1];
+  if (isInsuranceRoute(req.originalUrl)) {
+    return res.redirect(INSURANCE.COOKIES_SAVED);
   }
 
-  return res.render(TEMPLATE, {
-    userName: getUserNameFromSession(req.session.user),
-    ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: backLink, ORIGINAL_URL: req.originalUrl }),
-    FIELD: FIELDS[FIELD_IDS.OPTIONAL_COOKIES],
-    submittedValue: req.cookies.optionalCookies || req.cookies[SECURE_OPTION_COOKIE],
-    showSuccessMessage: true,
-    showSuccessMessageGoBackLink,
-  });
+  return res.redirect(COOKIES_SAVED);
 };

--- a/src/ui/server/controllers/root/cookies/saved/index.test.ts
+++ b/src/ui/server/controllers/root/cookies/saved/index.test.ts
@@ -1,0 +1,74 @@
+import { PAGE_VARIABLES, TEMPLATE, get } from '.';
+import { TEMPLATES } from '../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
+import { PAGES } from '../../../../content-strings';
+import corePageVariables from '../../../../helpers/page-variables/core';
+import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import { Request, Response } from '../../../../../types';
+import { mockReq, mockRes } from '../../../../test-mocks';
+
+const {
+  ACCOUNT: {
+    SIGN_IN: { ROOT: SIGN_IN_ROOT },
+  },
+} = INSURANCE_ROUTES;
+
+describe('controllers/root/cookies/saved', () => {
+  let req: Request;
+  let res: Response;
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+  });
+
+  describe('PAGE_VARIABLES', () => {
+    it('should have correct properties', () => {
+      const expected = {
+        PAGE_CONTENT_STRINGS: PAGES.COOKIES_SAVED_PAGE,
+      };
+
+      expect(PAGE_VARIABLES).toEqual(expected);
+    });
+  });
+
+  describe('TEMPLATE', () => {
+    it('should have the correct template defined', () => {
+      expect(TEMPLATE).toEqual(TEMPLATES.COOKIES_SAVED);
+    });
+  });
+
+  describe('get', () => {
+    it(`should render template with RETURN_TO_SERVICE_URL defaulted to ${SIGN_IN_ROOT}`, () => {
+      get(req, res);
+
+      expect(res.render).toHaveBeenCalledWith(TEMPLATE, {
+        userName: getUserNameFromSession(req.session.user),
+        ...corePageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer, ORIGINAL_URL: req.originalUrl }),
+        RETURN_TO_SERVICE_URL: SIGN_IN_ROOT,
+      });
+    });
+
+    describe('when req.session.returnToServiceUrl exists', () => {
+      const mockUrl = '/mock-url';
+
+      beforeEach(() => {
+        req.session.returnToServiceUrl = mockUrl;
+
+        get(req, res);
+      });
+
+      it('should render template with RETURN_TO_SERVICE_URL as req.session.returnToServiceUrl', () => {
+        expect(res.render).toHaveBeenCalledWith(TEMPLATE, {
+          userName: getUserNameFromSession(req.session.user),
+          ...corePageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer, ORIGINAL_URL: req.originalUrl }),
+          RETURN_TO_SERVICE_URL: mockUrl,
+        });
+      });
+
+      it('should delete req.session.returnToServiceUrl', () => {
+        expect(req.session.returnToServiceUrl).toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/root/cookies/saved/index.ts
+++ b/src/ui/server/controllers/root/cookies/saved/index.ts
@@ -1,0 +1,38 @@
+import { TEMPLATES } from '../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
+import { PAGES } from '../../../../content-strings';
+import corePageVariables from '../../../../helpers/page-variables/core';
+import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import { Request, Response } from '../../../../../types';
+
+const {
+  ACCOUNT: {
+    SIGN_IN: { ROOT: SIGN_IN_ROOT },
+  },
+} = INSURANCE_ROUTES;
+
+export const PAGE_VARIABLES = {
+  PAGE_CONTENT_STRINGS: PAGES.COOKIES_SAVED_PAGE,
+};
+
+export const TEMPLATE = TEMPLATES.COOKIES_SAVED;
+
+export const get = (req: Request, res: Response) => {
+  let RETURN_TO_SERVICE_URL;
+
+  if (req.session.returnToServiceUrl) {
+    const url = req.session.returnToServiceUrl;
+
+    RETURN_TO_SERVICE_URL = url;
+  } else {
+    RETURN_TO_SERVICE_URL = SIGN_IN_ROOT;
+  }
+
+  delete req.session.returnToServiceUrl;
+
+  return res.render(TEMPLATE, {
+    userName: getUserNameFromSession(req.session.user),
+    ...corePageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer, ORIGINAL_URL: req.originalUrl }),
+    RETURN_TO_SERVICE_URL,
+  });
+};

--- a/src/ui/server/controllers/root/cookies/saved/index.ts
+++ b/src/ui/server/controllers/root/cookies/saved/index.ts
@@ -11,15 +11,32 @@ const {
   },
 } = INSURANCE_ROUTES;
 
+/**
+ * PAGE_VARIABLES
+ * Page content
+ * @returns {Object} Page variables
+ */
 export const PAGE_VARIABLES = {
   PAGE_CONTENT_STRINGS: PAGES.COOKIES_SAVED_PAGE,
 };
 
 export const TEMPLATE = TEMPLATES.COOKIES_SAVED;
 
+/**
+ * get
+ * Render the Cookies saved page
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.render} Cookies saved page
+ */
 export const get = (req: Request, res: Response) => {
   let RETURN_TO_SERVICE_URL;
 
+  /**
+   * If we have a returnToServiceUrl in the session,
+   * Use this to render a link to the original URL a user was on,
+   * prior to visiting the cookies page and changing answers.
+   */
   if (req.session.returnToServiceUrl) {
     const url = req.session.returnToServiceUrl;
 
@@ -28,6 +45,10 @@ export const get = (req: Request, res: Response) => {
     RETURN_TO_SERVICE_URL = SIGN_IN_ROOT;
   }
 
+  /**
+   * No need to keep returnToServiceUrl in the session after consumption,
+   * it can be safely deleted.
+   */
   delete req.session.returnToServiceUrl;
 
   return res.render(TEMPLATE, {

--- a/src/ui/server/middleware/insurance/application-access/index.test.ts
+++ b/src/ui/server/middleware/insurance/application-access/index.test.ts
@@ -1,11 +1,20 @@
 import applicationAccessMiddleware, { IRRELEVANT_ROUTES } from '.';
-import { ROUTES } from '../../../constants/routes';
+import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import { mockReq, mockRes, mockApplication, mockAccount } from '../../../test-mocks';
 import { Next, Request, Response } from '../../../../types';
 
 const {
-  INSURANCE: { INSURANCE_ROOT, PAGE_NOT_FOUND, ELIGIBILITY, ACCOUNT, DASHBOARD, NO_ACCESS_TO_APPLICATION, ALL_SECTIONS, NO_ACCESS_APPLICATION_SUBMITTED },
-} = ROUTES;
+  INSURANCE_ROOT,
+  PAGE_NOT_FOUND,
+  ELIGIBILITY,
+  ACCOUNT,
+  DASHBOARD,
+  NO_ACCESS_TO_APPLICATION,
+  ALL_SECTIONS,
+  NO_ACCESS_APPLICATION_SUBMITTED,
+  COOKIES,
+  COOKIES_SAVED,
+} = INSURANCE_ROUTES;
 
 describe('middleware/insurance/application-access', () => {
   let req: Request;
@@ -35,6 +44,8 @@ describe('middleware/insurance/application-access', () => {
         DASHBOARD,
         NO_ACCESS_TO_APPLICATION,
         NO_ACCESS_APPLICATION_SUBMITTED,
+        COOKIES,
+        COOKIES_SAVED,
       ];
 
       expect(IRRELEVANT_ROUTES).toEqual(expected);

--- a/src/ui/server/middleware/insurance/application-access/index.ts
+++ b/src/ui/server/middleware/insurance/application-access/index.ts
@@ -1,7 +1,7 @@
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import { Next, Request, Response } from '../../../../types';
 
-const { PAGE_NOT_FOUND, ELIGIBILITY, ACCOUNT, DASHBOARD, NO_ACCESS_TO_APPLICATION, NO_ACCESS_APPLICATION_SUBMITTED } = INSURANCE_ROUTES;
+const { PAGE_NOT_FOUND, ELIGIBILITY, ACCOUNT, DASHBOARD, NO_ACCESS_TO_APPLICATION, NO_ACCESS_APPLICATION_SUBMITTED, COOKIES, COOKIES_SAVED } = INSURANCE_ROUTES;
 
 export const IRRELEVANT_ROUTES = [
   PAGE_NOT_FOUND,
@@ -14,6 +14,8 @@ export const IRRELEVANT_ROUTES = [
   DASHBOARD,
   NO_ACCESS_TO_APPLICATION,
   NO_ACCESS_APPLICATION_SUBMITTED,
+  COOKIES,
+  COOKIES_SAVED,
 ];
 
 export const applicationAccessMiddleware = async (req: Request, res: Response, next: Next) => {

--- a/src/ui/server/routes/root/index.test.ts
+++ b/src/ui/server/routes/root/index.test.ts
@@ -3,8 +3,9 @@ import { ROUTES } from '../../constants';
 import rootGet from '../../controllers/root';
 import { get as accessibilityStatementGet } from '../../controllers/root/accessibility-statement';
 import { get as cookiesGet, post as cookiesPost } from '../../controllers/root/cookies';
-import { get as contactUsGet } from '../../controllers/root/contact-us';
+import { get as cookiesSavedGet } from '../../controllers/root/cookies/saved';
 import cookiesConsentPost from '../../controllers/root/cookies-consent';
+import { get as contactUsGet } from '../../controllers/root/contact-us';
 import problemWithServiceGet from '../../controllers/root/problem-with-service';
 
 describe('routes/index', () => {
@@ -17,7 +18,7 @@ describe('routes/index', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(9);
+    expect(get).toHaveBeenCalledTimes(11);
     expect(post).toHaveBeenCalledTimes(4);
 
     expect(get).toHaveBeenCalledWith(ROUTES.ROOT, rootGet);
@@ -27,14 +28,16 @@ describe('routes/index', () => {
 
     expect(get).toHaveBeenCalledWith(ROUTES.COOKIES, cookiesGet);
     expect(post).toHaveBeenCalledWith(ROUTES.COOKIES, cookiesPost);
+    expect(get).toHaveBeenCalledWith(ROUTES.COOKIES_SAVED, cookiesSavedGet);
+    expect(post).toHaveBeenCalledWith(ROUTES.COOKIES_CONSENT, cookiesConsentPost);
+
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.COOKIES, cookiesGet);
     expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.COOKIES, cookiesPost);
+    expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.COOKIES_SAVED, cookiesSavedGet);
+    expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.COOKIES_CONSENT, cookiesConsentPost);
 
     expect(get).toHaveBeenCalledWith(ROUTES.CONTACT_US, contactUsGet);
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.CONTACT_US, contactUsGet);
-
-    expect(post).toHaveBeenCalledWith(ROUTES.COOKIES_CONSENT, cookiesConsentPost);
-    expect(post).toHaveBeenCalledWith(ROUTES.INSURANCE.COOKIES_CONSENT, cookiesConsentPost);
 
     expect(get).toHaveBeenCalledWith(ROUTES.PROBLEM_WITH_SERVICE, problemWithServiceGet);
     expect(get).toHaveBeenCalledWith(ROUTES.INSURANCE.PROBLEM_WITH_SERVICE, problemWithServiceGet);

--- a/src/ui/server/routes/root/index.ts
+++ b/src/ui/server/routes/root/index.ts
@@ -3,8 +3,9 @@ import { ROUTES } from '../../constants';
 import rootGet from '../../controllers/root';
 import { get as accessibilityStatementGet } from '../../controllers/root/accessibility-statement';
 import { get as cookiesGet, post as cookiesPost } from '../../controllers/root/cookies';
-import { get as contactUsGet } from '../../controllers/root/contact-us';
+import { get as cookiesSavedGet } from '../../controllers/root/cookies/saved';
 import cookiesConsentPost from '../../controllers/root/cookies-consent';
+import { get as contactUsGet } from '../../controllers/root/contact-us';
 import problemWithServiceGet from '../../controllers/root/problem-with-service';
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
@@ -18,14 +19,16 @@ rootRouter.get(ROUTES.INSURANCE.ACCESSIBILITY_STATEMENT, accessibilityStatementG
 
 rootRouter.get(ROUTES.COOKIES, cookiesGet);
 rootRouter.post(ROUTES.COOKIES, cookiesPost);
+rootRouter.get(ROUTES.COOKIES_SAVED, cookiesSavedGet);
+rootRouter.post(ROUTES.COOKIES_CONSENT, cookiesConsentPost);
+
 rootRouter.get(ROUTES.INSURANCE.COOKIES, cookiesGet);
 rootRouter.post(ROUTES.INSURANCE.COOKIES, cookiesPost);
+rootRouter.get(ROUTES.INSURANCE.COOKIES_SAVED, cookiesSavedGet);
+rootRouter.post(ROUTES.INSURANCE.COOKIES_CONSENT, cookiesConsentPost);
 
 rootRouter.get(ROUTES.CONTACT_US, contactUsGet);
 rootRouter.get(ROUTES.INSURANCE.CONTACT_US, contactUsGet);
-
-rootRouter.post(ROUTES.COOKIES_CONSENT, cookiesConsentPost);
-rootRouter.post(ROUTES.INSURANCE.COOKIES_CONSENT, cookiesConsentPost);
 
 rootRouter.get(ROUTES.PROBLEM_WITH_SERVICE, problemWithServiceGet);
 rootRouter.get(ROUTES.INSURANCE.PROBLEM_WITH_SERVICE, problemWithServiceGet);

--- a/src/ui/templates/cookies-saved.njk
+++ b/src/ui/templates/cookies-saved.njk
@@ -1,10 +1,5 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
-{% from "govuk/components/table/macro.njk" import govukTable %}
-{% from 'govuk/components/radios/macro.njk' import govukRadios %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% import './components/text-list.njk' as textList %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}

--- a/src/ui/templates/cookies-saved.njk
+++ b/src/ui/templates/cookies-saved.njk
@@ -1,0 +1,29 @@
+{% extends 'index.njk' %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from 'govuk/components/radios/macro.njk' import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% import './components/text-list.njk' as textList %}
+
+{% block pageTitle %}
+  {{ CONTENT_STRINGS.PAGE_TITLE }}
+{% endblock %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: CONTENT_STRINGS.LINKS.BACK,
+    href: BACK_LINK,
+    attributes: {
+      "data-cy": "back-link"
+    }
+  }) }}
+
+  <h1 class="govuk-heading-l" data-cy="heading">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
+
+  <p class="govuk-body" data-cy="body">{{ CONTENT_STRINGS.BODY }}</p>
+
+  <a class="govuk-button" href="{{ RETURN_TO_SERVICE_URL }}" data-cy="return-to-service-link-button">{{ CONTENT_STRINGS.BUTTONS.RETURN_TO_SERVICE }}</a>
+
+{% endblock %}

--- a/src/ui/templates/cookies.njk
+++ b/src/ui/templates/cookies.njk
@@ -1,7 +1,6 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
-{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from 'govuk/components/radios/macro.njk' import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
@@ -26,26 +25,6 @@
       titleText: "There is a problem",
       errorList: validationErrors.summary
     }) }}
-  {% endif %}
-
-  {% if showSuccessMessage %}
-    {% set html %}
-      <h3 class="govuk-notification-banner__heading" data-cy="success-message-heading">{{ CONTENT_STRINGS.SUCCESS_BANNER.HEADING }}</h3>
-      <p class="govuk-body" data-cy="success-message-body">{{ CONTENT_STRINGS.SUCCESS_BANNER.BODY }}</p>
-
-      {% if showSuccessMessageGoBackLink %}
-        <p class="govuk-body"><a class="govuk-notification-banner__link" href="{{ BACK_LINK }}" data-cy="success-message-go-back-link">{{ CONTENT_STRINGS.SUCCESS_BANNER.GO_BACK }}</a></p>
-      {% endif %}
-    {% endset %}
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds-from-desktop">
-        {{ govukNotificationBanner({
-          html: html,
-          type: 'success'
-        }) }}
-      </div>
-    </div>
   {% endif %}
 
   <h1 class="govuk-heading-l" data-cy="heading">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>

--- a/src/ui/types/express/index.d.ts
+++ b/src/ui/types/express/index.d.ts
@@ -60,6 +60,7 @@ interface RequestSession {
   emailAddressForPasswordReset?: string;
   passwordResetSuccess?: boolean;
   emailAddressForAccountReactivation?: string;
+  returnToServiceUrl?: string;
 }
 
 interface Request {


### PR DESCRIPTION
This PR adds a new "Cookies saved" page, replacing the "Cookes updated" success banner.

## Changes

- Create new route, controller and template for the "Cookies saved" page.
- Add E2E test coverage for the new page in both quote and insurance routes.
  - ⚠️ Note there is a lot of existing duplication for the cookies E2E tests, we can improve this in a future PR. 
- Update the existing cookies E2E tests to test for the correct redirection and "return to service" button link depending on how a user got to the page.