### PR TITLE
chore(EMS-1785): Check for existing account in keystone account creation resolver

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -4426,10 +4426,10 @@ var keystone_default = withAuth(
     server: {
       port: 5001,
       extendExpressApp: (app) => {
-        app.use(check_api_key_default);
         if (NODE_ENV === "production") {
           app.use(rate_limiter_default);
         }
+        app.use(check_api_key_default);
       }
     },
     db: {

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -573,6 +573,29 @@ var updateApplication = {
 };
 var update_application_default = updateApplication;
 
+// helpers/get-account-by-field/index.ts
+var getAccountByField = async (context, field, value) => {
+  try {
+    console.info("Getting account by field/value");
+    const accountsArray = await context.db.Account.findMany({
+      where: {
+        [field]: { equals: value }
+      },
+      take: 1
+    });
+    if (!accountsArray?.length || !accountsArray[0]) {
+      console.info("Getting account by field - no account exists with the provided field/value");
+      return false;
+    }
+    const account = accountsArray[0];
+    return account;
+  } catch (err) {
+    console.error(err);
+    throw new Error(`Getting account by field/value ${err}`);
+  }
+};
+var get_account_by_field_default = getAccountByField;
+
 // schema.ts
 var lists = {
   ReferenceNumber: {
@@ -908,6 +931,18 @@ var lists = {
         ref: "Application",
         many: true
       })
+    },
+    hooks: {
+      validateInput: async ({ context, operation, resolvedData }) => {
+        if (operation === "create") {
+          const { email } = resolvedData;
+          const requestedEmail = String(email);
+          const account = await get_account_by_field_default(context, account_default.EMAIL, requestedEmail);
+          if (account) {
+            throw new Error(`Unable to create a new account for ${requestedEmail} - account already exists`);
+          }
+        }
+      }
     },
     access: import_access.allowAll
   }),
@@ -1604,29 +1639,6 @@ var type_defs_default = typeDefs;
 // custom-resolvers/mutations/create-an-account/index.ts
 var import_crypto2 = __toESM(require("crypto"));
 
-// helpers/get-account-by-field/index.ts
-var getAccountByField = async (context, field, value) => {
-  try {
-    console.info("Getting account by field/value");
-    const accountsArray = await context.db.Account.findMany({
-      where: {
-        [field]: { equals: value }
-      },
-      take: 1
-    });
-    if (!accountsArray?.length || !accountsArray[0]) {
-      console.info("Getting account by field - no account exists with the provided field/value");
-      return false;
-    }
-    const account = accountsArray[0];
-    return account;
-  } catch (err) {
-    console.error(err);
-    throw new Error(`Getting account by field/value ${err}`);
-  }
-};
-var get_account_by_field_default = getAccountByField;
-
 // helpers/encrypt-password/index.ts
 var import_crypto = __toESM(require("crypto"));
 var { ENCRYPTION } = ACCOUNT2;
