### PR TITLE
chore(EMS-977-1317): Improve UI controller conditions, simplify some unit tests

### DIFF
--- a/src/ui/server/controllers/insurance/business/broker/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/broker/save-and-back/index.test.ts
@@ -32,82 +32,80 @@ describe('controllers/insurance/business/broker/save-and-back', () => {
     jest.resetAllMocks();
   });
 
-  describe('post - save and back', () => {
-    const validBody = mockBroker;
+  const validBody = mockBroker;
 
-    describe('when there are no validation errors', () => {
-      it('should redirect to all sections page', async () => {
-        req.body = validBody;
+  describe('when there are no validation errors', () => {
+    it('should redirect to all sections page', async () => {
+      req.body = validBody;
 
-        await post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
-      });
-
-      it('should call mapAndSave.broker once with data from constructPayload function', async () => {
-        req.body = {
-          ...validBody,
-          injection: 1,
-        };
-
-        await post(req, res);
-
-        const payload = constructPayload(req.body, FIELD_IDS);
-
-        expect(updateMapAndSave).toHaveBeenCalledTimes(1);
-
-        expect(updateMapAndSave).toHaveBeenCalledWith(payload, mockApplication, false);
-      });
+      expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
     });
 
-    describe('when there are validation errors', () => {
-      it('should redirect to all sections page', async () => {
-        req.body = {
-          [NAME]: 'Test',
-          [POSTCODE]: 'SW1',
-        };
+    it('should call mapAndSave.broker once with data from constructPayload function', async () => {
+      req.body = {
+        ...validBody,
+        injection: 1,
+      };
 
-        await post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
-      });
+      const payload = constructPayload(req.body, FIELD_IDS);
 
-      it('should call mapAndSave.broker once', async () => {
-        req.body = {
-          [NAME]: 'Test',
-          [POSTCODE]: 'SW1',
-        };
+      expect(updateMapAndSave).toHaveBeenCalledTimes(1);
 
-        await post(req, res);
+      expect(updateMapAndSave).toHaveBeenCalledWith(payload, mockApplication, false);
+    });
+  });
 
-        expect(updateMapAndSave).toHaveBeenCalledTimes(1);
-      });
+  describe('when there are validation errors', () => {
+    it('should redirect to all sections page', async () => {
+      req.body = {
+        [NAME]: 'Test',
+        [POSTCODE]: 'SW1',
+      };
+
+      await post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
     });
 
-    describe('when there is no application', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-      });
+    it('should call mapAndSave.broker once', async () => {
+      req.body = {
+        [NAME]: 'Test',
+        [POSTCODE]: 'SW1',
+      };
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-      });
+      expect(updateMapAndSave).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when there is no application', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
     });
 
-    describe('when mapAndSave.broker fails', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-        updateMapAndSave = jest.fn(() => Promise.reject());
-        mapAndSave.broker = updateMapAndSave;
-      });
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+      post(req, res);
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+    });
+  });
 
-        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-      });
+  describe('when mapAndSave.broker fails', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
+      updateMapAndSave = jest.fn(() => Promise.reject());
+      mapAndSave.broker = updateMapAndSave;
+    });
+
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+      post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
     });
   });
 });

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-address.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-address.ts
@@ -1,5 +1,6 @@
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { FIELD_IDS } from '../../../../../../../constants';
+import { objectHasProperty } from '../../../../../../../helpers/object';
 import generateValidationErrors from '../../../../../../../helpers/validation';
 import { RequestBody } from '../../../../../../../../types';
 
