### PR TITLE
chore(EMS-1816): Fix various issues reported by SonarCloud

### DIFF
--- a/e2e-tests/constants/examples/website-address-examples.js
+++ b/e2e-tests/constants/examples/website-address-examples.js
@@ -1,5 +1,5 @@
 export const WEBSITE_EXAMPLES = {
-  VALID: 'www.google.com',
+  VALID: 'www.gov.uk',
   VALID_UKEF: 'https://www.ukexportfinance.gov.uk/',
   INVALID: 'www',
   ABOVE_MAX_LENGTH: `www.google${'e'.repeat(178)}.com`,

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details-validation-account-already-exists.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details-validation-account-already-exists.spec.js
@@ -59,7 +59,7 @@ context('Insurance - Account - Create - Your details page - form validation - As
     const value = mockAccount.email;
     const fieldIndex = 0;
     const TOTAL_REQUIRED_FIELDS = 1;
-    const expectedMessage = YOUR_DETAILS_ERROR_MESSAGES[EMAIL].ACCOUNT_ALREADY_EXISTS;
+    const expectedMessage = String(YOUR_DETAILS_ERROR_MESSAGES[EMAIL].ACCOUNT_ALREADY_EXISTS);
 
     cy.submitAndAssertFieldErrors(field, value, fieldIndex, TOTAL_REQUIRED_FIELDS, expectedMessage);
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details-validation-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details-validation-email.spec.js
@@ -23,7 +23,7 @@ const {
   },
 } = ERROR_MESSAGES;
 
-const expectedMessage = YOUR_DETAILS_ERROR_MESSAGES[EMAIL].INCORRECT_FORMAT;
+const expectedMessage = String(YOUR_DETAILS_ERROR_MESSAGES[EMAIL].INCORRECT_FORMAT);
 
 const submitAndAssertFieldErrors = (fieldValue) => {
   const field = accountFormFields[EMAIL];

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details-validation.spec.js
@@ -51,7 +51,7 @@ context('Insurance - Account - Create - Your details page - empty form validatio
     const field = yourDetailsPage[FIRST_NAME];
     const value = null;
     const fieldIndex = 0;
-    const expectedMessage = YOUR_DETAILS_ERROR_MESSAGES[FIRST_NAME].IS_EMPTY;
+    const expectedMessage = String(YOUR_DETAILS_ERROR_MESSAGES[FIRST_NAME].IS_EMPTY);
 
     cy.navigateToUrl(url);
 
@@ -62,7 +62,7 @@ context('Insurance - Account - Create - Your details page - empty form validatio
     const field = yourDetailsPage[LAST_NAME];
     const value = null;
     const fieldIndex = 1;
-    const expectedMessage = YOUR_DETAILS_ERROR_MESSAGES[LAST_NAME].IS_EMPTY;
+    const expectedMessage = String(YOUR_DETAILS_ERROR_MESSAGES[LAST_NAME].IS_EMPTY);
 
     cy.submitAndAssertFieldErrors(field, value, fieldIndex, TOTAL_REQUIRED_FIELDS, expectedMessage);
   });
@@ -71,7 +71,7 @@ context('Insurance - Account - Create - Your details page - empty form validatio
     const field = accountFormFields[EMAIL];
     const value = null;
     const fieldIndex = 2;
-    const expectedMessage = YOUR_DETAILS_ERROR_MESSAGES[EMAIL].INCORRECT_FORMAT;
+    const expectedMessage = String(YOUR_DETAILS_ERROR_MESSAGES[EMAIL].INCORRECT_FORMAT);
 
     cy.submitAndAssertFieldErrors(field, value, fieldIndex, TOTAL_REQUIRED_FIELDS, expectedMessage);
   });
@@ -80,7 +80,7 @@ context('Insurance - Account - Create - Your details page - empty form validatio
     const field = accountFormFields[PASSWORD];
     const value = null;
     const fieldIndex = 3;
-    const expectedMessage = YOUR_DETAILS_ERROR_MESSAGES[PASSWORD].INCORRECT_FORMAT;
+    const expectedMessage = String(YOUR_DETAILS_ERROR_MESSAGES[PASSWORD].INCORRECT_FORMAT);
 
     cy.submitAndAssertFieldErrors(field, value, fieldIndex, TOTAL_REQUIRED_FIELDS, expectedMessage);
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/enter-code/validation/account-sign-in-enter-code-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/enter-code/validation/account-sign-in-enter-code-validation.spec.js
@@ -22,7 +22,7 @@ const field = enterCodePage[SECURITY_CODE];
 let value = null;
 const fieldIndex = 0;
 const TOTAL_REQUIRED_FIELDS = 1;
-const expectedMessage = SECURITY_CODE_ERROR_MESSAGE.INCORRECT;
+const expectedMessage = String(SECURITY_CODE_ERROR_MESSAGE.INCORRECT);
 
 context('Insurance - Account - Sign in - Enter code - validation', () => {
   const url = `${Cypress.config('baseUrl')}${ENTER_CODE}`;

--- a/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-and-exports-multiple-policy-type.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-and-exports-multiple-policy-type.spec.js
@@ -265,7 +265,7 @@ context('Insurance - Change your answers - Policy and exports - multiple contrac
 
           summaryList.field(fieldId).changeLink().click();
 
-          fieldVariables.newValueInput = `${application.POLICY_AND_EXPORTS[fieldId]} additional text`;
+          fieldVariables.newValueInput = `${String(application.POLICY_AND_EXPORTS[fieldId])} additional text`;
           changeAnswerField(fieldVariables, multipleContractPolicyPage[fieldId].input());
         });
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-and-exports-single-policy-type.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-and-exports-single-policy-type.spec.js
@@ -235,7 +235,7 @@ context('Insurance - Change your answers - Policy and exports - Single contract 
           cy.navigateToUrl(url);
 
           summaryList.field(fieldId).changeLink().click();
-          fieldVariables.newValueInput = `${application.POLICY_AND_EXPORTS[fieldId]} additional text`;
+          fieldVariables.newValueInput = `${String(application.POLICY_AND_EXPORTS[fieldId])} additional text`;
 
           changeAnswerField(fieldVariables, singleContractPolicyPage[fieldId].input());
         });

--- a/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-type-change-single-to-multiple-policy-type-summary-list.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-type-change-single-to-multiple-policy-type-summary-list.spec.js
@@ -146,7 +146,7 @@ context('Insurance - Change your answers - Policy and exports - Change single to
       });
 
       it('should render the new answers and `change` links to the newly submitted fields', () => {
-        const expectedTotalMonthsOfCover = `${application.POLICY_AND_EXPORTS[TOTAL_MONTHS_OF_COVER]} months`;
+        const expectedTotalMonthsOfCover = `${String(application.POLICY_AND_EXPORTS[TOTAL_MONTHS_OF_COVER])} months`;
 
         cy.assertSummaryListRowValueNew(summaryList, TOTAL_MONTHS_OF_COVER, expectedTotalMonthsOfCover);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/cookies.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/cookies.spec.js
@@ -182,7 +182,7 @@ context('Cookies page - Insurance', () => {
           partials.errorSummaryListItems().should('exist');
           partials.errorSummaryListItems().should('have.length', 1);
 
-          const expectedMessage = ERROR_MESSAGES[FIELD_IDS.OPTIONAL_COOKIES];
+          const expectedMessage = String(ERROR_MESSAGES[FIELD_IDS.OPTIONAL_COOKIES]);
 
           cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/anti-bribery.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/anti-bribery.spec.js
@@ -153,7 +153,7 @@ context('Insurance - Declarations - Anti-bribery page - As an Exporter, I want t
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY;
+        const expectedMessage = String(ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
@@ -119,7 +119,7 @@ context("Insurance - Declarations - Anti-bribery - Code of conduct page - As an 
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY;
+        const expectedMessage = String(ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/exporting-with-code-of-conduct/anti-bribery-exporting-with-code-of-conduct.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/anti-bribery/exporting-with-code-of-conduct/anti-bribery-exporting-with-code-of-conduct.spec.js
@@ -109,7 +109,7 @@ context("Insurance - Declarations - Anti-bribery - Exporting with code of conduc
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY;
+        const expectedMessage = String(ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/confidentiality/confidentiality.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/confidentiality/confidentiality.spec.js
@@ -142,7 +142,7 @@ context('Insurance - Declarations - Confidentiality page - As an Exporter, I wan
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY;
+        const expectedMessage = String(ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/confirmation-and-acknowledgements/confirmation-and-acknowledgements.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/confirmation-and-acknowledgements/confirmation-and-acknowledgements.spec.js
@@ -141,7 +141,7 @@ context("Insurance - Declarations - Confirmation and acknowledgements page - As 
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY;
+        const expectedMessage = String(ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/declarations/how-your-data-will-be-used/how-your-data-will-be-used.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/declarations/how-your-data-will-be-used/how-your-data-will-be-used.spec.js
@@ -141,7 +141,7 @@ context('Insurance - Declarations - How your data will be used page - As an Expo
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY;
+        const expectedMessage = String(ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/account-to-apply-online/account-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/account-to-apply-online/account-to-apply-online.spec.js
@@ -85,7 +85,7 @@ context('Insurance - Eligibility - Account to apply online page - I want to conf
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY;
+        const expectedMessage = String(ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
@@ -94,7 +94,7 @@ context('Insurance - Eligibility - Companies house number page - I want to check
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER].IS_EMPTY;
+        const expectedMessage = String(ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER].IS_EMPTY);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
@@ -55,7 +55,7 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.ELIGIBILITY[FIELD_IDS.ELIGIBILITY.VALID_EXPORTER_LOCATION];
+        const expectedMessage = String(ERROR_MESSAGES.ELIGIBILITY[FIELD_IDS.ELIGIBILITY.VALID_EXPORTER_LOCATION]);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
@@ -84,7 +84,7 @@ context('Insurance - Insured amount page - I want to check if I can use online s
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_AMOUNT].IS_EMPTY;
+        const expectedMessage = String(ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_AMOUNT].IS_EMPTY);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
@@ -90,7 +90,7 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT].IS_EMPTY;
+        const expectedMessage = String(ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT].IS_EMPTY);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
@@ -121,7 +121,7 @@ context('Insurance - Other parties page - I want to check if I can use online se
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED].IS_EMPTY;
+        const expectedMessage = String(ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED].IS_EMPTY);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -131,7 +131,7 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
       partials.errorSummaryListItems().should('exist');
       partials.errorSummaryListItems().should('have.length', 1);
 
-      const expectedMessage = ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY;
+      const expectedMessage = String(ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY);
 
       cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -125,7 +125,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
       partials.errorSummaryListItems().should('exist');
       partials.errorSummaryListItems().should('have.length', 1);
 
-      const expectedMessage = ERROR_MESSAGES.ELIGIBILITY[HAS_MINIMUM_UK_GOODS_OR_SERVICES].IS_EMPTY;
+      const expectedMessage = String(ERROR_MESSAGES.ELIGIBILITY[HAS_MINIMUM_UK_GOODS_OR_SERVICES].IS_EMPTY);
 
       cy.checkText(partials.errorSummaryListItems(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/feedback/validation/feedback-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/feedback/validation/feedback-validation.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Feedback - form validation', () => {
       const field = feedbackPage.field(IMPROVEMENT);
       const value = 'a'.repeat(1201);
       const fieldIndex = 0;
-      const expectedMessage = ERROR_MESSAGE_IMPROVEMENT;
+      const expectedMessage = String(ERROR_MESSAGE_IMPROVEMENT);
 
       cy.submitAndAssertFieldErrors(field, value, fieldIndex, TOTAL_REQUIRED_FIELDS, expectedMessage);
     });
@@ -52,7 +52,7 @@ context('Insurance - Feedback - form validation', () => {
       const field = feedbackPage.field(OTHER_COMMENTS);
       const value = 'a'.repeat(1201);
       const fieldIndex = 0;
-      const expectedMessage = ERROR_MESSAGE_OTHER_COMMENT;
+      const expectedMessage = String(ERROR_MESSAGE_OTHER_COMMENT);
 
       cy.submitAndAssertFieldErrors(field, value, fieldIndex, TOTAL_REQUIRED_FIELDS, expectedMessage);
     });

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/type-of-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/type-of-policy.spec.js
@@ -126,7 +126,7 @@ context('Insurance - Policy and exports - Type of policy page - As an exporter, 
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.INSURANCE.POLICY_AND_EXPORTS.TYPE_OF_POLICY[FIELD_ID].IS_EMPTY;
+        const expectedMessage = String(ERROR_MESSAGES.INSURANCE.POLICY_AND_EXPORTS.TYPE_OF_POLICY[FIELD_ID].IS_EMPTY);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
@@ -56,7 +56,7 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.ELIGIBILITY[VALID_BUYER_BODY];
+        const expectedMessage = String(ERROR_MESSAGES.ELIGIBILITY[VALID_BUYER_BODY]);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/quote/cookies.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/cookies.spec.js
@@ -182,7 +182,7 @@ context('Cookies page - Quote', () => {
           partials.errorSummaryListItems().should('exist');
           partials.errorSummaryListItems().should('have.length', 1);
 
-          const expectedMessage = ERROR_MESSAGES[FIELD_IDS.OPTIONAL_COOKIES];
+          const expectedMessage = String(ERROR_MESSAGES[FIELD_IDS.OPTIONAL_COOKIES]);
 
           cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
@@ -54,7 +54,7 @@ context('Exporter location page - as an exporter, I want to check if my company 
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.ELIGIBILITY[FIELD_IDS.ELIGIBILITY.VALID_EXPORTER_LOCATION];
+        const expectedMessage = String(ERROR_MESSAGES.ELIGIBILITY[FIELD_IDS.ELIGIBILITY.VALID_EXPORTER_LOCATION]);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -98,7 +98,7 @@ context('UK goods or services page - as an exporter, I want to check if my expor
         partials.errorSummaryListItems().should('exist');
         partials.errorSummaryListItems().should('have.length', 1);
 
-        const expectedMessage = ERROR_MESSAGES.ELIGIBILITY[HAS_MINIMUM_UK_GOODS_OR_SERVICES].IS_EMPTY;
+        const expectedMessage = String(ERROR_MESSAGES.ELIGIBILITY[HAS_MINIMUM_UK_GOODS_OR_SERVICES].IS_EMPTY);
 
         cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/support/analytics/check-cookies-consent-banner-is-not-visible.js
+++ b/e2e-tests/cypress/support/analytics/check-cookies-consent-banner-is-not-visible.js
@@ -9,8 +9,6 @@ const checkCookiesConsentBannerIsNotVisible = () => {
   partials.cookieBanner.question.copy2().should('not.exist');
   partials.cookieBanner.question.acceptButton().should('not.exist');
   partials.cookieBanner.question.rejectButton().should('not.exist');
-
-  // partials.cookieBanner.accepted.copy().should('not.be.visible');
 };
 
 export default checkCookiesConsentBannerIsNotVisible;

--- a/e2e-tests/cypress/support/api/index.js
+++ b/e2e-tests/cypress/support/api/index.js
@@ -328,7 +328,7 @@ const deleteApplicationByReferenceNumber = async (referenceNumber) => {
   } catch (err) {
     console.error(err);
 
-    throw new Error('Deleting applications by ID ', { err });
+    return err;
   }
 };
 

--- a/e2e-tests/cypress/support/api/index.js
+++ b/e2e-tests/cypress/support/api/index.js
@@ -163,7 +163,7 @@ const getAccountByEmail = async (email) => {
       url,
     });
 
-    if (!response.body || !response.body.data) {
+    if (!response.body?.data) {
       throw new Error('Getting account by email ', { response });
     }
 
@@ -299,7 +299,7 @@ const getApplicationByReferenceNumber = async (referenceNumber) => {
       url,
     });
 
-    if (!response.body || !response.body.data) {
+    if (!response.body?.data) {
       throw new Error(`Getting application by reference number ${referenceNumber}`, { response });
     }
 

--- a/e2e-tests/cypress/support/api/index.js
+++ b/e2e-tests/cypress/support/api/index.js
@@ -163,7 +163,7 @@ const getAccountByEmail = async (email) => {
       url,
     });
 
-    if (!response.body?.data) {
+    if (!response?.body?.data) {
       throw new Error('Getting account by email ', { response });
     }
 
@@ -299,7 +299,7 @@ const getApplicationByReferenceNumber = async (referenceNumber) => {
       url,
     });
 
-    if (!response.body?.data) {
+    if (!response?.body?.data) {
       throw new Error(`Getting application by reference number ${referenceNumber}`, { response });
     }
 

--- a/e2e-tests/cypress/support/api/index.js
+++ b/e2e-tests/cypress/support/api/index.js
@@ -216,7 +216,7 @@ const deleteAnAccount = async (email) => {
   } catch (err) {
     console.error(err);
 
-    throw new Error('Deleting account by email ', { err });
+    return err;
   }
 };
 

--- a/e2e-tests/cypress/support/check-buyer-country-form.js
+++ b/e2e-tests/cypress/support/check-buyer-country-form.js
@@ -87,7 +87,7 @@ const checkValidationErrors = () => {
   partials.errorSummaryListItems().should('exist');
   partials.errorSummaryListItems().should('have.length', 1);
 
-  const expectedMessage = ERROR_MESSAGES.ELIGIBILITY[FIELD_IDS.ELIGIBILITY.BUYER_COUNTRY];
+  const expectedMessage = String(ERROR_MESSAGES.ELIGIBILITY[FIELD_IDS.ELIGIBILITY.BUYER_COUNTRY]);
 
   cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
 

--- a/e2e-tests/cypress/support/insurance/account/complete-and-submit-create-account-form.js
+++ b/e2e-tests/cypress/support/insurance/account/complete-and-submit-create-account-form.js
@@ -21,7 +21,7 @@ const {
 } = INSURANCE_ROUTES;
 
 export default (params) => {
-  if (params && params.navigateToAccountCreationPage) {
+  if (params?.navigateToAccountCreationPage) {
     cy.navigateToUrl(YOUR_DETAILS);
   }
 

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -1590,7 +1590,7 @@ var getAccountByField = async (context, field, value) => {
       },
       take: 1
     });
-    if (!accountsArray || !accountsArray.length || !accountsArray[0]) {
+    if (!accountsArray?.length || !accountsArray[0]) {
       console.info("Getting account by field - no account exists with the provided field/value");
       return false;
     }
@@ -2876,7 +2876,7 @@ var delete_application_by_refrence_number_default = deleteApplicationByReference
 // helpers/map-sic-codes/index.ts
 var mapSicCodes = (company, sicCodes, industrySectorNames) => {
   const mapped = [];
-  if (!sicCodes || !sicCodes.length) {
+  if (!sicCodes?.length) {
     return mapped;
   }
   sicCodes.forEach((code, index) => {
@@ -2945,7 +2945,7 @@ var getCountryByField = async (context, field, value) => {
       },
       take: 1
     });
-    if (!countriesArray || !countriesArray.length || !countriesArray[0]) {
+    if (!countriesArray?.length || !countriesArray[0]) {
       console.info("Getting country by field - no country exists with the provided field/value");
       return false;
     }
@@ -4137,7 +4137,7 @@ var create_full_timestamp_from_day_month_default = createFullTimestampFromDayAnd
 // helpers/map-sic-code-descriptions/index.ts
 var mapSicCodeDescriptions = (sicCodes, sectors) => {
   const industrySectorNames = [];
-  if (!sicCodes || !sicCodes.length || !sectors || !sectors.length) {
+  if (!sicCodes?.length || !sectors?.length) {
     return industrySectorNames;
   }
   sicCodes.forEach((sicCode) => {

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /app
 # NPM
 COPY --chown=node:node package.json .
 COPY --chown=node:node package-lock.json .
-RUN npm ci --legacy-peer-deps --ignore-scripts
+RUN npm ci --legacy-peer-deps
 
 # Copy API
 COPY --chown=node:node ./keystone.ts .
@@ -48,7 +48,7 @@ RUN npm run build
 # Lean NPM - Only install `dependencies`
 # `devDependencies` will still be resolved inside `package-lock.json`,
 # however they will not be installed inside `node_modules` directory.
-RUN npm ci --legacy-peer-deps --omit=dev --ignore-scripts
+RUN npm ci --legacy-peer-deps --omit=dev
 
 # Non-root user
 USER node

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /app
 # NPM
 COPY --chown=node:node package.json .
 COPY --chown=node:node package-lock.json .
-RUN npm ci --legacy-peer-deps
+RUN npm ci --legacy-peer-deps --ignore-scripts
 
 # Copy API
 COPY --chown=node:node ./keystone.ts .
@@ -48,7 +48,7 @@ RUN npm run build
 # Lean NPM - Only install `dependencies`
 # `devDependencies` will still be resolved inside `package-lock.json`,
 # however they will not be installed inside `node_modules` directory.
-RUN npm ci --legacy-peer-deps --omit=dev
+RUN npm ci --legacy-peer-deps --omit=dev --ignore-scripts
 
 # Non-root user
 USER node

--- a/src/api/custom-resolvers/mutations/account-password-reset/index.ts
+++ b/src/api/custom-resolvers/mutations/account-password-reset/index.ts
@@ -43,7 +43,7 @@ const accountPasswordReset = async (root: any, variables: AccountPasswordResetVa
      * Check if the account has a reset hash and expiry.
      * If not, return success=false
      */
-    const { id: accountId, passwordResetHash, passwordResetExpiry, salt: currentSalt, hash: currentHash } = account as Account;
+    const { id: accountId, passwordResetHash, passwordResetExpiry, salt: currentSalt, hash: currentHash } = account;
 
     if (!passwordResetHash || !passwordResetExpiry) {
       console.info('Unable to reset account password - reset hash or expiry does not exist');

--- a/src/api/emails/send-application-submitted-emails/index.ts
+++ b/src/api/emails/send-application-submitted-emails/index.ts
@@ -14,7 +14,7 @@ import { SuccessResponse, ApplicationSubmissionEmailVariables, Application } fro
  */
 const send = async (application: Application, xlsxPath: string): Promise<SuccessResponse> => {
   try {
-    const { referenceNumber, owner, company, buyer, policyAndExport, business } = application as Application;
+    const { referenceNumber, owner, company, buyer, policyAndExport, business } = application;
 
     const { businessContactDetail } = business;
 

--- a/src/api/helpers/create-full-timestamp-from-day-month/index.test.ts
+++ b/src/api/helpers/create-full-timestamp-from-day-month/index.test.ts
@@ -14,7 +14,7 @@ describe('api/helpers/create-date-from-numbers', () => {
 
   describe('when month is not provided', () => {
     it('should return null', () => {
-      const result = createTimestampFromNumbers(day, undefined);
+      const result = createTimestampFromNumbers(day);
 
       expect(result).toEqual(null);
     });

--- a/src/api/helpers/get-account-by-field/index.ts
+++ b/src/api/helpers/get-account-by-field/index.ts
@@ -20,7 +20,7 @@ const getAccountByField = async (context: Context, field: string, value: string)
     });
 
     // ensure that we have found an account with the requsted field/value
-    if (!accountsArray || !accountsArray.length || !accountsArray[0]) {
+    if (!accountsArray?.length || !accountsArray[0]) {
       console.info('Getting account by field - no account exists with the provided field/value');
 
       return false;

--- a/src/api/helpers/get-country-by-field/index.ts
+++ b/src/api/helpers/get-country-by-field/index.ts
@@ -20,7 +20,7 @@ const getCountryByField = async (context: Context, field: string, value: string)
     });
 
     // ensure that we have found a country with the requsted field/value
-    if (!countriesArray || !countriesArray.length || !countriesArray[0]) {
+    if (!countriesArray?.length || !countriesArray[0]) {
       console.info('Getting country by field - no country exists with the provided field/value');
 
       return false;

--- a/src/api/helpers/map-sic-code-descriptions/index.ts
+++ b/src/api/helpers/map-sic-code-descriptions/index.ts
@@ -11,7 +11,7 @@ const mapSicCodeDescriptions = (sicCodes: Array<string>, sectors: Array<Industry
   const industrySectorNames = [] as Array<string>;
 
   // if sectors or sic codes is null or empty, then return empty array
-  if (!sicCodes || !sicCodes.length || !sectors || !sectors.length) {
+  if (!sicCodes?.length || !sectors?.length) {
     return industrySectorNames;
   }
 

--- a/src/api/helpers/map-sic-codes/index.ts
+++ b/src/api/helpers/map-sic-codes/index.ts
@@ -10,7 +10,7 @@ import { CompanyResponse, SicCode } from '../../types';
 const mapSicCodes = (company: CompanyResponse, sicCodes?: Array<string>, industrySectorNames?: Array<string>) => {
   const mapped = [] as Array<SicCode>;
 
-  if (!sicCodes || !sicCodes.length) {
+  if (!sicCodes?.length) {
     return mapped;
   }
 

--- a/src/api/test-mocks/index.ts
+++ b/src/api/test-mocks/index.ts
@@ -63,7 +63,7 @@ export const mockInsuranceFeedbackEmail = {
 export const mockInsuranceFeedback = {
   ...mockInsuranceFeedbackEmail,
   service: 'Insurance',
-  referralUrl: 'www.google.com',
+  referralUrl: 'www.gov.uk',
   product: 'EXIP',
 };
 

--- a/src/api/test-mocks/mock-buyer.ts
+++ b/src/api/test-mocks/mock-buyer.ts
@@ -12,7 +12,7 @@ const mockBuyer = {
     name: 'United Kingdom',
   },
   registrationNumber: '1234',
-  website: 'www.google.com',
+  website: 'www.gov.uk',
   contactFirstName: 'Bob',
   contactLastName: 'Smith',
   contactPosition: 'CEO',

--- a/src/ui/server/controllers/insurance/account/create/confirm-email/index.ts
+++ b/src/ui/server/controllers/insurance/account/create/confirm-email/index.ts
@@ -23,7 +23,7 @@ export const get = async (req: Request, res: Response) => {
     const { accountIdToConfirm } = req.session;
     const { id } = req.query;
 
-    const accountId = accountIdToConfirm || id;
+    const accountId = accountIdToConfirm ?? id;
 
     if (!accountId) {
       return res.redirect(PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/account/password-reset/link-sent/index.ts
+++ b/src/ui/server/controllers/insurance/account/password-reset/link-sent/index.ts
@@ -27,7 +27,7 @@ export const get = (req: Request, res: Response) => {
    */
   req.flash('emailAddressForPasswordReset', emailAddressForPasswordReset);
 
-  const accountEmail = emailAddressForPasswordReset || req.flash('emailAddressForPasswordReset');
+  const accountEmail = emailAddressForPasswordReset ?? req.flash('emailAddressForPasswordReset');
 
   if (!accountEmail) {
     return res.redirect(PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/account/password-reset/success/index.ts
+++ b/src/ui/server/controllers/insurance/account/password-reset/success/index.ts
@@ -32,7 +32,7 @@ export const get = (req: Request, res: Response) => {
    */
   req.flash('passwordResetSuccess', String(passwordResetSuccess));
 
-  const success = passwordResetSuccess || req.flash('passwordResetSuccess');
+  const success = passwordResetSuccess ?? req.flash('passwordResetSuccess');
 
   if (!success) {
     return res.redirect(PASSWORD_RESET_ROOT);

--- a/src/ui/server/controllers/insurance/account/suspended/email-sent/index.ts
+++ b/src/ui/server/controllers/insurance/account/suspended/email-sent/index.ts
@@ -28,7 +28,7 @@ export const get = (req: Request, res: Response) => {
    */
   req.flash('emailAddressForAccountReactivation', emailAddressForAccountReactivation);
 
-  const accountEmail = emailAddressForAccountReactivation || req.flash('emailAddressForAccountReactivation');
+  const accountEmail = emailAddressForAccountReactivation ?? req.flash('emailAddressForAccountReactivation');
 
   if (!accountEmail) {
     return res.redirect(PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/company-website.test.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/company-website.test.ts
@@ -45,7 +45,7 @@ describe('controllers/insurance/business/company-details/validation/company-deta
 
   describe(`${WEBSITE} is the correct format`, () => {
     it('should not return a validation error', () => {
-      mockBody[WEBSITE] = 'www.google.com';
+      mockBody[WEBSITE] = 'www.gov.uk';
 
       const result = companyWebsite(mockBody, mockErrors);
 

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
@@ -25,7 +25,7 @@ const { PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
 
 export const get = async (req: Request, res: Response) => {
   try {
-    if (!req.session.submittedData || !req.session.submittedData.insuranceEligibility) {
+    if (!req.session?.submittedData?.insuranceEligibility) {
       req.session.submittedData = {
         ...req.session.submittedData,
         insuranceEligibility: {},
@@ -40,7 +40,7 @@ export const get = async (req: Request, res: Response) => {
 
     let countryValue;
 
-    if (req.session.submittedData && req.session.submittedData.insuranceEligibility[FIELD_IDS.ELIGIBILITY.BUYER_COUNTRY]) {
+    if (req.session.submittedData.insuranceEligibility[FIELD_IDS.ELIGIBILITY.BUYER_COUNTRY]) {
       countryValue = req.session.submittedData.insuranceEligibility[FIELD_IDS.ELIGIBILITY.BUYER_COUNTRY];
     }
 

--- a/src/ui/server/controllers/insurance/feedback/feedback-form/index.ts
+++ b/src/ui/server/controllers/insurance/feedback/feedback-form/index.ts
@@ -116,7 +116,7 @@ const post = async (req: Request, res: Response) => {
 
       const saveResponse = await api.keystone.feedback.create(feedbackVariables);
 
-      if (!saveResponse || !saveResponse.success) {
+      if (!saveResponse?.success) {
         return res.redirect(PROBLEM_WITH_SERVICE);
       }
     }

--- a/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/validation/rules/website.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/validation/rules/website.test.ts
@@ -36,7 +36,7 @@ describe('controllers/insurance/your-buyer/validation/website', () => {
 
   describe('when the website is valid', () => {
     it('should not return validation errors', () => {
-      mockBody[FIELD_ID] = 'www.google.com';
+      mockBody[FIELD_ID] = 'www.gov.uk';
 
       const result = websiteRule(mockBody, mockErrors);
 

--- a/src/ui/server/controllers/quote/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.test.ts
@@ -20,7 +20,7 @@ describe('controllers/quote/buyer-country', () => {
   const mockCountriesResponse = mockCisCountries;
 
   // eslint-disable-next-line no-unused-vars
-  const [countryUnsupported, countrySupported, countrySupportedViaEmailOnly] = mockCountriesResponse;
+  const [countryUnsupported, countrySupportedViaEmailOnly] = mockCountriesResponse;
   const mockFlash = jest.fn();
 
   beforeEach(() => {

--- a/src/ui/server/controllers/quote/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.test.ts
@@ -19,8 +19,8 @@ describe('controllers/quote/buyer-country', () => {
 
   const mockCountriesResponse = mockCisCountries;
 
-  // eslint-disable-next-line no-unused-vars
-  const [countryUnsupported, countrySupportedViaEmailOnly] = mockCountriesResponse;
+  const { 0: countryUnsupported, 2: countrySupportedViaEmailOnly } = mockCountriesResponse;
+
   const mockFlash = jest.fn();
 
   beforeEach(() => {

--- a/src/ui/server/controllers/quote/buyer-country/index.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.ts
@@ -52,7 +52,7 @@ export const getBackLink = (referer?: string): string => {
 };
 
 export const get = async (req: Request, res: Response) => {
-  if (!req.session.submittedData || !req.session.submittedData.quoteEligibility) {
+  if (!req.session.submittedData?.quoteEligibility) {
     req.session.submittedData = {
       ...req.session.submittedData,
       quoteEligibility: {},

--- a/src/ui/server/controllers/root/cookies/index.ts
+++ b/src/ui/server/controllers/root/cookies/index.ts
@@ -44,7 +44,7 @@ export const get = (req: Request, res: Response) => {
     userName: getUserNameFromSession(req.session.user),
     ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer, ORIGINAL_URL: req.originalUrl }),
     FIELD: FIELDS[FIELD_IDS.OPTIONAL_COOKIES],
-    submittedValue: req.cookies.optionalCookies || req.cookies[SECURE_OPTION_COOKIE],
+    submittedValue: req.cookies.optionalCookies ?? req.cookies[SECURE_OPTION_COOKIE],
   });
 };
 

--- a/src/ui/server/helpers/get-application/index.test.ts
+++ b/src/ui/server/helpers/get-application/index.test.ts
@@ -37,9 +37,9 @@ describe('helpers/get-application', () => {
     });
   });
 
-  describe('when there is no application.policyAndExport.id', () => {
+  describe('when there is no application.id', () => {
     it('should return false', async () => {
-      getApplicationSpy = jest.fn(() => Promise.resolve({ policyAndExport: {} }));
+      getApplicationSpy = jest.fn(() => Promise.resolve({}));
       api.keystone.application.get = getApplicationSpy;
 
       const result = await getApplication(mockApplication.referenceNumber);

--- a/src/ui/server/helpers/get-application/index.ts
+++ b/src/ui/server/helpers/get-application/index.ts
@@ -11,7 +11,7 @@ const getApplication = async (referenceNumber: number) => {
     const application = await api.keystone.application.get(referenceNumber);
 
     // check that the application exists and has core structure.
-    if (!application || !application.policyAndExport || !application.policyAndExport.id) {
+    if (!application?.id) {
       return false;
     }
 

--- a/src/ui/server/helpers/get-values-from-user-session-or-application/index.ts
+++ b/src/ui/server/helpers/get-values-from-user-session-or-application/index.ts
@@ -12,7 +12,7 @@ import { objectHasKeysAndValues } from '../object';
  * @returns {Object} session or application section
  */
 const getValuesFromUserSessionOrApplication = (application: Application, section: string, field: string, userSession?: RequestSessionUser) => {
-  if (!application[section] || !application[section][field]) {
+  if (!application?.[section]?.[field]) {
     return userSession;
   }
 

--- a/src/ui/server/helpers/is-insurance-route/index.test.ts
+++ b/src/ui/server/helpers/is-insurance-route/index.test.ts
@@ -3,7 +3,7 @@ import { INSURANCE_ROOT } from '../../constants/routes/insurance';
 
 describe('helpers/is-insurance-route', () => {
   it('should return true if url is undefined', () => {
-    const response = isInsuranceRoute(undefined);
+    const response = isInsuranceRoute();
 
     expect(response).toEqual(true);
   });

--- a/src/ui/server/helpers/is-populated-array/index.ts
+++ b/src/ui/server/helpers/is-populated-array/index.ts
@@ -5,7 +5,7 @@
  * @returns {Boolean}
  */
 const isPopulatedArray = (arr?: Array<any>): boolean => {
-  if (arr && arr.length) {
+  if (arr?.length) {
     return true;
   }
 

--- a/src/ui/server/helpers/is-string-with-http/index.test.ts
+++ b/src/ui/server/helpers/is-string-with-http/index.test.ts
@@ -9,7 +9,7 @@ describe('helpers/isStringWithHttp', () => {
   });
 
   it('should not add "http://" to beginning of string incoming string already contains "http://"', () => {
-    const website = 'http://www.google.com';
+    const website = 'https://www.google.com';
 
     const result = isStringWithHttp(website);
     expect(result).toEqual(website);

--- a/src/ui/server/helpers/is-string-with-http/index.test.ts
+++ b/src/ui/server/helpers/is-string-with-http/index.test.ts
@@ -2,14 +2,14 @@ import isStringWithHttp from '.';
 
 describe('helpers/isStringWithHttp', () => {
   it('should add "http://" to beginning of string if missing in incoming string', () => {
-    const website = 'www.google.com';
+    const website = 'www.gov.uk';
 
     const result = isStringWithHttp(website);
     expect(result).toEqual(`http://${website}`);
   });
 
   it('should not add "http://" to beginning of string incoming string already contains "http://"', () => {
-    const website = 'https://www.google.com';
+    const website = 'https://www.gov.uk';
 
     const result = isStringWithHttp(website);
     expect(result).toEqual(website);

--- a/src/ui/server/helpers/is-valid-website-address/index.test.ts
+++ b/src/ui/server/helpers/is-valid-website-address/index.test.ts
@@ -34,7 +34,7 @@ describe('helpers/is-valid-website-address', () => {
   });
 
   it('should return true when website is in the correct format', () => {
-    const website = 'https://www.google.com';
+    const website = 'https://www.gov.uk';
 
     const result = isValidWebsiteAddress(website);
 
@@ -42,7 +42,7 @@ describe('helpers/is-valid-website-address', () => {
   });
 
   it('should return true when website is in the correct format but does not contain "www."', () => {
-    const website = 'https://google.com';
+    const website = 'https://gov.uk';
 
     const result = isValidWebsiteAddress(website);
 
@@ -50,7 +50,7 @@ describe('helpers/is-valid-website-address', () => {
   });
 
   it('should return true when website is in the correct format and has "/"', () => {
-    const website = 'https://google.com/123';
+    const website = 'https://gov.uk/123';
 
     const result = isValidWebsiteAddress(website);
 

--- a/src/ui/server/helpers/is-valid-website-address/index.test.ts
+++ b/src/ui/server/helpers/is-valid-website-address/index.test.ts
@@ -1,16 +1,16 @@
 import isValidWebsiteAddress from '.';
 
 describe('helpers/is-valid-website-address', () => {
-  it('should return false when website is not complete "http://www"', () => {
-    const website = 'http://www';
+  it('should return false when website is not complete "https://www"', () => {
+    const website = 'https://www';
 
     const result = isValidWebsiteAddress(website);
 
     expect(result).toEqual(false);
   });
 
-  it('should return false when website is not complete "http://google."', () => {
-    const website = 'http://google.';
+  it('should return false when website is not complete "https://google."', () => {
+    const website = 'https://google.';
 
     const result = isValidWebsiteAddress(website);
 
@@ -34,7 +34,7 @@ describe('helpers/is-valid-website-address', () => {
   });
 
   it('should return true when website is in the correct format', () => {
-    const website = 'http://www.google.com';
+    const website = 'https://www.google.com';
 
     const result = isValidWebsiteAddress(website);
 
@@ -42,7 +42,7 @@ describe('helpers/is-valid-website-address', () => {
   });
 
   it('should return true when website is in the correct format but does not contain "www."', () => {
-    const website = 'http://google.com';
+    const website = 'https://google.com';
 
     const result = isValidWebsiteAddress(website);
 
@@ -50,7 +50,7 @@ describe('helpers/is-valid-website-address', () => {
   });
 
   it('should return true when website is in the correct format and has "/"', () => {
-    const website = 'http://google.com/123';
+    const website = 'https://google.com/123';
 
     const result = isValidWebsiteAddress(website);
 

--- a/src/ui/server/helpers/mappings/map-application-to-form-fields/index.ts
+++ b/src/ui/server/helpers/mappings/map-application-to-form-fields/index.ts
@@ -35,7 +35,7 @@ const mapApplicationToFormFields = (application?: Application): object => {
       mapped[SUBMISSION_DEADLINE] = formatDate(application[SUBMISSION_DEADLINE]);
     }
 
-    if (application.policyAndExport && application.policyAndExport[REQUESTED_START_DATE]) {
+    if (application?.policyAndExport?.[REQUESTED_START_DATE]) {
       const timestamp = application.policyAndExport[REQUESTED_START_DATE];
 
       mapped.policyAndExport = {
@@ -44,7 +44,7 @@ const mapApplicationToFormFields = (application?: Application): object => {
       };
     }
 
-    if (application.policyAndExport && application.policyAndExport[CONTRACT_COMPLETION_DATE]) {
+    if (application?.policyAndExport?.[CONTRACT_COMPLETION_DATE]) {
       const timestamp = application.policyAndExport[CONTRACT_COMPLETION_DATE];
 
       mapped.policyAndExport = {
@@ -53,7 +53,7 @@ const mapApplicationToFormFields = (application?: Application): object => {
       };
     }
 
-    if (application.company && application.company[FINANCIAL_YEAR_END_DATE]) {
+    if (application?.company?.[FINANCIAL_YEAR_END_DATE]) {
       mapped.company = {
         ...mapped.company,
         [FINANCIAL_YEAR_END_DATE]: mapFinancialYearEndDate(application.company[FINANCIAL_YEAR_END_DATE]),

--- a/src/ui/server/helpers/mappings/map-applications/index.test.ts
+++ b/src/ui/server/helpers/mappings/map-applications/index.test.ts
@@ -16,7 +16,7 @@ describe('server/helpers/mappings/map-applications', () => {
         status,
         lastUpdated: formatDate(new Date(updatedAt)),
         referenceNumber,
-        buyerLocation: buyer?.country?.name || DEFAULT.EMPTY,
+        buyerLocation: buyer?.country?.name ?? DEFAULT.EMPTY,
         buyerName: replaceCharacterCodesWithCharacters(buyer.companyOrOrganisationName),
         insuredFor: mapInsuredFor(mockApplication),
       };

--- a/src/ui/server/helpers/mappings/map-applications/index.ts
+++ b/src/ui/server/helpers/mappings/map-applications/index.ts
@@ -17,7 +17,7 @@ export const mapApplication = (application: Application) => {
     status,
     lastUpdated: formatDate(new Date(updatedAt)),
     referenceNumber,
-    buyerLocation: buyer?.country?.name ?? DEFAULT.EMPTY,
+    buyerLocation: buyer.country?.name ? buyer.country.name : DEFAULT.EMPTY,
     buyerName: replaceCharacterCodesWithCharacters(buyer.companyOrOrganisationName) || DEFAULT.EMPTY,
     insuredFor: mapInsuredFor(application),
   };

--- a/src/ui/server/helpers/mappings/map-applications/index.ts
+++ b/src/ui/server/helpers/mappings/map-applications/index.ts
@@ -17,7 +17,7 @@ export const mapApplication = (application: Application) => {
     status,
     lastUpdated: formatDate(new Date(updatedAt)),
     referenceNumber,
-    buyerLocation: buyer?.country?.name || DEFAULT.EMPTY,
+    buyerLocation: buyer?.country?.name ?? DEFAULT.EMPTY,
     buyerName: replaceCharacterCodesWithCharacters(buyer.companyOrOrganisationName) || DEFAULT.EMPTY,
     insuredFor: mapInsuredFor(application),
   };

--- a/src/ui/server/helpers/mappings/map-financial-year-end-date.test.ts
+++ b/src/ui/server/helpers/mappings/map-financial-year-end-date.test.ts
@@ -25,7 +25,7 @@ describe('server/controllers/insurance/business/turnover/helpers/map-financial-y
 
   describe(`when ${FINANCIAL_YEAR_END_DATE} is undefined`, () => {
     it('should return formatted timestamp', () => {
-      const response = mapFinancialYearEndDate(undefined);
+      const response = mapFinancialYearEndDate();
 
       expect(response).toBeNull();
     });

--- a/src/ui/server/helpers/mappings/map-name-fields/index.ts
+++ b/src/ui/server/helpers/mappings/map-name-fields/index.ts
@@ -24,25 +24,25 @@ const mapNameFields = (application: Application): Application => {
     business.businessContactDetail[FIRST_NAME] = replaceCharacterCodesWithCharacters(fieldValue);
   }
 
-  if (business && business.businessContactDetail[LAST_NAME]) {
+  if (business?.businessContactDetail[LAST_NAME]) {
     const fieldValue = business.businessContactDetail[LAST_NAME];
 
     business.businessContactDetail[LAST_NAME] = replaceCharacterCodesWithCharacters(fieldValue);
   }
 
-  if (buyer && buyer[BUYER_NAME]) {
+  if (buyer?.[BUYER_NAME]) {
     const fieldValue = buyer[BUYER_NAME];
 
     buyer[BUYER_NAME] = replaceCharacterCodesWithCharacters(fieldValue);
   }
 
-  if (buyer && buyer[BUYER_CONTACT_FIRST_NAME]) {
+  if (buyer?.[BUYER_CONTACT_FIRST_NAME]) {
     const fieldValue = buyer[BUYER_CONTACT_FIRST_NAME];
 
     buyer[BUYER_CONTACT_FIRST_NAME] = replaceCharacterCodesWithCharacters(fieldValue);
   }
 
-  if (buyer && buyer[BUYER_CONTACT_LAST_NAME]) {
+  if (buyer?.[BUYER_CONTACT_LAST_NAME]) {
     const fieldValue = buyer[BUYER_CONTACT_LAST_NAME];
 
     buyer[BUYER_CONTACT_LAST_NAME] = replaceCharacterCodesWithCharacters(fieldValue);

--- a/src/ui/server/helpers/summary-lists/company-house-summary-list.test.ts
+++ b/src/ui/server/helpers/summary-lists/company-house-summary-list.test.ts
@@ -83,7 +83,7 @@ describe('server/helpers/summary-lists/company-house-summary-list', () => {
 
     describe('when there are no sic codes (undefined)', () => {
       it('should return default empty string', () => {
-        const result = generateSicCodesValue(undefined);
+        const result = generateSicCodesValue();
 
         const expected = DEFAULT.EMPTY;
 

--- a/src/ui/server/helpers/summary-lists/eligibility/index.ts
+++ b/src/ui/server/helpers/summary-lists/eligibility/index.ts
@@ -9,9 +9,7 @@ import generateEligibilityFields from './eligibility-fields';
  * @returns {Object} All your business values in an object structure for GOVUK summary list structure
  */
 const generateFields = (answersEligibility: InsuranceEligibility) => {
-  let fields = [] as Array<SummaryListItemData>;
-
-  fields = [...generateEligibilityFields(answersEligibility)];
+  const fields = [...generateEligibilityFields(answersEligibility)] as Array<SummaryListItemData>;
 
   return fields;
 };

--- a/src/ui/server/helpers/summary-lists/policy-and-export/index.ts
+++ b/src/ui/server/helpers/summary-lists/policy-and-export/index.ts
@@ -6,7 +6,7 @@ import generateCreditPeriodAndCurrencyFields from './credit-period-and-currency-
 import generateAboutGoodsOrServicesFields from './about-goods-or-services-fields';
 import generateSingleContractPolicyFields from './single-contract-policy-fields';
 import generateMultipleContractPolicyFields from './multiple-contract-policy-fields';
-import { ApplicationPolicyAndExport, Country, Currency, SummaryListItemData } from '../../../../types';
+import { ApplicationPolicyAndExport, Country, Currency } from '../../../../types';
 
 const {
   TYPE_OF_POLICY: { POLICY_TYPE },
@@ -26,7 +26,7 @@ const generateFields = (
   currencies: Array<Currency>,
   checkAndChange: boolean,
 ) => {
-  let fields = generatePolicyAndDateFields(answers, referenceNumber, checkAndChange) as Array<SummaryListItemData>;
+  let fields = generatePolicyAndDateFields(answers, referenceNumber, checkAndChange);
 
   if (isSinglePolicyType(answers[POLICY_TYPE])) {
     fields = [...fields, ...generateSingleContractPolicyFields(answers, referenceNumber, checkAndChange)];

--- a/src/ui/server/helpers/summary-lists/policy-and-export/index.ts
+++ b/src/ui/server/helpers/summary-lists/policy-and-export/index.ts
@@ -26,9 +26,7 @@ const generateFields = (
   currencies: Array<Currency>,
   checkAndChange: boolean,
 ) => {
-  let fields = [] as Array<SummaryListItemData>;
-
-  fields = generatePolicyAndDateFields(answers, referenceNumber, checkAndChange);
+  let fields = generatePolicyAndDateFields(answers, referenceNumber, checkAndChange) as Array<SummaryListItemData>;
 
   if (isSinglePolicyType(answers[POLICY_TYPE])) {
     fields = [...fields, ...generateSingleContractPolicyFields(answers, referenceNumber, checkAndChange)];

--- a/src/ui/server/helpers/summary-lists/your-business/index.ts
+++ b/src/ui/server/helpers/summary-lists/your-business/index.ts
@@ -28,14 +28,13 @@ const generateFields = (
   referenceNumber: number,
   checkAndChange: boolean,
 ) => {
-  let fields = [] as Array<SummaryListItemData>;
-  fields = [
+  const fields = [
     ...generateYourCompanyFields(answersCompany, referenceNumber, checkAndChange),
     ...generateBusinessContactFields(answersBusiness[BUSINESS_CONTACT_DETAIL], referenceNumber, checkAndChange),
     ...generateNatureOfYourBusinessFields(answersBusiness, referenceNumber, checkAndChange),
     ...generateTurnoverFields(answersBusiness, referenceNumber, checkAndChange),
     ...generateBrokerFields(answersBroker, referenceNumber, checkAndChange),
-  ];
+  ] as Array<SummaryListItemData>;
 
   return fields;
 };

--- a/src/ui/server/helpers/summary-lists/your-buyer/index.ts
+++ b/src/ui/server/helpers/summary-lists/your-buyer/index.ts
@@ -11,12 +11,10 @@ import { SummaryListItemData, ApplicationBuyer } from '../../../../types';
  * @returns {Object} All your business values in an object structure for GOVUK summary list structure
  */
 const generateFields = (answersBuyer: ApplicationBuyer, referenceNumber: number, checkAndChange: boolean) => {
-  let fields = [] as Array<SummaryListItemData>;
-
-  fields = [
+  const fields = [
     ...generateCompanyOrOrganisationFields(answersBuyer, referenceNumber, checkAndChange),
     ...workingWithBuyerFields(answersBuyer, referenceNumber, checkAndChange),
-  ];
+  ] as Array<SummaryListItemData>;
 
   return fields;
 };

--- a/src/ui/server/middleware/required-data-provided/helpers/index.ts
+++ b/src/ui/server/middleware/required-data-provided/helpers/index.ts
@@ -50,7 +50,7 @@ export const hasRequiredData = (
        * If the field is "buyer country"
        * We need to make sure that the country has support to apply or get a quote online
        */
-      if (submittedData[fieldId] && submittedData[fieldId].canApplyOnline) {
+      if (submittedData?.[fieldId].canApplyOnline) {
         suppliedDataCount += 1;
       }
     } else if (submittedData[fieldId] || submittedData[fieldId] === false) {

--- a/src/ui/server/middleware/required-data-provided/helpers/index.ts
+++ b/src/ui/server/middleware/required-data-provided/helpers/index.ts
@@ -50,7 +50,7 @@ export const hasRequiredData = (
        * If the field is "buyer country"
        * We need to make sure that the country has support to apply or get a quote online
        */
-      if (submittedData?.[fieldId].canApplyOnline) {
+      if (submittedData?.[fieldId]?.canApplyOnline) {
         suppliedDataCount += 1;
       }
     } else if (submittedData[fieldId] || submittedData[fieldId] === false) {

--- a/src/ui/server/shared-validation/website-address/index.test.ts
+++ b/src/ui/server/shared-validation/website-address/index.test.ts
@@ -16,7 +16,7 @@ describe('shared-validation/website', () => {
   });
 
   it('should NOT return an error when website is valid', () => {
-    const website = 'https://google.com';
+    const website = 'https://gov.uk';
 
     const result = validateWebsiteAddress(website, fieldId, errorMessage, errors);
 

--- a/src/ui/server/shared-validation/website-address/index.test.ts
+++ b/src/ui/server/shared-validation/website-address/index.test.ts
@@ -7,7 +7,7 @@ describe('shared-validation/website', () => {
   const errors = {};
 
   it('should return an error when website is invalid', () => {
-    const website = 'http://www';
+    const website = 'https://www';
 
     const result = validateWebsiteAddress(website, fieldId, errorMessage, errors);
     const expected = generateValidationErrors(fieldId, errorMessage);
@@ -16,7 +16,7 @@ describe('shared-validation/website', () => {
   });
 
   it('should NOT return an error when website is valid', () => {
-    const website = 'http://google.com';
+    const website = 'https://google.com';
 
     const result = validateWebsiteAddress(website, fieldId, errorMessage, errors);
 

--- a/src/ui/server/test-mocks/mock-buyer.ts
+++ b/src/ui/server/test-mocks/mock-buyer.ts
@@ -10,7 +10,7 @@ const mockBuyer = {
     name: 'United Kingdom',
   },
   registrationNumber: '1234',
-  website: 'www.google.com',
+  website: 'www.gov.uk',
   contactFirstName: 'Bob',
   contactLastName: 'Smith',
   contactPosition: 'CEO',


### PR DESCRIPTION
This PR fixes some security and code smell issues reported by SonarCloud on the `main-application` branch.

## Changes
- Wrap some "expected message" test assertions (that use content strings) in a `String()`.
- Simplify various conditions and destructurings.
- Remove some commented code.
- Remove some unnecessary type declarations.
- Add "https" to some mock website strings.
- Remove a `throw new Error()` from an E2E API call as this was throwing false errors (where a call to delete account does not return successful because the account does not exist.
- Change all instances of "google.com" to "gov.uk"