### PR TITLE
chore(EMS-972): Update all E2E tests to use checkLink command, remove some unnecessary assertions

### DIFF
--- a/e2e-tests/cypress/e2e/journeys/cookies-consent/banner/cookies-consent-accept.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/cookies-consent/banner/cookies-consent-accept.spec.js
@@ -42,10 +42,11 @@ context('Cookies consent - accept', () => {
 
       cy.checkText(partials.cookieBanner.accepted.copy(), expected);
 
-      partials.cookieBanner.cookiesLink().should('exist');
-      cy.checkText(partials.cookieBanner.cookiesLink(), COOKIES_CONSENT.COOKIES_LINK);
-
-      partials.cookieBanner.cookiesLink().should('have.attr', 'href', ROUTES.COOKIES);
+      cy.checkLink(
+        partials.cookieBanner.cookiesLink,
+        ROUTES.COOKIES,
+        COOKIES_CONSENT.COOKIES_LINK,
+      );
 
       partials.cookieBanner.hideButton().should('exist');
       cy.checkText(partials.cookieBanner.hideButton(), COOKIES_CONSENT.HIDE_BUTTON);

--- a/e2e-tests/cypress/e2e/journeys/cookies-consent/banner/cookies-consent-reject.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/cookies-consent/banner/cookies-consent-reject.spec.js
@@ -41,10 +41,11 @@ context('Cookies consent - reject', () => {
       const expected = `${REJECTED.COPY_1} ${COOKIES_CONSENT.COOKIES_LINK} ${REJECTED.COPY_2}`;
       cy.checkText(partials.cookieBanner.rejected.copy(), expected);
 
-      partials.cookieBanner.cookiesLink().should('exist');
-      cy.checkText(partials.cookieBanner.cookiesLink(), COOKIES_CONSENT.COOKIES_LINK);
-
-      partials.cookieBanner.cookiesLink().should('have.attr', 'href', ROUTES.COOKIES);
+      cy.checkLink(
+        partials.cookieBanner.cookiesLink,
+        ROUTES.COOKIES,
+        COOKIES_CONSENT.COOKIES_LINK,
+      );
 
       partials.cookieBanner.hideButton().should('exist');
       cy.checkText(partials.cookieBanner.hideButton(), COOKIES_CONSENT.HIDE_BUTTON);

--- a/e2e-tests/cypress/e2e/journeys/cookies-consent/banner/cookies-consent.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/cookies-consent/banner/cookies-consent.spec.js
@@ -49,10 +49,11 @@ context('Cookies consent - initial/default', () => {
     });
 
     it('should render a link to cookies', () => {
-      partials.cookieBanner.cookiesLink().should('exist');
-      cy.checkText(partials.cookieBanner.cookiesLink(), COOKIES_CONSENT.QUESTION.VIEW_COOKIES);
-
-      partials.cookieBanner.cookiesLink().should('have.attr', 'href', ROUTES.COOKIES);
+      cy.checkLink(
+        partials.cookieBanner.cookiesLink,
+        ROUTES.COOKIES,
+        COOKIES_CONSENT.QUESTION.VIEW_COOKIES,
+      );
     });
 
     it('should redirect to cookies page when clicking cookies link', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/accessibility-statement.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/accessibility-statement.spec.js
@@ -54,16 +54,12 @@ context('Accessibility statement page - Insurance', () => {
     });
   });
 
-  it('should render a header with href to insurance start', () => {
-    partials.header.serviceName().should('have.attr', 'href', startRoute);
-  });
-
   it('renders a service link', () => {
-    accessibilityStatementPage.serviceLink().invoke('text').then((text) => {
-      expect(text.trim()).equal(SERVICE_LINK.TEXT);
-    });
-
-    accessibilityStatementPage.serviceLink().should('have.attr', 'href', SERVICE_LINK.HREF);
+    cy.checkLink(
+      accessibilityStatementPage.serviceLink(),
+      SERVICE_LINK.HREF,
+      SERVICE_LINK.TEXT,
+    );
   });
 
   describe('using our service', () => {
@@ -103,11 +99,11 @@ context('Accessibility statement page - Insurance', () => {
 
     describe('outro', () => {
       it('renders AbilityNet link and outro copy', () => {
-        usingOurService.abilityNet.link().invoke('text').then((text) => {
-          expect(text.trim()).equal(USING_OUR_SERVICE.OUTRO.ABILITY_NET.LINK.TEXT);
-        });
-
-        usingOurService.abilityNet.link().should('have.attr', 'href', USING_OUR_SERVICE.OUTRO.ABILITY_NET.LINK.HREF);
+        cy.checkLink(
+          usingOurService.abilityNet.link(),
+          USING_OUR_SERVICE.OUTRO.ABILITY_NET.LINK.HREF,
+          USING_OUR_SERVICE.OUTRO.ABILITY_NET.LINK.TEXT,
+        );
 
         usingOurService.abilityNet.outro().invoke('text').then((text) => {
           expect(text.trim()).equal(USING_OUR_SERVICE.OUTRO.ABILITY_NET.DESCRIPTION);
@@ -174,11 +170,11 @@ context('Accessibility statement page - Insurance', () => {
     });
 
     it('renders a link', () => {
-      enforcementProcedure.link().invoke('text').then((text) => {
-        expect(text.trim()).equal(ENFORCEMENT_PROCEDURE.CONTACT.TEXT);
-      });
-
-      enforcementProcedure.link().should('have.attr', 'href', ENFORCEMENT_PROCEDURE.CONTACT.HREF);
+      cy.checkLink(
+        enforcementProcedure.link(),
+        ENFORCEMENT_PROCEDURE.CONTACT.HREF,
+        ENFORCEMENT_PROCEDURE.CONTACT.TEXT,
+      );
     });
   });
 
@@ -210,11 +206,11 @@ context('Accessibility statement page - Insurance', () => {
     });
 
     it('renders a link', () => {
-      complianceStatus.link().invoke('text').then((text) => {
-        expect(text.trim()).equal(COMPLIANCE_STATUS.GUIDLINES_LINK.TEXT);
-      });
-
-      complianceStatus.link().should('have.attr', 'href', COMPLIANCE_STATUS.GUIDLINES_LINK.HREF);
+      cy.checkLink(
+        complianceStatus.link(),
+        COMPLIANCE_STATUS.GUIDLINES_LINK.HREF,
+        COMPLIANCE_STATUS.GUIDLINES_LINK.TEXT,
+      );
     });
 
     it('renders an outro', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/account-signed-out.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/account-signed-out.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../partials';
 import signedOutPage from '../../../pages/insurance/account/signed-out';
 import { BUTTONS, PAGES } from '../../../../../content-strings';
 import { INSURANCE_ROUTES as ROUTES } from '../../../../../constants/routes/insurance';
@@ -39,10 +38,6 @@ context('Insurance - Account - Signed out -  As an Exporter I want the system to
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
     });
 
     it('renders a `sign in` button link', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/create/your-details/account-create-your-details.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../partials';
 import accountFormFields from '../../../../../partials/insurance/accountFormFields';
 import { yourDetailsPage } from '../../../../../pages/insurance/account/create';
 import { BUTTONS, PAGES } from '../../../../../../../content-strings';
@@ -59,10 +58,6 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
     });
 
     it('renders intro text', () => {
@@ -131,9 +126,14 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
     it('renders a `already got an account` copy and button link', () => {
       cy.checkText(yourDetailsPage.alreadyGotAnAccountHeading(), CONTENT_STRINGS.ALREADY_GOT_AN_ACCOUNT);
 
-      cy.checkText(yourDetailsPage.signInButtonLink(), BUTTONS.SIGN_IN);
+      const expectedHref = SIGN_IN.ROOT;
+      const expectedText = BUTTONS.SIGN_IN;
 
-      yourDetailsPage.signInButtonLink().should('have.attr', 'href', SIGN_IN.ROOT);
+      cy.checkLink(
+        yourDetailsPage.signInButtonLink(),
+        expectedHref,
+        expectedText,
+      );
     });
 
     describe('when clicking `already got an account`', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/manage/account-manage.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/manage/account-manage.spec.js
@@ -9,7 +9,6 @@ import { INSURANCE_ROUTES as ROUTES } from '../../../../../../constants/routes/i
 const CONTENT_STRINGS = PAGES.INSURANCE.ACCOUNT.MANAGE;
 
 const {
-  START,
   ACCOUNT: {
     CREATE: { YOUR_DETAILS },
     SIGN_IN: { ENTER_CODE },
@@ -90,10 +89,6 @@ context('Insurance - Account - Manage - As an Exporter, I want the service to ha
           assertSubmitButton: false,
           assertAuthenticatedHeader: true,
         });
-      });
-
-      it('should render a header with href to insurance start', () => {
-        partials.header.serviceName().should('have.attr', 'href', START);
       });
 
       it('renders an introduction', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/account-password-reset.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/account-password-reset.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../partials';
 import { backLink } from '../../../../pages/shared';
 import { signInPage } from '../../../../pages/insurance/account/sign-in';
 import { yourDetailsPage } from '../../../../pages/insurance/account/create';
@@ -11,7 +10,6 @@ import { INSURANCE_ROUTES as ROUTES } from '../../../../../../constants/routes/i
 const CONTENT_STRINGS = PAGES.INSURANCE.ACCOUNT.PASSWORD_RESET.ROOT;
 
 const {
-  START,
   ACCOUNT: {
     SIGN_IN: { ROOT: SIGN_IN_ROOT },
     PASSWORD_RESET: { ROOT: PASSWORD_RESET_ROOT, LINK_SENT },
@@ -67,10 +65,6 @@ context('Insurance - Account - Password reset page - As an Exporter, I want to r
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
     });
 
     it('renders `email` label, hint and input', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/link-sent/account-password-reset-link-sent.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/link-sent/account-password-reset-link-sent.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../partials';
 import { linkSentPage } from '../../../../../pages/insurance/account/password-reset';
 import { PAGES } from '../../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
@@ -73,9 +72,7 @@ context('Insurance - Account - Password reset - link sent page - As an Exporter,
       goToPasswordResetLinkSentPage();
     });
 
-    it('should render a header with href to insurance start and `check your inbox` copy with the submitted email', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
-
+    it('should render `check your inbox` copy with the submitted email', () => {
       const expected = `${CHECK_YOUR_INBOX} ${mockAccount[EMAIL]}`;
 
       cy.checkText(linkSentPage.checkInbox(), expected);

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/new-password/account-password-reset-new-password.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/password-reset/new-password/account-password-reset-new-password.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../partials';
 import { BUTTONS, PAGES } from '../../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { ACCOUNT_FIELDS } from '../../../../../../../content-strings/fields/insurance/account';
@@ -9,7 +8,6 @@ import account from '../../../../../../fixtures/account';
 const CONTENT_STRINGS = PAGES.INSURANCE.ACCOUNT.PASSWORD_RESET.NEW_PASSWORD;
 
 const {
-  START,
   ACCOUNT: {
     PASSWORD_RESET: {
       ROOT: PASSWORD_RESET_ROOT,
@@ -72,10 +70,6 @@ context('Insurance - Account - Password reset - new password page - As an Export
           assertAuthenticatedHeader: false,
           submitButtonCopy: BUTTONS.SUBMIT,
         });
-      });
-
-      it('should render a header with href to insurance start', () => {
-        partials.header.serviceName().should('have.attr', 'href', START);
       });
 
       describe('password', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/account-sign-in.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../partials';
 import { signInPage } from '../../../../pages/insurance/account/sign-in';
 import { yourDetailsPage } from '../../../../pages/insurance/account/create';
 import accountFormFields from '../../../../partials/insurance/accountFormFields';
@@ -66,10 +65,6 @@ context('Insurance - Account - Sign in - As an Exporter, I want to sign in into 
       cy.navigateToUrl(url);
     });
 
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
-    });
-
     it('renders `email` label and input', () => {
       const fieldId = EMAIL;
       const field = accountFormFields[fieldId];
@@ -101,17 +96,27 @@ context('Insurance - Account - Sign in - As an Exporter, I want to sign in into 
     });
 
     it('renders a `reset password` link', () => {
-      cy.checkText(signInPage.resetPasswordLink(), CONTENT_STRINGS.PASSWORD_RESET.TEXT);
+      const expectedHref = CONTENT_STRINGS.PASSWORD_RESET.HREF;
+      const expectedText = CONTENT_STRINGS.PASSWORD_RESET.TEXT;
 
-      signInPage.resetPasswordLink().should('have.attr', 'href', CONTENT_STRINGS.PASSWORD_RESET.HREF);
+      cy.checkLink(
+        signInPage.resetPasswordLink(),
+        expectedHref,
+        expectedText,
+      );
     });
 
     it('renders a `need to create an account` copy and button link', () => {
       cy.checkText(signInPage.needToCreateAccountHeading(), CONTENT_STRINGS.NEED_TO_CREATE_ACCOUNT.HEADING);
 
-      cy.checkText(signInPage.createAccountLink(), CONTENT_STRINGS.NEED_TO_CREATE_ACCOUNT.LINK.TEXT);
+      const expectedHref = CONTENT_STRINGS.NEED_TO_CREATE_ACCOUNT.LINK.HREF;
+      const expectedText = CONTENT_STRINGS.NEED_TO_CREATE_ACCOUNT.LINK.TEXT;
 
-      signInPage.createAccountLink().should('have.attr', 'href', CONTENT_STRINGS.NEED_TO_CREATE_ACCOUNT.LINK.HREF);
+      cy.checkLink(
+        signInPage.createAccountLink(),
+        expectedHref,
+        expectedText,
+      );
     });
 
     it(`should redirect to ${YOUR_DETAILS} when clicking 'need to create an account'`, () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/enter-code/account-sign-in-enter-code.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/enter-code/account-sign-in-enter-code.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../partials';
 import { enterCodePage } from '../../../../../pages/insurance/account/sign-in';
 import accountFormFields from '../../../../../partials/insurance/accountFormFields';
 import { PAGES } from '../../../../../../../content-strings';
@@ -60,10 +59,6 @@ context('Insurance - Account - Sign in - I want to sign in into my UKEF digital 
         cy.navigateToUrl(url);
       });
 
-      it('should render a header with href to insurance start', () => {
-        partials.header.serviceName().should('have.attr', 'href', START);
-      });
-
       it('renders `security code` label and input', () => {
         const fieldId = SECURITY_CODE;
         const field = accountFormFields[fieldId];
@@ -77,9 +72,14 @@ context('Insurance - Account - Sign in - I want to sign in into my UKEF digital 
       });
 
       it('renders a `request new code` link', () => {
-        cy.checkText(enterCodePage.requestNewCodeLink(), CONTENT_STRINGS.REQUEST_NEW_CODE.TEXT);
+        const expectedHref = CONTENT_STRINGS.REQUEST_NEW_CODE.HREF;
+        const expectedText = CONTENT_STRINGS.REQUEST_NEW_CODE.TEXT;
 
-        enterCodePage.requestNewCodeLink().should('have.attr', 'href', CONTENT_STRINGS.REQUEST_NEW_CODE.HREF);
+        cy.checkLink(
+          enterCodePage.requestNewCodeLink(),
+          expectedHref,
+          expectedText,
+        );
       });
 
       describe('when clicking `request new code`', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/request-new-code/account-sign-in-request-new-code.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/account/sign-in/request-new-code/account-sign-in-request-new-code.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../partials';
 import { submitButton } from '../../../../../pages/shared';
 import { enterCodePage, requestNewCodePage } from '../../../../../pages/insurance/account/sign-in';
 import { BUTTONS, PAGES } from '../../../../../../../content-strings';
@@ -49,10 +48,6 @@ context('Insurance - Account - Sign in - Request new code page - I want to enter
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
     });
 
     it('should render intro copy', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/all-sections.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/all-sections.spec.js
@@ -55,11 +55,15 @@ context('Insurance - All sections - new application', () => {
           cy.navigateToUrl(url);
 
           const task = taskList.initialChecks.tasks.eligibility;
-          const expectedLink = TASKS.LIST.INITIAL_CHECKS.TASKS.ELIGIBILITY;
 
-          cy.checkText(task.link(), expectedLink);
+          const expectedHref = '#';
+          const expectedText = TASKS.LIST.INITIAL_CHECKS.TASKS.ELIGIBILITY;
 
-          task.link().should('have.attr', 'href', '#');
+          cy.checkLink(
+            task.link(),
+            expectedText,
+            expectedHref,
+          );
 
           const expectedStatus = TASKS.STATUS.COMPLETED;
 
@@ -85,11 +89,14 @@ context('Insurance - All sections - new application', () => {
         it('should render a `type of policy and exports` task with link and `not started` status', () => {
           const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
-          const expectedLink = TASKS.LIST.PREPARE_APPLICATION.TASKS.POLICY_TYPE_AND_EXPORTS;
-          cy.checkText(task.link(), expectedLink);
+          const expectedHref = `${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.POLICY_AND_EXPORTS.TYPE_OF_POLICY}`;
+          const expectedText = TASKS.LIST.PREPARE_APPLICATION.TASKS.POLICY_TYPE_AND_EXPORTS;
 
-          const expectedUrl = `${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.POLICY_AND_EXPORTS.TYPE_OF_POLICY}`;
-          task.link().should('have.attr', 'href', expectedUrl);
+          cy.checkLink(
+            task.link(),
+            expectedText,
+            expectedHref,
+          );
 
           const expectedStatus = TASKS.STATUS.NOT_STARTED_YET;
 
@@ -99,12 +106,14 @@ context('Insurance - All sections - new application', () => {
         it('should render a `your business` task with link and `not started` status', () => {
           const task = taskList.prepareApplication.tasks.business;
 
-          const expectedLink = TASKS.LIST.PREPARE_APPLICATION.TASKS.EXPORTER_BUSINESS;
+          const expectedHref = `${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`;
+          const expectedText = TASKS.LIST.PREPARE_APPLICATION.TASKS.EXPORTER_BUSINESS;
 
-          cy.checkText(task.link(), expectedLink);
-
-          const expectedUrl = `${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`;
-          task.link().should('have.attr', 'href', expectedUrl);
+          cy.checkLink(
+            task.link(),
+            expectedText,
+            expectedHref,
+          );
 
           const expectedStatus = TASKS.STATUS.NOT_STARTED_YET;
           cy.checkText(task.status(), expectedStatus);
@@ -113,11 +122,14 @@ context('Insurance - All sections - new application', () => {
         it('should render a `your buyer` task with link and `not started` status', () => {
           const task = taskList.prepareApplication.tasks.buyer;
 
-          const expectedLink = TASKS.LIST.PREPARE_APPLICATION.TASKS.BUYER;
-          cy.checkText(task.link(), expectedLink);
+          const expectedText = TASKS.LIST.PREPARE_APPLICATION.TASKS.BUYER;
+          const expectedHref = `${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`;
 
-          const expectedUrl = `${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`;
-          task.link().should('have.attr', 'href', expectedUrl);
+          cy.checkLink(
+            task.link(),
+            expectedText,
+            expectedHref,
+          );
 
           const expectedStatus = TASKS.STATUS.NOT_STARTED_YET;
           cy.checkText(task.status(), expectedStatus);
@@ -144,8 +156,6 @@ context('Insurance - All sections - new application', () => {
           const expectedText = TASKS.LIST.SUBMIT_APPLICATION.TASKS.CHECK_ANSWERS;
           cy.checkText(task.text(), expectedText);
 
-          // const expectedUrl = `${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.CHECK_YOUR_ANSWERS.ELIGIBILITY}`;
-          // task.link().should('have.attr', 'href', expectedUrl);
           task.link().should('not.exist');
 
           const expectedStatus = TASKS.STATUS.CANNOT_START;

--- a/e2e-tests/cypress/e2e/journeys/insurance/apply-offline-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/apply-offline-page.spec.js
@@ -48,20 +48,6 @@ context('Insurance - apply offline exit page', () => {
   });
 
   it('renders `contact` copy with link', () => {
-    const expected = `${ACTIONS.CONTACT.TEXT} ${ACTIONS.CONTACT.LINK.TEXT}`;
-    cy.checkText(insurance.applyOfflinePage.contactCopy(), expected);
-
-    const expectedHref = ACTIONS.CONTACT.LINK.HREF;
-    const expectedText = ACTIONS.CONTACT.LINK.TEXT;
-
-    cy.checkLink(
-      insurance.applyOfflinePage.contactLink(),
-      expectedText,
-      expectedHref,
-    );
-  });
-
-  it('renders `contact` copy with link', () => {
     const expectedContactCopy = `${ACTIONS.CONTACT.TEXT} ${ACTIONS.CONTACT.LINK.TEXT}`;
 
     cy.checkText(insurance.applyOfflinePage.contactCopy(), expectedContactCopy);

--- a/e2e-tests/cypress/e2e/journeys/insurance/apply-offline-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/apply-offline-page.spec.js
@@ -40,15 +40,39 @@ context('Insurance - apply offline exit page', () => {
     const expected = `${ACTIONS.DOWNLOAD_FORM.LINK.TEXT} ${ACTIONS.DOWNLOAD_FORM.TEXT}`;
     cy.checkText(insurance.applyOfflinePage.downloadFormCopy(), expected);
 
-    cy.checkText(insurance.applyOfflinePage.downloadFormLink(), ACTIONS.DOWNLOAD_FORM.LINK.TEXT);
-
-    insurance.applyOfflinePage.downloadFormLink().should('have.attr', 'href', ACTIONS.DOWNLOAD_FORM.LINK.HREF_NBI);
+    cy.checkLink(
+      insurance.applyOfflinePage.downloadFormLink(),
+      ACTIONS.DOWNLOAD_FORM.LINK.HREF_NBI,
+      ACTIONS.DOWNLOAD_FORM.LINK.TEXT,
+    );
   });
 
   it('renders `contact` copy with link', () => {
     const expected = `${ACTIONS.CONTACT.TEXT} ${ACTIONS.CONTACT.LINK.TEXT}`;
     cy.checkText(insurance.applyOfflinePage.contactCopy(), expected);
 
-    insurance.applyOfflinePage.contactLink().should('have.attr', 'href', ACTIONS.CONTACT.LINK.HREF);
+    const expectedHref = ACTIONS.CONTACT.LINK.HREF;
+    const expectedText = ACTIONS.CONTACT.LINK.TEXT;
+
+    cy.checkLink(
+      insurance.applyOfflinePage.contactLink(),
+      expectedText,
+      expectedHref,
+    );
+  });
+
+  it('renders `contact` copy with link', () => {
+    const expectedContactCopy = `${ACTIONS.CONTACT.TEXT} ${ACTIONS.CONTACT.LINK.TEXT}`;
+
+    cy.checkText(insurance.applyOfflinePage.contactCopy(), expectedContactCopy);
+
+    const expectedLinkHref = ACTIONS.CONTACT.LINK.HREF;
+    const expectedLinkText = ACTIONS.CONTACT.LINK.TEXT;
+
+    cy.checkLink(
+      insurance.applyOfflinePage.contactLink(),
+      expectedLinkHref,
+      expectedLinkText,
+    );
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/eligibility/check-your-answers-eligibility-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/eligibility/check-your-answers-eligibility-page.spec.js
@@ -11,7 +11,6 @@ import { ROUTES } from '../../../../../../constants';
 
 const {
   ROOT: INSURANCE_ROOT,
-  START,
   ALL_SECTIONS,
   CHECK_YOUR_ANSWERS: {
     ELIGIBILITY,
@@ -70,10 +69,6 @@ context('Insurance - Check your answers - Eligibility page - I want to confirm m
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
     });
 
     it('renders a heading caption', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/need-to-start-new-application/need-to-start-new-application-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/need-to-start-new-application/need-to-start-new-application-page.spec.js
@@ -6,7 +6,6 @@ import { ROUTES, APPLICATION, DATE_FORMAT } from '../../../../../../constants';
 
 const {
   ROOT: INSURANCE_ROOT,
-  START,
   ALL_SECTIONS,
   ELIGIBILITY: { BUYER_COUNTRY },
   CHECK_YOUR_ANSWERS: { ELIGIBILITY, START_NEW_APPLICATION },
@@ -70,10 +69,6 @@ context('Insurance - Check your answers - Need to start new application page', (
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
     });
 
     it('renders inset text with submission deadline', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/policy-and-exports/check-your-answers-policy-and-exports-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/policy-and-exports/check-your-answers-policy-and-exports-page.spec.js
@@ -10,7 +10,6 @@ import { ROUTES } from '../../../../../../constants';
 
 const {
   ROOT: INSURANCE_ROOT,
-  START,
   ALL_SECTIONS,
   CHECK_YOUR_ANSWERS: {
     ELIGIBILITY,
@@ -69,10 +68,6 @@ context('Insurance - Check your answers - Policy and exports - I want to confirm
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
     });
 
     it('renders a heading caption', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/your-business/check-your-answers-your-business-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/your-business/check-your-answers-your-business-page.spec.js
@@ -10,7 +10,6 @@ import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const {
   ROOT: INSURANCE_ROOT,
-  START,
   ALL_SECTIONS,
   CHECK_YOUR_ANSWERS: {
     TYPE_OF_POLICY,
@@ -72,10 +71,6 @@ context('Insurance - Check your answers - Your business - I want to confirm my s
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
     });
 
     it('renders a heading caption', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/your-buyer/check-your-answers-your-buyer-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/check-your-answers/your-buyer/check-your-answers-your-buyer-page.spec.js
@@ -10,7 +10,6 @@ import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const {
   ROOT: INSURANCE_ROOT,
-  START,
   ALL_SECTIONS,
   CHECK_YOUR_ANSWERS: {
     YOUR_BUSINESS,
@@ -74,10 +73,6 @@ context('Insurance - Check your answers - Your buyer page - I want to confirm my
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
     });
 
     it('renders a heading caption', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/account-to-apply-online/account-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/account-to-apply-online/account-to-apply-online.spec.js
@@ -54,10 +54,6 @@ context('Insurance - Eligibility - Account to apply online page - I want to conf
       cy.navigateToUrl(url);
     });
 
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
-    });
-
     it('renders a `yes` radio button with a hint', () => {
       cy.checkText(yesRadio(), FIELD_VALUES.YES);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-country-only-apply-offline.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-country-only-apply-offline.spec.js
@@ -1,5 +1,6 @@
 import { backLink, buyerCountryPage, submitButton } from '../../../../pages/shared';
 import { ROUTES } from '../../../../../../constants';
+import { LINKS } from '../../../../../../content-strings';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility/forms';
 import { COUNTRY_SUPPORTRED_BY_EMAIL } from '../../../../../fixtures/countries';
 
@@ -31,11 +32,13 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
+    const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY}`;
 
-    const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY}`;
-
-    backLink().should('have.attr', 'href', expected);
+    cy.checkLink(
+      backLink(),
+      expectedHref,
+      LINKS.BACK,
+    );
   });
 
   it('should prepopulate the field when going back to the page via back link', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-unsupported-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country-unsupported-country.spec.js
@@ -1,7 +1,7 @@
 import {
   backLink, buyerCountryPage, cannotApplyPage, submitButton,
 } from '../../../../pages/shared';
-import { PAGES } from '../../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { COUNTRY_UNSUPPORTRED } from '../../../../../fixtures/countries';
 
@@ -36,11 +36,13 @@ context('Insurance - Buyer country page - as an exporter, I want to check if UKE
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
+    const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY}`;
 
-    const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY}`;
-
-    backLink().should('have.attr', 'href', expected);
+    cy.checkLink(
+      backLink(),
+      expectedHref,
+      LINKS.BACK,
+    );
   });
 
   it('should prepopulate the field when going back to the page via back link', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/buyer-country/buyer-country.spec.js
@@ -1,6 +1,6 @@
 import { backLink, buyerCountryPage, submitButton } from '../../../../pages/shared';
 import { ROUTES } from '../../../../../../constants';
-import { PAGES } from '../../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../../content-strings';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility/forms';
 import {
   checkInputHint,
@@ -75,11 +75,13 @@ context('Insurance - Buyer country page - as an exporter, I want to check if UKE
       });
 
       it('renders a back link with correct url', () => {
-        backLink().should('exist');
+        const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY}`;
 
-        const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY}`;
-
-        backLink().should('have.attr', 'href', expected);
+        cy.checkLink(
+          backLink(),
+          expectedHref,
+          LINKS.BACK,
+        );
       });
 
       it('should focus on input when clicking summary error message', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
@@ -52,17 +52,32 @@ context('Insurance Eligibility - Cannot apply exit page', () => {
 
     cy.checkText(cannotApplyPage.actions.eligibility(), expectedEligibility);
 
-    cannotApplyPage.actions.eligibilityLink().should('have.attr', 'href', CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.HREF);
+    cy.checkLink(
+      cannotApplyPage.actions.eligibilityLink(),
+      CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.HREF,
+      CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.TEXT,
+    );
 
     const expectedBroker = `${CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.LINK.TEXT} ${CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.TEXT}`;
     cy.checkText(cannotApplyPage.actions.approvedBroker(), expectedBroker);
 
-    cannotApplyPage.actions.approvedBrokerLink().should('have.attr', 'href', CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.LINK.HREF);
+    cy.checkLink(
+      cannotApplyPage.actions.approvedBrokerLink(),
+      CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.LINK.HREF,
+      CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.LINK.TEXT,
+    );
   });
 
   describe('when clicking `eligibility` link', () => {
     it('redirects to guidance page - eligibility section', () => {
-      cannotApplyPage.actions.eligibilityLink().should('have.attr', 'href', CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.HREF);
+      const expectedHref = CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.HREF;
+      const expectedText = CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.TEXT;
+
+      cy.checkLink(
+        cannotApplyPage.actions.eligibilityLink(),
+        expectedHref,
+        expectedText,
+      );
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
@@ -1,7 +1,7 @@
 import {
   backLink, cannotApplyPage, noRadio, noRadioInput, submitButton,
 } from '../../../../pages/shared';
-import { PAGES } from '../../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
 import {
@@ -50,11 +50,13 @@ context('Insurance - Eligibility - Companies house number page - I want to check
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
+    const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`;
 
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`;
-
-    backLink().should('have.attr', 'href', expectedUrl);
+    cy.checkLink(
+      backLink(),
+      expectedHref,
+      LINKS.BACK,
+    );
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/companies-house-number/companies-house-number.spec.js
@@ -61,10 +61,6 @@ context('Insurance - Eligibility - Companies house number page - I want to check
       cy.navigateToUrl(url);
     });
 
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
-    });
-
     it('renders `yes` radio button', () => {
       yesRadio().should('exist');
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online/eligible-to-apply-online.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/eligible-to-apply-online/eligible-to-apply-online.spec.js
@@ -1,6 +1,5 @@
 import { submitButton } from '../../../../pages/shared';
 import { insurance } from '../../../../pages';
-import partials from '../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
@@ -68,10 +67,6 @@ context('Insurance - Eligibility - You are eligible to apply online page - I wan
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
     });
 
     it('renders inset text', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location-answer-no.spec.js
@@ -1,7 +1,7 @@
 import {
   backLink, cannotApplyPage, noRadio, noRadioInput, submitButton,
 } from '../../../../pages/shared';
-import { PAGES } from '../../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../support/insurance/eligibility/forms';
@@ -35,11 +35,13 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
+    const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION}`;
 
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION}`;
-
-    backLink().should('have.attr', 'href', expectedUrl);
+    cy.checkLink(
+      backLink(),
+      expectedHref,
+      LINKS.BACK,
+    );
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/exporter-location/exporter-location.spec.js
@@ -9,8 +9,6 @@ import { completeStartForm, completeCheckIfEligibleForm } from '../../../../../s
 
 const CONTENT_STRINGS = PAGES.EXPORTER_LOCATION;
 
-const insuranceStartRoute = ROUTES.INSURANCE.START;
-
 context('Insurance - Exporter location page - as an exporter, I want to check if my company can get UKEF issue export insurance cover', () => {
   beforeEach(() => {
     cy.navigateToUrl(ROUTES.INSURANCE.START);
@@ -29,10 +27,6 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
       backLink: ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY,
       assertAuthenticatedHeader: false,
     });
-  });
-
-  it('should render a header with href to insurance start', () => {
-    partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
   });
 
   it('renders `yes` radio button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount-answer-yes.spec.js
@@ -1,7 +1,7 @@
 import {
   backLink, cannotApplyPage, yesRadio, yesRadioInput, submitButton,
 } from '../../../../pages/shared';
-import { PAGES } from '../../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
 import {
@@ -39,11 +39,13 @@ context('Insurance - Insured amount page - I want to check if I can use online s
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
+    const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT}`;
 
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT}`;
-
-    backLink().should('have.attr', 'href', expectedUrl);
+    cy.checkLink(
+      backLink(),
+      expectedHref,
+      LINKS.BACK,
+    );
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/insured-amount/insured-amount.spec.js
@@ -14,8 +14,6 @@ import {
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.INSURED_AMOUNT;
 
-const insuranceStartRoute = ROUTES.INSURANCE.START;
-
 context('Insurance - Insured amount page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction that is less than the maxium amount of cover available online', () => {
   let url;
 
@@ -49,10 +47,6 @@ context('Insurance - Insured amount page - I want to check if I can use online s
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
     });
 
     it('renders `yes` radio button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit-answer-yes.spec.js
@@ -1,7 +1,7 @@
 import {
   backLink, cannotApplyPage, yesRadio, yesRadioInput, submitButton,
 } from '../../../../pages/shared';
-import { PAGES } from '../../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
 import {
@@ -46,11 +46,13 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
+    const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`;
 
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT}`;
-
-    backLink().should('have.attr', 'href', expectedUrl);
+    cy.checkLink(
+      backLink(),
+      expectedHref,
+      LINKS.BACK,
+    );
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/letter-of-credit/letter-of-credit.spec.js
@@ -17,8 +17,6 @@ import {
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT;
 
-const insuranceStartRoute = ROUTES.INSURANCE.START;
-
 context('Insurance - Eligibility - Letter of credit page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction that is paid via letter of credit', () => {
   let url;
 
@@ -55,10 +53,6 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
     });
 
     it('renders `yes` radio button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/need-to-start-again.spec.js
@@ -1,12 +1,10 @@
 import { submitButton, needToStartAgainPage } from '../../../pages/shared';
 import { LINKS, PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
-import partials from '../../../partials';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../support/insurance/eligibility/forms';
 
 const CONTENT_STRINGS = PAGES.NEED_TO_START_AGAIN_PAGE;
 
-const insuranceStartRoute = ROUTES.INSURANCE.START;
 const buyerCountryRoute = ROUTES.INSURANCE.ELIGIBILITY.BUYER_COUNTRY;
 
 context('Insurance Eligibility - Need to start again exit page', () => {
@@ -34,10 +32,6 @@ context('Insurance Eligibility - Need to start again exit page', () => {
       submitButtonCopy: LINKS.START_AGAIN.TEXT,
       assertAuthenticatedHeader: false,
     });
-  });
-
-  it('should render a header with href to insurance start', () => {
-    partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
   });
 
   it('renders a reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties-answer-yes.spec.js
@@ -1,7 +1,7 @@
 import {
   backLink, cannotApplyPage, yesRadio, yesRadioInput, submitButton,
 } from '../../../../pages/shared';
-import { PAGES } from '../../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
 import {
@@ -44,11 +44,13 @@ context('Insurance - Insured amount page - I want to check if I can use online s
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
+    const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED}`;
 
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED}`;
-
-    backLink().should('have.attr', 'href', expectedUrl);
+    cy.checkLink(
+      backLink(),
+      expectedHref,
+      LINKS.BACK,
+    );
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/other-parties/other-parties.spec.js
@@ -17,8 +17,6 @@ import {
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED;
 
-const insuranceStartRoute = ROUTES.INSURANCE.START;
-
 context('Insurance - Other parties page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction if there are other parties involved in the export', () => {
   let url;
 
@@ -54,10 +52,6 @@ context('Insurance - Other parties page - I want to check if I can use online se
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
     });
 
     it('renders `yes` radio button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period-answer-yes.spec.js
@@ -1,7 +1,7 @@
 import {
   backLink, cannotApplyPage, yesRadio, yesRadioInput, submitButton,
 } from '../../../../pages/shared';
-import { PAGES } from '../../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
 import {
@@ -48,11 +48,13 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
+    const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD}`;
 
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD}`;
-
-    backLink().should('have.attr', 'href', expectedUrl);
+    cy.checkLink(
+      backLink(),
+      expectedHref,
+      LINKS.BACK,
+    );
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -24,7 +24,6 @@ import {
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD;
 
 const FIELD_ID = FIELD_IDS.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD;
-const insuranceStartRoute = ROUTES.INSURANCE.START;
 
 context('Insurance - Eligibility - Pre-credit period page - I want to check if I can use online service to apply for UKEF Export Insurance Policy for my export transaction that is paid via letter of credit', () => {
   const url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.PRE_CREDIT_PERIOD}`;
@@ -61,10 +60,6 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
     });
 
     it('renders `yes` radio button with hint', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
@@ -1,7 +1,7 @@
 import {
   backLink, cannotApplyPage, noRadio, noRadioInput, submitButton,
 } from '../../../../pages/shared';
-import { PAGES } from '../../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeStartForm, completeCheckIfEligibleForm, completeExporterLocationForm } from '../../../../../support/insurance/eligibility/forms';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../support/forms';
@@ -32,11 +32,13 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
+    const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES}`;
 
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES}`;
-
-    backLink().should('have.attr', 'href', expectedUrl);
+    cy.checkLink(
+      backLink(),
+      expectedHref,
+      LINKS.BACK,
+    );
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -27,8 +27,6 @@ const {
   ELIGIBILITY: { HAS_MINIMUM_UK_GOODS_OR_SERVICES },
 } = FIELD_IDS;
 
-const insuranceStartRoute = ROUTES.INSURANCE.START;
-
 context('Insurance - UK goods or services page - as an exporter, I want to check if my export value is eligible for UKEF export insurance cover', () => {
   let url;
 
@@ -61,10 +59,6 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
     });
 
     it('renders `yes` radio button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/feedback/feedback-confirmation-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/feedback/feedback-confirmation-page.spec.js
@@ -41,11 +41,7 @@ context('Insurance - Feedback Confirmation page', () => {
       cy.navigateToUrl(url);
     });
 
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
-    });
-
-    it('should render a text body confirming feedback', () => {
+    it('should render text confirming feedback', () => {
       cy.checkText(feedbackConfirmation.feedbackConfirmation(), CONTENT_STRINGS.FEEDBACK_TEXT);
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/insurance/feedback/feedback-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/feedback/feedback-page.spec.js
@@ -52,10 +52,6 @@ context('Insurance - Feedback - As an exporter I want to give feedback on the UK
       cy.navigateToUrl(url);
     });
 
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
-    });
-
     it(`should render the ${SATISFACTION} radios`, () => {
       const field = feedbackPage.field(SATISFACTION);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/header.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/header.spec.js
@@ -1,5 +1,4 @@
 import header from '../../partials/header';
-import { PRODUCT } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 
 context('Insurance - header', () => {
@@ -12,15 +11,18 @@ context('Insurance - header', () => {
   });
 
   it('renders a GOV home link', () => {
-    header.govHomeLink().should('exist');
+    const expectedHref = 'https://www.gov.uk';
+    const expectedText = 'GOV.UK';
 
-    header.govHomeLink().should('have.attr', 'href', 'https://www.gov.uk');
+    cy.checkLink(
+      header.govHomeLink(),
+      expectedHref,
+      expectedText,
+    );
   });
 
   it('renders service name link', () => {
-    cy.checkText(header.serviceName(), PRODUCT.DESCRIPTION.APPLICATION);
-
-    header.serviceName().should('have.attr', 'href', url);
+    cy.checkHeaderServiceNameHref({ isInsurancePage: true });
   });
 
   it('should NOT render authenticated navigation links', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/check-your-answers/check-your-answers.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/check-your-answers/check-your-answers.spec.js
@@ -13,13 +13,10 @@ import { INSURANCE_ROOT } from '../../../../../../constants/routes/insurance';
 
 const {
   POLICY_AND_EXPORTS,
-  START,
   EXPORTER_BUSINESS: {
     COMPANY_DETAILS,
   },
 } = ROUTES.INSURANCE;
-
-const insuranceStartRoute = START;
 
 const CONTENT_STRINGS = PAGES.INSURANCE.POLICY_AND_EXPORTS.CHECK_YOUR_ANSWERS;
 
@@ -67,10 +64,6 @@ context('Insurance - Policy and exports - Check your answers - As an exporter, I
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
     });
 
     it('renders a heading caption', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -164,9 +164,11 @@ context('Insurance - Policy and exports - Multiple contract policy page - As an 
       const expected = `${HINT.NEED_MORE_COVER} ${HINT.FILL_IN_FORM.TEXT}`;
       cy.checkText(field.hint.needMoreCover(), expected);
 
-      cy.checkText(field.hint.fillInFormLink(), HINT.FILL_IN_FORM.TEXT);
-
-      field.hint.fillInFormLink().should('have.attr', 'href', LINKS.EXTERNAL.PROPOSAL_FORM);
+      cy.checkLink(
+        field.hint.fillInFormLink(),
+        LINKS.EXTERNAL.PROPOSAL_FORM,
+        HINT.FILL_IN_FORM.TEXT,
+      );
 
       cy.checkText(field.hint.noDecimals(), HINT.NO_DECIMALS);
 

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/single-contract-policy/single-contract-policy.spec.js
@@ -139,12 +139,11 @@ context('Insurance - Policy and exports - Single contract policy page - As an ex
         hintContent.NEED_MORE_COVER,
       );
 
-      cy.checkText(
+      cy.checkLink(
         field.hint.link(),
+        LINKS.EXTERNAL.PROPOSAL_FORM,
         hintContent.FILL_IN_FORM.TEXT,
       );
-
-      field.hint.link().should('have.attr', 'href', LINKS.EXTERNAL.PROPOSAL_FORM);
 
       cy.checkText(
         field.hint.noDecimals(),

--- a/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/type-of-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/policy-and-exports/type-of-policy/type-of-policy.spec.js
@@ -16,8 +16,7 @@ import { POLICY_AND_EXPORT_FIELDS as FIELDS } from '../../../../../../content-st
 import { FIELD_IDS, FIELD_VALUES, ROUTES } from '../../../../../../constants';
 import { INSURANCE_ROOT } from '../../../../../../constants/routes/insurance';
 
-const { POLICY_AND_EXPORTS, START } = ROUTES.INSURANCE;
-const insuranceStartRoute = START;
+const { POLICY_AND_EXPORTS } = ROUTES.INSURANCE;
 
 const CONTENT_STRINGS = PAGES.INSURANCE.POLICY_AND_EXPORTS.TYPE_OF_POLICY;
 
@@ -69,10 +68,6 @@ context('Insurance - Policy and exports - Type of policy page - As an exporter, 
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
     });
 
     it('renders a heading caption', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/speak-to-ukef-efm.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/speak-to-ukef-efm.spec.js
@@ -47,11 +47,13 @@ context('Insurance - speak to UKEF EFM exit page', () => {
     const expectedText = `${ACTIONS.FIND_EFM[0][0].text} ${ACTIONS.FIND_EFM[0][1].text}${ACTIONS.FIND_EFM[0][2].text}`;
     cy.checkText(insurance.speakToUkefEfmPage.action.text(), expectedText);
 
-    const expectedLink = `${ACTIONS.FIND_EFM[0][1].text}`;
-    cy.checkText(insurance.speakToUkefEfmPage.action.link(), expectedLink);
-
+    const expectedLinkText = `${ACTIONS.FIND_EFM[0][1].text}`;
     const expectedHref = ACTIONS.FIND_EFM[0][1].href;
 
-    insurance.speakToUkefEfmPage.action.link().should('have.attr', 'href', expectedHref);
+    cy.checkLink(
+      insurance.speakToUkefEfmPage.action.link(),
+      expectedHref,
+      expectedLinkText,
+    );
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/start.spec.js
@@ -1,6 +1,5 @@
 import { insurance } from '../../pages';
 import { submitButton } from '../../pages/shared';
-import partials from '../../partials';
 import { BUTTONS, PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 
@@ -32,10 +31,6 @@ context('Insurance Eligibility - start page', () => {
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', url);
     });
 
     it('renders an intro', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/check-your-answers/check-your-answers-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/check-your-answers/check-your-answers-page.spec.js
@@ -13,7 +13,6 @@ import { INSURANCE_ROOT } from '../../../../../../constants/routes/insurance';
 
 const {
   ROOT,
-  START,
   ALL_SECTIONS,
   EXPORTER_BUSINESS: {
     BROKER,
@@ -23,8 +22,6 @@ const {
     COMPANY_OR_ORGANISATION,
   },
 } = ROUTES.INSURANCE;
-
-const insuranceStartRoute = START;
 
 const CONTENT_STRINGS = PAGES.INSURANCE.EXPORTER_BUSINESS.CHECK_YOUR_ANSWERS;
 
@@ -74,10 +71,6 @@ context('Insurance - Your Business - Check your answers - As an exporter, I want
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', insuranceStartRoute);
     });
 
     it('renders a heading caption', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-no-companies-house-link.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-no-companies-house-link.spec.js
@@ -39,7 +39,16 @@ context('Insurance - Your business - Company details page - As an Exporter it sh
 
     cy.navigateToUrl(url);
 
-    companyDetails.companiesHouseNoNumber().should('have.attr', 'href', `${ROOT}/${referenceNumber}${NO_COMPANIES_HOUSE_NUMBER}`);
+    const expectedHref = `${ROOT}/${referenceNumber}${NO_COMPANIES_HOUSE_NUMBER}`;
+
+    const expectedText = CONTENT_STRINGS.REASON.NO_COMPANIES_HOUSE_NUMBER;
+
+    cy.checkLink(
+      companyDetails.companiesHouseNoNumber(),
+      expectedHref,
+      expectedText,
+    );
+
     companyDetails.companiesHouseNoNumber().click();
   });
 
@@ -58,7 +67,14 @@ context('Insurance - Your business - Company details page - As an Exporter it sh
   });
 
   it('should contain link to proposal form on the apply offline page', () => {
-    insurance.applyOfflinePage.downloadFormLink().should('have.attr', 'href', ACTIONS.DOWNLOAD_FORM.LINK.HREF_PROPOSAL);
+    const expectedHref = ACTIONS.DOWNLOAD_FORM.LINK.HREF_PROPOSAL;
+    const expectedText = ACTIONS.DOWNLOAD_FORM.LINK.TEXT;
+
+    cy.checkLink(
+      insurance.applyOfflinePage.downloadFormLink(),
+      expectedHref,
+      expectedText,
+    );
   });
 
   it('should take you back to company-details page when pressing the back button', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-details-page.spec.js
@@ -21,8 +21,6 @@ const {
   },
 } = FIELD_IDS.INSURANCE.EXPORTER_BUSINESS;
 
-const insuranceStart = ROUTES.INSURANCE.START;
-
 const { taskList } = partials.insurancePartials;
 
 const task = taskList.prepareApplication.tasks.business;
@@ -65,10 +63,6 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', insuranceStart);
     });
 
     it('renders a heading caption', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-house-unavailable/company-house-unavailable-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/company-details/company-house-unavailable/company-house-unavailable-page.spec.js
@@ -1,13 +1,10 @@
 import { companiesHouseUnavailablePage } from '../../../../../pages/your-business';
-import partials from '../../../../../partials';
 import { PAGES } from '../../../../../../../content-strings';
 import { ROUTES } from '../../../../../../../constants';
 
 const { ROOT, ALL_SECTIONS } = ROUTES.INSURANCE;
 
 const CONTENT_STRINGS = PAGES.INSURANCE.EXPORTER_BUSINESS.COMPANIES_HOUSE_UNAVAILABLE;
-
-const insuranceStart = ROUTES.INSURANCE.START;
 
 const { COMPANY_DETAILS, COMPANIES_HOUSE_UNAVAILABLE } = ROUTES.INSURANCE.EXPORTER_BUSINESS;
 
@@ -52,10 +49,6 @@ context("Insurance - Your business - Companies house unavailable page - I want t
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', insuranceStart);
     });
 
     it('should display the correct text on the page', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/contact/your-contact-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/contact/your-contact-page.spec.js
@@ -31,8 +31,6 @@ const {
   },
 } = ROUTES.INSURANCE;
 
-const insuranceStart = ROUTES.INSURANCE.START;
-
 const { taskList } = partials.insurancePartials;
 
 const task = taskList.prepareApplication.tasks.business;
@@ -76,10 +74,6 @@ context('Insurance - Your business - Contact page - As an Exporter I want to ent
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', insuranceStart);
     });
 
     it('renders a heading caption', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/nature-of-business-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/nature-of-business/nature-of-business-page.spec.js
@@ -25,8 +25,6 @@ const {
   },
 } = ROUTES.INSURANCE;
 
-const insuranceStart = ROUTES.INSURANCE.START;
-
 const { taskList } = partials.insurancePartials;
 
 const task = taskList.prepareApplication.tasks.business;
@@ -72,10 +70,6 @@ context('Insurance - Your business - Nature of your business page - As an Export
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(natureOfBusinessUrl);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', insuranceStart);
     });
 
     it('renders a heading caption', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-business/turnover/turnover-page.spec.js
@@ -26,8 +26,6 @@ const {
   },
 } = ROUTES.INSURANCE;
 
-const insuranceStart = ROUTES.INSURANCE.START;
-
 const { taskList } = partials.insurancePartials;
 
 const task = taskList.prepareApplication.tasks.business;
@@ -73,10 +71,6 @@ context('Insurance - Your business - Turnover page - As an Exporter I want to en
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', insuranceStart);
     });
 
     it('renders a heading caption', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/check-your-answers/check-your-answers-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/check-your-answers/check-your-answers-page.spec.js
@@ -9,7 +9,6 @@ import { INSURANCE_ROOT } from '../../../../../../constants/routes/insurance';
 
 const {
   ROOT,
-  START,
   ALL_SECTIONS,
   YOUR_BUYER: {
     WORKING_WITH_BUYER,
@@ -62,10 +61,6 @@ context('Insurance - Your buyer - Check your answers - As an exporter, I want to
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
     });
 
     it('renders a heading caption', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/company-or-organisation/company-or-organisation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/company-or-organisation/company-or-organisation.spec.js
@@ -28,7 +28,6 @@ const {
 const { ELIGIBILITY: { BUYER_COUNTRY } } = FIELD_IDS;
 
 const {
-  START,
   YOUR_BUYER: { WORKING_WITH_BUYER, COMPANY_OR_ORGANISATION },
 } = ROUTES.INSURANCE;
 
@@ -74,10 +73,6 @@ context('Insurance - Your Buyer - Company or organisation page - As an exporter,
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
     });
 
     it('renders a heading caption', () => {

--- a/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/working-with-buyer/working-with-buyer.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/your-buyer/working-with-buyer/working-with-buyer.spec.js
@@ -17,7 +17,6 @@ const {
 } = FIELD_IDS;
 
 const {
-  START,
   YOUR_BUYER: { COMPANY_OR_ORGANISATION, WORKING_WITH_BUYER, CHECK_YOUR_ANSWERS },
 } = ROUTES.INSURANCE;
 
@@ -70,10 +69,6 @@ context('Insurance - Your Buyer - Working with buyer page - As an exporter, I wa
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to insurance start', () => {
-      partials.header.serviceName().should('have.attr', 'href', START);
     });
 
     it('renders a heading caption', () => {

--- a/e2e-tests/cypress/e2e/journeys/page-not-found.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/page-not-found.spec.js
@@ -1,4 +1,4 @@
-import partials from '../partials';
+import header from '../partials/header';
 import { PAGES, PRODUCT } from '../../../content-strings';
 
 const CONTENT_STRINGS = PAGES.PAGE_NOT_FOUND_PAGE;
@@ -26,15 +26,22 @@ context('404 Page not found', () => {
 
   describe('header', () => {
     it('renders a GOV home link', () => {
-      partials.header.govHomeLink().should('exist');
-
-      partials.header.govHomeLink().should('have.attr', 'href', 'https://www.gov.uk');
+      cy.checkLink(
+        header.govHomeLink(),
+        'https://www.gov.uk',
+        'GOV.UK',
+      );
     });
 
     it('renders service name link', () => {
-      cy.checkText(partials.header.serviceName(), PRODUCT.DESCRIPTION.GENERIC);
+      const expectedHref = '/';
+      const expectedText = PRODUCT.DESCRIPTION.GENERIC;
 
-      partials.header.serviceName().should('have.attr', 'href', '/');
+      cy.checkLink(
+        header.serviceName(),
+        expectedHref,
+        expectedText,
+      );
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/accessibility-statement.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/accessibility-statement.spec.js
@@ -28,8 +28,6 @@ const {
   PREPERATION_OF_STATEMENT,
 } = CONTENT_STRINGS;
 
-const startRoute = ROUTES.QUOTE.START;
-
 context('Accessibility statement page - Quote', () => {
   beforeEach(() => {
     cy.login();
@@ -53,16 +51,12 @@ context('Accessibility statement page - Quote', () => {
     });
   });
 
-  it('should render a header with href to quote start', () => {
-    partials.header.serviceName().should('have.attr', 'href', startRoute);
-  });
-
   it('renders a service link', () => {
-    accessibilityStatementPage.serviceLink().invoke('text').then((text) => {
-      expect(text.trim()).equal(SERVICE_LINK.TEXT);
-    });
-
-    accessibilityStatementPage.serviceLink().should('have.attr', 'href', SERVICE_LINK.HREF);
+    cy.checkLink(
+      accessibilityStatementPage.serviceLink(),
+      SERVICE_LINK.HREF,
+      SERVICE_LINK.TEXT,
+    );
   });
 
   describe('using our service', () => {
@@ -102,11 +96,11 @@ context('Accessibility statement page - Quote', () => {
 
     describe('outro', () => {
       it('renders AbilityNet link and outro copy', () => {
-        usingOurService.abilityNet.link().invoke('text').then((text) => {
-          expect(text.trim()).equal(USING_OUR_SERVICE.OUTRO.ABILITY_NET.LINK.TEXT);
-        });
-
-        usingOurService.abilityNet.link().should('have.attr', 'href', USING_OUR_SERVICE.OUTRO.ABILITY_NET.LINK.HREF);
+        cy.checkLink(
+          usingOurService.abilityNet.link(),
+          USING_OUR_SERVICE.OUTRO.ABILITY_NET.LINK.HREF,
+          USING_OUR_SERVICE.OUTRO.ABILITY_NET.LINK.TEXT,
+        );
 
         usingOurService.abilityNet.outro().invoke('text').then((text) => {
           expect(text.trim()).equal(USING_OUR_SERVICE.OUTRO.ABILITY_NET.DESCRIPTION);
@@ -173,11 +167,11 @@ context('Accessibility statement page - Quote', () => {
     });
 
     it('renders a link', () => {
-      enforcementProcedure.link().invoke('text').then((text) => {
-        expect(text.trim()).equal(ENFORCEMENT_PROCEDURE.CONTACT.TEXT);
-      });
-
-      enforcementProcedure.link().should('have.attr', 'href', ENFORCEMENT_PROCEDURE.CONTACT.HREF);
+      cy.checkLink(
+        enforcementProcedure.link(),
+        ENFORCEMENT_PROCEDURE.CONTACT.HREF,
+        ENFORCEMENT_PROCEDURE.CONTACT.TEXT,
+      );
     });
   });
 
@@ -209,11 +203,11 @@ context('Accessibility statement page - Quote', () => {
     });
 
     it('renders a link', () => {
-      complianceStatus.link().invoke('text').then((text) => {
-        expect(text.trim()).equal(COMPLIANCE_STATUS.GUIDLINES_LINK.TEXT);
-      });
-
-      complianceStatus.link().should('have.attr', 'href', COMPLIANCE_STATUS.GUIDLINES_LINK.HREF);
+      cy.checkLink(
+        complianceStatus.link(),
+        COMPLIANCE_STATUS.GUIDLINES_LINK.HREF,
+        COMPLIANCE_STATUS.GUIDLINES_LINK.TEXT,
+      );
     });
 
     it('renders an outro', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body-answer-yes.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body-answer-yes.spec.js
@@ -2,7 +2,7 @@ import {
   backLink, yesRadio, yesRadioInput, submitButton,
 } from '../../../pages/shared';
 import { getAQuoteByEmailPage } from '../../../pages/quote';
-import { PAGES } from '../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
 
@@ -30,9 +30,11 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
-
-    backLink().should('have.attr', 'href', url);
+    cy.checkLink(
+      backLink(),
+      url,
+      LINKS.BACK,
+    );
   });
 
   it('renders a specific reason and description', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
@@ -12,8 +12,6 @@ const {
   ELIGIBILITY: { VALID_BUYER_BODY },
 } = FIELD_IDS;
 
-const startRoute = ROUTES.QUOTE.START;
-
 context('Buyer body page - as an exporter, I want to check if I can get an EXIP online quote for my buyers country', () => {
   beforeEach(() => {
     cy.login();
@@ -30,10 +28,6 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
       assertAuthenticatedHeader: false,
       isInsurancePage: false,
     });
-  });
-
-  it('should render a header with href to quote start', () => {
-    partials.header.serviceName().should('have.attr', 'href', startRoute);
   });
 
   it('renders `yes` radio button', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country-country-only-get-a-quote-by-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country-country-only-get-a-quote-by-email.spec.js
@@ -1,5 +1,6 @@
 import { backLink, buyerCountryPage, submitButton } from '../../../pages/shared';
 import { ROUTES } from '../../../../../constants';
+import { LINKS } from '../../../../../content-strings';
 import { COUNTRY_SUPPORTRED_BY_EMAIL } from '../../../../fixtures/countries';
 
 context('Buyer country page - as an exporter, I want to check if UKEF issue export insurance cover for where my buyer is based - submit country that can only get a quote offline/via email', () => {
@@ -22,11 +23,11 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
-
-    const expected = ROUTES.QUOTE.BUYER_COUNTRY;
-
-    backLink().should('have.attr', 'href', expected);
+    cy.checkLink(
+      backLink(),
+      ROUTES.QUOTE.BUYER_COUNTRY,
+      LINKS.BACK,
+    );
   });
 
   it('should prepopulate the field when going back to the page via back link', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country-unsupported-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country-unsupported-country.spec.js
@@ -1,7 +1,7 @@
 import {
   backLink, buyerCountryPage, cannotApplyPage, submitButton,
 } from '../../../pages/shared';
-import { PAGES } from '../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import { COUNTRY_UNSUPPORTRED } from '../../../../fixtures/countries';
 
@@ -33,9 +33,11 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
-
-    backLink().should('have.attr', 'href', url);
+    cy.checkLink(
+      backLink(),
+      url,
+      LINKS.BACK,
+    );
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
@@ -72,11 +72,13 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue expo
       });
 
       it('renders a back link with correct url', () => {
-        backLink().should('exist');
+        const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.BUYER_COUNTRY}`;
 
-        const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.BUYER_COUNTRY}`;
-
-        backLink().should('have.attr', 'href', expected);
+        cy.checkLink(
+          backLink(),
+          expectedHref,
+          LINKS.BACK,
+        );
       });
 
       it('should focus on input when clicking summary error message', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
@@ -1,14 +1,12 @@
 import {
   cannotApplyPage, noRadio, submitButton,
 } from '../../pages/shared';
-import partials from '../../partials';
 import { PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../support/forms';
 import { completeAndSubmitBuyerBodyForm, completeAndSubmitExporterLocationForm } from '../../../support/quote/forms';
 
 const CONTENT_STRINGS = PAGES.QUOTE.CANNOT_APPLY;
-const startRoute = ROUTES.QUOTE.START;
 
 context('Cannot apply exit page', () => {
   beforeEach(() => {
@@ -39,10 +37,6 @@ context('Cannot apply exit page', () => {
     });
   });
 
-  it('should render a header with href to quote start', () => {
-    partials.header.serviceName().should('have.attr', 'href', startRoute);
-  });
-
   it('renders a reason', () => {
     cannotApplyPage.reason().should('exist');
   });
@@ -57,17 +51,30 @@ context('Cannot apply exit page', () => {
     const expectedEligibility = `${CONTENT_STRINGS.ACTIONS.ELIGIBILITY.TEXT} ${CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.TEXT}`;
     cy.checkText(cannotApplyPage.actions.eligibility(), expectedEligibility);
 
-    cannotApplyPage.actions.eligibilityLink().should('have.attr', 'href', CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.HREF);
+    cy.checkLink(
+      cannotApplyPage.actions.eligibilityLink(),
+      CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.HREF,
+      CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.TEXT,
+    );
 
     const expectedBroker = `${CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.LINK.TEXT} ${CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.TEXT}`;
+
     cy.checkText(cannotApplyPage.actions.approvedBroker(), expectedBroker);
 
-    cannotApplyPage.actions.approvedBrokerLink().should('have.attr', 'href', CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.LINK.HREF);
+    cy.checkLink(
+      cannotApplyPage.actions.approvedBrokerLink(),
+      CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.LINK.HREF,
+      CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.LINK.TEXT,
+    );
   });
 
   describe('when clicking `eligibility` link', () => {
     it('redirects to guidance page - eligibility section', () => {
-      cannotApplyPage.actions.eligibilityLink().should('have.attr', 'href', CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.HREF);
+      cy.checkLink(
+        cannotApplyPage.actions.eligibilityLink(),
+        CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.HREF,
+        CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.TEXT,
+      );
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-export-fields.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-export-fields.spec.js
@@ -3,6 +3,7 @@ import {
 } from '../../../pages/shared';
 import { checkYourAnswersPage } from '../../../pages/quote';
 import { FIELD_IDS, ROUTES } from '../../../../../constants';
+import { LINKS } from '../../../../../content-strings';
 
 const {
   ELIGIBILITY: {
@@ -45,10 +46,13 @@ context('Change your answers (export fields) - as an exporter, I want to change 
     });
 
     it('renders a back link with correct url', () => {
-      backLink().should('exist');
+      const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
 
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
-      backLink().should('have.attr', 'href', expected);
+      cy.checkLink(
+        backLink(),
+        expectedHref,
+        LINKS.BACK,
+      );
     });
 
     it('has originally submitted answer selected', () => {
@@ -107,10 +111,13 @@ context('Change your answers (export fields) - as an exporter, I want to change 
     });
 
     it('renders a back link with correct url', () => {
-      backLink().should('exist');
+      const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
 
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
-      backLink().should('have.attr', 'href', expected);
+      cy.checkLink(
+        backLink(),
+        expectedHref,
+        LINKS.BACK,
+      );
     });
 
     it('has originally submitted answer selected', () => {
@@ -144,10 +151,13 @@ context('Change your answers (export fields) - as an exporter, I want to change 
     });
 
     it('renders a back link with correct url', () => {
-      backLink().should('exist');
+      const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
 
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
-      backLink().should('have.attr', 'href', expected);
+      cy.checkLink(
+        backLink(),
+        expectedHref,
+        LINKS.BACK,
+      );
     });
 
     it('has originally submitted answer', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-policy-fields-multi-policy-credit-period.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-policy-fields-multi-policy-credit-period.spec.js
@@ -4,6 +4,7 @@ import {
   checkYourAnswersPage,
 } from '../../../pages/quote';
 import { FIELD_IDS, ROUTES } from '../../../../../constants';
+import { LINKS } from '../../../../../content-strings';
 
 const { ELIGIBILITY: { CREDIT_PERIOD } } = FIELD_IDS;
 
@@ -37,10 +38,13 @@ context('Change your answers (policy credit period field) - as an exporter, I wa
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
+    const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
 
-    const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
-    backLink().should('have.attr', 'href', expected);
+    cy.checkLink(
+      backLink(),
+      expectedHref,
+      LINKS.BACK,
+    );
   });
 
   it('has originally submitted answer', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-policy-type-and-length.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-policy-type-and-length.spec.js
@@ -5,6 +5,7 @@ import {
   tellUsAboutYourPolicyPage,
 } from '../../../pages/quote';
 import { FIELD_IDS, FIELD_VALUES, ROUTES } from '../../../../../constants';
+import { LINKS } from '../../../../../content-strings';
 
 const {
   ELIGIBILITY: {
@@ -98,10 +99,13 @@ context('Change your answers - as an exporter, I want to change the details befo
     });
 
     it('renders a back link with correct url', () => {
-      backLink().should('exist');
+      const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
 
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
-      backLink().should('have.attr', 'href', expected);
+      cy.checkLink(
+        backLink(),
+        expectedHref,
+        LINKS.BACK,
+      );
     });
 
     it('has originally submitted `policy type` (single)', () => {
@@ -192,8 +196,13 @@ context('Change your answers - as an exporter, I want to change the details befo
       it('renders a back link with correct url', () => {
         backLink().should('exist');
 
-        const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
-        backLink().should('have.attr', 'href', expected);
+        const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
+
+        cy.checkLink(
+          backLink(),
+          expectedHref,
+          LINKS.BACK,
+        );
       });
 
       it('has previously submitted `policy type` (single)', () => {
@@ -276,10 +285,13 @@ context('Change your answers - as an exporter, I want to change the details befo
       });
 
       it('renders a back link with correct url', () => {
-        backLink().should('exist');
+        const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
 
-        const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.CHECK_YOUR_ANSWERS}`;
-        backLink().should('have.attr', 'href', expected);
+        cy.checkLink(
+          backLink(),
+          expectedHref,
+          LINKS.BACK,
+        );
       });
 
       it('has previously submitted `policy type` (single)', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/check-your-answers/check-your-answers-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/check-your-answers/check-your-answers-multi-policy.spec.js
@@ -1,6 +1,5 @@
 import { submitButton } from '../../../pages/shared';
 import { checkYourAnswersPage } from '../../../pages/quote';
-import partials from '../../../partials';
 import {
   FIELDS,
   LINKS,
@@ -10,8 +9,6 @@ import {
 import { FIELD_IDS, FIELD_VALUES, ROUTES } from '../../../../../constants';
 
 const CONTENT_STRINGS = PAGES.QUOTE.CHECK_YOUR_ANSWERS;
-
-const startRoute = ROUTES.QUOTE.START;
 
 const {
   ELIGIBILITY: {
@@ -58,10 +55,6 @@ context('Check your answers page (multiple policy) - as an exporter, I want to r
       cy.checkText(list.heading(), CONTENT_STRINGS.GROUP_HEADING_EXPORT);
     });
 
-    it('should render a header with href to quote start', () => {
-      partials.header.serviceName().should('have.attr', 'href', startRoute);
-    });
-
     it('renders `Buyer based` key, value and change link', () => {
       const row = list[BUYER_COUNTRY];
       const expectedKeyText = FIELDS[BUYER_COUNTRY].SUMMARY.TITLE;
@@ -71,12 +64,14 @@ context('Check your answers page (multiple policy) - as an exporter, I want to r
       const expectedValue = submissionData[BUYER_COUNTRY];
       cy.checkText(row.value(), expectedValue);
 
-      const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-      cy.checkText(row.changeLink(), expectedChangeLink);
-
       const expectedHref = `${ROUTES.QUOTE.BUYER_COUNTRY_CHANGE}#heading`;
+      const expectedText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-      row.changeLink().should('have.attr', 'href', expectedHref);
+      cy.checkLink(
+        row.changeLink(),
+        expectedHref,
+        expectedText,
+      );
     });
 
     it('renders `Company` key, value and change link', () => {
@@ -87,11 +82,14 @@ context('Check your answers page (multiple policy) - as an exporter, I want to r
 
       cy.checkText(row.value(), SUMMARY_ANSWERS[VALID_EXPORTER_LOCATION]);
 
-      const expected = `${LINKS.CHANGE} ${expectedKeyText}`;
-      cy.checkText(row.changeLink(), expected);
-
       const expectedHref = `${ROUTES.QUOTE.EXPORTER_LOCATION_CHANGE}#heading`;
-      row.changeLink().should('have.attr', 'href', expectedHref);
+      const expectedText = `${LINKS.CHANGE} ${expectedKeyText}`;
+
+      cy.checkLink(
+        row.changeLink(),
+        expectedHref,
+        expectedText,
+      );
     });
 
     it('renders `UK goods` key, value and change link', () => {
@@ -102,11 +100,14 @@ context('Check your answers page (multiple policy) - as an exporter, I want to r
 
       cy.checkText(row.value(), SUMMARY_ANSWERS[HAS_MINIMUM_UK_GOODS_OR_SERVICES]);
 
-      const expected = `${LINKS.CHANGE} ${expectedKeyText}`;
-      cy.checkText(row.changeLink(), expected);
-
       const expectedHref = `${ROUTES.QUOTE.UK_GOODS_OR_SERVICES_CHANGE}#heading`;
-      row.changeLink().should('have.attr', 'href', expectedHref);
+      const expectedText = `${LINKS.CHANGE} ${expectedKeyText}`;
+
+      cy.checkLink(
+        row.changeLink(),
+        expectedHref,
+        expectedText,
+      );
     });
   });
 
@@ -129,11 +130,14 @@ context('Check your answers page (multiple policy) - as an exporter, I want to r
 
       cy.checkText(row.value(), submissionData[MULTIPLE_POLICY_TYPE]);
 
-      const expected = `${LINKS.CHANGE} ${expectedKeyText}`;
-      cy.checkText(row.changeLink(), expected);
+      const expectedChangeHref = `${ROUTES.QUOTE.POLICY_TYPE_CHANGE}#heading`;
+      const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-      const expectedHref = `${ROUTES.QUOTE.POLICY_TYPE_CHANGE}#heading`;
-      row.changeLink().should('have.attr', 'href', expectedHref);
+      cy.checkLink(
+        row.changeLink(),
+        expectedChangeHref,
+        expectedChangeText,
+      );
     });
 
     it('renders `Policy length` key and value (no change link)', () => {
@@ -157,11 +161,14 @@ context('Check your answers page (multiple policy) - as an exporter, I want to r
       const expectedValue = '£150,000';
       cy.checkText(row.value(), expectedValue);
 
-      const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-      cy.checkText(row.changeLink(), expectedChangeLink);
+      const expectedChangeHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${MAX_AMOUNT_OWED}-label`;
+      const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-      const expectedHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${MAX_AMOUNT_OWED}-label`;
-      row.changeLink().should('have.attr', 'href', expectedHref);
+      cy.checkLink(
+        row.changeLink(),
+        expectedChangeHref,
+        expectedChangeText,
+      );
     });
 
     it('renders `Credit period` key, value and change link', () => {
@@ -173,11 +180,14 @@ context('Check your answers page (multiple policy) - as an exporter, I want to r
       const expectedValue = `${submissionData[CREDIT_PERIOD]} month`;
       cy.checkText(row.value(), expectedValue);
 
-      const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-      cy.checkText(row.changeLink(), expectedChangeLink);
+      const expectedChangeHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${CREDIT_PERIOD}-label`;
+      const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-      const expectedHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${CREDIT_PERIOD}-label`;
-      row.changeLink().should('have.attr', 'href', expectedHref);
+      cy.checkLink(
+        row.changeLink(),
+        expectedChangeHref,
+        expectedChangeText,
+      );
     });
 
     it('renders `Percentage of cover` key, value and change link', () => {
@@ -189,11 +199,14 @@ context('Check your answers page (multiple policy) - as an exporter, I want to r
       const expectedValue = `${submissionData[PERCENTAGE_OF_COVER]}%`;
       cy.checkText(row.value(), expectedValue);
 
-      const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-      cy.checkText(row.changeLink(), expectedChangeLink);
+      const expectedChangeHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${PERCENTAGE_OF_COVER}-label`;
+      const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-      const expectedHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${PERCENTAGE_OF_COVER}-label`;
-      row.changeLink().should('have.attr', 'href', expectedHref);
+      cy.checkLink(
+        row.changeLink(),
+        expectedChangeHref,
+        expectedChangeText,
+      );
     });
   });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/check-your-answers/check-your-answers-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/check-your-answers/check-your-answers-single-policy.spec.js
@@ -1,6 +1,5 @@
 import { submitButton } from '../../../pages/shared';
 import { checkYourAnswersPage } from '../../../pages/quote';
-import partials from '../../../partials';
 import {
   FIELDS,
   LINKS,
@@ -11,8 +10,6 @@ import { ROUTES, FIELD_VALUES } from '../../../../../constants';
 import { FIELD_IDS } from '../../../../../constants/field-ids';
 
 const CONTENT_STRINGS = PAGES.QUOTE.CHECK_YOUR_ANSWERS;
-
-const startRoute = ROUTES.QUOTE.START;
 
 const {
   ELIGIBILITY: {
@@ -65,10 +62,6 @@ context('Check your answers page (single policy) - as an exporter, I want to rev
       cy.navigateToUrl(url);
     });
 
-    it('should render a header with href to quote start', () => {
-      partials.header.serviceName().should('have.attr', 'href', startRoute);
-    });
-
     context('export summary list', () => {
       beforeEach(() => {
         cy.navigateToUrl(url);
@@ -89,11 +82,14 @@ context('Check your answers page (single policy) - as an exporter, I want to rev
         const expectedValue = submissionData[BUYER_COUNTRY];
         cy.checkText(row.value(), expectedValue);
 
-        const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-        cy.checkText(row.changeLink(), expectedChangeLink);
+        const expectedChangeHref = `${ROUTES.QUOTE.BUYER_COUNTRY_CHANGE}#heading`;
+        const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-        const expectedHref = `${ROUTES.QUOTE.BUYER_COUNTRY_CHANGE}#heading`;
-        row.changeLink().should('have.attr', 'href', expectedHref);
+        cy.checkLink(
+          row.changeLink(),
+          expectedChangeHref,
+          expectedChangeText,
+        );
       });
 
       it('renders `Company` key, value and change link', () => {
@@ -104,11 +100,14 @@ context('Check your answers page (single policy) - as an exporter, I want to rev
 
         cy.checkText(row.value(), SUMMARY_ANSWERS[VALID_EXPORTER_LOCATION]);
 
-        const expected = `${LINKS.CHANGE} ${expectedKeyText}`;
-        cy.checkText(row.changeLink(), expected);
+        const expectedChangeHref = `${ROUTES.QUOTE.EXPORTER_LOCATION_CHANGE}#heading`;
+        const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-        const expectedHref = `${ROUTES.QUOTE.EXPORTER_LOCATION_CHANGE}#heading`;
-        row.changeLink().should('have.attr', 'href', expectedHref);
+        cy.checkLink(
+          row.changeLink(),
+          expectedChangeHref,
+          expectedChangeText,
+        );
       });
 
       it('renders `UK goods` key, value and change link', () => {
@@ -119,11 +118,14 @@ context('Check your answers page (single policy) - as an exporter, I want to rev
 
         cy.checkText(row.value(), SUMMARY_ANSWERS[HAS_MINIMUM_UK_GOODS_OR_SERVICES]);
 
-        const expected = `${LINKS.CHANGE} ${expectedKeyText}`;
-        cy.checkText(row.changeLink(), expected);
+        const expectedChangeHref = `${ROUTES.QUOTE.UK_GOODS_OR_SERVICES_CHANGE}#heading`;
+        const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-        const expectedHref = `${ROUTES.QUOTE.UK_GOODS_OR_SERVICES_CHANGE}#heading`;
-        row.changeLink().should('have.attr', 'href', expectedHref);
+        cy.checkLink(
+          row.changeLink(),
+          expectedChangeHref,
+          expectedChangeText,
+        );
       });
     });
 
@@ -146,11 +148,14 @@ context('Check your answers page (single policy) - as an exporter, I want to rev
 
         cy.checkText(row.value(), submissionData[SINGLE_POLICY_TYPE]);
 
-        const expected = `${LINKS.CHANGE} ${expectedKeyText}`;
-        cy.checkText(row.changeLink(), expected);
+        const expectedChangeHref = `${ROUTES.QUOTE.POLICY_TYPE_CHANGE}#heading`;
+        const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-        const expectedHref = `${ROUTES.QUOTE.POLICY_TYPE_CHANGE}#heading`;
-        row.changeLink().should('have.attr', 'href', expectedHref);
+        cy.checkLink(
+          row.changeLink(),
+          expectedChangeHref,
+          expectedChangeText,
+        );
       });
 
       it('renders `Policy length` key, value and change link', () => {
@@ -162,11 +167,14 @@ context('Check your answers page (single policy) - as an exporter, I want to rev
         const expectedValue = `${submissionData[SINGLE_POLICY_LENGTH]} months`;
         cy.checkText(row.value(), expectedValue);
 
-        const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-        cy.checkText(row.changeLink(), expectedChangeLink);
+        const expectedChangeHref = `${ROUTES.QUOTE.POLICY_TYPE_CHANGE}#${SINGLE_POLICY_LENGTH}-label`;
+        const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-        const expectedHref = `${ROUTES.QUOTE.POLICY_TYPE_CHANGE}#${SINGLE_POLICY_LENGTH}-label`;
-        row.changeLink().should('have.attr', 'href', expectedHref);
+        cy.checkLink(
+          row.changeLink(),
+          expectedChangeHref,
+          expectedChangeText,
+        );
       });
 
       it('renders `Contract value` key, value with no decimal points and change link', () => {
@@ -178,11 +186,14 @@ context('Check your answers page (single policy) - as an exporter, I want to rev
         const expectedValue = '£150,000';
         cy.checkText(row.value(), expectedValue);
 
-        const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-        cy.checkText(row.changeLink(), expectedChangeLink);
+        const expectedChangeHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${CONTRACT_VALUE}-label`;
+        const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-        const expectedHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${CONTRACT_VALUE}-label`;
-        row.changeLink().should('have.attr', 'href', expectedHref);
+        cy.checkLink(
+          row.changeLink(),
+          expectedChangeHref,
+          expectedChangeText,
+        );
       });
 
       it('renders `Percentage of cover` key, value and change link', () => {
@@ -194,11 +205,14 @@ context('Check your answers page (single policy) - as an exporter, I want to rev
         const expectedValue = `${submissionData[PERCENTAGE_OF_COVER]}%`;
         cy.checkText(row.value(), expectedValue);
 
-        const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-        cy.checkText(row.changeLink(), expectedChangeLink);
+        const expectedChangeHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${PERCENTAGE_OF_COVER}-label`;
+        const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-        const expectedHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${PERCENTAGE_OF_COVER}-label`;
-        row.changeLink().should('have.attr', 'href', expectedHref);
+        cy.checkLink(
+          row.changeLink(),
+          expectedChangeHref,
+          expectedChangeText,
+        );
       });
 
       it('does NOT render `Credit period` key, value or change link', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/exporter-location/exporter-location-answer-no.spec.js
@@ -1,7 +1,7 @@
 import {
   backLink, cannotApplyPage, noRadio, submitButton,
 } from '../../../pages/shared';
-import { PAGES } from '../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
 import { completeAndSubmitBuyerBodyForm } from '../../../../support/quote/forms';
@@ -33,9 +33,11 @@ context('Exporter location page - as an exporter, I want to check if my company 
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
-
-    backLink().should('have.attr', 'href', ROUTES.QUOTE.EXPORTER_LOCATION);
+    cy.checkLink(
+      backLink(),
+      ROUTES.QUOTE.EXPORTER_LOCATION,
+      LINKS.BACK,
+    );
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
@@ -1,14 +1,11 @@
 import { buyerCountryPage, submitButton } from '../../pages/shared';
 import { getAQuoteByEmailPage } from '../../pages/quote';
-import partials from '../../partials';
 import { PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 
 const CONTENT_STRINGS = PAGES.QUOTE.GET_A_QUOTE_BY_EMAIL;
 
 const COUNTRY_NAME_QUOTE_BY_EMAIL_ONLY = 'Egypt';
-
-const startRoute = ROUTES.QUOTE.START;
 
 context('Get a quote via email exit page', () => {
   beforeEach(() => {
@@ -40,10 +37,6 @@ context('Get a quote via email exit page', () => {
     });
   });
 
-  it('should render a header with href to quote start', () => {
-    partials.header.serviceName().should('have.attr', 'href', startRoute);
-  });
-
   it('renders a reason and description ', () => {
     cy.checkText(getAQuoteByEmailPage.reason(), CONTENT_STRINGS.REASON.BUYER_COUNTRY);
 
@@ -53,16 +46,19 @@ context('Get a quote via email exit page', () => {
   it('renders `action` content', () => {
     const [actionStrings] = CONTENT_STRINGS.ACTION;
     const expectedText = `${actionStrings[0].text}${actionStrings[1].text}${actionStrings[2].text} ${actionStrings[3].text}`;
+
     cy.checkText(getAQuoteByEmailPage.action.text(), expectedText);
 
-    const expectedLink = CONTENT_STRINGS.ACTION[0][0].text;
-    cy.checkText(getAQuoteByEmailPage.action.link1(), expectedLink);
+    cy.checkLink(
+      getAQuoteByEmailPage.action.link1(),
+      CONTENT_STRINGS.ACTION[0][0].href,
+      CONTENT_STRINGS.ACTION[0][0].text,
+    );
 
-    getAQuoteByEmailPage.action.link1().should('have.attr', 'href', CONTENT_STRINGS.ACTION[0][0].href);
-
-    const expectedLink2 = CONTENT_STRINGS.ACTION[0][3].text;
-    cy.checkText(getAQuoteByEmailPage.action.link2(), expectedLink2);
-
-    getAQuoteByEmailPage.action.link2().should('have.attr', 'href', CONTENT_STRINGS.ACTION[0][3].href);
+    cy.checkLink(
+      getAQuoteByEmailPage.action.link2(),
+      CONTENT_STRINGS.ACTION[0][3].href,
+      CONTENT_STRINGS.ACTION[0][3].text,
+    );
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/quote/header.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/header.spec.js
@@ -1,4 +1,4 @@
-import partials from '../../partials';
+import header from '../../partials/header';
 import { PRODUCT } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 
@@ -12,14 +12,24 @@ context('Get a quote - header', () => {
   });
 
   it('renders a GOV home link', () => {
-    partials.header.govHomeLink().should('exist');
+    const expectedHref = 'https://www.gov.uk';
+    const expectedText = 'GOV.UK';
 
-    partials.header.govHomeLink().should('have.attr', 'href', 'https://www.gov.uk');
+    cy.checkLink(
+      header.govHomeLink(),
+      expectedHref,
+      expectedText,
+    );
   });
 
   it('renders service name link', () => {
-    cy.checkText(partials.header.serviceName(), PRODUCT.DESCRIPTION.QUOTE);
+    const expectedHref = '/';
+    const expectedText = PRODUCT.DESCRIPTION.QUOTE;
 
-    partials.header.serviceName().should('have.attr', 'href', '/');
+    cy.checkLink(
+      header.serviceName(),
+      expectedHref,
+      expectedText,
+    );
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/quote/need-to-start-again.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/need-to-start-again.spec.js
@@ -1,13 +1,10 @@
 import { submitButton, needToStartAgainPage } from '../../pages/shared';
-import partials from '../../partials';
 import { LINKS, PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../support/forms';
 import { completeAndSubmitBuyerBodyForm } from '../../../support/quote/forms';
 
 const CONTENT_STRINGS = PAGES.NEED_TO_START_AGAIN_PAGE;
-
-const startRoute = ROUTES.QUOTE.START;
 
 context('Get a Quote - Need to start again exit page', () => {
   beforeEach(() => {
@@ -31,10 +28,6 @@ context('Get a Quote - Need to start again exit page', () => {
       assertAuthenticatedHeader: false,
       isInsurancePage: false,
     });
-  });
-
-  it('should render a header with href to quote start', () => {
-    partials.header.serviceName().should('have.attr', 'href', startRoute);
   });
 
   it('renders a reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/policy-type/policy-type.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/policy-type/policy-type.spec.js
@@ -6,7 +6,6 @@ import {
 } from '../../../../support/quote/forms';
 import { submitButton } from '../../../pages/shared';
 import { policyTypePage } from '../../../pages/quote';
-import partials from '../../../partials';
 import {
   LINKS,
   FIELDS,
@@ -17,8 +16,6 @@ import { ROUTES, FIELD_IDS } from '../../../../../constants';
 const CONTENT_STRINGS = PAGES.QUOTE.POLICY_TYPE;
 
 const { POLICY_TYPE } = FIELD_IDS;
-
-const startRoute = ROUTES.QUOTE.START;
 
 context('Policy type page - as an exporter, I want to get UKEF export insurance quote based on the export policy - provide policy type', () => {
   const url = ROUTES.QUOTE.POLICY_TYPE;
@@ -57,10 +54,6 @@ context('Policy type page - as an exporter, I want to get UKEF export insurance 
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to quote start', () => {
-      partials.header.serviceName().should('have.attr', 'href', startRoute);
     });
 
     it('renders `policy type` radio inputs with labels and hints', () => {
@@ -104,7 +97,13 @@ context('Policy type page - as an exporter, I want to get UKEF export insurance 
         });
 
         const expectedHref = LINKS.EXTERNAL.NBI_FORM;
-        singlePolicyLength.hintLink().should('have.attr', 'href', expectedHref);
+        const expectedText = FIELDS[singlePolicyLengthId].HINT[0][1].text;
+
+        cy.checkLink(
+          singlePolicyLength.hintLink(),
+          expectedHref,
+          expectedText,
+        );
       });
     });
 
@@ -124,7 +123,13 @@ context('Policy type page - as an exporter, I want to get UKEF export insurance 
         });
 
         const expectedHref = LINKS.EXTERNAL.NBI_FORM;
-        multiPolicyType.inset.link().should('have.attr', 'href', expectedHref);
+        const expectedText = insetText[1].text;
+
+        cy.checkLink(
+          multiPolicyType.inset.link(),
+          expectedHref,
+          expectedText,
+        );
       });
     });
 

--- a/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
@@ -7,7 +7,6 @@ import {
 } from '../../../../support/quote/forms';
 import { submitButton } from '../../../pages/shared';
 import { tellUsAboutYourPolicyPage } from '../../../pages/quote';
-import partials from '../../../partials';
 import {
   LINKS,
   FIELDS,
@@ -27,8 +26,6 @@ const {
     CREDIT_PERIOD,
   },
 } = FIELD_IDS;
-
-const startRoute = ROUTES.QUOTE.START;
 
 context('Tell us about your multiple policy page - as an exporter, I want to provide my Export insurance policy details', () => {
   const url = ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY;
@@ -68,10 +65,6 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to quote start', () => {
-      partials.header.serviceName().should('have.attr', 'href', startRoute);
     });
 
     it('renders `currency and amount` legend', () => {
@@ -165,7 +158,14 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
       const expectedHintText = `${HINT[0].text} ${HINT[1].text} ${HINT[2].text}`;
       cy.checkText(field.hint(), expectedHintText);
 
-      field.hintLink().should('have.attr', 'href', LINKS.EXTERNAL.NBI_FORM);
+      const expectedHintLinkHref = LINKS.EXTERNAL.NBI_FORM;
+      const expectedHintLinkText = HINT[1].text;
+
+      cy.checkLink(
+        field.hintLink(),
+        expectedHintLinkHref,
+        expectedHintLinkText,
+      );
 
       field.input().should('exist');
 

--- a/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
@@ -1,7 +1,7 @@
 import {
   backLink, cannotApplyPage, noRadio, submitButton,
 } from '../../../pages/shared';
-import { PAGES } from '../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../support/forms';
 import { completeAndSubmitBuyerBodyForm, completeAndSubmitExporterLocationForm } from '../../../../support/quote/forms';
@@ -26,9 +26,13 @@ context('UK goods or services page - as an exporter, I want to check if my expor
   });
 
   it('renders a back link with correct url', () => {
-    backLink().should('exist');
+    const expectedHref = ROUTES.QUOTE.UK_GOODS_OR_SERVICES;
 
-    backLink().should('have.attr', 'href', ROUTES.QUOTE.UK_GOODS_OR_SERVICES);
+    cy.checkLink(
+      backLink(),
+      expectedHref,
+      LINKS.BACK,
+    );
   });
 
   it('renders a specific reason', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -17,8 +17,6 @@ const {
   ELIGIBILITY: { HAS_MINIMUM_UK_GOODS_OR_SERVICES },
 } = FIELD_IDS;
 
-const startRoute = ROUTES.QUOTE.START;
-
 context('UK goods or services page - as an exporter, I want to check if my export value is eligible for UKEF export insurance cover', () => {
   const url = ROUTES.QUOTE.UK_GOODS_OR_SERVICES;
 
@@ -48,10 +46,6 @@ context('UK goods or services page - as an exporter, I want to check if my expor
   describe('page tests', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-    });
-
-    it('should render a header with href to quote start', () => {
-      partials.header.serviceName().should('have.attr', 'href', startRoute);
     });
 
     it('renders `yes` radio button', () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-change-answers-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-change-answers-multi-policy.spec.js
@@ -1,6 +1,7 @@
 import { backLink, buyerCountryPage, submitButton } from '../../../pages/shared';
 import { tellUsAboutYourPolicyPage, yourQuotePage } from '../../../pages/quote';
 import { FIELD_IDS, ROUTES } from '../../../../../constants';
+import { LINKS } from '../../../../../content-strings';
 
 const {
   ELIGIBILITY: {
@@ -46,10 +47,13 @@ context('Your quote page - change answers (policy type and length from multiple 
     });
 
     it('renders a back link with correct url', () => {
-      backLink().should('exist');
+      const expectedHref = `${Cypress.config('baseUrl')}${url}`;
 
-      const expected = `${Cypress.config('baseUrl')}${url}`;
-      backLink().should('have.attr', 'href', expected);
+      cy.checkLink(
+        backLink(),
+        expectedHref,
+        LINKS.BACK,
+      );
     });
 
     it(`redirects to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS} when submitting a new answer`, () => {
@@ -92,10 +96,13 @@ context('Your quote page - change answers (policy type and length from multiple 
     });
 
     it('renders a back link with correct url', () => {
-      backLink().should('exist');
+      const expectedHref = `${Cypress.config('baseUrl')}${url}`;
 
-      const expected = `${Cypress.config('baseUrl')}${url}`;
-      backLink().should('have.attr', 'href', expected);
+      cy.checkLink(
+        backLink(),
+        expectedHref,
+        LINKS.BACK,
+      );
     });
 
     it(`redirects to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS} when submitting a new answer`, () => {
@@ -137,10 +144,13 @@ context('Your quote page - change answers (policy type and length from multiple 
     });
 
     it('renders a back link with correct url', () => {
-      backLink().should('exist');
+      const expectedHref = `${Cypress.config('baseUrl')}${url}`;
 
-      const expected = `${Cypress.config('baseUrl')}${url}`;
-      backLink().should('have.attr', 'href', expected);
+      cy.checkLink(
+        backLink(),
+        expectedHref,
+        LINKS.BACK,
+      );
     });
 
     it(`redirects to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS} when submitting a new answer`, () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-change-answers-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-change-answers-single-policy.spec.js
@@ -5,6 +5,7 @@ import {
   yourQuotePage,
 } from '../../../pages/quote';
 import { ROUTES, FIELD_IDS, FIELD_VALUES } from '../../../../../constants';
+import { LINKS } from '../../../../../content-strings';
 
 const {
   ELIGIBILITY: {
@@ -51,10 +52,13 @@ context('Your quote page - change answers (single policy type to multiple policy
     });
 
     it('renders a back link with correct url', () => {
-      backLink().should('exist');
+      const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
 
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
-      backLink().should('have.attr', 'href', expected);
+      cy.checkLink(
+        backLink(),
+        expectedHref,
+        LINKS.BACK,
+      );
     });
 
     it(`redirects to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS} when submitting a new answer`, () => {
@@ -96,10 +100,13 @@ context('Your quote page - change answers (single policy type to multiple policy
     });
 
     it('renders a back link with correct url', () => {
-      backLink().should('exist');
+      const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
 
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
-      backLink().should('have.attr', 'href', expected);
+      cy.checkLink(
+        backLink(),
+        expectedHref,
+        LINKS.BACK,
+      );
     });
 
     it(`redirects to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS} when submitting a new answer`, () => {
@@ -141,10 +148,13 @@ context('Your quote page - change answers (single policy type to multiple policy
     });
 
     it('renders a back link with correct url', () => {
-      backLink().should('exist');
+      const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
 
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
-      backLink().should('have.attr', 'href', expected);
+      cy.checkLink(
+        backLink(),
+        expectedHref,
+        LINKS.BACK,
+      );
     });
 
     it(`redirects to ${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY} when submitting a new answer`, () => {
@@ -198,10 +208,13 @@ context('Your quote page - change answers (single policy type to multiple policy
     });
 
     it('renders a back link with correct url', () => {
-      backLink().should('exist');
+      const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
 
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.YOUR_QUOTE}`;
-      backLink().should('have.attr', 'href', expected);
+      cy.checkLink(
+        backLink(),
+        expectedHref,
+        LINKS.BACK,
+      );
     });
 
     it(`redirects to ${ROUTES.QUOTE.CHECK_YOUR_ANSWERS} when submitting a new answer`, () => {

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-multi-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-multi-policy.spec.js
@@ -1,6 +1,5 @@
 import { submitButton } from '../../../pages/shared';
 import { yourQuotePage } from '../../../pages/quote';
-import partials from '../../../partials';
 import {
   LINKS,
   QUOTE_TITLES,
@@ -29,7 +28,7 @@ const submissionData = {
   [BUYER_COUNTRY]: 'Algeria',
 };
 
-const startRoute = ROUTES.QUOTE.START;
+const { summaryList } = yourQuotePage.panel;
 
 context('Get a quote/your quote page (multiple policy) - as an exporter, I want to get an Export insurance quote', () => {
   const url = ROUTES.QUOTE.YOUR_QUOTE;
@@ -53,12 +52,6 @@ context('Get a quote/your quote page (multiple policy) - as an exporter, I want 
         cy.navigateToUrl(url);
       });
 
-      const { summaryList } = yourQuotePage.panel;
-
-      it('should render a header with href to quote start', () => {
-        partials.header.serviceName().should('have.attr', 'href', startRoute);
-      });
-
       it('renders `max amount owed` key, value with no decimal points and change link', () => {
         const row = summaryList[MAX_AMOUNT_OWED];
         const expectedKeyText = QUOTE_TITLES[MAX_AMOUNT_OWED];
@@ -68,11 +61,14 @@ context('Get a quote/your quote page (multiple policy) - as an exporter, I want 
         const expectedValue = '£150,000';
         cy.checkText(row.value(), expectedValue);
 
-        const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-        cy.checkText(row.changeLink(), expectedChangeLink);
+        const expectedChangeHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${MAX_AMOUNT_OWED}-label`;
+        const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-        const expectedHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${MAX_AMOUNT_OWED}-label`;
-        row.changeLink().should('have.attr', 'href', expectedHref);
+        cy.checkLink(
+          row.changeLink(),
+          expectedChangeHref,
+          expectedChangeText,
+        );
       });
 
       it('renders `percentage of cover` key, value and change link', () => {
@@ -84,11 +80,14 @@ context('Get a quote/your quote page (multiple policy) - as an exporter, I want 
         const expectedValue = '90%';
         cy.checkText(row.value(), expectedValue);
 
-        const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-        cy.checkText(row.changeLink(), expectedChangeLink);
+        const expectedChangeHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${PERCENTAGE_OF_COVER}-label`;
+        const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-        const expectedHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${PERCENTAGE_OF_COVER}-label`;
-        row.changeLink().should('have.attr', 'href', expectedHref);
+        cy.checkLink(
+          row.changeLink(),
+          expectedChangeHref,
+          expectedChangeText,
+        );
       });
 
       it('renders `insured for` key and value with decimal points (no change link)', () => {
@@ -148,11 +147,14 @@ context('Get a quote/your quote page (multiple policy) - as an exporter, I want 
         const expectedValue = submissionData[BUYER_COUNTRY];
         cy.checkText(row.value(), expectedValue);
 
-        const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-        cy.checkText(row.changeLink(), expectedChangeLink);
+        const expectedChangeHref = `${ROUTES.QUOTE.BUYER_COUNTRY_CHANGE}#heading`;
+        const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-        const expectedHref = `${ROUTES.QUOTE.BUYER_COUNTRY_CHANGE}#heading`;
-        row.changeLink().should('have.attr', 'href', expectedHref);
+        cy.checkLink(
+          row.changeLink(),
+          expectedChangeHref,
+          expectedChangeText,
+        );
       });
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
@@ -1,6 +1,5 @@
 import { buyerCountryPage, submitButton } from '../../../pages/shared';
 import { yourQuotePage } from '../../../pages/quote';
-import partials from '../../../partials';
 import {
   LINKS,
   PAGES,
@@ -43,8 +42,6 @@ const submissionData = {
   [CREDIT_PERIOD]: '1',
 };
 
-const startRoute = ROUTES.QUOTE.START;
-
 context('Get a quote/your quote page (single policy) - as an exporter, I want to get an Export insurance quote', () => {
   const url = ROUTES.QUOTE.YOUR_QUOTE;
 
@@ -77,12 +74,6 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
       cy.navigateToUrl(url);
     });
 
-    it('should render a header with href to quote start', () => {
-      cy.navigateToUrl(url);
-
-      partials.header.serviceName().should('have.attr', 'href', startRoute);
-    });
-
     context('panel/quote', () => {
       it('renders `your quote` heading', () => {
         cy.navigateToUrl(url);
@@ -106,11 +97,14 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
           const expectedValue = '£150,000';
           cy.checkText(row.value(), expectedValue);
 
-          const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-          cy.checkText(row.changeLink(), expectedChangeLink);
+          const expectedChangeHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${CONTRACT_VALUE}-label`;
+          const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-          const expectedHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${CONTRACT_VALUE}-label`;
-          row.changeLink().should('have.attr', 'href', expectedHref);
+          cy.checkLink(
+            row.changeLink(),
+            expectedChangeHref,
+            expectedChangeText,
+          );
         });
 
         it('renders `percentage of cover` key, value and change link', () => {
@@ -122,11 +116,14 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
           const expectedValue = '90%';
           cy.checkText(row.value(), expectedValue);
 
-          const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-          cy.checkText(row.changeLink(), expectedChangeLink);
+          const expectedChangeHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${PERCENTAGE_OF_COVER}-label`;
+          const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-          const expectedHref = `${ROUTES.QUOTE.TELL_US_ABOUT_YOUR_POLICY_CHANGE}#${PERCENTAGE_OF_COVER}-label`;
-          row.changeLink().should('have.attr', 'href', expectedHref);
+          cy.checkLink(
+            row.changeLink(),
+            expectedChangeHref,
+            expectedChangeText,
+          );
         });
 
         it('renders `insured for` key and value with decimal points (no change link)', () => {
@@ -174,11 +171,14 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
           const expectedValue = `${submissionData[SINGLE_POLICY_LENGTH]} months`;
           cy.checkText(row.value(), expectedValue);
 
-          const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-          cy.checkText(row.changeLink(), expectedChangeLink);
+          const expectedChangeHref = `${ROUTES.QUOTE.POLICY_TYPE_CHANGE}#${SINGLE_POLICY_LENGTH}-label`;
+          const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-          const expectedHref = `${ROUTES.QUOTE.POLICY_TYPE_CHANGE}#${SINGLE_POLICY_LENGTH}-label`;
-          row.changeLink().should('have.attr', 'href', expectedHref);
+          cy.checkLink(
+            row.changeLink(),
+            expectedChangeHref,
+            expectedChangeText,
+          );
         });
 
         it('renders `buyer location` key, value and change link', () => {
@@ -190,11 +190,14 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
           const expectedValue = submissionData[BUYER_COUNTRY];
           cy.checkText(row.value(), expectedValue);
 
-          const expectedChangeLink = `${LINKS.CHANGE} ${expectedKeyText}`;
-          cy.checkText(row.changeLink(), expectedChangeLink);
+          const expectedChangeHref = `${ROUTES.QUOTE.BUYER_COUNTRY_CHANGE}#heading`;
+          const expectedChangeText = `${LINKS.CHANGE} ${expectedKeyText}`;
 
-          const expectedHref = `${ROUTES.QUOTE.BUYER_COUNTRY_CHANGE}#heading`;
-          row.changeLink().should('have.attr', 'href', expectedHref);
+          cy.checkLink(
+            row.changeLink(),
+            expectedChangeHref,
+            expectedChangeText,
+          );
         });
       });
     });
@@ -289,19 +292,19 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
     });
 
     it('renders a `feedback` link', () => {
-      yourQuotePage.links.feedback().should('exist');
-
-      cy.checkText(yourQuotePage.links.feedback(), LINKS.GIVE_FEEDBACK);
-
-      yourQuotePage.links.feedback().should('have.attr', 'href', LINKS.EXTERNAL.FEEDBACK);
+      cy.checkLink(
+        yourQuotePage.links.feedback(),
+        LINKS.EXTERNAL.FEEDBACK,
+        LINKS.GIVE_FEEDBACK,
+      );
     });
 
     it('renders `start again` link', () => {
-      yourQuotePage.links.startAgain().should('exist');
-
-      cy.checkText(yourQuotePage.links.startAgain(), LINKS.START_AGAIN.TEXT);
-
-      yourQuotePage.links.startAgain().should('have.attr', 'href', ROUTES.ROOT);
+      cy.checkLink(
+        yourQuotePage.links.startAgain(),
+        ROUTES.ROOT,
+        LINKS.START_AGAIN.TEXT,
+      );
     });
 
     context('clicking `start again`', () => {

--- a/e2e-tests/cypress/support/analytics/check-cookies-consent-banner-is-visible.js
+++ b/e2e-tests/cypress/support/analytics/check-cookies-consent-banner-is-visible.js
@@ -17,10 +17,11 @@ const checkCookiesConsentBannerIsVisible = () => {
   partials.cookieBanner.question.rejectButton().should('exist');
   cy.checkText(partials.cookieBanner.question.rejectButton(), COOKIES_CONSENT.QUESTION.REJECT_BUTTON);
 
-  partials.cookieBanner.cookiesLink().should('exist');
-  cy.checkText(partials.cookieBanner.cookiesLink(), COOKIES_CONSENT.QUESTION.VIEW_COOKIES);
-
-  partials.cookieBanner.cookiesLink().should('have.attr', 'href', ROUTES.COOKIES);
+  cy.checkLink(
+    partials.cookieBanner.cookiesLink(),
+    ROUTES.COOKIES,
+    COOKIES_CONSENT.QUESTION.VIEW_COOKIES,
+  );
 };
 
 export default checkCookiesConsentBannerIsVisible;

--- a/e2e-tests/cypress/support/check-uk-goods-and-services-description.js
+++ b/e2e-tests/cypress/support/check-uk-goods-and-services-description.js
@@ -26,12 +26,20 @@ const checkDescriptionContentSections = {
     const expectedStaffingCostText = `${CONTENT_STRINGS.INCLUDES.STAFFING_COSTS.LINK.TEXT} ${CONTENT_STRINGS.INCLUDES.STAFFING_COSTS.TEXT}`;
     cy.checkText(partials.ukGoodsOrServicesDescription.includes.listItem3(), expectedStaffingCostText);
 
-    partials.ukGoodsOrServicesDescription.includes.listItem3Link().should('have.attr', 'href', CONTENT_STRINGS.INCLUDES.STAFFING_COSTS.LINK.HREF);
+    cy.checkLink(
+      partials.ukGoodsOrServicesDescription.includes.listItem3Link(),
+      CONTENT_STRINGS.INCLUDES.STAFFING_COSTS.LINK.HREF,
+      CONTENT_STRINGS.INCLUDES.STAFFING_COSTS.LINK.TEXT,
+    );
 
     const expectedPhysicalAssetsText = `${CONTENT_STRINGS.INCLUDES.NON_PHYSICAL_ASSETS.LINK.TEXT} ${CONTENT_STRINGS.INCLUDES.NON_PHYSICAL_ASSETS.TEXT}`;
     cy.checkText(partials.ukGoodsOrServicesDescription.includes.listItem4(), expectedPhysicalAssetsText);
 
-    partials.ukGoodsOrServicesDescription.includes.listItem4Link().should('have.attr', 'href', CONTENT_STRINGS.INCLUDES.NON_PHYSICAL_ASSETS.LINK.HREF);
+    cy.checkLink(
+      partials.ukGoodsOrServicesDescription.includes.listItem4Link(),
+      CONTENT_STRINGS.INCLUDES.NON_PHYSICAL_ASSETS.LINK.HREF,
+      CONTENT_STRINGS.INCLUDES.NON_PHYSICAL_ASSETS.LINK.TEXT,
+    );
 
     cy.checkText(partials.ukGoodsOrServicesDescription.includes.canCountAs(), CONTENT_STRINGS.INCLUDES.CAN_COUNT_AS);
   },

--- a/e2e-tests/cypress/support/insurance/account/assert-confirm-email-page-content.js
+++ b/e2e-tests/cypress/support/insurance/account/assert-confirm-email-page-content.js
@@ -38,8 +38,11 @@ const havingProblemsSection = {
     cy.checkText(confirmEmailPage.havingProblems.wrongEmail.enteredIncorrectly(), ENTERED_INCORRECTLY);
   },
   createAccountLink: () => {
-    cy.checkText(wrongEmail.createAccountAgainLink(), CREATE_ACCOUNT_AGAIN.TEXT);
-    wrongEmail.createAccountAgainLink().should('have.attr', 'href', ROUTES.ACCOUNT.CREATE.YOUR_DETAILS);
+    cy.checkLink(
+      wrongEmail.createAccountAgainLink(),
+      ROUTES.ACCOUNT.CREATE.YOUR_DETAILS,
+      CREATE_ACCOUNT_AGAIN.TEXT,
+    );
   },
 };
 

--- a/e2e-tests/cypress/support/insurance/check-policy-currency-code-input.js
+++ b/e2e-tests/cypress/support/insurance/check-policy-currency-code-input.js
@@ -29,12 +29,11 @@ const checkPolicyCurrencyCodeInput = () => {
     hintContent.NEED_DIFFERENT_CURRENCY,
   );
 
-  cy.checkText(
+  cy.checkLink(
     field.hint.link(),
+    LINKS.EXTERNAL.PROPOSAL_FORM,
     hintContent.APPLY_USING_FORM.TEXT,
   );
-
-  field.hint.link().should('have.attr', 'href', LINKS.EXTERNAL.PROPOSAL_FORM);
 
   field.input().should('exist');
 


### PR DESCRIPTION
This PR updates all link assertions in the E2E tests to use the `checkLink` command; Making the tests more consistent, simpler and ensuring that every link's text has a test. Also removed some unnecessary assertions for the header service name since this is already tested in `corePageChecks`.

## Changes

- Replace all instances of `.should('have.attr', 'href', ...` with `cy.checkLink(...)`.
- Remove all header service name tests as it's already tested in `corePageChecks`.