@@ -19,8 +20,7 @@ const { EXPORTER_BUSINESS } = ERROR_MESSAGES.INSURANCE;
 const tradingAddress = (responseBody: RequestBody, errors: object) => {
   let updatedErrors = errors;
 
-  // if no tradingName in response
-  if (!responseBody[TRADING_ADDRESS]) {
+  if (!objectHasProperty(responseBody, TRADING_ADDRESS)) {
     const errorMessage = EXPORTER_BUSINESS[TRADING_ADDRESS].IS_EMPTY;
     updatedErrors = generateValidationErrors(TRADING_ADDRESS, errorMessage, errors);
   }

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-name.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-name.ts
@@ -1,5 +1,6 @@
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { FIELD_IDS } from '../../../../../../../constants';
+import { objectHasProperty } from '../../../../../../../helpers/object';
 import generateValidationErrors from '../../../../../../../helpers/validation';
 import { RequestBody } from '../../../../../../../../types';
 
@@ -19,8 +20,7 @@ const { EXPORTER_BUSINESS } = ERROR_MESSAGES.INSURANCE;
 const tradingName = (responseBody: RequestBody, errors: object) => {
   let updatedErrors = errors;
 
-  // if no tradingName in response
-  if (!responseBody[TRADING_NAME]) {
+  if (!objectHasProperty(responseBody, TRADING_NAME)) {
     const errorMessage = EXPORTER_BUSINESS[TRADING_NAME].IS_EMPTY;
     updatedErrors = generateValidationErrors(TRADING_NAME, errorMessage, errors);
   }

--- a/src/ui/server/controllers/insurance/business/contact/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/contact/save-and-back/index.test.ts
@@ -32,91 +32,89 @@ describe('controllers/insurance/business/contact/save-and-back', () => {
     jest.resetAllMocks();
   });
 
-  describe('post - save and back', () => {
-    const validBody = {
-      [FIRST_NAME]: 'firstName',
-      [LAST_NAME]: 'lastName',
-      [EMAIL]: 'test@test.com',
-      [POSITION]: 'CEO',
-    };
+  const validBody = {
+    [FIRST_NAME]: 'firstName',
+    [LAST_NAME]: 'lastName',
+    [EMAIL]: 'test@test.com',
+    [POSITION]: 'CEO',
+  };
 
-    describe('when there are no validation errors', () => {
-      it('should redirect to all sections page', async () => {
-        req.body = validBody;
+  describe('when there are no validation errors', () => {
+    it('should redirect to all sections page', async () => {
+      req.body = validBody;
 
-        await post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
-      });
-
-      it('should call mapAndSave.broker once with data from constructPayload function', async () => {
-        req.body = {
-          ...validBody,
-          injection: 1,
-        };
-
-        await post(req, res);
-
-        const payload = constructPayload(req.body, FIELD_IDS);
-
-        expect(mapAndSave.contact).toHaveBeenCalledTimes(1);
-
-        expect(mapAndSave.contact).toHaveBeenCalledWith(payload, mockApplication, false);
-      });
+      expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
     });
 
-    describe('when there are validation errors', () => {
-      it('should redirect to all sections page', async () => {
-        req.body = {
-          [FIRST_NAME]: 'firstName',
-          [LAST_NAME]: 'lastName',
-          [EMAIL]: 'test',
-          [POSITION]: 'CEO',
-        };
+    it('should call mapAndSave.broker once with data from constructPayload function', async () => {
+      req.body = {
+        ...validBody,
+        injection: 1,
+      };
 
-        await post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
-      });
+      const payload = constructPayload(req.body, FIELD_IDS);
 
-      it('should call mapAndSave.contact once', async () => {
-        req.body = {
-          [FIRST_NAME]: 'firstName',
-          [LAST_NAME]: 'lastName',
-          [EMAIL]: 'test',
-          [POSITION]: 'CEO',
-        };
+      expect(mapAndSave.contact).toHaveBeenCalledTimes(1);
 
-        await post(req, res);
+      expect(mapAndSave.contact).toHaveBeenCalledWith(payload, mockApplication, false);
+    });
+  });
 
-        expect(updateMapAndSave).toHaveBeenCalledTimes(1);
-      });
+  describe('when there are validation errors', () => {
+    it('should redirect to all sections page', async () => {
+      req.body = {
+        [FIRST_NAME]: 'firstName',
+        [LAST_NAME]: 'lastName',
+        [EMAIL]: 'test',
+        [POSITION]: 'CEO',
+      };
+
+      await post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
     });
 
-    describe('when there is no application', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-      });
+    it('should call mapAndSave.contact once', async () => {
+      req.body = {
+        [FIRST_NAME]: 'firstName',
+        [LAST_NAME]: 'lastName',
+        [EMAIL]: 'test',
+        [POSITION]: 'CEO',
+      };
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-      });
+      expect(updateMapAndSave).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when there is no application', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
     });
 
-    describe('when mapAndSave.contact fails', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-        updateMapAndSave = jest.fn(() => Promise.reject());
-        mapAndSave.contact = updateMapAndSave;
-      });
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+      post(req, res);
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+    });
+  });
 
-        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-      });
+  describe('when mapAndSave.contact fails', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
+      updateMapAndSave = jest.fn(() => Promise.reject());
+      mapAndSave.contact = updateMapAndSave;
+    });
+
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+      post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
     });
   });
 });

