### PR TITLE
feat(EMS-1738): Account suspension - Ability to reactivate account when token has expired

### DIFF
--- a/e2e-tests/content-strings/pages/insurance/account/index.js
+++ b/e2e-tests/content-strings/pages/insurance/account/index.js
@@ -162,6 +162,7 @@ const ACCOUNT = {
     },
     VERIFY_EMAIL_LINK_EXPIRED: {
       PAGE_TITLE: 'Your link has expired',
+      BODY: "Your account has not been reactivated. You'll need to request another reactivation link.",
     },
   },
   REACTIVATED: {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/suspended/account-suspended-reactivate-after-link-expired.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/suspended/account-suspended-reactivate-after-link-expired.spec.js
@@ -1,0 +1,95 @@
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
+import { DATE_ONE_MINUTE_IN_THE_PAST } from '../../../../../../constants/dates';
+import { submitButton } from '../../../../pages/shared';
+import api from '../../../../../support/api';
+
+const {
+  ACCOUNT: {
+    SUSPENDED: {
+      VERIFY_EMAIL,
+      EMAIL_SENT,
+    },
+    REACTIVATED_ROOT,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  ACCOUNT: { REACTIVATION_EXPIRY, REACTIVATION_HASH },
+} = INSURANCE_FIELD_IDS;
+
+const accountEmail = Cypress.env('GOV_NOTIFY_EMAIL_RECIPIENT_1');
+
+context('Insurance - Account - Suspended - Reactivate account after verification link has expired', () => {
+  const baseUrl = Cypress.config('baseUrl');
+  const verifyEmailUrl = `${baseUrl}${VERIFY_EMAIL}`;
+  const emailSentUrl = `${baseUrl}${EMAIL_SENT}`;
+  const reactivatedUrl = `${baseUrl}${REACTIVATED_ROOT}`;
+
+  let updatedAccount;
+
+  before(() => {
+    cy.createAnAccountAndBecomeBlocked({ startReactivationJourney: true });
+  });
+
+  after(() => {
+    cy.deleteAccount();
+  });
+
+  describe(`when a reactivation token has expired, user navigates to ${VERIFY_EMAIL} with the expired token and submits the form`, () => {
+    beforeEach(async () => {
+      /**
+       * Get the latest account data
+       * So that we can use the ID
+       * to update the reactivation verification period.
+       */
+      const accountsResponse = await api.getAccountByEmail(accountEmail);
+
+      const { data } = accountsResponse.body;
+
+      const [firstAccount] = data.accounts;
+      const account = firstAccount;
+
+      /**
+       * Update the account's reactivation expiry date via the API,
+       * so that we can mimic missing the verification period.
+       */
+      const oneMinuteInThePast = DATE_ONE_MINUTE_IN_THE_PAST();
+
+      const updateObj = {
+        [REACTIVATION_EXPIRY]: oneMinuteInThePast,
+      };
+
+      updatedAccount = await api.updateAccount(account.id, updateObj);
+
+      cy.navigateToUrl(`${verifyEmailUrl}?token=${updatedAccount[REACTIVATION_HASH]}`);
+
+      submitButton().click();
+    });
+
+    it(`should redirect to ${EMAIL_SENT}`, () => {
+      cy.assertUrl(emailSentUrl);
+    });
+  });
+
+  describe(`when a user navigates to ${VERIFY_EMAIL} with a new, valid token and submits the form`, () => {
+    beforeEach(async () => {
+      /**
+       * Get the latest account data
+       * So that we can use the reactivation hash/token.
+       */
+      const accountsResponse = await api.getAccountByEmail(accountEmail);
+
+      const { data } = accountsResponse.body;
+
+      const [firstAccount] = data.accounts;
+      const account = firstAccount;
+
+      cy.navigateToUrl(`${verifyEmailUrl}?token=${account[REACTIVATION_HASH]}`);
+    });
+
+    it(`should redirect to ${REACTIVATED_ROOT}`, () => {
+      cy.assertUrl(reactivatedUrl);
+    });
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/suspended/link-expired/account-suspended-link-expired.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/suspended/link-expired/account-suspended-link-expired.spec.js
@@ -1,7 +1,9 @@
-import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { DATE_ONE_MINUTE_IN_THE_PAST } from '../../../../../../../constants/dates';
-import { PAGES } from '../../../../../../../content-strings';
+import { PAGES, BUTTONS } from '../../../../../../../content-strings';
+import { linkExpiredPage } from '../../../../../pages/insurance/account/suspended';
+import { submitButton } from '../../../../../pages/shared';
 import api from '../../../../../../support/api';
 
 const {
@@ -11,7 +13,7 @@ const {
       VERIFY_EMAIL_LINK_EXPIRED,
     },
   },
-} = ROUTES;
+} = INSURANCE_ROUTES;
 
 const {
   ACCOUNT: { REACTIVATION_EXPIRY, REACTIVATION_HASH },
@@ -62,18 +64,30 @@ context('Insurance - Account - Suspended - Verify email - Visit with an expired 
       updatedAccount = await api.updateAccount(account.id, updateObj);
     });
 
-    it(`should redirect to ${VERIFY_EMAIL_LINK_EXPIRED} and render core page elements`, () => {
+    it(`should redirect to ${VERIFY_EMAIL_LINK_EXPIRED} and renders page elements`, () => {
       cy.navigateToUrl(`${verifyEmailUrl}?token=${updatedAccount[REACTIVATION_HASH]}`);
 
-      cy.assertUrl(verifyEmailLinkExpiredUrl);
+      const expectedUrl = `${verifyEmailLinkExpiredUrl}?id=${updatedAccount.id}`;
+
+      cy.assertUrl(expectedUrl);
 
       cy.corePageChecks({
         pageTitle: CONTENT_STRINGS.PAGE_TITLE,
         currentHref: verifyEmailUrl,
         assertBackLink: false,
         assertAuthenticatedHeader: false,
-        assertSubmitButton: false,
+        submitButtonCopy: BUTTONS.REACTIVATE_ACCOUNT,
       });
+
+      cy.checkText(
+        linkExpiredPage.body(),
+        CONTENT_STRINGS.BODY,
+      );
+
+      cy.checkText(
+        submitButton(),
+        BUTTONS.REACTIVATE_ACCOUNT,
+      );
     });
   });
 });

--- a/e2e-tests/cypress/e2e/pages/insurance/account/suspended/index.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/account/suspended/index.js
@@ -1,7 +1,9 @@
 import suspendedPage from './suspended';
 import emailSentPage from './emailSent';
+import linkExpiredPage from './linkExpired';
 
 export {
   suspendedPage,
   emailSentPage,
+  linkExpiredPage,
 };

--- a/e2e-tests/cypress/e2e/pages/insurance/account/suspended/linkExpired.js
+++ b/e2e-tests/cypress/e2e/pages/insurance/account/suspended/linkExpired.js
@@ -1,0 +1,5 @@
+const linkExpiredPage = {
+  body: () => cy.get('[data-cy="body"]'),
+};
+
+export default linkExpiredPage;

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -1437,6 +1437,7 @@ var typeDefs = `
     success: Boolean!
     expired: Boolean
     invalid: Boolean
+    accountId: String
   }
 
   type AccountSendEmailReactivateAccountLinkResponse {
@@ -4081,7 +4082,8 @@ var verifyAccountReactivationToken = async (root, variables, context) => {
         console.info("Unable to reactivate account - reactivation period has expired");
         return {
           expired: true,
-          success: false
+          success: false,
+          accountId: account.id
         };
       }
       console.info(`Reactivating account ${account.id}`);

--- a/src/api/custom-resolvers/mutations/verify-account-reactivation-token/index.test.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-reactivation-token/index.test.ts
@@ -136,6 +136,7 @@ describe('custom-resolvers/verify-account-reactivation-token', () => {
       const expected = {
         success: false,
         expired: true,
+        accountId: account.id,
       };
 
       expect(result).toEqual(expected);

--- a/src/api/custom-resolvers/mutations/verify-account-reactivation-token/index.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-reactivation-token/index.ts
@@ -44,6 +44,7 @@ const verifyAccountReactivationToken = async (
         return {
           expired: true,
           success: false,
+          accountId: account.id,
         };
       }
 

--- a/src/api/custom-schema/type-defs.ts
+++ b/src/api/custom-schema/type-defs.ts
@@ -154,6 +154,7 @@ const typeDefs = `
     success: Boolean!
     expired: Boolean
     invalid: Boolean
+    accountId: String
   }
 
   type AccountSendEmailReactivateAccountLinkResponse {

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -2394,6 +2394,7 @@ type VerifyAccountReactivationTokenResponse {
   success: Boolean!
   expired: Boolean
   invalid: Boolean
+  accountId: String
 }
 
 type AccountSendEmailReactivateAccountLinkResponse {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -356,6 +356,7 @@ interface VerifyAccountReactivationTokenVariables {
 interface VerifyAccountReactivationTokenResponse extends SuccessResponse {
   expired?: boolean;
   invalid?: boolean;
+  accountId?: string;
 }
 
 interface SendExporterEmailVariables {

--- a/src/ui/server/content-strings/pages/insurance/account/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/account/index.ts
@@ -162,6 +162,7 @@ const ACCOUNT = {
     },
     VERIFY_EMAIL_LINK_EXPIRED: {
       PAGE_TITLE: 'Your link has expired',
+      BODY: "Your account has not been reactivated. You'll need to request another reactivation link.",
     },
   },
   REACTIVATED: {

--- a/src/ui/server/controllers/insurance/account/suspended/index.ts
+++ b/src/ui/server/controllers/insurance/account/suspended/index.ts
@@ -49,7 +49,10 @@ export const post = async (req: Request, res: Response) => {
     const response = await api.keystone.account.sendEmailReactivateAccountLink(urlOrigin, sanitisedId);
 
     if (response.success) {
-      // store the email address in local session, for consumption in the next part of the flow.
+      /**
+       * Store the email address in local session,
+       * for consumption in the next part of the flow.
+       */
       req.session.emailAddressForAccountReactivation = response.email;
 
       return res.redirect(EMAIL_SENT);

--- a/src/ui/server/controllers/insurance/account/suspended/link-expired/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/suspended/link-expired/index.test.ts
@@ -1,9 +1,19 @@
-import { TEMPLATE, PAGE_CONTENT_STRINGS, get } from '.';
+import { TEMPLATE, PAGE_CONTENT_STRINGS, get, post } from '.';
 import { PAGES } from '../../../../../content-strings';
 import { TEMPLATES } from '../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
 import insuranceCorePageVariables from '../../../../../helpers/page-variables/core/insurance';
+import { replaceCharactersWithCharacterCode } from '../../../../../helpers/sanitise-data';
+import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
 import { mockReq, mockRes, mockAccount } from '../../../../../test-mocks';
+
+const {
+  ACCOUNT: {
+    SUSPENDED: { EMAIL_SENT },
+  },
+  PROBLEM_WITH_SERVICE,
+} = INSURANCE_ROUTES;
 
 describe('controllers/insurance/account/suspended/link-sent', () => {
   let req: Request;
@@ -37,6 +47,69 @@ describe('controllers/insurance/account/suspended/link-sent', () => {
         PAGE_CONTENT_STRINGS,
         BACK_LINK: req.headers.referer,
       }),
+    });
+  });
+
+  describe('post', () => {
+    const sendEmailReactivateAccountLinkResponse = { success: true, email: mockAccount.email };
+
+    let sendEmailReactivateAccountLinkResponseSpy = jest.fn(() => Promise.resolve(sendEmailReactivateAccountLinkResponse));
+
+    const sanitisedId = replaceCharactersWithCharacterCode(mockAccount.id);
+
+    beforeEach(() => {
+      api.keystone.account.sendEmailReactivateAccountLink = sendEmailReactivateAccountLinkResponseSpy;
+
+      req.query.id = mockAccount.id;
+    });
+
+    it('should call api.keystone.account.sendEmailReactivateAccountLink with req.headers.origin and sanitised email', async () => {
+      await post(req, res);
+
+      expect(sendEmailReactivateAccountLinkResponseSpy).toHaveBeenCalledTimes(1);
+
+      expect(sendEmailReactivateAccountLinkResponseSpy).toHaveBeenCalledWith(req.headers.origin, sanitisedId);
+    });
+
+    it('should add the submitted email to req.session.emailAddressForAccountReactivation', async () => {
+      await post(req, res);
+
+      expect(req.session.emailAddressForAccountReactivation).toEqual(sendEmailReactivateAccountLinkResponse.email);
+    });
+
+    it(`should redirect to ${EMAIL_SENT} with ID param`, async () => {
+      await post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(EMAIL_SENT);
+    });
+
+    describe('when api.keystone.account.sendEmailReactivateAccountLink returns success=false', () => {
+      beforeEach(() => {
+        sendEmailReactivateAccountLinkResponseSpy = jest.fn(() => Promise.resolve({ success: false, email: mockAccount.email }));
+
+        api.keystone.account.sendEmailReactivateAccountLink = sendEmailReactivateAccountLinkResponseSpy;
+      });
+
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+      });
+    });
+
+    describe('api error handling', () => {
+      describe('when the send email reactivate account link API call fails', () => {
+        beforeEach(() => {
+          sendEmailReactivateAccountLinkResponseSpy = jest.fn(() => Promise.reject());
+          api.keystone.account.sendEmailReactivateAccountLink = sendEmailReactivateAccountLinkResponseSpy;
+        });
+
+        it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+          await post(req, res);
+
+          expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+        });
+      });
     });
   });
 });

