### PR TITLE
security(EMS-1820): Consume and sanitise only specific query params

### DIFF
--- a/src/ui/server/index.ts
+++ b/src/ui/server/index.ts
@@ -10,7 +10,7 @@ import csrf from 'csurf';
 import path from 'path';
 import flash from 'connect-flash';
 import basicAuth from 'express-basic-auth';
-import { csrf as csrfToken, cookiesConsent, security, seo } from './middleware';
+import { csrf as csrfToken, cookiesConsent, security, seo, queryParams } from './middleware';
 import { Request, Response } from '../types';
 
 import * as dotenv from 'dotenv';
@@ -44,6 +44,7 @@ const secureCookieName = https ? '__Host-exip-session' : 'exip-session';
 app1.use(seo);
 app1.use(security);
 app1.use(compression());
+app1.use(queryParams);
 
 const limiter = rateLimit({
   windowMs: 1 * 60 * 1000, // 1 minute

--- a/src/ui/server/middleware/index.ts
+++ b/src/ui/server/middleware/index.ts
@@ -2,3 +2,4 @@ export * from './csrf';
 export * from './headers/security';
 export * from './headers/seo';
 export * from './cookies-consent';
+export * from './query-params';

--- a/src/ui/server/middleware/query-params/index.test.ts
+++ b/src/ui/server/middleware/query-params/index.test.ts
@@ -1,0 +1,92 @@
+import { queryParams } from '.';
+import { replaceCharactersWithCharacterCode } from '../../helpers/sanitise-data';
+import { mockReq, mockRes } from '../../test-mocks';
+import { Request, Response } from '../../../types';
+
+describe('middleware/query-params', () => {
+  const req: Request = mockReq();
+  const res: Response = mockRes();
+
+  const nextSpy = jest.fn();
+  const statusSpy = jest.fn();
+
+  res.status = statusSpy;
+
+  req.query = {};
+
+  const mockId = 'mock-id';
+  const mockToken = 'mock-token';
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('when query params is populated with a single allowed param (id)', () => {
+    it('should sanitise and return the param', () => {
+      req.query = {
+        id: mockId,
+      };
+
+      queryParams(req, res, nextSpy);
+
+      const expected = {
+        id: replaceCharactersWithCharacterCode(mockId),
+      };
+
+      expect(req.query).toEqual(expected);
+    });
+  });
+
+  describe('when query params is populated with a single allowed param (token)', () => {
+    it('should sanitise and return the param', () => {
+      req.query = {
+        token: mockToken,
+      };
+
+      queryParams(req, res, nextSpy);
+
+      const expected = {
+        token: replaceCharactersWithCharacterCode(mockToken),
+      };
+
+      expect(req.query).toEqual(expected);
+    });
+  });
+
+  describe('when query params is populated with a multiple allowed params over MAXIMUM_PARAMS', () => {
+    // it('should sanitise and return only the first param', () => {
+    it('should return 400 status', () => {
+      req.query = {
+        id: mockId,
+        token: mockToken,
+      };
+
+      queryParams(req, res, nextSpy);
+
+      expect(statusSpy).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('when query params is populated with a disallowed param', () => {
+    it('should return 400 status', () => {
+      req.query = {
+        // @ts-ignore
+        notAllowed: mockId,
+      };
+
+      queryParams(req, res, nextSpy);
+
+      expect(statusSpy).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('when no params are provided', () => {
+    it('should call next()', () => {
+      req.query = {};
+
+      queryParams(req, res, nextSpy);
+
+      expect(nextSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/ui/server/middleware/query-params/index.ts
+++ b/src/ui/server/middleware/query-params/index.ts
@@ -1,0 +1,61 @@
+import { replaceCharactersWithCharacterCode } from '../../helpers/sanitise-data';
+import { Request, Response } from '../../../types';
+
+const ALLOWED_PARAMS = ['id', 'token'];
+const MAXIMUM_PARAMS = 1;
+
+/**
+ * Global middleware, ensures that only allowed query parameters are consumed and sanitised.
+ * @param {Object} req Request object
+ * @param {Object} res Response object
+ * @param {String} next Callback function name
+ */
+export const queryParams = (req: Request, res: Response, next: () => void) => {
+  const arr = Object.keys(req.query);
+
+  if (arr.length) {
+    /**
+     * Filter out any params that are not in the allowed list.
+     * We do not need to care or consume any params that are not used.
+     */
+    const filtered = arr.filter((key) => ALLOWED_PARAMS.includes(key));
+
+    if (filtered.length) {
+      /**
+       * If the filtered list is above MAXIMUM_PARAMS,
+       * this indicates that someone could be trying to tamper with the system.
+       * Therefore, reject the request.
+       */
+      if (filtered.length > MAXIMUM_PARAMS) {
+        return res.status(400);
+      }
+
+      /**
+       * Only one allowed query param has been provided.
+       * 1) Get the key.
+       * 2) Get the value.
+       * 3) Santise the value
+       * 4) Construct a fresh query object.
+       */
+      const [firstKey] = filtered;
+      const firstValue = req.query[firstKey];
+
+      const sanitisedValue = replaceCharactersWithCharacterCode(firstValue);
+
+      req.query = {
+        [firstKey]: sanitisedValue,
+      };
+
+      return next();
+    }
+
+    /**
+     * Filtered query params do not match anything in the allowed list.
+     * this indicates that someone could be trying to tamper with the system.
+     * Therefore, reject the request.
+     */
+    return res.status(400);
+  }
+
+  next();
+};

--- a/src/ui/server/test-mocks/index.ts
+++ b/src/ui/server/test-mocks/index.ts
@@ -55,6 +55,7 @@ const mockRes = () => {
 
   res.redirect = jest.fn();
   res.render = jest.fn();
+  res.status = jest.fn();
 
   res.locals = {
     csrfToken: 'mock',

--- a/src/ui/types/express/index.d.ts
+++ b/src/ui/types/express/index.d.ts
@@ -84,6 +84,7 @@ interface Response {
   locals: ResponseLocals;
   setHeader: (str1: string, str2?: string) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
   removeHeader: (str1: string) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  status: (status: number) => any;
 }
 
 declare module 'express-session' {


### PR DESCRIPTION
This PR adds some new security middleware to the UI so that we only consume and sanitise specific, allowed query parameters.

## Changes

- Create new middlware to:
  - Filter only query params that the service cares about via `ALLOWED_PARAMS` definition.
  - Check if query params exceeds the maximum that we will consume (1 - `MAXIMUM_PARAMS`). If so, reject the request.
  - If there is only 1 allowed parameter in the request, specifically strip and sanitise the value and reconstruct the query params.
  - If only invalid query params are in the request, reject the request.