--- a/src/ui/server/controllers/insurance/business/nature-of-business/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/save-and-back/index.test.ts
@@ -31,82 +31,80 @@ describe('controllers/insurance/business/nature-of-business/save-and-back', () =
     jest.resetAllMocks();
   });
 
-  describe('post - save and back', () => {
-    describe('when there are no validation errors', () => {
-      it('should redirect to all sections page', async () => {
-        req.body = {
-          ...mockBusinessNatureOfBusiness,
-        };
+  describe('when there are no validation errors', () => {
+    it('should redirect to all sections page', async () => {
+      req.body = {
+        ...mockBusinessNatureOfBusiness,
+      };
 
-        await post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
-      });
-
-      it('should call mapAndSave.natureOfBusiness once with data from constructPayload', async () => {
-        req.body = {
-          ...mockBusinessNatureOfBusiness,
-          injection: 1,
-        };
-
-        await post(req, res);
-
-        const payload = constructPayload(req.body, FIELD_IDS);
-
-        expect(updateMapAndSave).toHaveBeenCalledTimes(1);
-
-        expect(updateMapAndSave).toHaveBeenCalledWith(payload, mockApplication, false);
-      });
+      expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
     });
 
-    describe('when there are validation errors', () => {
-      it('should redirect to all sections page', async () => {
-        req.body = {
-          [YEARS_EXPORTING]: '5O',
-          [EMPLOYEES_UK]: '2000',
-        };
+    it('should call mapAndSave.natureOfBusiness once with data from constructPayload', async () => {
+      req.body = {
+        ...mockBusinessNatureOfBusiness,
+        injection: 1,
+      };
 
-        await post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
-      });
+      const payload = constructPayload(req.body, FIELD_IDS);
 
-      it('should call mapAndSave.natureOfBusiness once', async () => {
-        req.body = {
-          [YEARS_EXPORTING]: '5O',
-          [EMPLOYEES_UK]: '2000',
-        };
+      expect(updateMapAndSave).toHaveBeenCalledTimes(1);
 
-        await post(req, res);
+      expect(updateMapAndSave).toHaveBeenCalledWith(payload, mockApplication, false);
+    });
+  });
 
-        expect(updateMapAndSave).toHaveBeenCalledTimes(1);
-      });
+  describe('when there are validation errors', () => {
+    it('should redirect to all sections page', async () => {
+      req.body = {
+        [YEARS_EXPORTING]: '5O',
+        [EMPLOYEES_UK]: '2000',
+      };
+
+      await post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
     });
 
-    describe('when there is no application', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-      });
+    it('should call mapAndSave.natureOfBusiness once', async () => {
+      req.body = {
+        [YEARS_EXPORTING]: '5O',
+        [EMPLOYEES_UK]: '2000',
+      };
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-      });
+      expect(updateMapAndSave).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when there is no application', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
     });
 
-    describe('when mapAndSave.natureOfBusiness fails', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-        updateMapAndSave = jest.fn(() => Promise.reject());
-        mapAndSave.natureOfBusiness = updateMapAndSave;
-      });
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+      post(req, res);
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+    });
+  });
 
