### PR TITLE
fix(EMS-1345): UI application creation requests - immediately wipe eligibility answers from the session

### DIFF
--- a/src/ui/server/controllers/insurance/account/create/your-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/index.test.ts
@@ -182,6 +182,12 @@ describe('controllers/insurance/account/create/your-details', () => {
           };
         });
 
+        it('should wipe req.session.submittedData.insuranceEligibility', async () => {
+          await post(req, res);
+
+          expect(req.session.submittedData.insuranceEligibility).toEqual({});
+        });
+
         it('should call api.keystone.application.create', async () => {
           const eligibilityAnswers = sanitiseData(req.session.submittedData.insuranceEligibility);
 
@@ -190,18 +196,6 @@ describe('controllers/insurance/account/create/your-details', () => {
           expect(createApplicationSpy).toHaveBeenCalledTimes(1);
 
           expect(createApplicationSpy).toHaveBeenCalledWith(eligibilityAnswers, mockSaveDataResponse.id);
-        });
-
-        it('should mark req.session.requestedApplicationCreation as false', async () => {
-          await post(req, res);
-
-          expect(req.session.requestedApplicationCreation).toEqual(false);
-        });
-
-        it('should wipe req.session.submittedData.insuranceEligibility', async () => {
-          await post(req, res);
-
-          expect(req.session.submittedData.insuranceEligibility).toEqual({});
         });
 
         it(`should redirect to ${CONFIRM_EMAIL}`, async () => {

--- a/src/ui/server/controllers/insurance/account/create/your-details/index.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/index.ts
@@ -150,20 +150,16 @@ export const post = async (req: Request, res: Response) => {
      * 5) Redirect to the next part of the flow - "confirm email"
      */
     if (canCreateAnApplication(req.session)) {
-      req.session.requestedApplicationCreation = true;
-
       const eligibilityAnswers = sanitiseData(req.session.submittedData.insuranceEligibility);
 
-      const application = await api.keystone.application.create(eligibilityAnswers, accountId);
+      req.session.submittedData.insuranceEligibility = {};
 
-      req.session.requestedApplicationCreation = false;
+      const application = await api.keystone.application.create(eligibilityAnswers, accountId);
 
       if (!application) {
         console.error('Error creating application');
         return res.redirect(PROBLEM_WITH_SERVICE);
       }
-
-      req.session.submittedData.insuranceEligibility = {};
     }
 
     return res.redirect(CONFIRM_EMAIL);

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
@@ -232,6 +232,12 @@ describe('controllers/insurance/account/sign-in/enter-code', () => {
           };
         });
 
+        it('should wipe req.session.submittedData.insuranceEligibility', async () => {
+          await post(req, res);
+
+          expect(req.session.submittedData.insuranceEligibility).toEqual({});
+        });
+
         it('should call api.keystone.application.create', async () => {
           const eligibilityAnswers = sanitiseData(req.session.submittedData.insuranceEligibility);
 
@@ -240,18 +246,6 @@ describe('controllers/insurance/account/sign-in/enter-code', () => {
           expect(createApplicationSpy).toHaveBeenCalledTimes(1);
 
           expect(createApplicationSpy).toHaveBeenCalledWith(eligibilityAnswers, verifyAccountSignInCodeResponse.accountId);
-        });
-
-        it('should mark req.session.requestedApplicationCreation as false', async () => {
-          await post(req, res);
-
-          expect(req.session.requestedApplicationCreation).toEqual(false);
-        });
-
-        it('should wipe req.session.submittedData.insuranceEligibility', async () => {
-          await post(req, res);
-
-          expect(req.session.submittedData.insuranceEligibility).toEqual({});
         });
 
         it(`should redirect to ${DASHBOARD}`, async () => {

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
@@ -133,13 +133,11 @@ export const post = async (req: Request, res: Response) => {
        * 4) Remove eligibility answers in the session.
        */
       if (canCreateAnApplication(req.session)) {
-        req.session.requestedApplicationCreation = true;
-
         const eligibilityAnswers = sanitiseData(req.session.submittedData.insuranceEligibility);
 
-        const application = await api.keystone.application.create(eligibilityAnswers, accountId);
+        req.session.submittedData.insuranceEligibility = {};
 
-        req.session.requestedApplicationCreation = false;
+        const application = await api.keystone.application.create(eligibilityAnswers, accountId);
 
         if (!application) {
           console.error('Error creating application');

--- a/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.test.ts
@@ -77,6 +77,12 @@ describe('controllers/insurance/eligibility/eligible-to-apply-online', () => {
         };
       });
 
+      it('should wipe req.session.submittedData.insuranceEligibility', async () => {
+        await post(req, res);
+
+        expect(req.session.submittedData.insuranceEligibility).toEqual({});
+      });
+
       it('should call api.keystone.application.create', async () => {
         const eligibilityAnswers = req.session.submittedData.insuranceEligibility;
 
@@ -87,18 +93,6 @@ describe('controllers/insurance/eligibility/eligible-to-apply-online', () => {
         const sanitisedData = sanitiseData(eligibilityAnswers);
 
         expect(createApplicationSpy).toHaveBeenCalledWith(sanitisedData, mockAccount.id);
-      });
-
-      it('should mark req.session.requestedApplicationCreation as false', async () => {
-        await post(req, res);
-
-        expect(req.session.requestedApplicationCreation).toEqual(false);
-      });
-
-      it('should wipe req.session.submittedData.insuranceEligibility', async () => {
-        await post(req, res);
-
-        expect(req.session.submittedData.insuranceEligibility).toEqual({});
       });
 
       it(`should redirect to ${ALL_SECTIONS}`, async () => {

--- a/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.ts
@@ -36,21 +36,17 @@ export const post = async (req: Request, res: Response) => {
      * 5) Redirect to the application
      */
     if (req.session.user && canCreateAnApplication(req.session)) {
-      req.session.requestedApplicationCreation = true;
-
       const eligibilityAnswers = sanitiseData(req.session.submittedData.insuranceEligibility);
 
-      const application = await api.keystone.application.create(eligibilityAnswers, req.session.user.id);
+      req.session.submittedData.insuranceEligibility = {};
 
-      req.session.requestedApplicationCreation = false;
+      const application = await api.keystone.application.create(eligibilityAnswers, req.session.user.id);
 
       if (!application) {
         console.error('Error creating application');
 
         return res.redirect(PROBLEM_WITH_SERVICE);
       }
-
-      req.session.submittedData.insuranceEligibility = {};
 
       const applicationUrl = `${INSURANCE_ROOT}/${application.referenceNumber}${ALL_SECTIONS}`;
 

--- a/src/ui/server/helpers/can-create-an-application/index.test.ts
+++ b/src/ui/server/helpers/can-create-an-application/index.test.ts
@@ -9,7 +9,6 @@ describe('server/helpers/can-create-an-application', () => {
           insuranceEligibility: mockEligibility,
           quoteEligibility: {},
         },
-        requestedApplicationCreation: false,
       };
 
       const result = canCreateAnApplication(mockSession);
@@ -25,23 +24,6 @@ describe('server/helpers/can-create-an-application', () => {
           insuranceEligibility: {},
           quoteEligibility: {},
         },
-        requestedApplicationCreation: false,
-      };
-
-      const result = canCreateAnApplication(mockSession);
-
-      expect(result).toEqual(false);
-    });
-  });
-
-  describe('when session.requestedApplicationCreation is true', () => {
-    it('should return false', () => {
-      const mockSession = {
-        submittedData: {
-          insuranceEligibility: mockEligibility,
-          quoteEligibility: {},
-        },
-        requestedApplicationCreation: true,
       };
 
       const result = canCreateAnApplication(mockSession);

--- a/src/ui/server/helpers/can-create-an-application/index.ts
+++ b/src/ui/server/helpers/can-create-an-application/index.ts
@@ -9,7 +9,7 @@ import { RequestSession } from '../../../types';
  * @returns {Boolean}
  */
 const canCreateAnApplication = (session: RequestSession) => {
-  if (session.submittedData && objectHasKeysAndValues(session.submittedData.insuranceEligibility) && !session.requestedApplicationCreation) {
+  if (session.submittedData && objectHasKeysAndValues(session.submittedData.insuranceEligibility)) {
     return true;
   }
 

--- a/src/ui/types/express/index.d.ts
+++ b/src/ui/types/express/index.d.ts
@@ -61,7 +61,6 @@ interface RequestSession {
   passwordResetSuccess?: boolean;
   emailAddressForAccountReactivation?: string;
   returnToServiceUrl?: string;
-  requestedApplicationCreation?: boolean;
 }
 
 interface Request {


### PR DESCRIPTION
This PR updates all instances of the UI's application creation requests so that eligibility answers are immediately wiped from the session instead of waiting for an API response.

## Changes
- Revert previous changes that added `requestedApplicationCreation` to the session as this is not helping to prevent multiple application submission requests/spam.
- Update all instances of application creation requests to wipe the eligibility answers stored in session before calling the API.