--- a/src/ui/server/controllers/insurance/account/suspended/link-expired/index.ts
+++ b/src/ui/server/controllers/insurance/account/suspended/link-expired/index.ts
@@ -1,7 +1,17 @@
 import { PAGES } from '../../../../../content-strings';
 import { TEMPLATES } from '../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
 import insuranceCorePageVariables from '../../../../../helpers/page-variables/core/insurance';
+import { replaceCharactersWithCharacterCode } from '../../../../../helpers/sanitise-data';
+import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
+
+const {
+  ACCOUNT: {
+    SUSPENDED: { ROOT: SUSPENDED_ROOT, EMAIL_SENT },
+  },
+  PROBLEM_WITH_SERVICE,
+} = INSURANCE_ROUTES;
 
 export const TEMPLATE = TEMPLATES.INSURANCE.ACCOUNT.SUSPENDED.VERIFY_EMAIL_LINK_EXPIRED;
 
@@ -21,3 +31,34 @@ export const get = (req: Request, res: Response) =>
       BACK_LINK: req.headers.referer,
     }),
   });
+
+export const post = async (req: Request, res: Response) => {
+  try {
+    console.info('Posting reactivate account - link expired form');
+
+    const urlOrigin = req.headers.origin;
+
+    if (!req.query.id) {
+      return res.redirect(SUSPENDED_ROOT);
+    }
+
+    const sanitisedId = replaceCharactersWithCharacterCode(req.query.id);
+
+    const response = await api.keystone.account.sendEmailReactivateAccountLink(urlOrigin, sanitisedId);
+
+    if (response.success) {
+      /**
+       * Store the email address in local session,
+       * for consumption in the next part of the flow.
+       */
+      req.session.emailAddressForAccountReactivation = response.email;
+
+      return res.redirect(EMAIL_SENT);
+    }
+
+    return res.redirect(PROBLEM_WITH_SERVICE);
+  } catch (err) {
+    console.error('Error posting reactivate account - link expired form', { err });
+    return res.redirect(PROBLEM_WITH_SERVICE);
+  }
+};