-        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-      });
+  describe('when mapAndSave.natureOfBusiness fails', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
+      updateMapAndSave = jest.fn(() => Promise.reject());
+      mapAndSave.natureOfBusiness = updateMapAndSave;
+    });
+
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+      post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
     });
   });
 });

--- a/src/ui/server/controllers/insurance/business/turnover/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/save-and-back/index.test.ts
@@ -31,82 +31,80 @@ describe('controllers/insurance/business/turnover/save-and-back', () => {
     jest.resetAllMocks();
   });
 
-  describe('post - save and back', () => {
-    const validBody = mockBusinessTurnover;
+  const validBody = mockBusinessTurnover;
 
-    describe('when there are no validation errors', () => {
-      it('should redirect to all sections page', async () => {
-        req.body = validBody;
+  describe('when there are no validation errors', () => {
+    it('should redirect to all sections page', async () => {
+      req.body = validBody;
 
-        await post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
-      });
-
-      it('should call mapAndSave.turnover once with the data from constructPayload function', async () => {
-        req.body = {
-          ...validBody,
-          injection: 1,
-        };
-
-        await post(req, res);
-
-        const payload = constructPayload(req.body, FIELD_IDS);
-
-        expect(updateMapAndSave).toHaveBeenCalledTimes(1);
-
-        expect(updateMapAndSave).toHaveBeenCalledWith(payload, mockApplication, false);
-      });
+      expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
     });
 
-    describe('when there are validation errors', () => {
-      it('should redirect to all sections page', async () => {
-        req.body = {
-          [ESTIMATED_ANNUAL_TURNOVER]: '5O',
-          [PERCENTAGE_TURNOVER]: '101',
-        };
+    it('should call mapAndSave.turnover once with the data from constructPayload function', async () => {
+      req.body = {
+        ...validBody,
+        injection: 1,
+      };
 
-        await post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
-      });
+      const payload = constructPayload(req.body, FIELD_IDS);
 
-      it('should call mapAndSave.turnover once', async () => {
-        req.body = {
-          [ESTIMATED_ANNUAL_TURNOVER]: '5O',
-          [PERCENTAGE_TURNOVER]: '101',
-        };
+      expect(updateMapAndSave).toHaveBeenCalledTimes(1);
 
-        await post(req, res);
+      expect(updateMapAndSave).toHaveBeenCalledWith(payload, mockApplication, false);
+    });
+  });
 
-        expect(updateMapAndSave).toHaveBeenCalledTimes(1);
-      });
+  describe('when there are validation errors', () => {
+    it('should redirect to all sections page', async () => {
+      req.body = {
+        [ESTIMATED_ANNUAL_TURNOVER]: '5O',
+        [PERCENTAGE_TURNOVER]: '101',
+      };
+
+      await post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
     });
 
-    describe('when there is no application', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-      });
+    it('should call mapAndSave.turnover once', async () => {
+      req.body = {
+        [ESTIMATED_ANNUAL_TURNOVER]: '5O',
+        [PERCENTAGE_TURNOVER]: '101',
+      };
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-      });
+      expect(updateMapAndSave).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when there is no application', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
     });
 
-    describe('when mapAndSave.turnover fails', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-        updateMapAndSave = jest.fn(() => Promise.reject());
-        mapAndSave.turnover = updateMapAndSave;
-      });
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+      post(req, res);
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+    });
+  });
 
-        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-      });
+  describe('when mapAndSave.turnover fails', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
+      updateMapAndSave = jest.fn(() => Promise.reject());
+      mapAndSave.turnover = updateMapAndSave;
+    });
+
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+      post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
     });
   });
 });

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
@@ -1,6 +1,7 @@
 import { PAGES } from '../../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import api from '../../../../api';
