### PR TITLE
fix(EMS-1898): Cookies banner typos, invalid/misleading E2E tests

### DIFF
--- a/e2e-tests/content-strings/cookies-consent.js
+++ b/e2e-tests/content-strings/cookies-consent.js
@@ -10,11 +10,11 @@ export const COOKIES_CONSENT = {
     VIEW_COOKIES: 'View cookies',
   },
   ACCEPTED: {
-    COPY_1: "You've accepted analytics cookies.You can change your cookie preferences at any time by using the",
+    COPY_1: "You've accepted analytics cookies. You can change your cookie preferences at any time by using the",
     COPY_2: 'in our footer.',
   },
   REJECTED: {
-    COPY_1: "You've rejected analytics cookies.You can change your cookie preferences at any time by using the",
+    COPY_1: "You've rejected analytics cookies. You can change your cookie preferences at any time by using the",
     COPY_2: 'in our footer.',
   },
 };

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
@@ -3,7 +3,7 @@ import {
   cannotApplyPage,
   submitButton,
 } from '../../../pages/shared';
-import { PAGES } from '../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import { completeStartForm, completeCheckIfEligibleForm } from '../../../../support/insurance/eligibility/forms';
 
@@ -61,8 +61,10 @@ context('Insurance Eligibility - Cannot apply exit page', () => {
   });
 
   describe('when clicking `eligibility` link', () => {
-    it('redirects to guidance page - eligibility section', () => {
-      cannotApplyPage.actions.eligibilityLink().should('have.attr', 'href', CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.HREF);
+    it(`redirects to ${LINKS.EXTERNAL.GUIDANCE}`, () => {
+      cannotApplyPage.actions.eligibilityLink().click();
+      
+      cy.url().should('eq', LINKS.EXTERNAL.GUIDANCE);
     });
   });
 });

--- a/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/insurance/eligibility/cannot-apply-page.spec.js
@@ -71,7 +71,7 @@ context('Insurance Eligibility - Cannot apply exit page', () => {
   describe('when clicking `eligibility` link', () => {
     it(`redirects to ${LINKS.EXTERNAL.GUIDANCE}`, () => {
       cannotApplyPage.actions.eligibilityLink().click();
-      
+
       cy.url().should('eq', LINKS.EXTERNAL.GUIDANCE);
     });
   });

--- a/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
@@ -1,12 +1,7 @@
 import {
   cannotApplyPage, noRadio, submitButton,
 } from '../../pages/shared';
-<<<<<<< HEAD
-import partials from '../../partials';
 import { LINKS, PAGES } from '../../../../content-strings';
-=======
-import { PAGES } from '../../../../content-strings';
->>>>>>> main-application
 import { ROUTES } from '../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../support/forms';
 import { completeAndSubmitBuyerBodyForm, completeAndSubmitExporterLocationForm } from '../../../support/quote/forms';

--- a/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
@@ -2,7 +2,7 @@ import {
   cannotApplyPage, noRadio, submitButton,
 } from '../../pages/shared';
 import partials from '../../partials';
-import { PAGES } from '../../../../content-strings';
+import { LINKS, PAGES } from '../../../../content-strings';
 import { ROUTES } from '../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../support/forms';
 import { completeAndSubmitBuyerBodyForm, completeAndSubmitExporterLocationForm } from '../../../support/quote/forms';
@@ -66,8 +66,10 @@ context('Cannot apply exit page', () => {
   });
 
   describe('when clicking `eligibility` link', () => {
-    it('redirects to guidance page - eligibility section', () => {
-      cannotApplyPage.actions.eligibilityLink().should('have.attr', 'href', CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.HREF);
+    it(`redirects to ${LINKS.EXTERNAL.GUIDANCE}`, () => {
+      cannotApplyPage.actions.eligibilityLink().click();
+
+      cy.url().should('eq', LINKS.EXTERNAL.GUIDANCE);
     });
   });
 });

--- a/src/ui/server/content-strings/cookies-consent.ts
+++ b/src/ui/server/content-strings/cookies-consent.ts
@@ -10,11 +10,11 @@ export const COOKIES_CONSENT = {
     VIEW_COOKIES: 'View cookies',
   },
   ACCEPTED: {
-    COPY_1: "You've accepted analytics cookies.You can change your cookie preferences at any time by using the",
+    COPY_1: "You've accepted analytics cookies. You can change your cookie preferences at any time by using the",
     COPY_2: 'in our footer.',
   },
   REJECTED: {
-    COPY_1: "You've rejected analytics cookies.You can change your cookie preferences at any time by using the",
+    COPY_1: "You've rejected analytics cookies. You can change your cookie preferences at any time by using the",
     COPY_2: 'in our footer.',
   },
 };


### PR DESCRIPTION
This PR fixes some typos (missing space), in the cookies banner and also fixes some invalid/misleading E2E tests.

## Changes
- Fix cookies banner typos in content strings.
- Update 2x "cannot apply" E2E tests so that they are asserting a URL after clicking a link - previously the description mentions this, but was not actually testing this.