### PR TITLE
fix(EMS-1890): add temporary logs to debug in dev environment

### DIFF
--- a/src/ui/server/middleware/headers/security/index.ts
+++ b/src/ui/server/middleware/headers/security/index.ts
@@ -24,6 +24,10 @@ import { Request, Response } from '../../../../types';
  */
 
 export const security = (req: Request, res: Response, next: () => void) => {
+  console.log('--> req..hostname ', req.hostname); // eslint-disable-line no-console
+  console.log('--> req.headers.referer ', req.headers.referer); // eslint-disable-line no-console
+  console.log('--> req.headers.origin ', req.headers.origin); // eslint-disable-line no-console
+
   const { hostname } = req;
 
   if (req.headers.referer) {


### PR DESCRIPTION
There's currently an issue in the dev environment where some UI request headers do not match or could be undefined. 

We have some middleware that checks these headers and if they don't match, we nullify the headers. One of these headers is used to render a back link in each page which is currently not working.

Unable to replicate the issue locally so need to add some logs so that we can debug in the dev envrionment.