+import { objectHasProperty } from '../../../../helpers/object';
 import { isPopulatedArray } from '../../../../helpers/array';
 import { mapCisCountries } from '../../../../helpers/mappings/map-cis-countries';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
@@ -26,7 +27,9 @@ const { PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
 
 export const get = async (req: Request, res: Response) => {
   try {
-    if (!req.session?.submittedData?.insuranceEligibility) {
+    const { submittedData } = req.session;
+
+    if (!submittedData || !objectHasProperty(submittedData, 'insuranceEligibility')) {
       req.session.submittedData = {
         ...req.session.submittedData,
         insuranceEligibility: {},
@@ -40,9 +43,10 @@ export const get = async (req: Request, res: Response) => {
     }
 
     let countryValue;
+    const { insuranceEligibility } = req.session.submittedData;
 
-    if (req.session.submittedData.insuranceEligibility[FIELD_IDS.ELIGIBILITY.BUYER_COUNTRY]) {
-      countryValue = req.session.submittedData.insuranceEligibility[FIELD_IDS.ELIGIBILITY.BUYER_COUNTRY];
+    if (objectHasProperty(insuranceEligibility, FIELD_ID)) {
+      countryValue = insuranceEligibility[FIELD_ID];
     }
 
     let mappedCountries;
@@ -95,7 +99,7 @@ export const post = async (req: Request, res: Response) => {
       });
     }
 
-    const submittedCountryName = payload[FIELD_IDS.ELIGIBILITY.BUYER_COUNTRY];
+    const submittedCountryName = payload[FIELD_ID];
 
     const country = getCountryByName(mappedCountries, submittedCountryName);
 

--- a/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/save-and-back/index.test.ts
@@ -33,98 +33,96 @@ describe('controllers/insurance/your-buyer/company-or-organisation/save-and-back
     jest.resetAllMocks();
   });
 
-  describe('post - save and back', () => {
-    const { exporterIsConnectedWithBuyer, exporterHasTradedWithBuyer, ...companyOrOrganisationMock } = mockBuyer;
-    const validBody = companyOrOrganisationMock;
+  const { exporterIsConnectedWithBuyer, exporterHasTradedWithBuyer, ...companyOrOrganisationMock } = mockBuyer;
+  const validBody = companyOrOrganisationMock;
 
-    describe('when there are no validation errors', () => {
-      it('should redirect to all sections page', async () => {
-        req.body = validBody;
+  describe('when there are no validation errors', () => {
+    it('should redirect to all sections page', async () => {
+      req.body = validBody;
 
-        await post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
-      });
-
-      it('should call mapAndSave.buyer once with data from constructPayload function', async () => {
-        req.body = validBody;
-
-        await post(req, res);
-
-        expect(updateMapAndSave).toHaveBeenCalledTimes(1);
-
-        const payload = constructPayload(req.body, FIELD_IDS);
-        const validationErrors = generateValidationErrors(payload);
-
-        expect(updateMapAndSave).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
-      });
+      expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
     });
 
-    describe('when there are validation errors', () => {
-      it('should redirect to all sections page', async () => {
-        req.body = {
-          [NAME]: 'Test',
-        };
+    it('should call mapAndSave.buyer once with data from constructPayload function', async () => {
+      req.body = validBody;
 
-        await post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
-      });
+      expect(updateMapAndSave).toHaveBeenCalledTimes(1);
 
-      it('should call mapAndSave.buyer once with data from constructPayload function', async () => {
-        req.body = {
-          [NAME]: 'Test',
-        };
+      const payload = constructPayload(req.body, FIELD_IDS);
+      const validationErrors = generateValidationErrors(payload);
 
-        await post(req, res);
+      expect(updateMapAndSave).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
+    });
+  });
 
-        expect(updateMapAndSave).toHaveBeenCalledTimes(1);
+  describe('when there are validation errors', () => {
+    it('should redirect to all sections page', async () => {
+      req.body = {
+        [NAME]: 'Test',
+      };
 
-        const payload = constructPayload(req.body, FIELD_IDS);
-        const validationErrors = generateValidationErrors(payload);
+      await post(req, res);
 
-        expect(updateMapAndSave).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
-      });
+      expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
     });
 
-    describe('when there is no application', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-      });
+    it('should call mapAndSave.buyer once with data from constructPayload function', async () => {
+      req.body = {
+        [NAME]: 'Test',
+      };
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-      });
+      expect(updateMapAndSave).toHaveBeenCalledTimes(1);
+
+      const payload = constructPayload(req.body, FIELD_IDS);
+      const validationErrors = generateValidationErrors(payload);
+
+      expect(updateMapAndSave).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
+    });
+  });
+
+  describe('when there is no application', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
     });
 
-    describe('when mapAndSave.buyer returns false', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-        updateMapAndSave = jest.fn(() => Promise.resolve(false));
-        mapAndSave.yourBuyer = updateMapAndSave;
-      });
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+      post(req, res);
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+    });
+  });
 
-        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-      });
+  describe('when mapAndSave.buyer returns false', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
+      updateMapAndSave = jest.fn(() => Promise.resolve(false));
+      mapAndSave.yourBuyer = updateMapAndSave;
     });
 