@@ -1947,7 +1959,7 @@ var createAnAccount = async (root, variables, context) => {
   console.info("Creating new account for ", variables.email);
   try {
     const { urlOrigin, firstName, lastName, email, password: password2 } = variables;
-    const account = await get_account_by_field_default(context, "email", email);
+    const account = await get_account_by_field_default(context, account_default.EMAIL, email);
     if (account) {
       console.info(`Unable to create a new account for ${variables.email} - account already exists`);
       return { success: false };

--- a/src/api/custom-resolvers/mutations/account-password-reset/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-password-reset/index.test.ts
@@ -45,7 +45,7 @@ describe('custom-resolvers/account-password-reset', () => {
 
     expect(authEntries.length).toEqual(0);
 
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     // create an AuthenticationRetry so we can assert it becomes wiped.
     await createAuthenticationRetryEntry(context, account.id);
@@ -224,7 +224,7 @@ describe('custom-resolvers/account-password-reset', () => {
   describe('when the provided password has been used before', () => {
     test('it should return success=false and hasBeenUsedBefore=true', async () => {
       // create an account
-      account = await accounts.create(context);
+      account = await accounts.create({ context });
 
       const authEntry = {
         account: {

--- a/src/api/custom-resolvers/mutations/account-sign-in-new-code/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in-new-code/index.test.ts
@@ -30,7 +30,7 @@ describe('custom-resolvers/account-sign-in-new-code', () => {
   beforeEach(async () => {
     await accounts.deleteAll(context);
 
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     jest.resetAllMocks();
 

--- a/src/api/custom-resolvers/mutations/account-sign-in/account-checks/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/account-checks/index.test.ts
@@ -57,7 +57,7 @@ describe('custom-resolvers/account-sign-in/account-checks', () => {
     });
 
     // create an account
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     jest.resetAllMocks();
 

--- a/src/api/custom-resolvers/mutations/account-sign-in/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/index.test.ts
@@ -59,7 +59,7 @@ describe('custom-resolvers/account-sign-in', () => {
         where: retries,
       });
 
-      account = await accounts.create(context);
+      account = await accounts.create({ context });
 
       result = await accountSignIn({}, variables, context);
     });
@@ -97,7 +97,7 @@ describe('custom-resolvers/account-sign-in', () => {
         where: retries,
       });
 
-      account = await accounts.create(context);
+      account = await accounts.create({ context });
 
       result = await accountSignIn({}, variables, context);
 
@@ -128,10 +128,12 @@ describe('custom-resolvers/account-sign-in', () => {
         await accounts.deleteAll(context);
 
         // create a new account and ensure it is not blocked so that we have a clean slate.
-        account = await accounts.create(context, {
+        const unblockedAccount = {
           ...mockAccount,
           isBlocked: false,
-        });
+        };
+
+        account = await accounts.create({ context, accountData: unblockedAccount });
 
         // wipe the AuthenticationRetry table so we have a clean slate.
         retries = await context.query.AuthenticationRetry.findMany();
@@ -170,7 +172,7 @@ describe('custom-resolvers/account-sign-in', () => {
       beforeEach(async () => {
         await accounts.deleteAll(context);
 
-        account = await accounts.create(context);
+        account = await accounts.create({ context });
 
         account = (await context.query.Account.updateOne({
           where: { id: account.id },

--- a/src/api/custom-resolvers/mutations/account-sign-in/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/index.test.ts
@@ -133,7 +133,7 @@ describe('custom-resolvers/account-sign-in', () => {
           isBlocked: false,
         };
 
-        account = await accounts.create({ context, accountData: unblockedAccount });
+        account = await accounts.create({ context, data: unblockedAccount });
 
         // wipe the AuthenticationRetry table so we have a clean slate.
         retries = await context.query.AuthenticationRetry.findMany();

--- a/src/api/custom-resolvers/mutations/add-and-get-OTP/index.test.ts
+++ b/src/api/custom-resolvers/mutations/add-and-get-OTP/index.test.ts
@@ -23,7 +23,7 @@ describe('custom-resolvers/add-and-get-OTP', () => {
   beforeEach(async () => {
     await accounts.deleteAll(context);
 
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     result = await addAndGetOTP({}, variables, context);
 

--- a/src/api/custom-resolvers/mutations/create-an-account/index.ts
+++ b/src/api/custom-resolvers/mutations/create-an-account/index.ts
@@ -1,6 +1,7 @@
 import { Context } from '.keystone/types'; // eslint-disable-line
 import crypto from 'crypto';
 import { ACCOUNT } from '../../../constants';
+import ACCOUNT_FIELD_IDS from '../../../constants/field-ids/insurance/account';
 import getAccountByField from '../../../helpers/get-account-by-field';
 import encryptPassword from '../../../helpers/encrypt-password';
 import getFullNameString from '../../../helpers/get-full-name-string';
@@ -24,7 +25,7 @@ const createAnAccount = async (root: any, variables: AccountCreationVariables, c
     const { urlOrigin, firstName, lastName, email, password } = variables;
 
     // check if an account with the email already exists
-    const account = await getAccountByField(context, 'email', email);
+    const account = await getAccountByField(context, ACCOUNT_FIELD_IDS.EMAIL, email);
 
     if (account) {
       console.info(`Unable to create a new account for ${variables.email} - account already exists`);

--- a/src/api/custom-resolvers/mutations/delete-an-account/index.test.ts
+++ b/src/api/custom-resolvers/mutations/delete-an-account/index.test.ts
@@ -18,7 +18,7 @@ describe('custom-resolvers/delete-an-account', () => {
   beforeAll(async () => {
     await accounts.deleteAll(context);
 
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
   });
 
   test('it should return success=true', async () => {
@@ -35,7 +35,7 @@ describe('custom-resolvers/delete-an-account', () => {
     let retries;
 
     beforeEach(async () => {
-      account = await accounts.create(context);
+      account = await accounts.create({ context });
 
       // wipe the table so we have a clean slate.
       retries = await context.query.AuthenticationRetry.findMany();

--- a/src/api/custom-resolvers/mutations/send-email-confirm-email-address/index.test.ts
+++ b/src/api/custom-resolvers/mutations/send-email-confirm-email-address/index.test.ts
@@ -19,7 +19,7 @@ describe('custom-resolvers/send-email-confirm-email-address', () => {
   });
 
   beforeEach(async () => {
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     variables = {
       urlOrigin: 'https://mock-origin.com',

--- a/src/api/custom-resolvers/mutations/send-email-password-reset-link/index.test.ts
+++ b/src/api/custom-resolvers/mutations/send-email-password-reset-link/index.test.ts
@@ -47,7 +47,7 @@ describe('custom-resolvers/send-email-password-reset-link', () => {
       where: retries,
     });
 
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     jest.resetAllMocks();
 

--- a/src/api/custom-resolvers/mutations/send-email-reactivate-account-link/index.test.ts
+++ b/src/api/custom-resolvers/mutations/send-email-reactivate-account-link/index.test.ts
@@ -38,7 +38,7 @@ describe('custom-resolvers/send-email-reactivate-account-link', () => {
 
     const blockedAccount = { ...mockAccount, isBlocked: true };
 
-    account = await accounts.create(context, blockedAccount);
+    account = await accounts.create({ context, accountData: blockedAccount });
 
     jest.resetAllMocks();
 

--- a/src/api/custom-resolvers/mutations/send-email-reactivate-account-link/index.test.ts
+++ b/src/api/custom-resolvers/mutations/send-email-reactivate-account-link/index.test.ts
@@ -38,7 +38,7 @@ describe('custom-resolvers/send-email-reactivate-account-link', () => {
 
     const blockedAccount = { ...mockAccount, isBlocked: true };
 
-    account = await accounts.create({ context, accountData: blockedAccount });
+    account = await accounts.create({ context, data: blockedAccount });
 
     jest.resetAllMocks();
 

--- a/src/api/custom-resolvers/mutations/verify-account-email-address/index.test.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-email-address/index.test.ts
@@ -61,7 +61,7 @@ describe('custom-resolvers/verify-account-email-address', () => {
       verificationExpiry,
     };
 
-    account = await accounts.create(context, unverifiedAccount);
+    account = await accounts.create({ context, accountData: unverifiedAccount });
 
     expect(account.isVerified).toEqual(false);
 
@@ -111,7 +111,7 @@ describe('custom-resolvers/verify-account-email-address', () => {
         [VERIFICATION_EXPIRY]: oneMinuteInThePast,
       };
 
-      account = await accounts.create(context, accountVerificationExpired);
+      account = await accounts.create({ context, accountData: accountVerificationExpired });
 
       result = await verifyAccountEmailAddress({}, variables, context);
 

--- a/src/api/custom-resolvers/mutations/verify-account-email-address/index.test.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-email-address/index.test.ts
@@ -61,7 +61,7 @@ describe('custom-resolvers/verify-account-email-address', () => {
       verificationExpiry,
     };
 
-    account = await accounts.create({ context, accountData: unverifiedAccount });
+    account = await accounts.create({ context, data: unverifiedAccount });
 
     expect(account.isVerified).toEqual(false);
 
@@ -111,7 +111,7 @@ describe('custom-resolvers/verify-account-email-address', () => {
         [VERIFICATION_EXPIRY]: oneMinuteInThePast,
       };
 
-      account = await accounts.create({ context, accountData: accountVerificationExpired });
+      account = await accounts.create({ context, data: accountVerificationExpired });
 
       result = await verifyAccountEmailAddress({}, variables, context);
 

--- a/src/api/custom-resolvers/mutations/verify-account-reactivation-token/index.test.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-reactivation-token/index.test.ts
@@ -64,7 +64,7 @@ describe('custom-resolvers/verify-account-reactivation-token', () => {
       reactivationExpiry,
     };
 
-    account = await accounts.create({ context, accountData: unverifiedAndBlockedAccount });
+    account = await accounts.create({ context, data: unverifiedAndBlockedAccount });
 
     expect(account.isVerified).toEqual(false);
     expect(account.isBlocked).toEqual(true);
@@ -129,7 +129,7 @@ describe('custom-resolvers/verify-account-reactivation-token', () => {
         [REACTIVATION_EXPIRY]: oneMinuteInThePast,
       };
 
-      account = await accounts.create({ context, accountData: accountBlockedAndReactivationExpired });
+      account = await accounts.create({ context, data: accountBlockedAndReactivationExpired });
 
       result = await verifyAccountReactivationToken({}, variables, context);
 

--- a/src/api/custom-resolvers/mutations/verify-account-reactivation-token/index.test.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-reactivation-token/index.test.ts
@@ -64,7 +64,7 @@ describe('custom-resolvers/verify-account-reactivation-token', () => {
       reactivationExpiry,
     };
 
-    account = await accounts.create(context, unverifiedAndBlockedAccount);
+    account = await accounts.create({ context, accountData: unverifiedAndBlockedAccount });
 
     expect(account.isVerified).toEqual(false);
     expect(account.isBlocked).toEqual(true);
@@ -129,7 +129,7 @@ describe('custom-resolvers/verify-account-reactivation-token', () => {
         [REACTIVATION_EXPIRY]: oneMinuteInThePast,
       };
 
-      account = await accounts.create(context, accountBlockedAndReactivationExpired);
+      account = await accounts.create({ context, accountData: accountBlockedAndReactivationExpired });
 
       result = await verifyAccountReactivationToken({}, variables, context);
 

--- a/src/api/custom-resolvers/mutations/verify-account-sign-in-code/index.test.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-sign-in-code/index.test.ts
@@ -34,7 +34,7 @@ describe('custom-resolvers/verify-account-sign-in-code', () => {
   create.JWT = () => mockJWT;
 
   beforeEach(async () => {
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     // wipe the AuthenticationRetry table so we have a clean slate.
     retries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
@@ -163,7 +163,7 @@ describe('custom-resolvers/verify-account-sign-in-code', () => {
 
   describe(`when the account's OTP has expired`, () => {
     beforeAll(async () => {
-      account = await accounts.create(context);
+      account = await accounts.create({ context });
     });
 
     const otp = generate.otp();
@@ -212,7 +212,7 @@ describe('custom-resolvers/verify-account-sign-in-code', () => {
 
   describe('when the account does not have OTP salt, hash or expiry', () => {
     test('it should return success=false', async () => {
-      account = await accounts.create(context);
+      account = await accounts.create({ context });
 
       result = await verifyAccountSignInCode({}, variables, context);
 

--- a/src/api/custom-resolvers/queries/get-account-password-reset-token/index.test.ts
+++ b/src/api/custom-resolvers/queries/get-account-password-reset-token/index.test.ts
@@ -23,7 +23,7 @@ describe('custom-resolvers/get-account-password-reset-token', () => {
   beforeEach(async () => {
     await accounts.deleteAll(context);
 
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     result = await getAccountPasswordResetToken({}, variables, context);
   });

--- a/src/api/custom-resolvers/queries/verify-account-password-reset-token/index.test.ts
+++ b/src/api/custom-resolvers/queries/verify-account-password-reset-token/index.test.ts
@@ -24,7 +24,7 @@ describe('custom-resolvers/verify-account-password-reset-token', () => {
   beforeEach(async () => {
     await accounts.deleteAll(context);
 
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     result = await verifyAccountPasswordResetToken({}, variables, context);
   });

--- a/src/api/helpers/account-has-used-password-before/index.test.ts
+++ b/src/api/helpers/account-has-used-password-before/index.test.ts
@@ -23,7 +23,7 @@ describe('helpers/account-has-used-password-before', () => {
   let mockEntry: object;
 
   beforeAll(async () => {
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     // wipe the Authentication table so we have a clean slate.
     const retries = await context.query.Authentication.findMany();

--- a/src/api/helpers/block-account/index.test.ts
+++ b/src/api/helpers/block-account/index.test.ts
@@ -25,7 +25,7 @@ describe('helpers/block-account', () => {
       isBlocked: false,
     };
 
-    account = await accounts.create({ context, accountData: unblockedAccount });
+    account = await accounts.create({ context, data: unblockedAccount });
 
     result = await blockAccount(context, account.id);
   });

--- a/src/api/helpers/block-account/index.test.ts
+++ b/src/api/helpers/block-account/index.test.ts
@@ -25,7 +25,7 @@ describe('helpers/block-account', () => {
       isBlocked: false,
     };
 
-    account = await accounts.create(context, unblockedAccount);
+    account = await accounts.create({ context, accountData: unblockedAccount });
 
     result = await blockAccount(context, account.id);
   });

--- a/src/api/helpers/create-authentication-entry/index.test.ts
+++ b/src/api/helpers/create-authentication-entry/index.test.ts
@@ -29,7 +29,7 @@ describe('helpers/create-authentication-entry', () => {
 
     expect(entries.length).toEqual(0);
 
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     const authEntry = {
       account: {

--- a/src/api/helpers/create-authentication-retry-entry/index.test.ts
+++ b/src/api/helpers/create-authentication-retry-entry/index.test.ts
@@ -18,7 +18,7 @@ describe('helpers/create-authentication-retry-entry', () => {
   let account: Account;
 
   beforeAll(async () => {
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     // wipe the AuthenticationRetry table so we have a clean slate.
     const retries = await context.query.AuthenticationRetry.findMany();

--- a/src/api/helpers/delete-authentication-retries/index.test.ts
+++ b/src/api/helpers/delete-authentication-retries/index.test.ts
@@ -30,7 +30,7 @@ describe('helpers/delete-authentication-retries', () => {
       where: retries,
     });
 
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     // create some entries
     const mockEntry = {

--- a/src/api/helpers/generate-otp-and-update-account/index.test.ts
+++ b/src/api/helpers/generate-otp-and-update-account/index.test.ts
@@ -28,7 +28,7 @@ describe('helpers/generate-otp-and-update-account', () => {
   beforeEach(async () => {
     await accounts.deleteAll(context);
 
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     result = await generateOTPAndUpdateAccount(context, account.id);
 

--- a/src/api/helpers/get-account-by-field/index.test.ts
+++ b/src/api/helpers/get-account-by-field/index.test.ts
@@ -24,7 +24,7 @@ describe('helpers/get-account-by-field', () => {
   beforeEach(async () => {
     await accounts.deleteAll(context);
 
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
   });
 
   it('should return an account by ID', async () => {

--- a/src/api/helpers/get-account-by-id/index.test.ts
+++ b/src/api/helpers/get-account-by-id/index.test.ts
@@ -18,7 +18,7 @@ describe('helpers/get-account-by-id', () => {
   let account: Account;
 
   beforeEach(async () => {
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
   });
 
   it('should return an account/account by ID', async () => {

--- a/src/api/helpers/get-authentication-retries-by-account-id/index.test.ts
+++ b/src/api/helpers/get-authentication-retries-by-account-id/index.test.ts
@@ -32,7 +32,7 @@ describe('helpers/get-authentication-retries-by-account-id', () => {
       isBlocked: false,
     };
 
-    account = await accounts.create({ context, accountData: unblockedAccount });
+    account = await accounts.create({ context, data: unblockedAccount });
 
     // create some new entries
     await createAuthenticationRetryEntry(context, account.id);

--- a/src/api/helpers/get-authentication-retries-by-account-id/index.test.ts
+++ b/src/api/helpers/get-authentication-retries-by-account-id/index.test.ts
@@ -32,7 +32,7 @@ describe('helpers/get-authentication-retries-by-account-id', () => {
       isBlocked: false,
     };
 
-    account = await accounts.create(context, unblockedAccount);
+    account = await accounts.create({ context, accountData: unblockedAccount });
 
     // create some new entries
     await createAuthenticationRetryEntry(context, account.id);

--- a/src/api/helpers/send-email-confirm-email-address/index.test.ts
+++ b/src/api/helpers/send-email-confirm-email-address/index.test.ts
@@ -29,7 +29,7 @@ describe('helpers/send-email-confirm-email-address', () => {
   });
 
   beforeEach(async () => {
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
 
     jest.resetAllMocks();
 

--- a/src/api/helpers/should-block-account/index.test.ts
+++ b/src/api/helpers/should-block-account/index.test.ts
@@ -25,7 +25,7 @@ describe('helpers/should-block-account', () => {
   beforeEach(async () => {
     await accounts.deleteAll(context);
 
-    account = await accounts.create(context);
+    account = await accounts.create({ context });
   });
 
   describe(`when the account has ${MAX_AUTH_RETRIES} entries in the AuthenticationRetry table that are within MAX_AUTH_RETRIES_TIMEFRAME`, () => {

--- a/src/api/keystone.test.ts
+++ b/src/api/keystone.test.ts
@@ -257,7 +257,7 @@ describe('Account', () => {
 
     describe('when an account already exists with the provided email', () => {
       test('it should not create the account', async () => {
-        const response = (await accounts.create({ context, accountData: mockAccount, deleteAccounts: false })) as Account;
+        const response = (await accounts.create({ context, data: mockAccount, deleteAccounts: false })) as Account;
 
         expect(response.id).toBeUndefined();
         expect(response.email).toBeUndefined();

--- a/src/api/keystone.test.ts
+++ b/src/api/keystone.test.ts
@@ -6,6 +6,7 @@ import * as PrismaModule from '.prisma/client'; // eslint-disable-line import/no
 import { APPLICATION } from './constants';
 import updateApplication from './helpers/update-application';
 import accounts from './test-helpers/accounts';
+import { mockAccount } from './test-mocks';
 import { Application, Account } from './types';
 
 const dbUrl = String(process.env.DATABASE_URL);
@@ -249,15 +250,34 @@ describe('Create an Application', () => {
 describe('Account', () => {
   let account: Account;
 
+  describe('create', () => {
+    beforeAll(async () => {
+      await accounts.create({ context });
+    });
+
+    describe('when an account already exists with the provided email', () => {
+      test('it should not create the account', async () => {
+        const response = (await accounts.create({ context, accountData: mockAccount, deleteAccounts: false })) as Account;
+
+        expect(response.id).toBeUndefined();
+        expect(response.email).toBeUndefined();
+
+        const allAccounts = await context.query.Account.findMany();
+
+        expect(allAccounts.length).toEqual(1);
+      });
+    });
+  });
+
   describe('update', () => {
-    let updatedExporter: Account;
+    let updatedAccount: Account;
 
     const accountUpdate = { firstName: 'Updated' };
 
     beforeAll(async () => {
-      account = await accounts.create(context);
+      account = await accounts.create({ context });
 
-      updatedExporter = (await context.query.Account.updateOne({
+      updatedAccount = (await context.query.Account.updateOne({
         where: { id: account.id },
         data: accountUpdate,
         query: 'id createdAt updatedAt firstName lastName email salt hash isVerified verificationHash verificationExpiry',
@@ -265,11 +285,11 @@ describe('Account', () => {
     });
 
     test('it should update the provided fields', () => {
-      expect(updatedExporter.firstName).toEqual(accountUpdate.firstName);
+      expect(updatedAccount.firstName).toEqual(accountUpdate.firstName);
     });
 
     test('it should update updatedAt', () => {
-      expect(updatedExporter.updatedAt).not.toEqual(account.createdAt);
+      expect(updatedAccount.updatedAt).not.toEqual(account.createdAt);
     });
   });
 });

--- a/src/api/keystone.ts
+++ b/src/api/keystone.ts
@@ -15,11 +15,11 @@ export default withAuth(
     server: {
       port: 5001,
       extendExpressApp: (app) => {
-        app.use(checkApiKey);
-
         if (NODE_ENV === 'production') {
           app.use(rateLimiter);
         }
+
+        app.use(checkApiKey);
       },
     },
     db: {

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -5,7 +5,9 @@ import { document } from '@keystone-6/fields-document';
 import { addMonths } from 'date-fns';
 import { Lists } from '.keystone/types'; // eslint-disable-line
 import { ANSWERS, APPLICATION, FEEDBACK } from './constants';
+import ACCOUNT_FIELD_IDS from './constants/field-ids/insurance/account';
 import updateApplication from './helpers/update-application';
+import getAccountByField from './helpers/get-account-by-field';
 
 export const lists = {
   ReferenceNumber: {
@@ -404,6 +406,25 @@ export const lists = {
         ref: 'Application',
         many: true,
       }),
+    },
+    hooks: {
+      validateInput: async ({ context, operation, resolvedData }) => {
+        if (operation === 'create') {
+          const { email } = resolvedData;
+
+          const requestedEmail = String(email);
+
+          /**
+           * Check if an account with the email already exists.
+           * If so, reject.
+           */
+          const account = await getAccountByField(context, ACCOUNT_FIELD_IDS.EMAIL, requestedEmail);
+
+          if (account) {
+            throw new Error(`Unable to create a new account for ${requestedEmail} - account already exists`);
+          }
+        }
+      },
     },
     access: allowAll,
   }),

--- a/src/api/test-helpers/accounts.ts
+++ b/src/api/test-helpers/accounts.ts
@@ -1,6 +1,6 @@
 import { Context } from '.keystone/types'; // eslint-disable-line
 import { mockAccount } from '../test-mocks';
-import { Account } from '../types';
+import { Account, TestHelperAccountCreate } from '../types';
 
 /**
  * deleteAll test helper
@@ -29,12 +29,6 @@ const deleteAll = async (context: Context) => {
   }
 };
 
-interface TestHelperAccountCreate {
-  context: Context;
-  accountData?: Account;
-  deleteAccounts?: boolean;
-}
-
 /**
  * create account test helper
  * Create an account with mock account data and any provied custom account data.
@@ -42,7 +36,7 @@ interface TestHelperAccountCreate {
  * @param {Object} Account data
  * @returns {Object} Created account
  */
-const create = async ({ context, accountData, deleteAccounts = true }: TestHelperAccountCreate) => {
+const create = async ({ context, data, deleteAccounts = true }: TestHelperAccountCreate) => {
   try {
     console.info('Creating an account (test helpers)');
 
@@ -52,8 +46,8 @@ const create = async ({ context, accountData, deleteAccounts = true }: TestHelpe
 
     let accountInput = mockAccount;
 
-    if (accountData) {
-      accountInput = accountData;
+    if (data) {
+      accountInput = data;
     }
 
     const account = (await context.query.Account.createOne({

--- a/src/api/test-helpers/accounts.ts
+++ b/src/api/test-helpers/accounts.ts
@@ -3,36 +3,6 @@ import { mockAccount } from '../test-mocks';
 import { Account } from '../types';
 
 /**
- * create account test helper
- * Create an account with mock account data and any provied custom account data.
- * @param {Object} KeystoneJS context API
- * @param {Object} Account data
- * @returns {Object} Created account
- */
-const create = async (context: Context, accountData?: Account) => {
-  try {
-    console.info('Creating an account (test helpers)');
-
-    let accountInput = mockAccount;
-
-    if (accountData) {
-      accountInput = accountData;
-    }
-
-    const account = (await context.query.Account.createOne({
-      data: accountInput,
-      query:
-        'id email firstName lastName email salt hash verificationHash sessionExpiry otpExpiry reactivationHash reactivationExpiry isVerified isBlocked passwordResetHash passwordResetExpiry',
-    })) as Account;
-
-    return account;
-  } catch (err) {
-    console.error(err);
-    throw new Error(`Creating an account (test helpers) ${err}`);
-  }
-};
-
-/**
  * deleteAll test helper
  * Get all accounts and delete them.
  * @param {Object} KeystoneJS context API
@@ -56,6 +26,47 @@ const deleteAll = async (context: Context) => {
   } catch (err) {
     console.error(err);
     throw new Error(`Getting and deleting accounts (test helpers) ${err}`);
+  }
+};
+
+interface TestHelperAccountCreate {
+  context: Context;
+  accountData?: Account;
+  deleteAccounts?: boolean;
+}
+
+/**
+ * create account test helper
+ * Create an account with mock account data and any provied custom account data.
+ * @param {Object} KeystoneJS context API
+ * @param {Object} Account data
+ * @returns {Object} Created account
+ */
+const create = async ({ context, accountData, deleteAccounts = true }: TestHelperAccountCreate) => {
+  try {
+    console.info('Creating an account (test helpers)');
+
+    if (deleteAccounts) {
+      await deleteAll(context);
+    }
+
+    let accountInput = mockAccount;
+
+    if (accountData) {
+      accountInput = accountData;
+    }
+
+    const account = (await context.query.Account.createOne({
+      data: accountInput,
+      query:
+        'id email firstName lastName email salt hash verificationHash sessionExpiry otpExpiry reactivationHash reactivationExpiry isVerified isBlocked passwordResetHash passwordResetExpiry',
+    })) as Account;
+
+    return account;
+  } catch (err) {
+    console.error(err);
+    // throw new Error(`Creating an account (test helpers) ${err}`);
+    return err;
   }
 };
 

--- a/src/api/test-helpers/accounts.ts
+++ b/src/api/test-helpers/accounts.ts
@@ -32,8 +32,7 @@ const deleteAll = async (context: Context) => {
 /**
  * create account test helper
  * Create an account with mock account data and any provied custom account data.
- * @param {Object} KeystoneJS context API
- * @param {Object} Account data
+ * @param {Object} KeystoneJS context API, account data, deleteAccounts flag
  * @returns {Object} Created account
  */
 const create = async ({ context, data, deleteAccounts = true }: TestHelperAccountCreate) => {

--- a/src/api/test-helpers/accounts.ts
+++ b/src/api/test-helpers/accounts.ts
@@ -58,7 +58,6 @@ const create = async ({ context, data, deleteAccounts = true }: TestHelperAccoun
     return account;
   } catch (err) {
     console.error(err);
-    // throw new Error(`Creating an account (test helpers) ${err}`);
     return err;
   }
 };

--- a/src/api/test-helpers/create-full-application.ts
+++ b/src/api/test-helpers/create-full-application.ts
@@ -55,7 +55,7 @@ export const createFullApplication = async (context: Context) => {
     throw new Error('No country found from mock country ISO code');
   }
 
-  const account = await accounts.create(context);
+  const account = await accounts.create({ context });
 
   // create a new application
   const application = (await context.query.Application.createOne({

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,4 +1,4 @@
-import { AccountUpdateInput, CompanyUpdateInput } from '.keystone/types'; // eslint-disable-line
+import { AccountUpdateInput, CompanyUpdateInput, Context } from '.keystone/types'; // eslint-disable-line
 
 interface SuccessResponse {
   success: boolean;
@@ -434,6 +434,12 @@ interface IndustrySector {
   ukefIndustryName: string;
 }
 
+interface TestHelperAccountCreate {
+  context: Context;
+  data?: Account;
+  deleteAccounts?: boolean;
+}
+
 interface XLSXTitleRowIndexes {
   HEADER: number;
   KEY_INFORMATION: number;
@@ -502,6 +508,7 @@ export {
   SendExporterEmailVariables,
   SubmitApplicationVariables,
   SuccessResponse,
+  TestHelperAccountCreate,
   UpdateCompanyAndCompanyAddressVariables,
   XLSXTitleRowIndexes,
   XLSXRowIndexes,


### PR DESCRIPTION
This PR adds a `validateInput` hook to the `Account` keystone schema definition so that if an account with the same email address already exists, the request will be rejected. We don't actually use this (we have our own custom resolver instead), but the resolver is automatically generated and we need to add this logic incase someone calls the default account resolver.

## Changes

- Add `validateInput` to `Account` keystone schema definition to use an existing helper during "create" operation. If an account with the same email is provided, the request is rejected.
- Update API test helper `account.create` so that:
  - `accountData` param is just `data`.
  - Params are now an object so you can pass certain optional params.
  - Accounts are deleted before creating a new one, via optional `deleteAccounts` param (defaults to true).
- Update unit tests instances of `account.create`.
- Re-order API middleware so that the rate limiter is called before the API key check.