### PR TITLE
fix(EMS-1901): Quote - policy type - missing error message

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -38,7 +38,7 @@ export const ERROR_MESSAGES = {
     [FIELD_IDS.ELIGIBILITY.PERCENTAGE_OF_COVER]: {
       IS_EMPTY: 'Select the percentage of cover you need',
     },
-    [FIELD_IDS.ELIGIBILITY.POLICY_TYPE]: 'Select whether you need a single or multiple contract policy',
+    [FIELD_IDS.POLICY_TYPE]: 'Select whether you need a single or multiple contract policy',
     [FIELD_IDS.SINGLE_POLICY_LENGTH]: {
       NOT_A_NUMBER: 'Policy length must be a number',
       NOT_A_WHOLE_NUMBER: 'Policy length must be a whole number, like 10 - you cannot enter decimal points',

--- a/e2e-tests/cypress/e2e/journeys/quote/policy-type/policy-type-validation.spec.js
+++ b/e2e-tests/cypress/e2e/journeys/quote/policy-type/policy-type-validation.spec.js
@@ -36,6 +36,19 @@ context('Policy type page - policy type & length validation - single policy type
     policyTypePage[POLICY_TYPE].single.input().click();
   });
 
+  describe('when submitting an empty form', () => {
+    it('should render a validation error when submitting an empty form', () => {
+      cy.navigateToUrl(url);
+      submitButton().click();
+
+      partials.errorSummaryListItems().should('have.length', 1);
+
+      const expectedMessage = ERROR_MESSAGES.ELIGIBILITY[POLICY_TYPE];
+
+      cy.checkText(partials.errorSummaryListItems().first(), expectedMessage);
+    });
+  });
+
   it('should render a validation error when `single policy length` is not provided', () => {
     submitButton().click();
 

--- a/src/ui/server/controllers/quote/policy-type/validation/rules/policy-type.test.ts
+++ b/src/ui/server/controllers/quote/policy-type/validation/rules/policy-type.test.ts
@@ -17,7 +17,7 @@ describe('controllers/quote/policy-type/validation/rules/policy-type', () => {
 
       const result = rule(mockBody, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_IDS.SINGLE_POLICY_TYPE, ERROR_MESSAGES[FIELD_IDS.POLICY_TYPE], mockErrors);
+      const expected = generateValidationErrors(FIELD_IDS.SINGLE_POLICY_TYPE, ERROR_MESSAGES.ELIGIBILITY[FIELD_IDS.POLICY_TYPE], mockErrors);
 
       expect(result).toEqual(expected);
     });

--- a/src/ui/server/controllers/quote/policy-type/validation/rules/policy-type.ts
+++ b/src/ui/server/controllers/quote/policy-type/validation/rules/policy-type.ts
@@ -8,7 +8,7 @@ const policyTypeRules = (formBody: RequestBody, errors: object) => {
   let updatedErrors = errors;
 
   if (!objectHasProperty(formBody, FIELD_IDS.POLICY_TYPE)) {
-    updatedErrors = generateValidationErrors(FIELD_IDS.SINGLE_POLICY_TYPE, ERROR_MESSAGES[FIELD_IDS.POLICY_TYPE], errors);
+    updatedErrors = generateValidationErrors(FIELD_IDS.SINGLE_POLICY_TYPE, ERROR_MESSAGES.ELIGIBILITY[FIELD_IDS.POLICY_TYPE], errors);
   }
 
   return updatedErrors;


### PR DESCRIPTION
This PR fixes an issue where when submitting an empty form in the "Quote - policy type" page, the validation error summary would not not display an error message.

## Changes
- Fix a typo in E2E error message content strings.
- Fix a typo in UI validation function.
- Add missing E2E test coverage.