-    describe('when mapAndSave.buyer fails', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-        updateMapAndSave = jest.fn(() => Promise.reject());
-        mapAndSave.yourBuyer = updateMapAndSave;
-      });
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+      post(req, res);
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+    });
+  });
 
-        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-      });
+  describe('when mapAndSave.buyer fails', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
+      updateMapAndSave = jest.fn(() => Promise.reject());
+      mapAndSave.yourBuyer = updateMapAndSave;
+    });
+
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+      post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
     });
   });
 });

--- a/src/ui/server/controllers/insurance/your-buyer/working-with-buyer/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/working-with-buyer/save-and-back/index.test.ts
@@ -33,100 +33,98 @@ describe('controllers/insurance/your-buyer/working-with-buyer/save-and-back', ()
     jest.resetAllMocks();
   });
 
-  describe('post - save and back', () => {
-    const validBody = {
-      [CONNECTED_WITH_BUYER]: mockBuyer[CONNECTED_WITH_BUYER],
-      [TRADED_WITH_BUYER]: mockBuyer[TRADED_WITH_BUYER],
-    };
+  const validBody = {
+    [CONNECTED_WITH_BUYER]: mockBuyer[CONNECTED_WITH_BUYER],
+    [TRADED_WITH_BUYER]: mockBuyer[TRADED_WITH_BUYER],
+  };
 
-    describe('when there are no validation errors', () => {
-      it('should redirect to all sections page', async () => {
-        req.body = validBody;
+  describe('when there are no validation errors', () => {
+    it('should redirect to all sections page', async () => {
+      req.body = validBody;
 
-        await post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
-      });
-
-      it('should call mapAndSave.buyer once with data from constructPayload function', async () => {
-        req.body = validBody;
-
-        await post(req, res);
-
-        expect(updateMapAndSave).toHaveBeenCalledTimes(1);
-
-        const payload = constructPayload(req.body, FIELD_IDS);
-        const validationErrors = generateValidationErrors(payload);
-
-        expect(updateMapAndSave).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
-      });
+      expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
     });
 
-    describe('when there are validation errors', () => {
-      it('should redirect to all sections page', async () => {
-        req.body = {
-          [TRADED_WITH_BUYER]: mockBuyer[TRADED_WITH_BUYER],
-        };
+    it('should call mapAndSave.buyer once with data from constructPayload function', async () => {
+      req.body = validBody;
 
-        await post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
-      });
+      expect(updateMapAndSave).toHaveBeenCalledTimes(1);
 
-      it('should call mapAndSave.buyer once with data from constructPayload function', async () => {
-        req.body = {
-          [TRADED_WITH_BUYER]: mockBuyer[TRADED_WITH_BUYER],
-        };
+      const payload = constructPayload(req.body, FIELD_IDS);
+      const validationErrors = generateValidationErrors(payload);
 
-        await post(req, res);
+      expect(updateMapAndSave).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
+    });
+  });
 
-        expect(updateMapAndSave).toHaveBeenCalledTimes(1);
+  describe('when there are validation errors', () => {
+    it('should redirect to all sections page', async () => {
+      req.body = {
+        [TRADED_WITH_BUYER]: mockBuyer[TRADED_WITH_BUYER],
+      };
 
-        const payload = constructPayload(req.body, FIELD_IDS);
-        const validationErrors = generateValidationErrors(payload);
+      await post(req, res);
 
-        expect(updateMapAndSave).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
-      });
+      expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
     });
 
-    describe('when there is no application', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-      });
+    it('should call mapAndSave.buyer once with data from constructPayload function', async () => {
+      req.body = {
+        [TRADED_WITH_BUYER]: mockBuyer[TRADED_WITH_BUYER],
+      };
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      await post(req, res);
 
-        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-      });
+      expect(updateMapAndSave).toHaveBeenCalledTimes(1);
+
+      const payload = constructPayload(req.body, FIELD_IDS);
+      const validationErrors = generateValidationErrors(payload);
+
+      expect(updateMapAndSave).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
+    });
+  });
+
+  describe('when there is no application', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
     });
 
-    describe('when mapAndSave.buyer returns false', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-        updateMapAndSave = jest.fn(() => Promise.resolve(false));
-        mapAndSave.yourBuyer = updateMapAndSave;
-      });
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+      post(req, res);
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+    });
+  });
 
