### PR TITLE
fix(EMS-1846): Duplicate h1 headings, radio/checkbox legend issues

### DIFF
--- a/e2e-tests/cypress/e2e/pages/your-business/companies-house-search/companyDetails.js
+++ b/e2e-tests/cypress/e2e/pages/your-business/companies-house-search/companyDetails.js
@@ -27,12 +27,12 @@ const companyDetails = {
   yourBusinessSummaryList: () => cy.get(`[data-cy="${SEARCH}-summary-list`),
 
   tradingName: () => cy.get(`[data-cy="${TRADING_NAME}`),
-  tradingNameLabel: () => cy.get(`[data-cy="${TRADING_NAME}-heading`),
+  tradingNameLabel: () => cy.get(`[data-cy="${TRADING_NAME}-legend`),
   tradingNameYesRadioInput: () => yesRadioInput().first(),
   tradingNameNoRadioInput: () => noRadioInput().first(),
 
   tradingAddress: () => cy.get(`[data-cy="${TRADING_ADDRESS}`),
-  tradingAddressLabel: () => cy.get(`[data-cy="${TRADING_ADDRESS}-heading`),
+  tradingAddressLabel: () => cy.get(`[data-cy="${TRADING_ADDRESS}-legend`),
   tradingAddressYesRadioInput: () => yesRadioInput().eq(1),
   tradingAddressNoRadioInput: () => noRadioInput().eq(1),
 

--- a/src/ui/templates/components/yes-no-radio-buttons.njk
+++ b/src/ui/templates/components/yes-no-radio-buttons.njk
@@ -3,7 +3,7 @@
 {% macro render(params) %}
 
   {% set fieldId = params.fieldId %}
-  {% set heading = params.heading %}
+  {% set legendText = params.legendText %}
   {% set hintText = params.hintText %}
   {% set hintHtml = params.hintHtml %}
   {% set submittedAnswer = params.submittedAnswer %}
@@ -18,10 +18,10 @@
     {% set headingLevel = 1 %}
   {% endif %}
 
-  {% if params.headingClass %}
-    {% set headingClass = params.headingClass %}
+  {% if params.legendClass %}
+    {% set legendClass = params.legendClass %}
   {% else %}
-    {% set headingClass = 'govuk-heading-l' %}
+    {% set legendClass = 'govuk-heading-l' %}
   {% endif %}
 
   {% if params.dataCyLegend %}
@@ -30,11 +30,10 @@
     {% set dataCyLegend = 'heading' %}
   {% endif %}
 
-  {% if params.spanLegend %}
-    {% set legendHtml = "<span data-cy='" + dataCyLegend + "' class='" + headingClass + "'>" + heading + "</span>" %}
-
+  {% if params.legendSpan %}
+    {% set legendHtml = "<span data-cy='" + dataCyLegend + "' class='" + legendClass + "'>" + legendText + "</span>" %}
   {% else %}
-    {% set legendHtml = "<h" + headingLevel + " class=" + headingClass + " id='heading' data-cy='" + dataCyLegend + "'>" + heading + "</h" + headingLevel + ">" %}
+    {% set legendHtml = "<h" + headingLevel + " class=" + legendClass + " id='heading' data-cy='" + dataCyLegend + "'>" + legendText + "</h" + headingLevel + ">" %}
   {% endif %}
 
   {% if params.dataCyHint %}
@@ -85,7 +84,7 @@
         },
         attributes: {
           "data-cy": "yes-input",
-          'aria-label': heading + ' Yes'
+          'aria-label': legendText + ' Yes'
         },
         checked: submittedAnswer === yesValue
       },
@@ -102,7 +101,7 @@
         },
         attributes: {
           "data-cy": "no-input",
-          'aria-label': heading + ' No'
+          'aria-label': legendText + ' No'
         },
         checked: submittedAnswer === noValue
       }

--- a/src/ui/templates/components/yes-no-radio-buttons.njk
+++ b/src/ui/templates/components/yes-no-radio-buttons.njk
@@ -12,16 +12,29 @@
   {% set conditionalYesHtml = params.conditionalYesHtml %}
   {% set conditionalNoHtml = params.conditionalNoHtml %}
 
