### PR TITLE
fix(EMS-1345): Add missing form IDs

### DIFF
--- a/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
+++ b/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
@@ -40,8 +40,9 @@
     </div>
   </div>
 
-  <form method="POST" novalidate="novalidate">
+  <form method="POST" id="form" novalidate="novalidate">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters-from-desktop">
 

--- a/src/ui/templates/insurance/your-buyer/working-with-buyer.njk
+++ b/src/ui/templates/insurance/your-buyer/working-with-buyer.njk
@@ -45,8 +45,9 @@
     </div>
   </div>
 
-  <form method="POST" novalidate="novalidate">
+  <form method="POST" id="form" novalidate="novalidate">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters-from-desktop">
         {{ yesNoRadioButtons.render({


### PR DESCRIPTION
This PR adds some missing form IDs - therefore the form submission script will now find a form when on a page with these forms.

## Changes
- Add missing IDs to "company or organisation" and "working with buyer" forms.