-        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-      });
+  describe('when mapAndSave.buyer returns false', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
+      updateMapAndSave = jest.fn(() => Promise.resolve(false));
+      mapAndSave.yourBuyer = updateMapAndSave;
     });
 
-    describe('when mapAndSave.buyer fails', () => {
-      beforeEach(() => {
-        res.locals = { csrfToken: '1234' };
-        updateMapAndSave = jest.fn(() => Promise.reject());
-        mapAndSave.yourBuyer = updateMapAndSave;
-      });
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+      post(req, res);
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+    });
+  });
 
-        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-      });
+  describe('when mapAndSave.buyer fails', () => {
+    beforeEach(() => {
+      res.locals = { csrfToken: '1234' };
+      updateMapAndSave = jest.fn(() => Promise.reject());
+      mapAndSave.yourBuyer = updateMapAndSave;
+    });
+
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+      post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
     });
   });
 });

--- a/src/ui/server/controllers/quote/buyer-country/index.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.ts
@@ -1,6 +1,7 @@
 import { LINKS, PAGES } from '../../../content-strings';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../constants';
 import api from '../../../api';
+import { objectHasProperty } from '../../../helpers/object';
 import { isPopulatedArray } from '../../../helpers/array';
 import { mapCisCountries } from '../../../helpers/mappings/map-cis-countries';
 import singleInputPageVariables from '../../../helpers/page-variables/single-input/quote';
