### PR TITLE
fix(EMS-1771): Yes/no radio inputs aria labels

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
@@ -90,12 +90,16 @@ context("Insurance - Declarations - Anti-bribery - Code of conduct page - As an 
       yesRadio().should('exist');
 
       cy.checkText(yesRadio(), FIELD_VALUES.YES);
+
+      cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     it('renders `no` radio button', () => {
       noRadio().should('exist');
 
       cy.checkText(noRadio(), FIELD_VALUES.NO);
+
+      cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     it('renders a submit button and `save and back` button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/exporting-with-code-of-conduct/anti-bribery-exporting-with-code-of-conduct.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/exporting-with-code-of-conduct/anti-bribery-exporting-with-code-of-conduct.spec.js
@@ -80,12 +80,16 @@ context("Insurance - Declarations - Anti-bribery - Exporting with code of conduc
       yesRadio().should('exist');
 
       cy.checkText(yesRadio(), FIELD_VALUES.YES);
+
+      cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     it('renders `no` radio button', () => {
       noRadio().should('exist');
 
       cy.checkText(noRadio(), FIELD_VALUES.NO);
+
+      cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     it('renders a submit button and `save and back` button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/account-to-apply-online/account-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/account-to-apply-online/account-to-apply-online.spec.js
@@ -58,16 +58,18 @@ context('Insurance - Eligibility - Account to apply online page - I want to conf
       partials.header.serviceName().should('have.attr', 'href', START);
     });
 
-    it('renders yes and no radio buttons with a hint', () => {
-      yesRadio().should('exist');
-
+    it('renders a `yes` radio button with a hint', () => {
       cy.checkText(yesRadio(), FIELD_VALUES.YES);
 
-      noRadio().should('exist');
+      cy.checkText(yesNoRadioHint(), FIELDS[FIELD_ID].HINT);
 
+      cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
+    });
+
+    it('renders a `no` radio button', () => {
       cy.checkText(noRadio(), FIELD_VALUES.NO);
 
-      cy.checkText(yesNoRadioHint(), FIELDS[FIELD_ID].HINT);
+      cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
@@ -69,12 +69,16 @@ context('Insurance - Eligibility - Companies house number page - I want to check
       yesRadio().should('exist');
 
       cy.checkText(yesRadio(), FIELD_VALUES.YES);
+
+      cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     it('renders `no` radio button', () => {
       noRadio().should('exist');
 
       cy.checkText(noRadio(), FIELD_VALUES.NO);
+
+      cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
@@ -35,14 +35,16 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
     partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
   });
 
-  it('renders yes and no radio buttons', () => {
-    yesRadio().should('exist');
-
+  it('renders `yes` radio button', () => {
     cy.checkText(yesRadio(), FIELD_VALUES.YES);
 
-    noRadio().should('exist');
+    cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
+  });
 
+  it('renders `no` radio button', () => {
     cy.checkText(noRadio(), FIELD_VALUES.NO);
+
+    cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
@@ -59,12 +59,16 @@ context('Insurance - Insured amount page - I want to check if I can use online s
       yesRadio().should('exist');
 
       cy.checkText(yesRadio(), FIELD_VALUES.YES);
+
+      cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     it('renders `no` radio button', () => {
       noRadio().should('exist');
 
       cy.checkText(noRadio(), FIELD_VALUES.NO);
+
+      cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
@@ -65,12 +65,16 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
       yesRadio().should('exist');
 
       cy.checkText(yesRadio(), FIELD_VALUES.YES);
+
+      cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     it('renders `no` radio button', () => {
       noRadio().should('exist');
 
       cy.checkText(noRadio(), FIELD_VALUES.NO);
+
+      cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
@@ -64,12 +64,16 @@ context('Insurance - Other parties page - I want to check if I can use online se
       yesRadio().should('exist');
 
       cy.checkText(yesRadio(), FIELD_VALUES.YES);
+
+      cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     it('renders `no` radio button', () => {
       noRadio().should('exist');
 
       cy.checkText(noRadio(), FIELD_VALUES.NO);
+
+      cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     describe('expandable details', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -67,22 +67,18 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
       partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
     });
 
-    it('renders radio button hint', () => {
-      yesNoRadioHint().should('exist');
+    it('renders `yes` radio button with hint', () => {
+      cy.checkText(yesRadio(), FIELD_VALUES.YES);
 
       cy.checkText(yesNoRadioHint(), FIELDS.INSURANCE.ELIGIBILITY[FIELD_ID].HINT);
-    });
 
-    it('renders `yes` radio button', () => {
-      yesRadio().should('exist');
-
-      cy.checkText(yesRadio(), FIELD_VALUES.YES);
+      cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     it('renders `no` radio button', () => {
-      noRadio().should('exist');
-
       cy.checkText(noRadio(), FIELD_VALUES.NO);
+
+      cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     describe('expandable details', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -67,22 +67,18 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
       partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
     });
 
-    it('renders radio button hint', () => {
-      yesNoRadioHint().should('exist');
+    it('renders `yes` radio button', () => {
+      cy.checkText(yesRadio(), FIELD_VALUES.YES);
 
       cy.checkText(yesNoRadioHint(), FIELDS[HAS_MINIMUM_UK_GOODS_OR_SERVICES].HINT);
-    });
 
-    it('renders `yes` radio button', () => {
-      yesRadio().should('exist');
-
-      cy.checkText(yesRadio(), FIELD_VALUES.YES);
+      cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     it('renders `no` radio button', () => {
-      noRadio().should('exist');
-
       cy.checkText(noRadio(), FIELD_VALUES.NO);
+
+      cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     describe('expandable details - how to calculate percentage', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/broker/broker-page.spec.js
@@ -106,14 +106,9 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
     });
 
     it(`should display ${USING_BROKER} section`, () => {
-      const fieldId = USING_BROKER;
-      const field = broker[fieldId];
+      cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
 
-      field.yesRadioInput().should('exist');
-      cy.checkAriaLabel(field.yesRadioInput(), `${CONTENT_STRINGS.PAGE_TITLE} yes radio`);
-
-      field.noRadioInput().should('exist');
-      cy.checkAriaLabel(field.noRadioInput(), `${CONTENT_STRINGS.PAGE_TITLE} no radio`);
+      cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     it('should display additional broker section when yes radio is selected', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
@@ -104,9 +104,9 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
     it('should display the trading address radios', () => {
       cy.checkText(companyDetails.tradingAddressLabel(), FIELDS[TRADING_ADDRESS].LABEL);
 
-      cy.checkAriaLabel(companyDetails.tradingAddressYesRadioInput(), `${FIELDS[TRADING_ADDRESS].LABEL} yes`);
+      cy.checkAriaLabel(companyDetails.tradingAddressYesRadioInput(), `${FIELDS[TRADING_ADDRESS].LABEL} Yes`);
 
-      cy.checkAriaLabel(companyDetails.tradingAddressNoRadioInput(), `${FIELDS[TRADING_ADDRESS].LABEL} no`);
+      cy.checkAriaLabel(companyDetails.tradingAddressNoRadioInput(), `${FIELDS[TRADING_ADDRESS].LABEL} No`);
     });
 
     it('should display the company website text area', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
@@ -96,23 +96,17 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
     it('should display the trading name radios', () => {
       cy.checkText(companyDetails.tradingNameLabel(), FIELDS[TRADING_NAME].LABEL);
 
-      companyDetails.tradingNameYesRadioInput().should('exist');
+      cy.checkRadioInputYesAriaLabel(FIELDS[TRADING_NAME].LABEL);
 
-      cy.checkAriaLabel(companyDetails.tradingNameYesRadioInput(), `${FIELDS[TRADING_NAME].LABEL} yes radio`);
-
-      companyDetails.tradingNameNoRadioInput().should('exist');
-
-      cy.checkAriaLabel(companyDetails.tradingNameNoRadioInput(), `${FIELDS[TRADING_NAME].LABEL} no radio`);
+      cy.checkRadioInputNoAriaLabel(FIELDS[TRADING_NAME].LABEL);
     });
 
     it('should display the trading address radios', () => {
       cy.checkText(companyDetails.tradingAddressLabel(), FIELDS[TRADING_ADDRESS].LABEL);
 
-      companyDetails.tradingAddressYesRadioInput().should('exist');
-      cy.checkAriaLabel(companyDetails.tradingAddressYesRadioInput(), `${FIELDS[TRADING_ADDRESS].LABEL} yes radio`);
+      cy.checkAriaLabel(companyDetails.tradingAddressYesRadioInput(), `${FIELDS[TRADING_ADDRESS].LABEL} yes`);
 
-      companyDetails.tradingAddressNoRadioInput().should('exist');
-      cy.checkAriaLabel(companyDetails.tradingAddressNoRadioInput(), `${FIELDS[TRADING_ADDRESS].LABEL} no radio`);
+      cy.checkAriaLabel(companyDetails.tradingAddressNoRadioInput(), `${FIELDS[TRADING_ADDRESS].LABEL} no`);
     });
 
     it('should display the company website text area', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/working-with-buyer/working-with-buyer.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/working-with-buyer/working-with-buyer.spec.js
@@ -84,25 +84,31 @@ context('Insurance - Your Buyer - Working with buyer page - As an exporter, I wa
       const fieldId = CONNECTED_WITH_BUYER;
       const field = workingWithBuyerPage[fieldId];
 
+      const labelCopy = FIELDS.WORKING_WITH_BUYER[fieldId].LABEL;
+
       field.label().should('exist');
-      cy.checkText(field.label(), FIELDS.WORKING_WITH_BUYER[fieldId].LABEL);
+      cy.checkText(field.label(), labelCopy);
 
       field.hint().should('exist');
       cy.checkText(field.hint(), FIELDS.WORKING_WITH_BUYER[fieldId].HINT);
 
-      field.yesRadioInput().should('exist');
-      field.noRadioInput().should('exist');
+      cy.checkAriaLabel(field.yesRadioInput(), `${labelCopy} Yes`);
+
+      cy.checkAriaLabel(field.noRadioInput(), `${labelCopy} No`);
     });
 
     it(`renders an ${TRADED_WITH_BUYER} label, radio buttons and details section`, () => {
       const fieldId = TRADED_WITH_BUYER;
       const field = workingWithBuyerPage[fieldId];
 
-      field.label().should('exist');
-      cy.checkText(field.label(), FIELDS.WORKING_WITH_BUYER[fieldId].LABEL);
+      const labelCopy = FIELDS.WORKING_WITH_BUYER[fieldId].LABEL;
 
-      field.yesRadioInput().should('exist');
-      field.noRadioInput().should('exist');
+      field.label().should('exist');
+      cy.checkText(field.label(), labelCopy);
+
+      cy.checkAriaLabel(field.yesRadioInput(), `${labelCopy} Yes`);
+
+      cy.checkAriaLabel(field.noRadioInput(), `${labelCopy} No`);
 
       field.details().should('exist');
       cy.checkText(field.details(), FIELDS.WORKING_WITH_BUYER[fieldId].DETAILS);

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
@@ -36,14 +36,16 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
     partials.header.serviceName().should('have.attr', 'href', startRoute);
   });
 
-  it('renders yes and no radio buttons', () => {
-    yesRadio().should('exist');
-
+  it('renders `yes` radio button', () => {
     cy.checkText(yesRadio(), FIELD_VALUES.YES);
 
-    noRadio().should('exist');
+    cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
+  });
 
+  it('renders `no` radio button', () => {
     cy.checkText(noRadio(), FIELD_VALUES.NO);
+
+    cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
@@ -34,14 +34,16 @@ context('Exporter location page - as an exporter, I want to check if my company 
     });
   });
 
-  it('renders yes and no radio buttons', () => {
-    yesRadio().should('exist');
-
+  it('renders `yes` radio button', () => {
     cy.checkText(yesRadio(), FIELD_VALUES.YES);
 
-    noRadio().should('exist');
+    cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
+  });
 
+  it('renders `no` radio button', () => {
     cy.checkText(noRadio(), FIELD_VALUES.NO);
+
+    cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
   });
 
   describe('form submission', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -55,15 +55,15 @@ context('UK goods or services page - as an exporter, I want to check if my expor
     });
 
     it('renders `yes` radio button', () => {
-      yesRadio().should('exist');
-
       cy.checkText(yesRadio(), FIELD_VALUES.YES);
+
+      cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     it('renders `no` radio button', () => {
-      noRadio().should('exist');
-
       cy.checkText(noRadio(), FIELD_VALUES.NO);
+
+      cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
     });
 
     describe('expandable details', () => {

--- a/e2e-tests/cypress/support/check-aria-label.js
+++ b/e2e-tests/cypress/support/check-aria-label.js
@@ -1,5 +1,13 @@
-export default (selector, expectedMessage) => {
+/**
+ * checkAriaLabel
+ * Check an element's aria label
+ * @param {Function} Cypress selector
+ * @param {String} Expected message
+ */
+const checkAriaLabel = (selector, expectedMessage) => {
   selector.invoke('attr', 'aria-label').then((text) => {
     expect(text.trim()).equal(expectedMessage);
   });
 };
+
+export default checkAriaLabel;

--- a/e2e-tests/cypress/support/check-radio-input-no-aria-label.js
+++ b/e2e-tests/cypress/support/check-radio-input-no-aria-label.js
@@ -1,0 +1,16 @@
+import { noRadioInput } from '../e2e/pages/shared';
+import { FIELD_VALUES } from '../../constants';
+import checkAriaLabel from './check-aria-label';
+
+/**
+ * checkRadioInputNoAriaLabel
+ * Check a "no" radio input's aria label
+ * @param {String} Expected message without "No" copy
+ */
+const checkRadioInputNoAriaLabel = (message) => {
+  const expectedMessage = `${message} ${FIELD_VALUES.NO}`;
+
+  checkAriaLabel(noRadioInput(), expectedMessage);
+};
+
+export default checkRadioInputNoAriaLabel;

--- a/e2e-tests/cypress/support/check-radio-input-yes-aria-label.js
+++ b/e2e-tests/cypress/support/check-radio-input-yes-aria-label.js
@@ -1,0 +1,16 @@
+import { yesRadioInput } from '../e2e/pages/shared';
+import { FIELD_VALUES } from '../../constants';
+import checkAriaLabel from './check-aria-label';
+
+/**
+ * checkRadioInputYesAriaLabel
+ * Check a "yes" radio input's aria label
+ * @param {String} Expected message without "Yes" copy
+ */
+const checkRadioInputYesAriaLabel = (message) => {
+  const expectedMessage = `${message} ${FIELD_VALUES.YES}`;
+
+  checkAriaLabel(yesRadioInput(), expectedMessage);
+};
+
+export default checkRadioInputYesAriaLabel;

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -135,6 +135,9 @@ Cypress.Commands.add('assertCustomerServiceContactDetailsContent', require('./as
 Cypress.Commands.add('checkText', require('./check-text'));
 Cypress.Commands.add('checkValue', require('./check-value'));
 Cypress.Commands.add('checkAriaLabel', require('./check-aria-label'));
+Cypress.Commands.add('checkRadioInputYesAriaLabel', require('./check-radio-input-yes-aria-label'));
+Cypress.Commands.add('checkRadioInputNoAriaLabel', require('./check-radio-input-no-aria-label'));
+
 Cypress.Commands.add('checkTaskStatus', require('./check-task-status'));
 Cypress.Commands.add('checkTaskStatusCompleted', require('./check-completed-task-status'));
 Cypress.Commands.add('checkLink', require('./check-link'));

--- a/src/ui/templates/components/yes-no-radio-buttons.njk
+++ b/src/ui/templates/components/yes-no-radio-buttons.njk
@@ -72,7 +72,7 @@
         },
         attributes: {
           "data-cy": "yes-input",
-          'aria-label': heading + ' yes radio'
+          'aria-label': heading + ' Yes'
         },
         checked: submittedAnswer === yesValue
       },
@@ -89,7 +89,7 @@
         },
         attributes: {
           "data-cy": "no-input",
-          'aria-label': heading + ' no radio'
+          'aria-label': heading + ' No'
         },
         checked: submittedAnswer === noValue
       }


### PR DESCRIPTION
This PR fixes an issue where any "yes/no" radio inputs would render a misleading arial label that would result in screenreaders mentioning "radio" twice, e.g "Radio label - yes radio radio", instead of "Radio label - yes radio".

## Changes
- Remove "radio" copy from both inputs in the "yes no radios" nunjuck component.
- Add a new cypress command to check a "yes" and "no" radio aria labels:
  - `checkRadioInputYesAriaLabel`
  - `checkRadioInputNoAriaLabel`
- Add E2E test for all yes/no radio buttons aria labels.
- Simplify some E2E tests - no need to manually check that yes/no radio inputs exist as other tests will fail if the input does not exist.