### PR TITLE
fix(EMS-1345): Add requestedApplicationCreation to session when creating an application

### DIFF
--- a/src/ui/server/controllers/insurance/account/create/your-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/index.test.ts
@@ -192,6 +192,12 @@ describe('controllers/insurance/account/create/your-details', () => {
           expect(createApplicationSpy).toHaveBeenCalledWith(eligibilityAnswers, mockSaveDataResponse.id);
         });
 
+        it('should mark req.session.requestedApplicationCreation as false', async () => {
+          await post(req, res);
+
+          expect(req.session.requestedApplicationCreation).toEqual(false);
+        });
+
         it('should wipe req.session.submittedData.insuranceEligibility', async () => {
           await post(req, res);
 

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
@@ -241,6 +241,12 @@ describe('controllers/insurance/account/sign-in/enter-code', () => {
           expect(createApplicationSpy).toHaveBeenCalledWith(eligibilityAnswers, verifyAccountSignInCodeResponse.accountId);
         });
 
+        it('should mark req.session.requestedApplicationCreation as false', async () => {
+          await post(req, res);
+
+          expect(req.session.requestedApplicationCreation).toEqual(false);
+        });
+
         it('should wipe req.session.submittedData.insuranceEligibility', async () => {
           await post(req, res);
 

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
@@ -114,13 +114,19 @@ export const post = async (req: Request, res: Response) => {
 
       /**
        * If there are eligibility answers in the session:
-       * 1) Create an application
-       * 2) Wipe the eligibility answers in the session.
+       * 1) Add requestedApplicationCreation to the session
+       * 2) Create an application
+       * 3) Remove requestedApplicationCreation from the session
+       * 4) Remove eligibility answers in the session.
        */
       if (canCreateAnApplication(req.session)) {
+        req.session.requestedApplicationCreation = true;
+
         const eligibilityAnswers = sanitiseData(req.session.submittedData.insuranceEligibility);
 
         const application = await api.keystone.application.create(eligibilityAnswers, accountId);
+
+        req.session.requestedApplicationCreation = false;
 
         if (!application) {
           console.error('Error creating application');

--- a/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.test.ts
@@ -89,6 +89,12 @@ describe('controllers/insurance/eligibility/eligible-to-apply-online', () => {
         expect(createApplicationSpy).toHaveBeenCalledWith(sanitisedData, mockAccount.id);
       });
 
+      it('should mark req.session.requestedApplicationCreation as false', async () => {
+        await post(req, res);
+
+        expect(req.session.requestedApplicationCreation).toEqual(false);
+      });
+
       it('should wipe req.session.submittedData.insuranceEligibility', async () => {
         await post(req, res);
 

--- a/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.ts
@@ -29,13 +29,20 @@ export const post = async (req: Request, res: Response) => {
   try {
     /**
      * If the user is signed in and there are eligibility answers in the session:
-     * 1) Create an application
-     * 2) Wipe the eligibility answers in the session.
+     * 1) Add requestedApplicationCreation to the session
+     * 2) Create an application
+     * 3) Remove requestedApplicationCreation from the session
+     * 4) Wipe the eligibility answers in the session.
+     * 5) Redirect to the application
      */
     if (req.session.user && canCreateAnApplication(req.session)) {
+      req.session.requestedApplicationCreation = true;
+
       const eligibilityAnswers = sanitiseData(req.session.submittedData.insuranceEligibility);
 
       const application = await api.keystone.application.create(eligibilityAnswers, req.session.user.id);
+
+      req.session.requestedApplicationCreation = false;
 
       if (!application) {
         console.error('Error creating application');

--- a/src/ui/server/helpers/can-create-an-application/index.test.ts
+++ b/src/ui/server/helpers/can-create-an-application/index.test.ts
@@ -2,13 +2,14 @@ import canCreateAnApplication from '.';
 import mockEligibility from '../../test-mocks/mock-eligibility';
 
 describe('server/helpers/can-create-an-application', () => {
-  describe('when session.submittedData.insuranceEligibility has answers', () => {
+  describe('when session.submittedData.insuranceEligibility has answers and session.requestedApplicationCreation is false', () => {
     it('should return true', () => {
       const mockSession = {
         submittedData: {
           insuranceEligibility: mockEligibility,
           quoteEligibility: {},
         },
+        requestedApplicationCreation: false,
       };
 
       const result = canCreateAnApplication(mockSession);
@@ -24,6 +25,23 @@ describe('server/helpers/can-create-an-application', () => {
           insuranceEligibility: {},
           quoteEligibility: {},
         },
+        requestedApplicationCreation: false,
+      };
+
+      const result = canCreateAnApplication(mockSession);
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('when session.requestedApplicationCreation is true', () => {
+    it('should return false', () => {
+      const mockSession = {
+        submittedData: {
+          insuranceEligibility: mockEligibility,
+          quoteEligibility: {},
+        },
+        requestedApplicationCreation: true,
       };
 
       const result = canCreateAnApplication(mockSession);

--- a/src/ui/server/helpers/can-create-an-application/index.ts
+++ b/src/ui/server/helpers/can-create-an-application/index.ts
@@ -9,7 +9,7 @@ import { RequestSession } from '../../../types';
  * @returns {Boolean}
  */
 const canCreateAnApplication = (session: RequestSession) => {
-  if (session.submittedData && objectHasKeysAndValues(session.submittedData.insuranceEligibility)) {
+  if (session.submittedData && objectHasKeysAndValues(session.submittedData.insuranceEligibility) && !session.requestedApplicationCreation) {
     return true;
   }
 

--- a/src/ui/types/express/index.d.ts
+++ b/src/ui/types/express/index.d.ts
@@ -61,6 +61,7 @@ interface RequestSession {
   passwordResetSuccess?: boolean;
   emailAddressForAccountReactivation?: string;
   returnToServiceUrl?: string;
+  requestedApplicationCreation?: boolean;
 }
 
 interface Request {


### PR DESCRIPTION
This PR should fix an issue where if a user spams particular submit buttons/form POSTs, multiple applications requests would be made.

## Changes
- In each POST controller that requests application creation from the API, add a `requestedApplicationCreation` flag to the session and after the call has been made, reverse the flag to be false.
- Update `canCreateAnApplication` helper so that if the session has a `requestedApplicationCreation` flag, the helper will return false.
- Documentation improvements.
- Note: unfortunately, it doesn't seem possible to write an E2E test for this scenario (spamming a submit button during a POST).