@@ -55,7 +56,9 @@ export const getBackLink = (referer?: string): string => {
 };
 
 export const get = async (req: Request, res: Response) => {
-  if (!req.session.submittedData?.quoteEligibility) {
+  const { submittedData } = req.session;
+
+  if (!submittedData || !objectHasProperty(submittedData, 'quoteEligibility')) {
     req.session.submittedData = {
       ...req.session.submittedData,
       quoteEligibility: {},
@@ -70,9 +73,10 @@ export const get = async (req: Request, res: Response) => {
     }
 
     let countryValue;
+    const { quoteEligibility } = req.session.submittedData;
 
-    if (req.session.submittedData.quoteEligibility[FIELD_ID]) {
-      countryValue = req.session.submittedData.quoteEligibility[FIELD_ID];
+    if (objectHasProperty(quoteEligibility, FIELD_ID)) {
+      countryValue = quoteEligibility[FIELD_ID];
     }
 
     let mappedCountries;

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.ts
@@ -1,6 +1,7 @@
 import { BUTTONS, COOKIES_CONSENT, FIELDS, QUOTE_FOOTER, LINKS, PAGES, PHASE_BANNER, PRODUCT, HEADER } from '../../../content-strings';
 import { FIELD_IDS as ALL_FIELD_IDS, PERCENTAGES_OF_COVER, ROUTES, TEMPLATES } from '../../../constants';
 import api from '../../../api';
+import { objectHasProperty } from '../../../helpers/object';
 import { isPopulatedArray } from '../../../helpers/array';
 import { mapCurrencies } from '../../../helpers/mappings/map-currencies';
 import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
@@ -114,7 +115,8 @@ const get = async (req: Request, res: Response) => {
     }
 
     let mappedCurrencies;
-    if (submittedData?.quoteEligibility && submittedData.quoteEligibility[CURRENCY]) {
+
+    if (objectHasProperty(submittedData.quoteEligibility, CURRENCY)) {
       mappedCurrencies = mapCurrencies(currencies, submittedData.quoteEligibility[CURRENCY].isoCode);
     } else {
       mappedCurrencies = mapCurrencies(currencies);
@@ -122,7 +124,7 @@ const get = async (req: Request, res: Response) => {
 
     let mappedPercentageOfCover;
 
-    if (submittedData?.quoteEligibility && submittedData.quoteEligibility[PERCENTAGE_OF_COVER]) {
+    if (objectHasProperty(submittedData.quoteEligibility, PERCENTAGE_OF_COVER)) {
       mappedPercentageOfCover = mapPercentageOfCover(PERCENTAGES_OF_COVER, Number(submittedData.quoteEligibility[PERCENTAGE_OF_COVER]));
     } else {
       mappedPercentageOfCover = mapPercentageOfCover(PERCENTAGES_OF_COVER);
@@ -131,7 +133,7 @@ const get = async (req: Request, res: Response) => {
     const creditPeriodOptions = FIELDS[CREDIT_PERIOD].OPTIONS as Array<SelectOption>;
     let mappedCreditPeriod;
 
-    if (submittedData?.quoteEligibility && submittedData.quoteEligibility[CREDIT_PERIOD]) {
+    if (objectHasProperty(submittedData.quoteEligibility, CREDIT_PERIOD)) {
       mappedCreditPeriod = mapCreditPeriod(creditPeriodOptions, String(submittedData.quoteEligibility[CREDIT_PERIOD]));
     } else {
       mappedCreditPeriod = mapCreditPeriod(creditPeriodOptions);

--- a/src/ui/server/helpers/get-valid-fields/index.ts
+++ b/src/ui/server/helpers/get-valid-fields/index.ts
@@ -15,8 +15,10 @@ const getValidFields = (formData: object, errorList: object) => {
   Object.keys(formData).forEach((fieldName) => {
     const fieldValue = formData[fieldName];
 
-    // do not return fields that are in the errors,
-    // but return fields that are empty - a user might have deleted an answer.
+    /**
+     * Do not return fields that are in the errors,
+     * but return fields that are empty - a user might have deleted an answer.
+     */
     if (!fieldsWithErrors.includes(fieldName) || isEmptyString(fieldValue)) {
       validFields[fieldName] = fieldValue;
     }


### PR DESCRIPTION
This PR makes various updates to some conditions in UI controllers and simplifies some unit tests.

## Changes
- Update some UI controller conditions to use `objectHasProperty` and use more destructuring.
- Remove some unnecessary `describe('post - save and back', () => { ... ` blocks in some unit tests.
- Minor documentation improvement.