### PR TITLE
fix(EMS-1300): Quote - tell us about your policy heading, improve test coverage

### DIFF
--- a/e2e-tests/commands/check-buyer-country-form.js
+++ b/e2e-tests/commands/check-buyer-country-form.js
@@ -84,7 +84,8 @@ const checkSubmitButton = () => {
 };
 
 const checkValidationErrors = () => {
-  partials.errorSummaryListItems().should('exist');
+  cy.checkErrorSummaryListHeading();
+
   partials.errorSummaryListItems().should('have.length', 1);
 
   const expectedMessage = String(ERROR_MESSAGES.ELIGIBILITY[FIELD_IDS.ELIGIBILITY.BUYER_COUNTRY]);

--- a/e2e-tests/commands/check-error-summary-list-heading.js
+++ b/e2e-tests/commands/check-error-summary-list-heading.js
@@ -2,6 +2,10 @@ import partials from '../partials';
 import checkText from './check-text';
 import { ERROR_MESSAGES } from '../content-strings';
 
+/**
+ * checkErrorSummaryListHeading
+ * Check that the error summary list has the correct heading.
+ */
 const checkErrorSummaryListHeading = () => {
   checkText(
     partials.errorSummaryListHeading(),

--- a/e2e-tests/commands/check-error-summary-list-heading.js
+++ b/e2e-tests/commands/check-error-summary-list-heading.js
@@ -1,0 +1,12 @@
+import partials from '../partials';
+import checkText from './check-text';
+import { ERROR_MESSAGES } from '../content-strings';
+
+const checkErrorSummaryListHeading = () => {
+  checkText(
+    partials.errorSummaryListHeading(),
+    ERROR_MESSAGES.THERE_IS_A_PROBLEM,
+  );
+};
+
+export default checkErrorSummaryListHeading;

--- a/e2e-tests/commands/shared-commands.js
+++ b/e2e-tests/commands/shared-commands.js
@@ -45,6 +45,7 @@ Cypress.Commands.add('accountAddAndGetOTP', require('./insurance/account/add-and
 
 Cypress.Commands.add('assertCustomerServiceContactDetailsContent', require('./assert-customer-service-contact-details-content'));
 
+Cypress.Commands.add('checkErrorSummaryListHeading', require('./check-error-summary-list-heading'));
 Cypress.Commands.add('checkText', require('./check-text'));
 Cypress.Commands.add('checkValue', require('./check-value'));
 Cypress.Commands.add('checkAriaLabel', require('./check-aria-label'));

--- a/e2e-tests/commands/submit-and-assert-field-errors.js
+++ b/e2e-tests/commands/submit-and-assert-field-errors.js
@@ -18,6 +18,8 @@ export default (field, fieldValue, errorIndex, errorSummaryLength, errorMessage)
 
   submitButton().click();
 
+  cy.checkErrorSummaryListHeading();
+
   partials.errorSummaryListItems().should('have.length', errorSummaryLength);
 
   cy.checkText(

--- a/e2e-tests/commands/submit-and-assert-radio-errors.js
+++ b/e2e-tests/commands/submit-and-assert-radio-errors.js
@@ -11,6 +11,8 @@ import partials from '../partials';
 export default (field, errorIndex, errorSummaryLength, errorMessage, inlineErrorIndex = 0) => {
   submitButton().click();
 
+  cy.checkErrorSummaryListHeading();
+
   partials.errorSummaryListItems().should('have.length', errorSummaryLength);
 
   cy.checkText(

--- a/e2e-tests/insurance/cypress/e2e/journeys/cookies.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/cookies.spec.js
@@ -179,7 +179,7 @@ context('Cookies page - Insurance', () => {
         });
 
         it('should render validation errors', () => {
-          partials.errorSummaryListItems().should('exist');
+          cy.checkErrorSummaryListHeading();
           partials.errorSummaryListItems().should('have.length', 1);
 
           const expectedMessage = String(ERROR_MESSAGES[FIELD_IDS.OPTIONAL_COOKIES]);

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/anti-bribery.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/anti-bribery.spec.js
@@ -150,7 +150,7 @@ context('Insurance - Declarations - Anti-bribery page - As an Exporter, I want t
       it('should render a validation error', () => {
         submitButton().click();
 
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
@@ -116,7 +116,7 @@ context("Insurance - Declarations - Anti-bribery - Code of conduct page - As an 
       it('should render a validation error', () => {
         submitButton().click();
 
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/anti-bribery-exporting-with-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/anti-bribery-exporting-with-code-of-conduct.spec.js
@@ -106,7 +106,7 @@ context("Insurance - Declarations - Anti-bribery - Exporting with code of conduc
       it('should render a validation error', () => {
         submitButton().click();
 
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/confidentiality/confidentiality.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/confidentiality/confidentiality.spec.js
@@ -139,7 +139,7 @@ context('Insurance - Declarations - Confidentiality page - As an Exporter, I wan
       it('should render a validation error', () => {
         submitButton().click();
 
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/confirmation-and-acknowledgements/confirmation-and-acknowledgements.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/confirmation-and-acknowledgements/confirmation-and-acknowledgements.spec.js
@@ -138,7 +138,7 @@ context("Insurance - Declarations - Confirmation and acknowledgements page - As 
       it('should render a validation error', () => {
         submitButton().click();
 
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/how-your-data-will-be-used/how-your-data-will-be-used.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/how-your-data-will-be-used/how-your-data-will-be-used.spec.js
@@ -138,7 +138,7 @@ context('Insurance - Declarations - How your data will be used page - As an Expo
       it('should render a validation error', () => {
         submitButton().click();
 
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/account-to-apply-online/account-to-apply-online.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/account-to-apply-online/account-to-apply-online.spec.js
@@ -78,7 +78,7 @@ context('Insurance - Eligibility - Account to apply online page - I want to conf
       });
 
       it('should render validation errors', () => {
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house-number/companies-house-number.spec.js
@@ -87,7 +87,7 @@ context('Insurance - Eligibility - Companies house number page - I want to check
       it('should render validation errors', () => {
         submitButton().click();
 
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
@@ -60,7 +60,7 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
       it('should render validation errors', () => {
         submitButton().click();
 
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.ELIGIBILITY[FIELD_IDS.ELIGIBILITY.VALID_EXPORTER_LOCATION]);

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/insured-amount/insured-amount.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/insured-amount/insured-amount.spec.js
@@ -75,7 +75,7 @@ context('Insurance - Insured amount page - I want to check if I can use online s
       it('should render validation errors', () => {
         submitButton().click();
 
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.WANT_COVER_OVER_MAX_AMOUNT].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/letter-of-credit/letter-of-credit.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/letter-of-credit/letter-of-credit.spec.js
@@ -81,7 +81,7 @@ context('Insurance - Eligibility - Letter of credit page - I want to check if I 
       });
 
       it('should render validation errors', () => {
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.LETTER_OF_CREDIT].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/other-parties/other-parties.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/other-parties/other-parties.spec.js
@@ -112,7 +112,7 @@ context('Insurance - Other parties page - I want to check if I can use online se
       it('should render validation errors', () => {
         submitButton().click();
 
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_IDS.INSURANCE.ELIGIBILITY.OTHER_PARTIES_INVOLVED].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/pre-credit-period/pre-credit-period.spec.js
@@ -123,7 +123,7 @@ context('Insurance - Eligibility - Pre-credit period page - I want to check if I
     it('should render validation errors', () => {
       submitButton().click();
 
-      partials.errorSummaryListItems().should('exist');
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 1);
 
       const expectedMessage = String(ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -122,7 +122,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
     it('should render validation errors', () => {
       submitButton().click();
 
-      partials.errorSummaryListItems().should('exist');
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 1);
 
       const expectedMessage = String(ERROR_MESSAGES.ELIGIBILITY[HAS_MINIMUM_UK_GOODS_OR_SERVICES].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/about-goods-or-services/validation/about-goods-or-services-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/about-goods-or-services/validation/about-goods-or-services-validation.spec.js
@@ -53,7 +53,7 @@ context('Insurance - Policy and exports - About goods or services page - form va
   it('should render validation errors for all required fields', () => {
     submitButton().click();
 
-    partials.errorSummaryListItems().should('exist');
+    cy.checkErrorSummaryListHeading();
 
     const TOTAL_REQUIRED_FIELDS = 2;
     partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
@@ -64,7 +64,7 @@ context('Insurance - Policy and exports - Multiple contract policy page - form v
   it('should render validation errors for all required fields', () => {
     submitButton().click();
 
-    partials.errorSummaryListItems().should('exist');
+    cy.checkErrorSummaryListHeading();
 
     const TOTAL_REQUIRED_FIELDS = 6;
     partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation.spec.js
@@ -63,7 +63,7 @@ context('Insurance - Policy and exports - Single contract policy page - form val
   it('should render validation errors for all required fields', () => {
     submitButton().click();
 
-    partials.errorSummaryListItems().should('exist');
+    cy.checkErrorSummaryListHeading();
 
     const TOTAL_REQUIRED_FIELDS = 5;
     partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/type-of-policy/type-of-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/type-of-policy/type-of-policy.spec.js
@@ -118,7 +118,7 @@ context('Insurance - Policy and exports - Type of policy page - As an exporter, 
       it('should render a validation error', () => {
         submitButton().click();
 
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.INSURANCE.POLICY_AND_EXPORTS.TYPE_OF_POLICY[FIELD_ID].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-company-website-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-company-website-validation.spec.js
@@ -59,6 +59,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should display validation errors', () => {
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         cy.checkText(partials.errorSummaryListItems().first(), COMPANY_DETAILS_ERRORS[WEBSITE].INCORRECT_FORMAT);
@@ -85,6 +86,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should display validation errors', () => {
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         cy.checkText(partials.errorSummaryListItems().first(), COMPANY_DETAILS_ERRORS[WEBSITE].INCORRECT_FORMAT);

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-invalid-phone-number-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-invalid-phone-number-validation.spec.js
@@ -63,6 +63,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should display validation errors', () => {
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 1);
 
         cy.checkText(partials.errorSummaryListItems().first(), errorMessage);
@@ -81,6 +82,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     it('should display validation errors for international phone number', () => {
       completeAllFields(INVALID_PHONE_NUMBERS.INTERNATIONAL);
 
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 1);
 
       cy.checkText(partials.errorSummaryListItems().first(), errorMessage);
@@ -91,6 +93,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     it('should display validation errors for international phone number with full code', () => {
       completeAllFields(INVALID_PHONE_NUMBERS.INTERNATIONAL_PLUS);
 
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 1);
 
       cy.checkText(partials.errorSummaryListItems().first(), errorMessage);
@@ -101,6 +104,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     it('should display validation errors for mobile number with too many numbers', () => {
       completeAllFields(INVALID_PHONE_NUMBERS.MOBILE.LONG);
 
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 1);
       cy.checkText(partials.errorSummaryListItems().first(), errorMessage);
 
@@ -110,6 +114,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     it('should display validation errors for landline number with too few numbers', () => {
       completeAllFields(INVALID_PHONE_NUMBERS.LANDLINE.SHORT);
 
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 1);
       cy.checkText(partials.errorSummaryListItems().first(), errorMessage);
 
@@ -119,6 +124,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     it('should display validation errors for special characters in phone number', () => {
       completeAllFields(INVALID_PHONE_NUMBERS.LANDLINE.SPECIAL_CHAR);
 
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 1);
       cy.checkText(partials.errorSummaryListItems().first(), errorMessage);
 
@@ -128,6 +134,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     it('should display validation errors for letters in phone number', () => {
       completeAllFields(INVALID_PHONE_NUMBERS.LANDLINE.LETTER);
 
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 1);
       cy.checkText(partials.errorSummaryListItems().first(), errorMessage);
 
@@ -137,6 +144,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     it('should display validation errors for special characters in mobile number', () => {
       completeAllFields(INVALID_PHONE_NUMBERS.MOBILE.SPECIAL_CHAR);
 
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 1);
       cy.checkText(partials.errorSummaryListItems().first(), errorMessage);
 
@@ -146,6 +154,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     it('should display validation errors for too short a number with special chars', () => {
       completeAllFields(INVALID_PHONE_NUMBERS.TOO_SHORT);
 
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 1);
       cy.checkText(partials.errorSummaryListItems().first(), errorMessage);
 
@@ -155,6 +164,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     it('should display validation errors for a number above the maximum allowed characters', () => {
       completeAllFields(INVALID_PHONE_NUMBERS.ABOVE_MAX_CHARS);
 
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 1);
       cy.checkText(partials.errorSummaryListItems().first(), errorMessage);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-address-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-address-validation.spec.js
@@ -46,6 +46,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
   });
 
   it('should display validation errors if trading address question is not answered', () => {
+    cy.checkErrorSummaryListHeading();
     partials.errorSummaryListItems().should('have.length', 1);
 
     cy.checkText(partials.errorSummaryListItems().first(), COMPANY_DETAILS_ERRORS[TRADING_ADDRESS].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-name-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-name-validation.spec.js
@@ -47,6 +47,7 @@ describe("Insurance - Your business - Company details page- As an Exporter I wan
   });
 
   it('should display validation errors if trading name question is not answered', () => {
+    cy.checkErrorSummaryListHeading();
     partials.errorSummaryListItems().should('have.length', 1);
 
     cy.checkText(partials.errorSummaryListItems().first(), COMPANY_DETAILS_ERRORS[TRADING_NAME].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
@@ -60,6 +60,8 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
     const errorMessage = NATURE_OF_BUSINESS_ERRORS[GOODS_OR_SERVICES].IS_EMPTY;
 
     it('should display validation errors', () => {
+      cy.checkErrorSummaryListHeading();
+
       partials.errorSummaryListItems().should('have.length', 4);
       cy.checkText(partials.errorSummaryListItems().first(), errorMessage);
     });
@@ -83,7 +85,9 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
     const errorMessage = NATURE_OF_BUSINESS_ERRORS[GOODS_OR_SERVICES].ABOVE_MAXIMUM;
 
     it(`should display validation errors if ${GOODS_OR_SERVICES} left empty`, () => {
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 4);
+
       cy.checkText(partials.errorSummaryListItems().first(), errorMessage);
     });
 
@@ -98,6 +102,8 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
 
       cy.keyboardInput(field.input(), 'test');
       submitButton().click();
+
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 3);
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
@@ -59,7 +59,9 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       });
 
       it(`should display validation errors if ${YEARS_EXPORTING} left empty`, () => {
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 4);
+
         cy.checkText(partials.errorSummaryListItems().eq(1), errorMessage);
       });
 
@@ -85,7 +87,9 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       });
 
       it(`should display validation errors for ${YEARS_EXPORTING}`, () => {
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 4);
+
         cy.checkText(partials.errorSummaryListItems().eq(1), errorMessage);
       });
 
@@ -106,7 +110,9 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       });
 
       it(`should display validation errors for ${YEARS_EXPORTING}`, () => {
+        cy.checkErrorSummaryListHeading();
         partials.errorSummaryListItems().should('have.length', 4);
+
         cy.checkText(partials.errorSummaryListItems().eq(1), errorMessage);
       });
 
@@ -122,6 +128,8 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
 
       cy.keyboardInput(field.input(), '5');
       submitButton().click();
+
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 3);
     });
   });
@@ -132,6 +140,8 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
 
       cy.keyboardInput(field.input(), '5,00');
       submitButton().click();
+
+      cy.checkErrorSummaryListHeading();
       partials.errorSummaryListItems().should('have.length', 3);
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-address.spec.js
@@ -58,6 +58,8 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
   });
 
   it('should render a validation error when address is above the maximum', () => {
+    cy.checkErrorSummaryListHeading();
+
     cy.checkText(
       partials.errorSummaryListItems().eq(1),
       COMPANY_OR_ORG_ERROR_MESSAGES[ADDRESS].ABOVE_MAXIMUM,

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-can-contact-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-can-contact-buyer.spec.js
@@ -72,6 +72,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
 
     submitButton().click();
 
+    cy.checkErrorSummaryListHeading();
     partials.errorSummaryListItems().should('have.length', 6);
   });
 
@@ -80,6 +81,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
 
     submitButton().click();
 
+    cy.checkErrorSummaryListHeading();
     partials.errorSummaryListItems().should('have.length', 6);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation.spec.js
@@ -55,7 +55,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
   it('should render validation errors for all required fields', () => {
     submitButton().click();
 
-    partials.errorSummaryListItems().should('exist');
+    cy.checkErrorSummaryListHeading();
 
     const TOTAL_REQUIRED_FIELDS = 7;
     partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);

--- a/e2e-tests/partials/index.js
+++ b/e2e-tests/partials/index.js
@@ -12,6 +12,7 @@ const partials = {
   ukGoodsOrServicesCalculateDescription,
   cookieBanner,
   customerServiceContactDetails,
+  errorSummaryListHeading: () => cy.get('.govuk-error-summary h2'),
   errorSummaryListItems: () => cy.get('.govuk-error-summary li'),
   errorSummaryListItemLinks: () => cy.get('.govuk-error-summary li a'),
   footer,

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
@@ -59,7 +59,8 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
       it('should render validation errors', () => {
         submitButton().click();
 
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
+
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.ELIGIBILITY[VALID_BUYER_BODY]);

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/cookies.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/cookies.spec.js
@@ -179,7 +179,8 @@ context('Cookies page - Quote', () => {
         });
 
         it('should render validation errors', () => {
-          partials.errorSummaryListItems().should('exist');
+          cy.checkErrorSummaryListHeading();
+
           partials.errorSummaryListItems().should('have.length', 1);
 
           const expectedMessage = String(ERROR_MESSAGES[FIELD_IDS.OPTIONAL_COOKIES]);

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
@@ -61,7 +61,8 @@ context('Exporter location page - as an exporter, I want to check if my company 
       it('should render validation errors', () => {
         submitButton().click();
 
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
+
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.ELIGIBILITY[FIELD_IDS.ELIGIBILITY.VALID_EXPORTER_LOCATION]);

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/policy-type/policy-type-validation.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/policy-type/policy-type-validation.spec.js
@@ -41,6 +41,8 @@ context('Policy type page - policy type & length validation - single policy type
       cy.navigateToUrl(url);
       submitButton().click();
 
+      cy.checkErrorSummaryListHeading();
+
       partials.errorSummaryListItems().should('have.length', 1);
 
       const expectedMessage = ERROR_MESSAGES.ELIGIBILITY[POLICY_TYPE];

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy-validation.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy-validation.spec.js
@@ -46,7 +46,7 @@ context('Tell us about the multiple policy you need - form validation', () => {
     });
 
     it('should render validation errors for all required fields', () => {
-      partials.errorSummaryListItems().should('exist');
+      cy.checkErrorSummaryListHeading();
 
       const TOTAL_REQUIRED_FIELDS = 4;
       partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy-validation.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy-validation.spec.js
@@ -45,7 +45,7 @@ context('Tell us about the policy you need page - form validation', () => {
     });
 
     it('should render validation errors for all required fields', () => {
-      partials.errorSummaryListItems().should('exist');
+      cy.checkErrorSummaryListHeading();
 
       const TOTAL_REQUIRED_FIELDS = 3;
       partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -99,7 +99,8 @@ context('UK goods or services page - as an exporter, I want to check if my expor
       it('should render validation errors', () => {
         submitButton().click();
 
-        partials.errorSummaryListItems().should('exist');
+        cy.checkErrorSummaryListHeading();
+
         partials.errorSummaryListItems().should('have.length', 1);
 
         const expectedMessage = String(ERROR_MESSAGES.ELIGIBILITY[HAS_MINIMUM_UK_GOODS_OR_SERVICES].IS_EMPTY);

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -4542,3 +4542,4 @@ var keystone_default = withAuth(
     telemetry: false
   })
 );
+//# sourceMappingURL=config.js.map

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
@@ -1,5 +1,5 @@
 import { FIELD_IDS, generatePageVariables, TEMPLATE, get, post } from '.';
-import { BUTTONS, COOKIES_CONSENT, FIELDS, QUOTE_FOOTER, LINKS, PAGES, PHASE_BANNER, PRODUCT, HEADER } from '../../../content-strings';
+import { BUTTONS, COOKIES_CONSENT, ERROR_MESSAGES, FIELDS, QUOTE_FOOTER, LINKS, PAGES, PHASE_BANNER, PRODUCT, HEADER } from '../../../content-strings';
 import { FIELD_IDS as ALL_FIELD_IDS, FIELD_VALUES, PERCENTAGES_OF_COVER, ROUTES, TEMPLATES } from '../../../constants';
 import api from '../../../api';
 import { mapCurrencies } from '../../../helpers/mappings/map-currencies';
@@ -19,6 +19,8 @@ const {
   POLICY_TYPE,
   POLICY_LENGTH,
 } = ALL_FIELD_IDS;
+
+const { THERE_IS_A_PROBLEM } = ERROR_MESSAGES;
 
 const { START: quoteStart } = ROUTES.QUOTE;
 
@@ -69,6 +71,7 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
           CONTENT_STRINGS: {
             BUTTONS,
             COOKIES_CONSENT,
+            ERROR_MESSAGES: { THERE_IS_A_PROBLEM },
             HEADER,
             FOOTER: QUOTE_FOOTER,
             LINKS,
@@ -125,6 +128,7 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
           CONTENT_STRINGS: {
             BUTTONS,
             COOKIES_CONSENT,
+            ERROR_MESSAGES: { THERE_IS_A_PROBLEM },
             HEADER,
             FOOTER: QUOTE_FOOTER,
             LINKS,
@@ -185,6 +189,7 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
             PRODUCT: {
               DESCRIPTION: PRODUCT.DESCRIPTION.QUOTE,
             },
+            ERROR_MESSAGES: { THERE_IS_A_PROBLEM },
             HEADER,
             FOOTER: QUOTE_FOOTER,
             LINKS,

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.ts
@@ -1,4 +1,4 @@
-import { BUTTONS, COOKIES_CONSENT, FIELDS, QUOTE_FOOTER, LINKS, PAGES, PHASE_BANNER, PRODUCT, HEADER } from '../../../content-strings';
+import { BUTTONS, COOKIES_CONSENT, ERROR_MESSAGES, FIELDS, QUOTE_FOOTER, LINKS, PAGES, PHASE_BANNER, PRODUCT, HEADER } from '../../../content-strings';
 import { FIELD_IDS as ALL_FIELD_IDS, PERCENTAGES_OF_COVER, ROUTES, TEMPLATES } from '../../../constants';
 import api from '../../../api';
 import { objectHasProperty } from '../../../helpers/object';
@@ -20,6 +20,8 @@ const {
   POLICY_TYPE,
 } = ALL_FIELD_IDS;
 
+const { THERE_IS_A_PROBLEM } = ERROR_MESSAGES;
+
 const { START: quoteStart } = ROUTES.QUOTE;
 
 export const FIELD_IDS = [AMOUNT_CURRENCY, CONTRACT_VALUE, CREDIT_PERIOD, CURRENCY, MAX_AMOUNT_OWED, PERCENTAGE_OF_COVER];
@@ -29,6 +31,7 @@ const generatePageVariables = (policyType: string, ORIGINAL_URL: string) => {
     CONTENT_STRINGS: {
       BUTTONS,
       COOKIES_CONSENT,
+      ERROR_MESSAGES: { THERE_IS_A_PROBLEM },
       LINKS,
       PHASE_BANNER,
       HEADER,

--- a/src/ui/types/pages/tell-us-about-your-policy.d.ts
+++ b/src/ui/types/pages/tell-us-about-your-policy.d.ts
@@ -1,6 +1,7 @@
 type TellUsAboutPolicyPageVariablesContentStrings = {
   BUTTONS: object;
   COOKIES_CONSENT: object;
+  ERROR_MESSAGES: object;
   FOOTER: object;
   LINKS: object;
   PHASE_BANNER: object;


### PR DESCRIPTION
This PR adds a missing content string to the "quote - tell us about your policy" page/controller, so that the error summary will display a "There is a problem" heading. This was caused by a recent tech improvement.

## Changes
- Update "tell us about your policy" controller to include `ERROR_MESSAGES` content strings.
- Create a new cypress command to check an error summary list's heading, `cy.checkErrorSummaryListHeading`.
- Update `submitAndAssertFieldErrors` and `submitAndAssertRadioErrors` cypress commands to check the summary list heading.
- Update all other E2E tests that do not use `submitAndAssertFieldErrors`, to call `cy.checkErrorSummaryListHeading();