### PR TITLE
feat(EMS-1918): Quote - Kind of policy - copy updates

### DIFF
--- a/e2e-tests/content-strings/fields/index.js
+++ b/e2e-tests/content-strings/fields/index.js
@@ -105,13 +105,22 @@ export const FIELDS = {
         ID: FIELD_IDS.SINGLE_POLICY_TYPE,
         VALUE: FIELD_VALUES.POLICY_TYPE.SINGLE,
         TEXT: 'Single contract policy',
-        HINT: 'This covers a single export contract with a single buyer for one or more shipments. You need to pay before the policy starts.',
+        HINT: [
+          'Covers a single contract with a buyer, for one or more shipments',
+          'Cover for up to 2 years',
+          'Best for a one off- project, when you know the exact value of your export contract now',
+          'You pay for the insurance before the policy starts',
+        ],
       },
       MULTIPLE: {
         ID: FIELD_IDS.MULTIPLE_POLICY_TYPE,
         VALUE: FIELD_VALUES.POLICY_TYPE.MULTIPLE,
-        TEXT: 'Multiple contract policy (also known as a revolving policy)',
-        HINT: "This covers multiple export contracts with the same buyer for a policy period of 12 months. You do not need to pay before the policy starts. You'll pay each time you declare a new export sale.",
+        TEXT: 'Multiple contract policy',
+        HINT: [
+          'Covers multiple contracts with the same buyer, usually for 12 months',
+          "Best if you'll have an ongoing relationship with the buyer but you're not sure yet how many contracts or sales you'll have",
+          'You only pay for your insurance each time you declare a new contract or sale - no need to pay before the policy starts',
+        ],
         INSET: [
           [
             {

--- a/e2e-tests/content-strings/fields/index.js
+++ b/e2e-tests/content-strings/fields/index.js
@@ -1,6 +1,13 @@
+import { APPLICATION } from '../../constants/application';
+import { ELIGIBILITY } from '../../constants/eligibility';
 import { FIELD_IDS } from '../../constants/field-ids';
 import { FIELD_VALUES } from '../../constants/field-values';
 import { LINKS } from '../links';
+
+const { MAX_COVER_PERIOD_YEARS } = ELIGIBILITY;
+const {
+  POLICY_AND_EXPORT: { TOTAL_MONTHS_OF_COVER },
+} = APPLICATION;
 
 export const FIELDS = {
   [FIELD_IDS.OPTIONAL_COOKIES]: {
@@ -107,7 +114,7 @@ export const FIELDS = {
         TEXT: 'Single contract policy',
         HINT: [
           'Covers a single contract with a buyer, for one or more shipments',
-          'Cover for up to 2 years',
+          `Cover for up to ${MAX_COVER_PERIOD_YEARS} years`,
           'Best for a one off- project, when you know the exact value of your export contract now',
           'You pay for the insurance before the policy starts',
         ],
@@ -117,14 +124,14 @@ export const FIELDS = {
         VALUE: FIELD_VALUES.POLICY_TYPE.MULTIPLE,
         TEXT: 'Multiple contract policy',
         HINT: [
-          'Covers multiple contracts with the same buyer, usually for 12 months',
+          `Covers multiple contracts with the same buyer, usually for ${TOTAL_MONTHS_OF_COVER} months`,
           "Best if you'll have an ongoing relationship with the buyer but you're not sure yet how many contracts or sales you'll have",
           'You only pay for your insurance each time you declare a new contract or sale - no need to pay before the policy starts',
         ],
         INSET: [
           [
             {
-              text: 'If you need a policy of over 12 months',
+              text: `If you need a policy of over ${TOTAL_MONTHS_OF_COVER} months`,
             },
             {
               text: 'fill in this form',

--- a/e2e-tests/content-strings/fields/insurance/policy-and-exports/index.js
+++ b/e2e-tests/content-strings/fields/insurance/policy-and-exports/index.js
@@ -1,8 +1,18 @@
-import { APPLICATION, FIELD_IDS, FIELD_VALUES } from '../../../../constants';
+import {
+  APPLICATION,
+  ELIGIBILITY,
+  FIELD_IDS,
+  FIELD_VALUES,
+} from '../../../../constants';
 import { LINKS } from '../../../links';
 
 const { POLICY_AND_EXPORTS } = FIELD_IDS.INSURANCE;
 const { CONTRACT_POLICY, ABOUT_GOODS_OR_SERVICES } = POLICY_AND_EXPORTS;
+
+const { MAX_COVER_PERIOD_YEARS } = ELIGIBILITY;
+const {
+  POLICY_AND_EXPORT: { TOTAL_MONTHS_OF_COVER },
+} = APPLICATION;
 
 export const POLICY_AND_EXPORT_FIELDS = {
   [POLICY_AND_EXPORTS.POLICY_TYPE]: {
@@ -14,7 +24,7 @@ export const POLICY_AND_EXPORT_FIELDS = {
         TEXT: 'Single contract policy',
         HINT_LIST: [
           'Covers a single contract with a buyer, for one or more shipments',
-          'Cover for up to 2 years',
+          `Cover for up to ${MAX_COVER_PERIOD_YEARS} years`,
           'Best for a one off- project, when you know the exact value of your export contract now',
           'You pay for the insurance before the policy starts',
         ],
@@ -90,7 +100,7 @@ export const POLICY_AND_EXPORT_FIELDS = {
     MULTIPLE: {
       [CONTRACT_POLICY.MULTIPLE.TOTAL_MONTHS_OF_COVER]: {
         LABEL: 'How many months do you want to be insured for?',
-        HINT: `The maximum is ${APPLICATION.POLICY_AND_EXPORT.TOTAL_MONTHS_OF_COVER} months.`,
+        HINT: `The maximum is ${TOTAL_MONTHS_OF_COVER} months.`,
         OPTIONS: FIELD_VALUES.TOTAL_MONTHS_OF_COVER,
         SUMMARY: {
           TITLE: 'How many months you want to be insured for',

--- a/e2e-tests/pages/quote/policyType.js
+++ b/e2e-tests/pages/quote/policyType.js
@@ -3,23 +3,23 @@ import {
   FIELD_VALUES,
 } from '../../constants';
 
-const { POLICY_TYPE, SINGLE_POLICY_LENGTH } = FIELD_IDS;
+const { POLICY_TYPE, SINGLE_POLICY_TYPE, MULTIPLE_POLICY_TYPE, SINGLE_POLICY_LENGTH } = FIELD_IDS;
+
+const {
+  POLICY_TYPE: { SINGLE, MULTIPLE },
+} = FIELD_VALUES;
 
 const policyTypePage = {
   [POLICY_TYPE]: {
     single: {
-      label: () => cy.get(`[data-cy="${POLICY_TYPE}-${FIELD_VALUES.POLICY_TYPE.SINGLE}-label"]`),
-      hint: () => cy.get(`[data-cy="${POLICY_TYPE}-${FIELD_VALUES.POLICY_TYPE.SINGLE}-hint"]`),
-      input: () => cy.get(`[data-cy="${POLICY_TYPE}-${FIELD_VALUES.POLICY_TYPE.SINGLE}-input"]`),
+      label: () => cy.get(`[data-cy="${SINGLE_POLICY_TYPE}-label"]`),
+      hintListItem: (index) => cy.get(`[data-cy="${SINGLE_POLICY_TYPE}-hint-list-item-${index}"]`),
+      input: () => cy.get(`[data-cy="${SINGLE_POLICY_TYPE}-input"]`),
     },
     multiple: {
-      label: () => cy.get(`[data-cy="${POLICY_TYPE}-${FIELD_VALUES.POLICY_TYPE.MULTIPLE}-label"]`),
-      hint: () => cy.get(`[data-cy="${POLICY_TYPE}-${FIELD_VALUES.POLICY_TYPE.MULTIPLE}-hint"]`),
-      input: () => cy.get(`[data-cy="${POLICY_TYPE}-${FIELD_VALUES.POLICY_TYPE.MULTIPLE}-input"]`),
-      inset: {
-        text: () => cy.get('[data-cy="multiple-policy-inset"] [data-cy="details-1"]'),
-        link: () => cy.get('[data-cy="multiple-policy-inset"] [data-cy="details-1"] a').eq(0),
-      },
+      label: () => cy.get(`[data-cy="${MULTIPLE_POLICY_TYPE}-label"]`),
+      hintListItem: (index) => cy.get(`[data-cy="${MULTIPLE_POLICY_TYPE}-hint-list-item-${index}"]`),
+      input: () => cy.get(`[data-cy="${MULTIPLE_POLICY_TYPE}-input"]`),
     },
     errorMessage: () => cy.get(`[data-cy="${POLICY_TYPE}-error-message"]`),
   },

--- a/e2e-tests/pages/quote/policyType.js
+++ b/e2e-tests/pages/quote/policyType.js
@@ -1,13 +1,11 @@
-import {
-  FIELD_IDS,
-  FIELD_VALUES,
-} from '../../constants';
-
-const { POLICY_TYPE, SINGLE_POLICY_TYPE, MULTIPLE_POLICY_TYPE, SINGLE_POLICY_LENGTH } = FIELD_IDS;
+import { FIELD_IDS } from '../../constants';
 
 const {
-  POLICY_TYPE: { SINGLE, MULTIPLE },
-} = FIELD_VALUES;
+  POLICY_TYPE,
+  SINGLE_POLICY_TYPE,
+  MULTIPLE_POLICY_TYPE,
+  SINGLE_POLICY_LENGTH,
+} = FIELD_IDS;
 
 const policyTypePage = {
   [POLICY_TYPE]: {

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/policy-type/policy-type.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/policy-type/policy-type.spec.js
@@ -15,7 +15,7 @@ import { ROUTES, FIELD_IDS } from '../../../../../../constants';
 
 const CONTENT_STRINGS = PAGES.QUOTE.POLICY_TYPE;
 
-const { POLICY_TYPE } = FIELD_IDS;
+const { POLICY_TYPE: FIELD_ID } = FIELD_IDS;
 
 const {
   QUOTE: {
@@ -66,19 +66,32 @@ context('Policy type page - as an exporter, I want to get UKEF export insurance 
       cy.navigateToUrl(url);
     });
 
-    it('renders `policy type` radio inputs with labels and hints', () => {
-      const fieldId = POLICY_TYPE;
-      const field = policyTypePage[fieldId];
+    it('should render `single policy type` radio input with a label and hint', () => {
+      const field = policyTypePage[FIELD_ID].single;
 
-      field.single.input().should('exist');
-      cy.checkText(field.single.label(), FIELDS[fieldId].OPTIONS.SINGLE.TEXT);
+      field.input().should('exist');
 
-      cy.checkText(field.single.hint(), FIELDS[fieldId].OPTIONS.SINGLE.HINT);
+      cy.checkText(field.label(), FIELDS[FIELD_ID].OPTIONS.SINGLE.TEXT);
 
-      field.multiple.input().should('exist');
-      cy.checkText(field.multiple.label(), FIELDS[fieldId].OPTIONS.MULTIPLE.TEXT);
+      const HINT_STRINGS = FIELDS[FIELD_ID].OPTIONS.SINGLE.HINT;
 
-      cy.checkText(field.multiple.hint(), FIELDS[fieldId].OPTIONS.MULTIPLE.HINT);
+      cy.checkText(field.hintListItem(1), HINT_STRINGS[0]);
+      cy.checkText(field.hintListItem(2), HINT_STRINGS[1]);
+      cy.checkText(field.hintListItem(3), HINT_STRINGS[2]);
+      cy.checkText(field.hintListItem(4), HINT_STRINGS[3]);
+    });
+
+    it('should render `multiple policy type` radio input with a label and hint', () => {
+      const field = policyTypePage[FIELD_ID].multiple;
+
+      field.input().should('exist');
+      cy.checkText(field.label(), FIELDS[FIELD_ID].OPTIONS.MULTIPLE.TEXT);
+
+      const HINT_STRINGS = FIELDS[FIELD_ID].OPTIONS.MULTIPLE.HINT;
+
+      cy.checkText(field.hintListItem(1), HINT_STRINGS[0]);
+      cy.checkText(field.hintListItem(2), HINT_STRINGS[1]);
+      cy.checkText(field.hintListItem(3), HINT_STRINGS[2]);
     });
 
     it('should not render policy length inputs by default', () => {
@@ -88,7 +101,7 @@ context('Policy type page - as an exporter, I want to get UKEF export insurance 
 
     describe('when clicking `single` policy type', () => {
       it('should reveal policy length input with label and hint', () => {
-        const singlePolicyType = policyTypePage[POLICY_TYPE].single;
+        const singlePolicyType = policyTypePage[FIELD_ID].single;
         singlePolicyType.label().click();
 
         const singlePolicyLengthId = FIELD_IDS.SINGLE_POLICY_LENGTH;
@@ -117,35 +130,9 @@ context('Policy type page - as an exporter, I want to get UKEF export insurance 
       });
     });
 
-    describe('when clicking `multiple` policy type', () => {
-      it('should reveal inset text and link', () => {
-        const multiPolicyType = policyTypePage[POLICY_TYPE].multiple;
-        multiPolicyType.label().click();
-
-        const field = FIELDS[POLICY_TYPE];
-
-        const [insetText] = field.OPTIONS.MULTIPLE.INSET;
-
-        multiPolicyType.inset.text().invoke('text').then((text) => {
-          expect(text.trim()).includes(insetText[0].text);
-          expect(text.trim()).includes(insetText[1].text);
-          expect(text.trim()).includes(insetText[2].text);
-        });
-
-        const expectedHref = LINKS.EXTERNAL.NBI_FORM;
-        const expectedText = insetText[1].text;
-
-        cy.checkLink(
-          multiPolicyType.inset.link(),
-          expectedHref,
-          expectedText,
-        );
-      });
-    });
-
     describe('when form is valid', () => {
       it(`should redirect to ${TELL_US_ABOUT_YOUR_POLICY}`, () => {
-        policyTypePage[POLICY_TYPE].single.input().click();
+        policyTypePage[FIELD_ID].single.input().click();
         cy.keyboardInput(policyTypePage[FIELD_IDS.SINGLE_POLICY_LENGTH].input(), '8');
 
         submitButton().click();

--- a/src/ui/server/content-strings/fields/index.ts
+++ b/src/ui/server/content-strings/fields/index.ts
@@ -105,13 +105,22 @@ export const FIELDS = {
         ID: FIELD_IDS.SINGLE_POLICY_TYPE,
         VALUE: FIELD_VALUES.POLICY_TYPE.SINGLE,
         TEXT: 'Single contract policy',
-        HINT: 'This covers a single export contract with a single buyer for one or more shipments. You need to pay before the policy starts.',
+        HINT: [
+          'Covers a single contract with a buyer, for one or more shipments',
+          'Cover for up to 2 years',
+          'Best for a one off- project, when you know the exact value of your export contract now',
+          'You pay for the insurance before the policy starts',
+        ],
       },
       MULTIPLE: {
         ID: FIELD_IDS.MULTIPLE_POLICY_TYPE,
         VALUE: FIELD_VALUES.POLICY_TYPE.MULTIPLE,
-        TEXT: 'Multiple contract policy (also known as a revolving policy)',
-        HINT: "This covers multiple export contracts with the same buyer for a policy period of 12 months. You do not need to pay before the policy starts. You'll pay each time you declare a new export sale.",
+        TEXT: 'Multiple contract policy',
+        HINT: [
+          'Covers multiple contracts with the same buyer, usually for 12 months',
+          "Best if you'll have an ongoing relationship with the buyer but you're not sure yet how many contracts or sales you'll have",
+          'You only pay for your insurance each time you declare a new contract or sale - no need to pay before the policy starts',
+        ],
         INSET: [
           [
             {

--- a/src/ui/server/content-strings/fields/index.ts
+++ b/src/ui/server/content-strings/fields/index.ts
@@ -1,5 +1,10 @@
-import { FIELD_IDS, FIELD_VALUES } from '../../constants';
+import { APPLICATION, ELIGIBILITY, FIELD_IDS, FIELD_VALUES } from '../../constants';
 import { LINKS } from '../links';
+
+const { MAX_COVER_PERIOD_YEARS } = ELIGIBILITY;
+const {
+  POLICY_AND_EXPORT: { TOTAL_MONTHS_OF_COVER },
+} = APPLICATION;
 
 export const FIELDS = {
   [FIELD_IDS.OPTIONAL_COOKIES]: {
@@ -107,7 +112,7 @@ export const FIELDS = {
         TEXT: 'Single contract policy',
         HINT: [
           'Covers a single contract with a buyer, for one or more shipments',
-          'Cover for up to 2 years',
+          `Cover for up to ${MAX_COVER_PERIOD_YEARS} years`,
           'Best for a one off- project, when you know the exact value of your export contract now',
           'You pay for the insurance before the policy starts',
         ],
@@ -117,14 +122,14 @@ export const FIELDS = {
         VALUE: FIELD_VALUES.POLICY_TYPE.MULTIPLE,
         TEXT: 'Multiple contract policy',
         HINT: [
-          'Covers multiple contracts with the same buyer, usually for 12 months',
+          `Covers multiple contracts with the same buyer, usually for ${TOTAL_MONTHS_OF_COVER} months`,
           "Best if you'll have an ongoing relationship with the buyer but you're not sure yet how many contracts or sales you'll have",
           'You only pay for your insurance each time you declare a new contract or sale - no need to pay before the policy starts',
         ],
         INSET: [
           [
             {
-              text: 'If you need a policy of over 12 months',
+              text: `If you need a policy of over ${TOTAL_MONTHS_OF_COVER} months`,
             },
             {
               text: 'fill in this form',

--- a/src/ui/server/content-strings/fields/insurance/policy-and-exports/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy-and-exports/index.ts
@@ -1,8 +1,13 @@
-import { APPLICATION, FIELD_IDS, FIELD_VALUES } from '../../../../constants';
+import { APPLICATION, ELIGIBILITY, FIELD_IDS, FIELD_VALUES } from '../../../../constants';
 import { LINKS } from '../../../links';
 
 const { POLICY_AND_EXPORTS } = FIELD_IDS.INSURANCE;
 const { CONTRACT_POLICY, ABOUT_GOODS_OR_SERVICES } = POLICY_AND_EXPORTS;
+
+const { MAX_COVER_PERIOD_YEARS } = ELIGIBILITY;
+const {
+  POLICY_AND_EXPORT: { TOTAL_MONTHS_OF_COVER },
+} = APPLICATION;
 
 export const POLICY_AND_EXPORTS_FIELDS = {
   [POLICY_AND_EXPORTS.POLICY_TYPE]: {
@@ -14,7 +19,7 @@ export const POLICY_AND_EXPORTS_FIELDS = {
         TEXT: 'Single contract policy',
         HINT_LIST: [
           'Covers a single contract with a buyer, for one or more shipments',
-          'Cover for up to 2 years',
+          `Cover for up to ${MAX_COVER_PERIOD_YEARS} years`,
           'Best for a one off- project, when you know the exact value of your export contract now',
           'You pay for the insurance before the policy starts',
         ],
@@ -24,7 +29,7 @@ export const POLICY_AND_EXPORTS_FIELDS = {
         VALUE: FIELD_VALUES.POLICY_TYPE.MULTIPLE,
         TEXT: 'Multiple contract policy',
         HINT_LIST: [
-          'Covers multiple contracts with the same buyer, usually for 12 months',
+          `Covers multiple contracts with the same buyer, usually for ${TOTAL_MONTHS_OF_COVER} months`,
           "Best if you'll have an ongoing relationship with the buyer but you're not sure yet how many contracts or sales you'll have",
           'You only pay for your insurance each time you declare a new contract or sale - no need to pay before the policy starts',
         ],
@@ -90,7 +95,7 @@ export const POLICY_AND_EXPORTS_FIELDS = {
     MULTIPLE: {
       [CONTRACT_POLICY.MULTIPLE.TOTAL_MONTHS_OF_COVER]: {
         LABEL: 'How many months do you want to be insured for?',
-        HINT: `The maximum is ${APPLICATION.POLICY_AND_EXPORT.TOTAL_MONTHS_OF_COVER} months.`,
+        HINT: `The maximum is ${TOTAL_MONTHS_OF_COVER} months.`,
         OPTIONS: FIELD_VALUES.TOTAL_MONTHS_OF_COVER,
         SUMMARY: {
           TITLE: 'How many months you want to be insured for',

--- a/src/ui/templates/quote/policy-type.njk
+++ b/src/ui/templates/quote/policy-type.njk
@@ -35,12 +35,28 @@
 
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
+        {% set singlePolicyHintHtml %}
+          <ul>
+            {% for item in FIELDS.POLICY_TYPE.OPTIONS.SINGLE.HINT %}
+              <li class="govuk-!-margin-bottom-5" data-cy="{{ FIELDS.POLICY_TYPE.OPTIONS.SINGLE.ID }}-hint-list-item-{{ loop.index }}">{{ item }} </li>
+            {% endfor %}
+          </ul>
+        {% endset %}
+
         {% set singlePolicyLengthHintHtml %}
           <div data-cy="{{ FIELDS.SINGLE_POLICY_LENGTH.ID }}-hint">
-            {{detailsText.render({
+            {{ detailsText.render({
               items: FIELDS.SINGLE_POLICY_LENGTH.HINT
             }) }}
           </div>
+        {% endset %}
+
+        {% set multiplePolicyHintHtml %}
+          <ul>
+            {% for item in FIELDS.POLICY_TYPE.OPTIONS.MULTIPLE.HINT %}
+              <li class="govuk-!-margin-bottom-5" data-cy="{{ FIELDS.POLICY_TYPE.OPTIONS.MULTIPLE.ID }}-hint-list-item-{{ loop.index }}">{{ item }} </li>
+            {% endfor %}
+          </ul>
         {% endset %}
 
         {% set singlePolicyLengthHtml %}
@@ -77,14 +93,6 @@
           }) }}
         {% endset %}
 
-        {% set multiplePolicyTypeInsetHtml %}
-          <div data-cy="multiple-policy-inset">
-            {{ detailsText.render({
-              items: FIELDS.POLICY_TYPE.OPTIONS.MULTIPLE.INSET
-            }) }}
-          </div>
-        {% endset %}
-
         {% if validationErrors.errorList[FIELDS.POLICY_TYPE.ID] %}
           {% set validationError = validationErrors.errorList[FIELDS.POLICY_TYPE.ID] %}
         {% endif %}
@@ -108,18 +116,17 @@
               value: FIELDS.POLICY_TYPE.OPTIONS.SINGLE.VALUE,
               text: FIELDS.POLICY_TYPE.OPTIONS.SINGLE.TEXT,
               label: {
+                classes: 'govuk-heading-m govuk-!-font-weight-bold govuk-!-font-size-24',
                 attributes: {
-                  'data-cy': FIELDS.POLICY_TYPE.ID + '-' + FIELDS.POLICY_TYPE.OPTIONS.SINGLE.VALUE + '-label'
+                  'data-cy': FIELDS.POLICY_TYPE.OPTIONS.SINGLE.ID + '-label'
                 }
               },
               hint: {
-                text: FIELDS.POLICY_TYPE.OPTIONS.SINGLE.HINT,
-                attributes: {
-                  'data-cy': FIELDS.POLICY_TYPE.ID + '-' + FIELDS.POLICY_TYPE.OPTIONS.SINGLE.VALUE + '-hint'
-                }
+                html: singlePolicyHintHtml,
+                classes: 'govuk-!-padding-left-0 govuk-!-margin-bottom-8'
               },
               attributes: {
-                'data-cy': FIELDS.POLICY_TYPE.ID + '-' + FIELDS.POLICY_TYPE.OPTIONS.SINGLE.VALUE + '-input'
+                'data-cy': FIELDS.POLICY_TYPE.OPTIONS.SINGLE.ID + '-input'
               },
               checked: submittedValues[FIELDS.POLICY_TYPE.ID] === FIELDS.POLICY_TYPE.OPTIONS.SINGLE.VALUE,
               conditional: {
@@ -131,18 +138,17 @@
               value: FIELDS.POLICY_TYPE.OPTIONS.MULTIPLE.VALUE,
               text: FIELDS.POLICY_TYPE.OPTIONS.MULTIPLE.TEXT,
               label: {
+                classes: 'govuk-heading-m govuk-!-font-weight-bold govuk-!-font-size-24',
                 attributes: {
-                  'data-cy': FIELDS.POLICY_TYPE.ID + '-' + FIELDS.POLICY_TYPE.OPTIONS.MULTIPLE.VALUE + '-label'
+                  'data-cy': FIELDS.POLICY_TYPE.OPTIONS.MULTIPLE.ID + '-label'
                 }
               },
               hint: {
-                text: FIELDS.POLICY_TYPE.OPTIONS.MULTIPLE.HINT,
-                attributes: {
-                  'data-cy': FIELDS.POLICY_TYPE.ID + '-' + FIELDS.POLICY_TYPE.OPTIONS.MULTIPLE.VALUE + '-hint'
-                }
+                html: multiplePolicyHintHtml,
+                classes: 'govuk-!-padding-left-0'
               },
               attributes: {
-                'data-cy': FIELDS.POLICY_TYPE.ID + '-' + FIELDS.POLICY_TYPE.OPTIONS.MULTIPLE.VALUE + '-input'
+                'data-cy': FIELDS.POLICY_TYPE.OPTIONS.MULTIPLE.ID + '-input'
               },
               checked: submittedValues[FIELDS.POLICY_TYPE.ID] === FIELDS.POLICY_TYPE.OPTIONS.MULTIPLE.VALUE,
               conditional: {


### PR DESCRIPTION
This PR updates the "kind of policy page in the quote tool so that more information is available in the hints for a user. Also made some technical improvements.

## Changes
- Update "policy type" hint content strings, and nunjucks template.
- Remove the inset text previously used for multiple contract policies.
- Simplify policy type input, label and hint `data-cy` attributes.