### PR TITLE
feat(EMS-1761): Account sign in - Enter code - Redirect if already signed in

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/new-password/validation/account-password-reset-new-password-valdation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/new-password/validation/account-password-reset-new-password-valdation.spec.js
@@ -44,6 +44,8 @@ context('Insurance - Account - Password reset - new password page - form validat
   let resetPasswordToken;
 
   before(() => {
+    cy.deleteAccount();
+
     cy.completeAndSubmitCreateAccountForm({ navigateToAccountCreationPage: true });
 
     // navigate to password reset page

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/enter-code/account-sign-in-enter-code-visit-directly-when-signed-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/enter-code/account-sign-in-enter-code-visit-directly-when-signed-in.spec.js
@@ -1,0 +1,32 @@
+import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const {
+  ACCOUNT: {
+    SIGN_IN: { ENTER_CODE },
+  },
+  DASHBOARD,
+} = ROUTES;
+
+context("Insurance - Account - Visit the 'Enter code' page directly when already signed in", () => {
+  const baseUrl = Cypress.config('baseUrl');
+  const enterCodeUrl = `${baseUrl}${ENTER_CODE}`;
+  const dashboardUrl = `${baseUrl}${DASHBOARD}`;
+
+  before(() => {
+    cy.completeSignInAndGoToDashboard();
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteAccount();
+  });
+
+  it(`should redirect to ${DASHBOARD}`, () => {
+    cy.navigateToUrl(enterCodeUrl);
+
+    cy.assertUrl(dashboardUrl);
+  });
+});

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/request-new-code/account-sign-in-request-new-code-visit-directly-when-signed-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/request-new-code/account-sign-in-request-new-code-visit-directly-when-signed-in.spec.js
@@ -1,0 +1,32 @@
+import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const {
+  ACCOUNT: {
+    SIGN_IN: { REQUEST_NEW_CODE },
+  },
+  DASHBOARD,
+} = ROUTES;
+
+context("Insurance - Account - Visit the 'Request new code' page directly when already signed in", () => {
+  const baseUrl = Cypress.config('baseUrl');
+  const requestNewCodeUrl = `${baseUrl}${REQUEST_NEW_CODE}`;
+  const dashboardUrl = `${baseUrl}${DASHBOARD}`;
+
+  before(() => {
+    cy.completeSignInAndGoToDashboard();
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteAccount();
+  });
+
+  it(`should redirect to ${DASHBOARD}`, () => {
+    cy.navigateToUrl(requestNewCodeUrl);
+
+    cy.assertUrl(dashboardUrl);
+  });
+});

--- a/src/ui/server/controllers/insurance/account/create/your-details/index.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/index.ts
@@ -66,7 +66,10 @@ export const PAGE_CONTENT_STRINGS = PAGES.INSURANCE.ACCOUNT.CREATE.YOUR_DETAILS;
  */
 export const get = (req: Request, res: Response) => {
   if (req.session.user?.id) {
-    // user is already signed in
+    /**
+     * User is already signed in.
+     * Redirect to the dashboard.
+     */
     return res.redirect(DASHBOARD);
   }
 

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
@@ -106,21 +106,22 @@ describe('controllers/insurance/account/sign-in/enter-code', () => {
       });
     });
 
-    describe('when there is no req.session.accountId', () => {
+    describe('when there is req.session.user.id', () => {
       beforeEach(() => {
-        delete req.session.accountId;
+        req.session.user = mockAccount;
       });
 
-      it(`should redirect to ${SIGN_IN_ROOT}`, () => {
+      it(`should redirect to ${DASHBOARD}`, () => {
         get(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(SIGN_IN_ROOT);
+        expect(res.redirect).toHaveBeenCalledWith(DASHBOARD);
       });
     });
 
     describe('when there is no req.session.accountId', () => {
       beforeEach(() => {
         delete req.session.accountId;
+        delete req.session.user;
       });
 
       it(`should redirect to ${SIGN_IN_ROOT}`, () => {

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
@@ -48,7 +48,20 @@ export const PAGE_CONTENT_STRINGS = PAGES.INSURANCE.ACCOUNT.SIGN_IN.ENTER_CODE;
  * @returns {Express.Response.render} Enter code page
  */
 export const get = (req: Request, res: Response) => {
+  if (req.session.user?.id) {
+    /**
+     * User is already signed in.
+     * Redirect to the dashboard.
+     */
+    return res.redirect(DASHBOARD);
+  }
+
   if (!req.session.accountId) {
+    /**
+     * No account ID is in the session.
+     * We cannot make an API call in the POST without this.
+     * Therfore, redirect to the sign in route.
+     */
     return res.redirect(SIGN_IN_ROOT);
   }
 

--- a/src/ui/server/controllers/insurance/account/sign-in/index.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/index.ts
@@ -54,7 +54,10 @@ export const PAGE_CONTENT_STRINGS = PAGES.INSURANCE.ACCOUNT.SIGN_IN.ROOT;
  */
 export const get = (req: Request, res: Response) => {
   if (req.session.user?.id) {
-    // user is already signed in
+    /**
+     * User is already signed in.
+     * Redirect to the dashboard.
+     */
     return res.redirect(DASHBOARD);
   }
 

--- a/src/ui/server/controllers/insurance/account/sign-in/request-new-code/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/request-new-code/index.test.ts
@@ -12,6 +12,7 @@ const {
     ACCOUNT: {
       SIGN_IN: { ROOT: SIGN_IN_ROOT, ENTER_CODE },
     },
+    DASHBOARD,
     PROBLEM_WITH_SERVICE,
   },
 } = ROUTES;
@@ -53,8 +54,21 @@ describe('controllers/insurance/account/sign-in/request-new-code', () => {
       });
     });
 
+    describe('when there is req.session.user.id', () => {
+      beforeEach(() => {
+        req.session.user = mockAccount;
+      });
+
+      it(`should redirect to ${DASHBOARD}`, () => {
+        get(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(DASHBOARD);
+      });
+    });
+
     describe('when there is no req.session.accountId', () => {
       beforeEach(() => {
+        delete req.session.user;
         delete req.session.accountId;
       });
 

--- a/src/ui/server/controllers/insurance/account/sign-in/request-new-code/index.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/request-new-code/index.ts
@@ -10,6 +10,7 @@ const {
     ACCOUNT: {
       SIGN_IN: { ROOT: SIGN_IN_ROOT, ENTER_CODE },
     },
+    DASHBOARD,
   },
 } = ROUTES;
 
@@ -25,7 +26,20 @@ export const PAGE_CONTENT_STRINGS = PAGES.INSURANCE.ACCOUNT.SIGN_IN.REQUEST_NEW_
  * @returns {Express.Response.render} Request a new security code page
  */
 export const get = (req: Request, res: Response) => {
+  if (req.session.user?.id) {
+    /**
+     * User is already signed in.
+     * Redirect to the dashboard.
+     */
+    return res.redirect(DASHBOARD);
+  }
+
   if (!req.session.accountId) {
+    /**
+     * No account ID is in the session.
+     * We cannot make an API call in the POST without this.
+     * Therfore, redirect to the sign in route.
+     */
     return res.redirect(SIGN_IN_ROOT);
   }
 

--- a/src/ui/server/index.ts
+++ b/src/ui/server/index.ts
@@ -10,7 +10,6 @@ import csrf from 'csurf';
 import path from 'path';
 import flash from 'connect-flash';
 import basicAuth from 'express-basic-auth';
-// TODO: Replace `csurf` package https://ukef-dtfs.atlassian.net/browse/EMS-1011
 import { csrf as csrfToken, cookiesConsent, security, seo } from './middleware';
 import { Request, Response } from '../types';
 

--- a/src/ui/server/middleware/headers/security.ts
+++ b/src/ui/server/middleware/headers/security.ts
@@ -26,7 +26,6 @@ export const security = (req: Request, res: Response, next: () => void) => {
   res.setHeader('X-Frame-Options', 'deny');
   res.setHeader('X-XSS-Protection', '1; mode=block');
   res.setHeader('X-Content-Type-Options', 'nosniff');
-  // TODO: script-src nounce https://developers.google.com/tag-platform/tag-manager/web/csp
   res.setHeader(
     'Content-Security-Policy',
     "default-src 'none';connect-src https://region1.google-analytics.com 'self';base-uri 'self';block-all-mixed-content;font-src 'self' data:;form-action 'self';frame-ancestors 'self';img-src 'self';object-src 'none';script-src https://www.googletagmanager.com 'self' 'unsafe-inline';script-src-attr 'self' 'unsafe-inline';style-src 'self';upgrade-insecure-requests",


### PR DESCRIPTION
This PR updates the "enter code" GET controllers to redirect to the dashboard page if the user is already signed in.

## Changes
- Update the "enter code" controller to redirect to the dashboard if a user session exists.
- Update the "enter code - request new code" controller to redirect to the dashboard if a user session exists.
- Add E2E test coverage.
- Improve some documentation.
- Removed some TODO comments (fix/EMS-1761).