-  {% if params.headerClass %}
-    {% set headerClass = params.headerClass %}
+  {% if params.headingLevel %}
+    {% set headingLevel = params.headingLevel %}
   {% else %}
-    {% set headerClass = 'govuk-heading-l' %}
+    {% set headingLevel = 1 %}
   {% endif %}
 
-  {% if params.dataCyHeading %}
-    {% set dataCyHeading = params.dataCyHeading %}
+  {% if params.headingClass %}
+    {% set headingClass = params.headingClass %}
   {% else %}
-    {% set dataCyHeading = 'heading' %}
+    {% set headingClass = 'govuk-heading-l' %}
+  {% endif %}
+
+  {% if params.dataCyLegend %}
+    {% set dataCyLegend = params.dataCyLegend %}
+  {% else %}
+    {% set dataCyLegend = 'heading' %}
+  {% endif %}
+
+  {% if params.spanLegend %}
+    {% set legendHtml = "<span data-cy='" + dataCyLegend + "' class='" + headingClass + "'>" + heading + "</span>" %}
+
+  {% else %}
+    {% set legendHtml = "<h" + headingLevel + " class=" + headingClass + " id='heading' data-cy='" + dataCyLegend + "'>" + heading + "</h" + headingLevel + ">" %}
   {% endif %}
 
   {% if params.dataCyHint %}
