### PR TITLE
chore(EMS-1864): Update various UI controllers to use and test payload construction

### DIFF
--- a/src/ui/server/controllers/insurance/account/create/your-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/index.test.ts
@@ -142,7 +142,7 @@ describe('controllers/insurance/account/create/your-details', () => {
           ...PAGE_VARIABLES,
           userName: getUserNameFromSession(req.session.user),
           submittedValues: payload,
-          validationErrors: generateValidationErrors(req.body),
+          validationErrors: generateValidationErrors(payload),
         });
       });
     });

--- a/src/ui/server/controllers/insurance/account/password-reset/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/password-reset/index.test.ts
@@ -1,8 +1,9 @@
-import { PAGE_VARIABLES, TEMPLATE, PAGE_CONTENT_STRINGS, get, post } from '.';
+import { FIELD_ID, PAGE_VARIABLES, TEMPLATE, PAGE_CONTENT_STRINGS, get, post } from '.';
 import { PAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import { ACCOUNT_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance/account';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
+import constructPayload from '../../../../helpers/construct-payload';
 import { sanitiseValue } from '../../../../helpers/sanitise-data';
 import generateValidationErrors from './validation';
 import api from '../../../../api';
@@ -11,7 +12,7 @@ import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes, mockAccount } from '../../../../test-mocks';
 
 const {
-  ACCOUNT: { EMAIL: FIELD_ID },
+  ACCOUNT: { EMAIL },
 } = FIELD_IDS.INSURANCE;
 
 const {
@@ -32,6 +33,14 @@ describe('controllers/insurance/account/password-reset', () => {
     req = mockReq();
 
     res = mockRes();
+  });
+
+  describe('FIELD_ID', () => {
+    it('should have the correct ID', () => {
+      const expected = EMAIL;
+
+      expect(FIELD_ID).toEqual(expected);
+    });
   });
 
   describe('PAGE_VARIABLES', () => {
@@ -87,8 +96,10 @@ describe('controllers/insurance/account/password-reset', () => {
     });
 
     describe('when there are validation errors', () => {
-      it('should render template with validation errors and submitted values', async () => {
+      it('should render template with validation errors and submitted values from constructPayload function', async () => {
         await post(req, res);
+
+        const payload = constructPayload(req.body, [FIELD_ID]);
 
         expect(res.render).toHaveBeenCalledWith(TEMPLATE, {
           ...insuranceCorePageVariables({
@@ -96,8 +107,8 @@ describe('controllers/insurance/account/password-reset', () => {
             BACK_LINK: req.headers.referer,
           }),
           ...PAGE_VARIABLES,
-          submittedValues: req.body,
-          validationErrors: generateValidationErrors(req.body),
+          submittedValues: payload,
+          validationErrors: generateValidationErrors(payload),
         });
       });
     });
@@ -136,8 +147,10 @@ describe('controllers/insurance/account/password-reset', () => {
           api.keystone.account.sendEmailPasswordResetLink = sendEmailPasswordResetLinkSpy;
         });
 
-        it('should render template with validation errors and submitted values', async () => {
+        it('should render template with validation errors and submitted values from constructPayload function', async () => {
           await post(req, res);
+
+          const payload = constructPayload(req.body, [FIELD_ID]);
 
           expect(res.render).toHaveBeenCalledWith(TEMPLATE, {
             ...insuranceCorePageVariables({
@@ -145,7 +158,7 @@ describe('controllers/insurance/account/password-reset', () => {
               BACK_LINK: req.headers.referer,
             }),
             ...PAGE_VARIABLES,
-            submittedValues: req.body,
+            submittedValues: payload,
             validationErrors: accountDoesNotExistValidation(),
           });
         });

--- a/src/ui/server/controllers/insurance/account/password-reset/index.ts
+++ b/src/ui/server/controllers/insurance/account/password-reset/index.ts
@@ -2,6 +2,7 @@ import { PAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import { ACCOUNT_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance/account';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
+import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import { sanitiseValue } from '../../../../helpers/sanitise-data';
 import api from '../../../../api';
@@ -9,7 +10,7 @@ import accountDoesNotExistValidation from './validation/account-does-not-exist';
 import { Request, Response } from '../../../../../types';
 
 const {
-  ACCOUNT: { EMAIL: FIELD_ID },
+  ACCOUNT: { EMAIL },
 } = FIELD_IDS.INSURANCE;
 
 const {
@@ -20,6 +21,8 @@ const {
     },
   },
 } = ROUTES;
+
+export const FIELD_ID = EMAIL;
 
 /**
  * PAGE_VARIABLES
@@ -64,7 +67,9 @@ export const post = async (req: Request, res: Response) => {
   try {
     console.info('Posting account password reset form');
 
-    let validationErrors = generateValidationErrors(req.body);
+    const payload = constructPayload(req.body, [FIELD_ID]);
+
+    let validationErrors = generateValidationErrors(payload);
 
     if (validationErrors) {
       return res.render(TEMPLATE, {
@@ -73,14 +78,14 @@ export const post = async (req: Request, res: Response) => {
           BACK_LINK: req.headers.referer,
         }),
         ...PAGE_VARIABLES,
-        submittedValues: req.body,
+        submittedValues: payload,
         validationErrors,
       });
     }
 
     const urlOrigin = req.headers.origin;
 
-    const email = String(sanitiseValue({ value: req.body[FIELD_ID] }));
+    const email = String(sanitiseValue({ value: payload[FIELD_ID] }));
 
     const response = await api.keystone.account.sendEmailPasswordResetLink(urlOrigin, email);
 
@@ -104,7 +109,7 @@ export const post = async (req: Request, res: Response) => {
         BACK_LINK: req.headers.referer,
       }),
       ...PAGE_VARIABLES,
-      submittedValues: req.body,
+      submittedValues: payload,
       validationErrors,
     });
   } catch (err) {

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
@@ -4,6 +4,7 @@ import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../../constants';
 import { ACCOUNT_FIELDS as FIELDS } from '../../../../../content-strings/fields/insurance/account';
 import insuranceCorePageVariables from '../../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../../helpers/get-user-name-from-session';
+import constructPayload from '../../../../../helpers/construct-payload';
 import { sanitiseData, sanitiseValue } from '../../../../../helpers/sanitise-data';
 import generateValidationErrors from './validation';
 import securityCodeValidationErrors from './validation/rules/security-code';
@@ -177,8 +178,10 @@ describe('controllers/insurance/account/sign-in/enter-code', () => {
     });
 
     describe('when there are validation errors', () => {
-      it('should render template with validation errors and submitted values', async () => {
+      it('should render template with validation errors and submitted values from constructPayload function', async () => {
         await post(req, res);
+
+        const payload = constructPayload(req.body, [FIELD_ID]);
 
         expect(res.render).toHaveBeenCalledWith(TEMPLATE, {
           ...insuranceCorePageVariables({
@@ -187,8 +190,8 @@ describe('controllers/insurance/account/sign-in/enter-code', () => {
           }),
           ...PAGE_VARIABLES,
           userName: getUserNameFromSession(req.session.user),
-          submittedValues: req.body,
-          validationErrors: generateValidationErrors(req.body),
+          submittedValues: payload,
+          validationErrors: generateValidationErrors(payload),
         });
       });
     });
@@ -307,8 +310,10 @@ describe('controllers/insurance/account/sign-in/enter-code', () => {
           api.keystone.account.verifyAccountSignInCode = verifyAccountSignInCodeSpy;
         });
 
-        it('should render template with validation errors and submitted values', async () => {
+        it('should render template with validation errors and submitted values from constructPayload function', async () => {
           await post(req, res);
+
+          const payload = constructPayload(req.body, [FIELD_ID]);
 
           expect(res.render).toHaveBeenCalledWith(TEMPLATE, {
             ...insuranceCorePageVariables({
@@ -317,7 +322,7 @@ describe('controllers/insurance/account/sign-in/enter-code', () => {
             }),
             ...PAGE_VARIABLES,
             userName: getUserNameFromSession(req.session.user),
-            submittedValues: req.body,
+            submittedValues: payload,
             validationErrors: securityCodeValidationErrors({}, {}),
           });
         });

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.ts
@@ -3,6 +3,7 @@ import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../../constants';
 import { ACCOUNT_FIELDS as FIELDS } from '../../../../../content-strings/fields/insurance/account';
 import insuranceCorePageVariables from '../../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../../helpers/get-user-name-from-session';
+import constructPayload from '../../../../../helpers/construct-payload';
 import { sanitiseData, sanitiseValue } from '../../../../../helpers/sanitise-data';
 import generateValidationErrors from './validation';
 import securityCodeValidationErrors from './validation/rules/security-code';
@@ -95,14 +96,16 @@ export const post = async (req: Request, res: Response) => {
       return res.redirect(SIGN_IN_ROOT);
     }
 
-    const submittedCode = req.body[FIELD_ID];
+    const payload = constructPayload(req.body, [FIELD_ID]);
+
+    const submittedCode = payload[FIELD_ID];
 
     const securityCode = sanitiseValue({
       key: FIELD_ID,
       value: submittedCode,
     });
 
-    let validationErrors = generateValidationErrors(req.body);
+    let validationErrors = generateValidationErrors(payload);
 
     if (validationErrors) {
       return res.render(TEMPLATE, {
@@ -112,7 +115,7 @@ export const post = async (req: Request, res: Response) => {
         }),
         ...PAGE_VARIABLES,
         userName: getUserNameFromSession(req.session.user),
-        submittedValues: req.body,
+        submittedValues: payload,
         validationErrors,
       });
     }

--- a/src/ui/server/controllers/insurance/business/broker/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/business/broker/save-and-back/index.ts
@@ -32,7 +32,7 @@ const post = async (req: Request, res: Response) => {
     const payload = constructPayload(body, FIELD_IDS);
 
     // run validation on inputs
-    const validationErrors = generateValidationErrors(body);
+    const validationErrors = generateValidationErrors(payload);
 
     // runs save and go back commmand
     const saveResponse = await mapAndSave.broker(payload, application, validationErrors);

--- a/src/ui/server/controllers/insurance/business/contact/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/business/contact/save-and-back/index.ts
@@ -27,7 +27,7 @@ const post = async (req: Request, res: Response) => {
     const payload = constructPayload(body, FIELD_IDS);
 
     // run validation on inputs
-    const validationErrors = generateValidationErrors(body);
+    const validationErrors = generateValidationErrors(payload);
 
     // runs save and go back commmand
     const saveResponse = await mapAndSave.contact(payload, application, validationErrors);

--- a/src/ui/server/controllers/insurance/business/nature-of-business/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/index.test.ts
@@ -141,7 +141,7 @@ describe('controllers/insurance/business/nature-of-business', () => {
 
         const payload = constructPayload(req.body, FIELD_IDS);
 
-        const validationErrors = generateValidationErrors(req.body);
+        const validationErrors = generateValidationErrors(payload);
 
         expect(res.render).toHaveBeenCalledWith(TEMPLATE, {
           ...insuranceCorePageVariables({

--- a/src/ui/server/controllers/insurance/business/nature-of-business/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/save-and-back/index.ts
@@ -32,7 +32,7 @@ const post = async (req: Request, res: Response) => {
     const payload = constructPayload(body, FIELD_IDS);
 
     // run validation on inputs
-    const validationErrors = generateValidationErrors(body);
+    const validationErrors = generateValidationErrors(payload);
 
     // runs save and go back commmand
     const saveResponse = await mapAndSave.natureOfBusiness(payload, application, validationErrors);

--- a/src/ui/server/controllers/insurance/business/turnover/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/save-and-back/index.ts
@@ -32,7 +32,7 @@ const post = async (req: Request, res: Response) => {
     const payload = constructPayload(body, FIELD_IDS);
 
     // run validation on inputs
-    const validationErrors = generateValidationErrors(body);
+    const validationErrors = generateValidationErrors(payload);
 
     // runs save and go back commmand
     const saveResponse = await mapAndSave.turnover(payload, application, validationErrors);

--- a/src/ui/server/controllers/insurance/declarations/how-your-data-will-be-used/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/how-your-data-will-be-used/index.test.ts
@@ -190,8 +190,10 @@ describe('controllers/insurance/declarations/how-your-data-will-be-used', () => 
         expect(getLatestHowDataWillBeUsedSpy).toHaveBeenCalledTimes(1);
       });
 
-      it('should render template with validation errors', async () => {
+      it('should render template with validation errors from constructPayload function', async () => {
         await post(req, res);
+
+        const payload = constructPayload(req.body, [FIELD_ID]);
 
         const expectedVariables = {
           ...insuranceCorePageVariables({
@@ -202,7 +204,7 @@ describe('controllers/insurance/declarations/how-your-data-will-be-used', () => 
           userName: getUserNameFromSession(req.session.user),
           documentContent: mockDeclarations.howDataWillBeUsed.content.document,
           documentConfig: keystoneDocumentRendererConfig(),
-          validationErrors: generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY),
+          validationErrors: generateValidationErrors(payload, FIELD_ID, ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY),
         };
 
         expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);

--- a/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/multiple-contract-policy/index.test.ts
@@ -303,7 +303,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy', () 
         req.body = validBody;
       });
 
-      it('should call mapAndSave.policyAndExport with data from from constructPayload function and application', async () => {
+      it('should call mapAndSave.policyAndExport with data from constructPayload function and application', async () => {
         await post(req, res);
 
         const payload = constructPayload(req.body, FIELD_IDS);
@@ -353,12 +353,12 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy', () 
         expect(getCurrenciesSpy).toHaveBeenCalledTimes(1);
       });
 
-      it('should render template with validation errors', async () => {
+      it('should render template with validation errors and submitted values from constructPayload function', async () => {
         await post(req, res);
 
         const payload = constructPayload(req.body, FIELD_IDS);
 
-        const expectedCurrencies = mapCurrencies(mockCurrencies, req.body[POLICY_CURRENCY_CODE]);
+        const expectedCurrencies = mapCurrencies(mockCurrencies, payload[POLICY_CURRENCY_CODE]);
 
         const expectedVariables = {
           ...insuranceCorePageVariables({
@@ -371,7 +371,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy', () 
           submittedValues: payload,
           currencies: expectedCurrencies,
           monthOptions: mapTotalMonthsOfCover(totalMonthsOfCoverOptions),
-          validationErrors: generateValidationErrors(req.body),
+          validationErrors: generateValidationErrors(payload),
         };
 
         expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
@@ -404,7 +404,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy', () 
             submittedValues: payload,
             currencies: expectedCurrencies,
             monthOptions: mapTotalMonthsOfCover(totalMonthsOfCoverOptions),
-            validationErrors: generateValidationErrors(req.body),
+            validationErrors: generateValidationErrors(payload),
           };
 
           expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
@@ -438,7 +438,7 @@ describe('controllers/insurance/policy-and-export/multiple-contract-policy', () 
             submittedValues: payload,
             currencies: mapCurrencies(mockCurrencies),
             monthOptions: expectedMonthOptions,
-            validationErrors: generateValidationErrors(req.body),
+            validationErrors: generateValidationErrors(payload),
           };
 
           expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/index.test.ts
@@ -254,7 +254,7 @@ describe('controllers/insurance/policy-and-export/single-contract-policy', () =>
         req.body = validBody;
       });
 
-      it('should call mapAndSave.policyAndExport with data from from constructPayload function and application', async () => {
+      it('should call mapAndSave.policyAndExport with data from constructPayload function and application', async () => {
         await post(req, res);
 
         const payload = constructPayload(req.body, FIELD_IDS);

--- a/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.test.ts
@@ -110,7 +110,7 @@ describe('controllers/insurance/policy-and-export/type-of-policy', () => {
         };
       });
 
-      it('should call mapAndSave.policyAndExport with data from from constructPayload function and application', async () => {
+      it('should call mapAndSave.policyAndExport with data from constructPayload function and application', async () => {
         await post(req, res);
 
         const payload = constructPayload(req.body, FIELD_IDS);
@@ -146,8 +146,10 @@ describe('controllers/insurance/policy-and-export/type-of-policy', () => {
     });
 
     describe('when there are validation errors', () => {
-      it('should render template with validation errors', async () => {
+      it('should render template with validation errors from constructPayload function', async () => {
         await post(req, res);
+
+        const payload = constructPayload(req.body, FIELD_IDS);
 
         const expectedVariables = {
           ...insuranceCorePageVariables({
@@ -156,7 +158,7 @@ describe('controllers/insurance/policy-and-export/type-of-policy', () => {
           }),
           ...pageVariables(refNumber),
           userName: getUserNameFromSession(req.session.user),
-          validationErrors: generateValidationErrors(req.body),
+          validationErrors: generateValidationErrors(payload),
         };
 
         expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);

--- a/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/save-and-back/index.test.ts
@@ -38,7 +38,7 @@ describe('controllers/insurance/policy-and-export/type-of-policy/save-and-back',
   });
 
   describe('when the form has data', () => {
-    it('should call mapAndSave.policyAndExport with with data from from constructPayload function and application', async () => {
+    it('should call mapAndSave.policyAndExport with with data from constructPayload function and application', async () => {
       await post(req, res);
 
       const payload = constructPayload(req.body, FIELD_IDS);

--- a/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/save-and-back/index.test.ts
@@ -1,12 +1,16 @@
-import { Request, Response } from '../../../../../../types';
-import { post } from '.';
-import { FIELD_IDS, ROUTES } from '../../../../../constants';
-import { mockReq, mockRes, mockApplication, mockBuyer } from '../../../../../test-mocks';
 import mapAndSave from '../../map-and-save';
+import { FIELD_IDS } from '..';
+import { post } from '.';
+import { ROUTES } from '../../../../../constants';
+import INSURANCE_FIELD_IDS from '../../../../../constants/field-ids/insurance';
+import constructPayload from '../../../../../helpers/construct-payload';
+import generateValidationErrors from '../validation';
+import { Request, Response } from '../../../../../../types';
+import { mockReq, mockRes, mockApplication, mockBuyer } from '../../../../../test-mocks';
 
 const {
   COMPANY_OR_ORGANISATION: { NAME },
-} = FIELD_IDS.INSURANCE.YOUR_BUYER;
+} = INSURANCE_FIELD_IDS.YOUR_BUYER;
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
 
@@ -42,12 +46,17 @@ describe('controllers/insurance/your-buyer/company-or-organisation/save-and-back
         expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
       });
 
-      it('should call mapAndSave.buyer once', async () => {
+      it('should call mapAndSave.buyer once with data from constructPayload function', async () => {
         req.body = validBody;
 
         await post(req, res);
 
         expect(updateMapAndSave).toHaveBeenCalledTimes(1);
+
+        const payload = constructPayload(req.body, FIELD_IDS);
+        const validationErrors = generateValidationErrors(payload);
+
+        expect(updateMapAndSave).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
       });
     });
 
@@ -62,7 +71,7 @@ describe('controllers/insurance/your-buyer/company-or-organisation/save-and-back
         expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
       });
 
-      it('should call mapAndSave.buyer once', async () => {
+      it('should call mapAndSave.buyer once with data from constructPayload function', async () => {
         req.body = {
           [NAME]: 'Test',
         };
@@ -70,6 +79,11 @@ describe('controllers/insurance/your-buyer/company-or-organisation/save-and-back
         await post(req, res);
 
         expect(updateMapAndSave).toHaveBeenCalledTimes(1);
+
+        const payload = constructPayload(req.body, FIELD_IDS);
+        const validationErrors = generateValidationErrors(payload);
+
+        expect(updateMapAndSave).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
       });
     });
 

--- a/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/save-and-back/index.ts
@@ -1,7 +1,9 @@
-import { Request, Response } from '../../../../../../types';
+import { FIELD_IDS } from '..';
 import { ROUTES } from '../../../../../constants';
+import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save';
+import { Request, Response } from '../../../../../../types';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
 
@@ -21,12 +23,13 @@ const post = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    const { body } = req;
+    const payload = constructPayload(req.body, FIELD_IDS);
+
     // run validation on inputs
-    const validationErrors = generateValidationErrors(body);
+    const validationErrors = generateValidationErrors(payload);
 
     // runs save and go back commmand
-    const saveResponse = await mapAndSave.yourBuyer(body, application, validationErrors);
+    const saveResponse = await mapAndSave.yourBuyer(payload, application, validationErrors);
 
     if (!saveResponse) {
       return res.redirect(PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/your-buyer/working-with-buyer/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/working-with-buyer/save-and-back/index.test.ts
@@ -1,12 +1,16 @@
-import { Request, Response } from '../../../../../../types';
+import { FIELD_IDS } from '..';
 import { post } from '.';
-import { FIELD_IDS, ROUTES } from '../../../../../constants';
-import { mockReq, mockRes, mockApplication, mockBuyer } from '../../../../../test-mocks';
+import { ROUTES } from '../../../../../constants';
+import INSURANCE_FIELD_IDS from '../../../../../constants/field-ids/insurance';
+import constructPayload from '../../../../../helpers/construct-payload';
+import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save';
+import { Request, Response } from '../../../../../../types';
+import { mockReq, mockRes, mockApplication, mockBuyer } from '../../../../../test-mocks';
 
 const {
   WORKING_WITH_BUYER: { CONNECTED_WITH_BUYER, TRADED_WITH_BUYER },
-} = FIELD_IDS.INSURANCE.YOUR_BUYER;
+} = INSURANCE_FIELD_IDS.YOUR_BUYER;
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
 
@@ -44,12 +48,17 @@ describe('controllers/insurance/your-buyer/working-with-buyer/save-and-back', ()
         expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
       });
 
-      it('should call mapAndSave.buyer once', async () => {
+      it('should call mapAndSave.buyer once with data from constructPayload function', async () => {
         req.body = validBody;
 
         await post(req, res);
 
         expect(updateMapAndSave).toHaveBeenCalledTimes(1);
+
+        const payload = constructPayload(req.body, FIELD_IDS);
+        const validationErrors = generateValidationErrors(payload);
+
+        expect(updateMapAndSave).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
       });
     });
 
@@ -64,7 +73,7 @@ describe('controllers/insurance/your-buyer/working-with-buyer/save-and-back', ()
         expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
       });
 
-      it('should call mapAndSave.buyer once', async () => {
+      it('should call mapAndSave.buyer once with data from constructPayload function', async () => {
         req.body = {
           [TRADED_WITH_BUYER]: mockBuyer[TRADED_WITH_BUYER],
         };
@@ -72,6 +81,11 @@ describe('controllers/insurance/your-buyer/working-with-buyer/save-and-back', ()
         await post(req, res);
 
         expect(updateMapAndSave).toHaveBeenCalledTimes(1);
+
+        const payload = constructPayload(req.body, FIELD_IDS);
+        const validationErrors = generateValidationErrors(payload);
+
+        expect(updateMapAndSave).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
       });
     });
 

--- a/src/ui/server/controllers/insurance/your-buyer/working-with-buyer/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/working-with-buyer/save-and-back/index.ts
@@ -1,7 +1,9 @@
-import { Request, Response } from '../../../../../../types';
+import { FIELD_IDS } from '..';
 import { ROUTES } from '../../../../../constants';
+import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save';
+import { Request, Response } from '../../../../../../types';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
 
@@ -21,12 +23,13 @@ const post = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    const { body } = req;
+    const payload = constructPayload(req.body, FIELD_IDS);
+
     // run validation on inputs
-    const validationErrors = generateValidationErrors(body);
+    const validationErrors = generateValidationErrors(payload);
 
     // runs save and go back commmand
-    const saveResponse = await mapAndSave.yourBuyer(body, application, validationErrors);
+    const saveResponse = await mapAndSave.yourBuyer(payload, application, validationErrors);
 
     if (!saveResponse) {
       return res.redirect(PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/root/cookies/index.test.ts
+++ b/src/ui/server/controllers/root/cookies/index.test.ts
@@ -1,7 +1,8 @@
-import { PAGE_VARIABLES, TEMPLATE, get, post } from '.';
+import { FIELD_ID, PAGE_VARIABLES, TEMPLATE, get, post } from '.';
 import { ERROR_MESSAGES, FIELDS, PAGES } from '../../../content-strings';
 import { FIELD_IDS, FIELD_VALUES, ROUTES, TEMPLATES } from '../../../constants';
 import singleInputPageVariables from '../../../helpers/page-variables/single-input';
+import constructPayload from '../../../helpers/construct-payload';
 import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
 import generateValidationErrors from '../../../shared-validation/yes-no-radios-form';
 import { Request, Response } from '../../../../types';
@@ -16,6 +17,14 @@ describe('controllers/root/cookies', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
+  });
+
+  describe('FIELD_ID', () => {
+    it('should have the correct ID', () => {
+      const expected = FIELD_IDS.OPTIONAL_COOKIES;
+
+      expect(FIELD_ID).toEqual(expected);
+    });
   });
 
   describe('PAGE_VARIABLES', () => {
@@ -56,14 +65,16 @@ describe('controllers/root/cookies', () => {
 
   describe('post', () => {
     describe('when there are validation errors', () => {
-      it('should render template with validation errors and submittedValue', () => {
+      it('should render template with validation errors and submittedValue from constructPayload function', () => {
         post(req, res);
+
+        const payload = constructPayload(req.body, [FIELD_ID]);
 
         expect(res.render).toHaveBeenCalledWith(TEMPLATE, {
           userName: getUserNameFromSession(req.session.user),
           ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: req.headers.referer, ORIGINAL_URL: req.originalUrl }),
           FIELD: FIELDS[FIELD_IDS.OPTIONAL_COOKIES],
-          validationErrors: generateValidationErrors(req.body, PAGE_VARIABLES.FIELD_ID, ERROR_MESSAGES[PAGE_VARIABLES.FIELD_ID]),
+          validationErrors: generateValidationErrors(payload, PAGE_VARIABLES.FIELD_ID, ERROR_MESSAGES[PAGE_VARIABLES.FIELD_ID]),
         });
       });
     });

--- a/src/ui/server/controllers/root/cookies/index.ts
+++ b/src/ui/server/controllers/root/cookies/index.ts
@@ -1,12 +1,13 @@
 import { ERROR_MESSAGES, FIELDS, PAGES } from '../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES, SECURE_OPTION_COOKIE } from '../../../constants';
 import singleInputPageVariables from '../../../helpers/page-variables/single-input';
+import constructPayload from '../../../helpers/construct-payload';
 import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
 import generateValidationErrors from '../../../shared-validation/yes-no-radios-form';
 import isInsuranceRoute from '../../../helpers/is-insurance-route';
 import { Request, Response } from '../../../../types';
 
-const FIELD_ID = FIELD_IDS.OPTIONAL_COOKIES;
+export const FIELD_ID = FIELD_IDS.OPTIONAL_COOKIES;
 
 const { COOKIES_SAVED, INSURANCE } = ROUTES;
 
@@ -56,7 +57,9 @@ export const get = (req: Request, res: Response) => {
  * @returns {Express.Response.redirect} Cookies page with validation errors or the Cookies saved page
  */
 export const post = (req: Request, res: Response) => {
-  const validationErrors = generateValidationErrors(req.body, FIELD_ID, ERROR_MESSAGES[FIELD_ID]);
+  const payload = constructPayload(req.body, [FIELD_ID]);
+
+  const validationErrors = generateValidationErrors(payload, FIELD_ID, ERROR_MESSAGES[FIELD_ID]);
 
   if (validationErrors) {
     return res.render(TEMPLATE, {

--- a/src/ui/server/helpers/task-list/index.ts
+++ b/src/ui/server/helpers/task-list/index.ts
@@ -42,7 +42,7 @@ export const generateSimplifiedTaskList = (taskList: TaskListData): Array<TaskLi
           status: task.status,
           title: task.title,
         })),
-      } as TaskListGroup),
+      }) as TaskListGroup,
   );
 };
 

--- a/src/ui/server/helpers/task-list/index.ts
+++ b/src/ui/server/helpers/task-list/index.ts
@@ -42,7 +42,7 @@ export const generateSimplifiedTaskList = (taskList: TaskListData): Array<TaskLi
           status: task.status,
           title: task.title,
         })),
-      }) as TaskListGroup,
+      } as TaskListGroup),
   );
 };
 


### PR DESCRIPTION
This PR updates various UI controllers to ensure that:
  - Submitted values and Validation errors are consuming a payload instead of `req.body`.
  - API requests are using a payload instead of `req.body`.

# Changes

- Account sign in, password reset controllers.
- Declarations - How your data will be used controller.
- Your business - various  controllers.
- Your buyer - various  controllers.
- Policy and export - various controllers.
- Cookies  controller.