--- a/src/ui/server/controllers/insurance/account/suspended/verify-email/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/suspended/verify-email/index.test.ts
@@ -2,7 +2,7 @@ import { get } from '.';
 import { ROUTES } from '../../../../../constants';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes } from '../../../../../test-mocks';
+import { mockAccount, mockReq, mockRes } from '../../../../../test-mocks';
 
 const {
   INSURANCE: {
@@ -50,9 +50,9 @@ describe('controllers/insurance/account/suspended/verify-email', () => {
     });
   });
 
-  describe('when api.keystone.account.verifyAccountReactivationToken returns expired=true', () => {
+  describe('when api.keystone.account.verifyAccountReactivationToken returns expired=true and an accountId', () => {
     beforeEach(() => {
-      verifyAccountReactivationTokenSpy = jest.fn(() => Promise.resolve({ success: true, expired: true }));
+      verifyAccountReactivationTokenSpy = jest.fn(() => Promise.resolve({ success: true, expired: true, accountId: mockAccount.id }));
 
       api.keystone.account.verifyAccountReactivationToken = verifyAccountReactivationTokenSpy;
     });
@@ -60,7 +60,9 @@ describe('controllers/insurance/account/suspended/verify-email', () => {
     it(`should redirect to ${VERIFY_EMAIL_LINK_EXPIRED}`, async () => {
       await get(req, res);
 
-      expect(res.redirect).toHaveBeenCalledWith(VERIFY_EMAIL_LINK_EXPIRED);
+      const expected = `${VERIFY_EMAIL_LINK_EXPIRED}?id=${mockAccount.id}`;
+
+      expect(res.redirect).toHaveBeenCalledWith(expected);
     });
   });
 

--- a/src/ui/server/controllers/insurance/account/suspended/verify-email/index.ts
+++ b/src/ui/server/controllers/insurance/account/suspended/verify-email/index.ts
@@ -1,16 +1,14 @@
-import { ROUTES } from '../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
 
 const {
-  INSURANCE: {
-    ACCOUNT: {
-      SUSPENDED: { ROOT: SUSPENDED_ROOT, VERIFY_EMAIL_LINK_EXPIRED, VERIFY_EMAIL_LINK_INVALID },
-      REACTIVATED_ROOT,
-    },
-    PROBLEM_WITH_SERVICE,
+  ACCOUNT: {
+    SUSPENDED: { ROOT: SUSPENDED_ROOT, VERIFY_EMAIL_LINK_EXPIRED, VERIFY_EMAIL_LINK_INVALID },
+    REACTIVATED_ROOT,
   },
-} = ROUTES;
+  PROBLEM_WITH_SERVICE,
+} = INSURANCE_ROUTES;
 
 /**
  * get
@@ -29,8 +27,10 @@ export const get = async (req: Request, res: Response) => {
 
     const response = await api.keystone.account.verifyAccountReactivationToken(token);
 
-    if (response.expired) {
-      return res.redirect(VERIFY_EMAIL_LINK_EXPIRED);
+    if (response.expired && response.accountId) {
+      const url = `${VERIFY_EMAIL_LINK_EXPIRED}?id=${response.accountId}`;
+
+      return res.redirect(url);
     }
 
     if (response.invalid || !response.success) {

--- a/src/ui/server/graphql/mutations/account/verify-account-reactivation-token.ts
+++ b/src/ui/server/graphql/mutations/account/verify-account-reactivation-token.ts
@@ -6,6 +6,7 @@ const verifyAccountReactivationTokenMutation = gql`
       success
       invalid
       expired
+      accountId
     }
   }
 `;

--- a/src/ui/server/routes/insurance/account/index.test.ts
+++ b/src/ui/server/routes/insurance/account/index.test.ts
@@ -19,7 +19,11 @@ import { get as signOutGet } from '../../../controllers/insurance/account/sign-o
 import { get as signedOutGet } from '../../../controllers/insurance/account/signed-out';
 import { get as suspendedGet, post as suspendedPost } from '../../../controllers/insurance/account/suspended';
 import { get as suspendedVerifyEmailGet } from '../../../controllers/insurance/account/suspended/verify-email';
-import { get as suspendedVerifyEmailLinkExpiredGet } from '../../../controllers/insurance/account/suspended/link-expired';
+import {
+  get as suspendedVerifyEmailLinkExpiredGet,
+  post as suspendedVerifyEmailLinkExpiredPost,
+} from '../../../controllers/insurance/account/suspended/link-expired';
+import { get as suspendedVerifyEmailLinkInvalidGet } from '../../../controllers/insurance/account/invalid-link';
 import { get as reactivatedGet } from '../../../controllers/insurance/account/reactivated';
 
 describe('routes/insurance/account', () => {
@@ -33,7 +37,7 @@ describe('routes/insurance/account', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(23);
-    expect(post).toHaveBeenCalledTimes(8);
+    expect(post).toHaveBeenCalledTimes(9);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.ACCOUNT.CREATE.YOUR_DETAILS, yourDetailsGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.ACCOUNT.CREATE.YOUR_DETAILS, yourDetailsPost);
@@ -79,6 +83,9 @@ describe('routes/insurance/account', () => {
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.ACCOUNT.SUSPENDED.VERIFY_EMAIL, suspendedVerifyEmailGet);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.ACCOUNT.SUSPENDED.VERIFY_EMAIL_LINK_EXPIRED, suspendedVerifyEmailLinkExpiredGet);
+    expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.ACCOUNT.SUSPENDED.VERIFY_EMAIL_LINK_EXPIRED, suspendedVerifyEmailLinkExpiredPost);
+
+    expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.ACCOUNT.SUSPENDED.VERIFY_EMAIL_LINK_INVALID, suspendedVerifyEmailLinkInvalidGet);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.ACCOUNT.REACTIVATED_ROOT, reactivatedGet);
   });

--- a/src/ui/server/routes/insurance/account/index.ts
+++ b/src/ui/server/routes/insurance/account/index.ts
@@ -20,7 +20,10 @@ import { get as signedOutGet } from '../../../controllers/insurance/account/sign
 import { get as suspendedGet, post as suspendedPost } from '../../../controllers/insurance/account/suspended';
 import { get as suspendedEmailSentGet } from '../../../controllers/insurance/account/suspended/email-sent';
 import { get as suspendedVerifyEmailGet } from '../../../controllers/insurance/account/suspended/verify-email';
-import { get as suspendedVerifyEmailLinkExpiredGet } from '../../../controllers/insurance/account/suspended/link-expired';
+import {
+  get as suspendedVerifyEmailLinkExpiredGet,
+  post as suspendedVerifyEmailLinkExpiredPost,
+} from '../../../controllers/insurance/account/suspended/link-expired';
 import { get as suspendedVerifyEmailLinkInvalidGet } from '../../../controllers/insurance/account/invalid-link';
 import { get as reactivatedGet } from '../../../controllers/insurance/account/reactivated';
 
@@ -74,6 +77,8 @@ insuranceAccountRouter.get(INSURANCE_ROUTES.ACCOUNT.SUSPENDED.EMAIL_SENT, suspen
 insuranceAccountRouter.get(INSURANCE_ROUTES.ACCOUNT.SUSPENDED.VERIFY_EMAIL, suspendedVerifyEmailGet);
 
 insuranceAccountRouter.get(INSURANCE_ROUTES.ACCOUNT.SUSPENDED.VERIFY_EMAIL_LINK_EXPIRED, suspendedVerifyEmailLinkExpiredGet);
+insuranceAccountRouter.post(INSURANCE_ROUTES.ACCOUNT.SUSPENDED.VERIFY_EMAIL_LINK_EXPIRED, suspendedVerifyEmailLinkExpiredPost);
+
 insuranceAccountRouter.get(INSURANCE_ROUTES.ACCOUNT.SUSPENDED.VERIFY_EMAIL_LINK_INVALID, suspendedVerifyEmailLinkInvalidGet);
 
 insuranceAccountRouter.get(INSURANCE_ROUTES.ACCOUNT.REACTIVATED_ROOT, reactivatedGet);

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -22,7 +22,7 @@ describe('routes/insurance', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(100);
-    expect(post).toHaveBeenCalledTimes(92);
+    expect(post).toHaveBeenCalledTimes(93);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);

--- a/src/ui/templates/insurance/account/suspended/link-expired.njk
+++ b/src/ui/templates/insurance/account/suspended/link-expired.njk
@@ -1,4 +1,5 @@
 {% extends 'index.njk' %}
+{% from 'govuk/components/button/macro.njk' import govukButton %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -11,6 +12,23 @@
 
       <h1 class="govuk-heading-xl" data-cy="heading">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 
+      <p class="govuk-body" data-cy="body">{{ CONTENT_STRINGS.BODY }}</p>
+
+      <form method="POST" novalidate>
+
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: CONTENT_STRINGS.BUTTONS.REACTIVATE_ACCOUNT,
+            attributes: {
+              'data-cy': 'submit-button'
+            }
+          }) }}
+        </div>
+
+      </form>
+        
     </div>
   </div>
 


### PR DESCRIPTION
This PR adds the ability to reactivate an account when a user is on the "link expired" page.

## Changes
- Update `/account/suspended/verify-email` GET controller to consume the account ID returned from the API response.
- Add a `account/suspended/link-expired` POST route/controller to call the API to send a new reactivation link.
- Update the "account suspended - link expired" page to render a form and some body text.
- Add E2E test coverage for:
  -  Reactivating an account after requesting a new verifiaction link when trying to become verified wih an expired verification link.
  - "Account suspended - link expired" page content.