@@ -48,7 +61,7 @@
     name: fieldId,
     fieldset: {
       legend: {
-        html: "<h1 class=" + headerClass + " id='heading' data-cy='" + dataCyHeading + "'>" + heading + "</h1>"
+        html: legendHtml
       }
     },
     hint: {

--- a/src/ui/templates/insurance/declarations/anti-bribery.njk
+++ b/src/ui/templates/insurance/declarations/anti-bribery.njk
@@ -54,7 +54,7 @@
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     {% set legendHtml %}
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m" data-cy="{{ FIELD.ID }}-label">{{ FIELD.LABEL }}</legend>
+      <span class="govuk-fieldset__legend govuk-fieldset__legend--m" data-cy="{{ FIELD.ID }}-label">{{ FIELD.LABEL }}</span>
     {% endset %}
 
     {{ govukCheckboxes({

--- a/src/ui/templates/insurance/declarations/anti-bribery/code-of-conduct.njk
+++ b/src/ui/templates/insurance/declarations/anti-bribery/code-of-conduct.njk
@@ -52,10 +52,10 @@
 
     {{ yesNoRadioButtons.render({
       fieldId: FIELD.ID,
-      heading: CONTENT_STRINGS.PAGE_TITLE,
+      legendText: CONTENT_STRINGS.PAGE_TITLE,
+      legendClass: 'govuk-heading-xl',
       submittedAnswer: application.declaration[FIELD.ID],
       errorMessage: validationErrors.errorList[FIELD.ID],
-      headingClass: 'govuk-heading-xl',
       hintHtml: hintHtml,
       horizontalRadios: true,
       conditionalYesHtml: conditionalYesHtml,

--- a/src/ui/templates/insurance/declarations/anti-bribery/code-of-conduct.njk
+++ b/src/ui/templates/insurance/declarations/anti-bribery/code-of-conduct.njk
@@ -55,7 +55,7 @@
       heading: CONTENT_STRINGS.PAGE_TITLE,
       submittedAnswer: application.declaration[FIELD.ID],
       errorMessage: validationErrors.errorList[FIELD.ID],
-      headerClass: 'govuk-heading-xl',
+      headingClass: 'govuk-heading-xl',
       hintHtml: hintHtml,
       horizontalRadios: true,
       conditionalYesHtml: conditionalYesHtml,

--- a/src/ui/templates/insurance/declarations/anti-bribery/exporting-with-code-of-conduct.njk
+++ b/src/ui/templates/insurance/declarations/anti-bribery/exporting-with-code-of-conduct.njk
@@ -38,7 +38,7 @@
       heading: CONTENT_STRINGS.PAGE_TITLE,
       submittedAnswer: application.declaration[FIELD.ID],
       errorMessage: validationErrors.errorList[FIELD.ID],
-      headerClass: 'govuk-heading-xl',
+      headingClass: 'govuk-heading-xl',
       horizontalRadios: true,
       yesNoValueString: true
     }) }}

--- a/src/ui/templates/insurance/declarations/anti-bribery/exporting-with-code-of-conduct.njk
+++ b/src/ui/templates/insurance/declarations/anti-bribery/exporting-with-code-of-conduct.njk
@@ -35,10 +35,10 @@
 
     {{ yesNoRadioButtons.render({
       fieldId: FIELD.ID,
-      heading: CONTENT_STRINGS.PAGE_TITLE,
+      legendText: CONTENT_STRINGS.PAGE_TITLE,
+      legendClass: 'govuk-heading-xl',
       submittedAnswer: application.declaration[FIELD.ID],
       errorMessage: validationErrors.errorList[FIELD.ID],
-      headingClass: 'govuk-heading-xl',
       horizontalRadios: true,
       yesNoValueString: true
     }) }}

--- a/src/ui/templates/insurance/declarations/confidentiality.njk
+++ b/src/ui/templates/insurance/declarations/confidentiality.njk
@@ -88,7 +88,7 @@
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     {% set legendHtml %}
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m" data-cy="{{ FIELD.ID }}-label">{{ FIELD.LABEL }}</legend>
+      <span class="govuk-fieldset__legend govuk-fieldset__legend--m" data-cy="{{ FIELD.ID }}-label">{{ FIELD.LABEL }}</span>
     {% endset %}
 
     {{ govukCheckboxes({

--- a/src/ui/templates/insurance/eligibility/account-to-apply-online.njk
+++ b/src/ui/templates/insurance/eligibility/account-to-apply-online.njk
@@ -36,7 +36,7 @@
 
         {{ yesNoRadioButtons.render({
           fieldId: FIELD_ID,
-          heading: CONTENT_STRINGS.PAGE_TITLE,
+          legendText: CONTENT_STRINGS.PAGE_TITLE,
           hintText: FIELD_HINT,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]

--- a/src/ui/templates/insurance/eligibility/companies-house-number.njk
+++ b/src/ui/templates/insurance/eligibility/companies-house-number.njk
@@ -35,7 +35,7 @@
 
         {{ yesNoRadioButtons.render({
           fieldId: FIELD_ID,
-          heading: CONTENT_STRINGS.PAGE_TITLE,
+          legendText: CONTENT_STRINGS.PAGE_TITLE,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]
         }) }}

--- a/src/ui/templates/insurance/eligibility/insured-amount.njk
+++ b/src/ui/templates/insurance/eligibility/insured-amount.njk
@@ -35,7 +35,7 @@
 
         {{ yesNoRadioButtons.render({
           fieldId: FIELD_ID,
-          heading: CONTENT_STRINGS.PAGE_TITLE,
+          legendText: CONTENT_STRINGS.PAGE_TITLE,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]
         }) }}

--- a/src/ui/templates/insurance/eligibility/insured-period.njk
+++ b/src/ui/templates/insurance/eligibility/insured-period.njk
@@ -35,7 +35,7 @@
 
         {{ yesNoRadioButtons.render({
           fieldId: FIELD_ID,
-          heading: CONTENT_STRINGS.PAGE_TITLE,
+          legendText: CONTENT_STRINGS.PAGE_TITLE,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]
         }) }}

--- a/src/ui/templates/insurance/eligibility/letter-of-credit.njk
+++ b/src/ui/templates/insurance/eligibility/letter-of-credit.njk
@@ -35,7 +35,7 @@
 
         {{ yesNoRadioButtons.render({
           fieldId: FIELD_ID,
-          heading: CONTENT_STRINGS.PAGE_TITLE,
+          legendText: CONTENT_STRINGS.PAGE_TITLE,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]
         }) }}

--- a/src/ui/templates/insurance/eligibility/other-parties.njk
+++ b/src/ui/templates/insurance/eligibility/other-parties.njk
@@ -36,7 +36,7 @@
 
         {{ yesNoRadioButtons.render({
           fieldId: FIELD_ID,
-          heading: CONTENT_STRINGS.PAGE_TITLE,
+          legendText: CONTENT_STRINGS.PAGE_TITLE,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]
         }) }}

--- a/src/ui/templates/insurance/eligibility/pre-credit-period.njk
+++ b/src/ui/templates/insurance/eligibility/pre-credit-period.njk
@@ -37,7 +37,7 @@
 
         {{ yesNoRadioButtons.render({
           fieldId: FIELD_ID,
-          heading: CONTENT_STRINGS.PAGE_TITLE,
+          legendText: CONTENT_STRINGS.PAGE_TITLE,
           hintText: FIELD_HINT,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]

--- a/src/ui/templates/insurance/eligibility/uk-goods-or-services.njk
+++ b/src/ui/templates/insurance/eligibility/uk-goods-or-services.njk
@@ -36,7 +36,7 @@
 
         {{ yesNoRadioButtons.render({
           fieldId: FIELD_ID,
-          heading: CONTENT_STRINGS.PAGE_TITLE,
+          legendText: CONTENT_STRINGS.PAGE_TITLE,
           hintText: FIELD_HINT,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]

--- a/src/ui/templates/insurance/policy-and-exports/type-of-policy.njk
+++ b/src/ui/templates/insurance/policy-and-exports/type-of-policy.njk
@@ -35,7 +35,9 @@
 
         {% set legendHtml %}
           <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l"><h1 class="govuk-fieldset__heading" id="heading" data-cy="heading">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1></legend>
+          <span class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading" id="heading" data-cy="heading">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
+          </span>
           <p class="govuk-body" data-cy="intro">{{ CONTENT_STRINGS.INTRO }}</p>
         {% endset %}
 

--- a/src/ui/templates/insurance/your-business/broker.njk
+++ b/src/ui/templates/insurance/your-business/broker.njk
@@ -109,10 +109,10 @@
       <div class="govuk-grid-column-three-quarters-from-desktop">
         {{ yesNoRadioButtons.render({
           fieldId: FIELDS.USING_BROKER.ID,
-          heading: CONTENT_STRINGS.PAGE_TITLE,
+          legendText: CONTENT_STRINGS.PAGE_TITLE,
+          legendClass: 'govuk-fieldset__legend--xl',
           submittedAnswer: submittedValues[FIELDS.USING_BROKER.ID] or application.broker[FIELDS.USING_BROKER.ID],
           errorMessage: validationErrors.errorList[FIELDS.USING_BROKER.ID],
-          headingClass: 'govuk-fieldset__legend--xl',
           yesNoValueString: true,
           conditionalYesHtml: brokerHTML,
           horizontalRadios: true

--- a/src/ui/templates/insurance/your-business/broker.njk
+++ b/src/ui/templates/insurance/your-business/broker.njk
@@ -112,7 +112,7 @@
           heading: CONTENT_STRINGS.PAGE_TITLE,
           submittedAnswer: submittedValues[FIELDS.USING_BROKER.ID] or application.broker[FIELDS.USING_BROKER.ID],
           errorMessage: validationErrors.errorList[FIELDS.USING_BROKER.ID],
-          headerClass: 'govuk-fieldset__legend--xl',
+          headingClass: 'govuk-fieldset__legend--xl',
           yesNoValueString: true,
           conditionalYesHtml: brokerHTML,
           horizontalRadios: true

--- a/src/ui/templates/insurance/your-business/company-details.njk
+++ b/src/ui/templates/insurance/your-business/company-details.njk
@@ -111,8 +111,9 @@
           heading: CONTENT_STRINGS.TRADING_NAME,
           submittedAnswer: submittedValues[FIELDS.YOUR_COMPANY.TRADING_NAME],
           errorMessage: validationErrors.errorList[FIELDS.YOUR_COMPANY.TRADING_NAME],
-          headerClass: 'govuk-fieldset__legend--m',
-          dataCyHeading: FIELDS.YOUR_COMPANY.TRADING_NAME + '-heading',
+          spanLegend: true,
+          headingClass: 'govuk-fieldset__legend--m',
+          dataCyLegend: FIELDS.YOUR_COMPANY.TRADING_NAME + '-legend',
           yesNoValueString: true
         }) }}
       </div>
@@ -123,8 +124,9 @@
             heading: CONTENT_STRINGS.TRADING_ADDRESS,
             submittedAnswer: submittedValues[FIELDS.YOUR_COMPANY.TRADING_ADDRESS],
             errorMessage: validationErrors.errorList[FIELDS.YOUR_COMPANY.TRADING_ADDRESS],
-            headerClass: 'govuk-fieldset__legend--m',
-            dataCyHeading: FIELDS.YOUR_COMPANY.TRADING_ADDRESS + '-heading',
+            spanLegend: true,
+            headingClass: 'govuk-fieldset__legend--m',
+            dataCyLegend: FIELDS.YOUR_COMPANY.TRADING_ADDRESS + '-legend',
             yesNoValueString: true
           }) }}
       </div>

--- a/src/ui/templates/insurance/your-business/company-details.njk
+++ b/src/ui/templates/insurance/your-business/company-details.njk
@@ -108,11 +108,11 @@
       <div class="govuk-grid-column-three-quarters-from-desktop">
         {{ yesNoRadioButtons.render({
           fieldId: FIELDS.YOUR_COMPANY.TRADING_NAME,
-          heading: CONTENT_STRINGS.TRADING_NAME,
+          legendText: CONTENT_STRINGS.TRADING_NAME,
+          legendClass: 'govuk-fieldset__legend--m',
+          legendSpan: true,
           submittedAnswer: submittedValues[FIELDS.YOUR_COMPANY.TRADING_NAME],
           errorMessage: validationErrors.errorList[FIELDS.YOUR_COMPANY.TRADING_NAME],
-          spanLegend: true,
-          headingClass: 'govuk-fieldset__legend--m',
           dataCyLegend: FIELDS.YOUR_COMPANY.TRADING_NAME + '-legend',
           yesNoValueString: true
         }) }}
@@ -121,11 +121,11 @@
       <div class="govuk-grid-column-three-quarters-from-desktop">
           {{ yesNoRadioButtons.render({
             fieldId: FIELDS.YOUR_COMPANY.TRADING_ADDRESS,
-            heading: CONTENT_STRINGS.TRADING_ADDRESS,
+            legendText: CONTENT_STRINGS.TRADING_ADDRESS,
+            legendClass: 'govuk-fieldset__legend--m',
+            legendSpan: true,
             submittedAnswer: submittedValues[FIELDS.YOUR_COMPANY.TRADING_ADDRESS],
             errorMessage: validationErrors.errorList[FIELDS.YOUR_COMPANY.TRADING_ADDRESS],
-            spanLegend: true,
-            headingClass: 'govuk-fieldset__legend--m',
             dataCyLegend: FIELDS.YOUR_COMPANY.TRADING_ADDRESS + '-legend',
             yesNoValueString: true
           }) }}

--- a/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
+++ b/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
@@ -259,8 +259,9 @@
           hintText: FIELDS.CAN_CONTACT_BUYER.HINT,
           submittedAnswer: submittedValues[FIELDS.CAN_CONTACT_BUYER.ID] or application.buyer[FIELDS.CAN_CONTACT_BUYER.ID],
           errorMessage: validationErrors.errorList[FIELDS.CAN_CONTACT_BUYER.ID],
-          headerClass: 'govuk-fieldset__legend--m',
-          dataCyHeading: FIELDS.CAN_CONTACT_BUYER.ID + '-label',
+          spanLegend: true,
+          headingClass: 'govuk-fieldset__legend--m',
+          dataCyLegend: FIELDS.CAN_CONTACT_BUYER.ID + '-label',
           yesNoValueString: true
         }) }}
       </div>

--- a/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
+++ b/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
@@ -255,12 +255,12 @@
 
         {{ yesNoRadioButtons.render({
           fieldId: FIELDS.CAN_CONTACT_BUYER.ID,
-          heading: FIELDS.CAN_CONTACT_BUYER.LABEL,
+          legendText: FIELDS.CAN_CONTACT_BUYER.LABEL,
+          legendClass: 'govuk-fieldset__legend--m',
+          legendSpan: true,
           hintText: FIELDS.CAN_CONTACT_BUYER.HINT,
           submittedAnswer: submittedValues[FIELDS.CAN_CONTACT_BUYER.ID] or application.buyer[FIELDS.CAN_CONTACT_BUYER.ID],
           errorMessage: validationErrors.errorList[FIELDS.CAN_CONTACT_BUYER.ID],
-          spanLegend: true,
-          headingClass: 'govuk-fieldset__legend--m',
           dataCyLegend: FIELDS.CAN_CONTACT_BUYER.ID + '-label',
           yesNoValueString: true
         }) }}

--- a/src/ui/templates/insurance/your-buyer/working-with-buyer.njk
+++ b/src/ui/templates/insurance/your-buyer/working-with-buyer.njk
@@ -52,12 +52,12 @@
       <div class="govuk-grid-column-three-quarters-from-desktop">
         {{ yesNoRadioButtons.render({
           fieldId: FIELDS.CONNECTED_WITH_BUYER.ID,
-          heading: FIELDS.CONNECTED_WITH_BUYER.LABEL,
+          legendText: FIELDS.CONNECTED_WITH_BUYER.LABEL,
+          legendClass: 'govuk-fieldset__legend--m',
+          legendSpan: true,
           hintText: FIELDS.CONNECTED_WITH_BUYER.HINT,
           submittedAnswer: submittedValues[FIELDS.CONNECTED_WITH_BUYER.ID] or application.buyer[FIELDS.CONNECTED_WITH_BUYER.ID],
           errorMessage: validationErrors.errorList[FIELDS.CONNECTED_WITH_BUYER.ID],
-          spanLegend: true,
-          headingClass: 'govuk-fieldset__legend--m',
           dataCyLegend: FIELDS.CONNECTED_WITH_BUYER.ID + '-label',
           dataCyHint: FIELDS.CONNECTED_WITH_BUYER.ID + '-hint',
           yesNoValueString: true,
@@ -66,11 +66,11 @@
 
         {{ yesNoRadioButtons.render({
           fieldId: FIELDS.TRADED_WITH_BUYER.ID,
-          heading: FIELDS.TRADED_WITH_BUYER.LABEL,
+          legendText: FIELDS.TRADED_WITH_BUYER.LABEL,
+          legendClass: 'govuk-fieldset__legend--m',
+          legendSpan: true,
           submittedAnswer: submittedValues[FIELDS.TRADED_WITH_BUYER.ID] or application.buyer[FIELDS.TRADED_WITH_BUYER.ID],
           errorMessage: validationErrors.errorList[FIELDS.TRADED_WITH_BUYER.ID],
-          spanLegend: true,
-          headingClass: 'govuk-fieldset__legend--m',
           dataCyLegend: FIELDS.TRADED_WITH_BUYER.ID + '-label',
           yesNoValueString: true,
           conditionalYesHtml: tradedHTML,

--- a/src/ui/templates/insurance/your-buyer/working-with-buyer.njk
+++ b/src/ui/templates/insurance/your-buyer/working-with-buyer.njk
@@ -56,8 +56,9 @@
           hintText: FIELDS.CONNECTED_WITH_BUYER.HINT,
           submittedAnswer: submittedValues[FIELDS.CONNECTED_WITH_BUYER.ID] or application.buyer[FIELDS.CONNECTED_WITH_BUYER.ID],
           errorMessage: validationErrors.errorList[FIELDS.CONNECTED_WITH_BUYER.ID],
-          headerClass: 'govuk-fieldset__legend--m',
-          dataCyHeading: FIELDS.CONNECTED_WITH_BUYER.ID + '-label',
+          spanLegend: true,
+          headingClass: 'govuk-fieldset__legend--m',
+          dataCyLegend: FIELDS.CONNECTED_WITH_BUYER.ID + '-label',
           dataCyHint: FIELDS.CONNECTED_WITH_BUYER.ID + '-hint',
           yesNoValueString: true,
           horizontalRadios: true
@@ -68,8 +69,9 @@
           heading: FIELDS.TRADED_WITH_BUYER.LABEL,
           submittedAnswer: submittedValues[FIELDS.TRADED_WITH_BUYER.ID] or application.buyer[FIELDS.TRADED_WITH_BUYER.ID],
           errorMessage: validationErrors.errorList[FIELDS.TRADED_WITH_BUYER.ID],
-          headerClass: 'govuk-fieldset__legend--m',
-          dataCyHeading: FIELDS.TRADED_WITH_BUYER.ID + '-label',
+          spanLegend: true,
+          headingClass: 'govuk-fieldset__legend--m',
+          dataCyLegend: FIELDS.TRADED_WITH_BUYER.ID + '-label',
           yesNoValueString: true,
           conditionalYesHtml: tradedHTML,
           horizontalRadios: true

--- a/src/ui/templates/quote/buyer-body.njk
+++ b/src/ui/templates/quote/buyer-body.njk
@@ -35,7 +35,7 @@
 
         {{ yesNoRadioButtons.render({
           fieldId: FIELD_ID,
-          heading: CONTENT_STRINGS.PAGE_TITLE,
+          legendText: CONTENT_STRINGS.PAGE_TITLE,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]
         }) }}

--- a/src/ui/templates/quote/uk-goods-or-services.njk
+++ b/src/ui/templates/quote/uk-goods-or-services.njk
@@ -36,7 +36,7 @@
 
         {{ yesNoRadioButtons.render({
           fieldId: FIELD_ID,
-          heading: CONTENT_STRINGS.PAGE_TITLE,
+          legendText: CONTENT_STRINGS.PAGE_TITLE,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]
         }) }}

--- a/src/ui/templates/shared-pages/declaration.njk
+++ b/src/ui/templates/shared-pages/declaration.njk
@@ -49,7 +49,7 @@
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     {% set legendHtml %}
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m" data-cy="{{ FIELD.ID }}-label">{{ FIELD.LABEL }}</legend>
+      <span class="govuk-fieldset__legend govuk-fieldset__legend--m" data-cy="{{ FIELD.ID }}-label">{{ FIELD.LABEL }}</span>
     {% endset %}
 
     {{ govukCheckboxes({

--- a/src/ui/templates/shared-pages/exporter-location.njk
+++ b/src/ui/templates/shared-pages/exporter-location.njk
@@ -34,7 +34,7 @@
 
         {{ yesNoRadioButtons.render({
           fieldId: FIELD_ID,
-          heading: CONTENT_STRINGS.PAGE_TITLE,
+          legendText: CONTENT_STRINGS.PAGE_TITLE,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]
         }) }}


### PR DESCRIPTION
This PR fixes some radio and checkbox accessibility issues where:

- Some instances were unnecessarily rendering a h1 tag, causing duplicate h1 elements on the same page.
- Some legends were rendering inside of a legend - there should only be one legend.

## Changes
- Update the `yes-no-radio-buttons` nunjucks component:
  - Ability to render a custom heading level via new `headingLevel` param.
  - Ability to render a span inside a legend, instead of a heading via new `legendSpan` param.
  - Rename `heading` param to `legendText` and `headerClass` param to `legendClass` as it's not always a heading.
- Update all relevant instances of `yes-no-radio-buttons` and re-order some params.
- Change some `legendHtml` instances to render a span tag instead of a legend, otherwise duplicate legend's are rendered.