### PR TITLE
fix(EMS-1938): Submission - Trading name and address incorrect XLSX format

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -3925,7 +3925,7 @@ var mapSicCodes2 = (sicCodes) => {
 };
 var mapBroker = (application2) => {
   const { broker } = application2;
-  let mapped = [xlsx_row_default(XLSX.FIELDS[USING_BROKER4], broker[USING_BROKER4])];
+  let mapped = [xlsx_row_default(XLSX.FIELDS[USING_BROKER4], map_yes_no_field_default(broker[USING_BROKER4]))];
   if (broker[USING_BROKER4]) {
     const addressAnswer = {
       lineOneAndTwo: `${broker[ADDRESS_LINE_12]} ${xlsx_new_line_default}${broker[ADDRESS_LINE_2]}`,
@@ -3987,9 +3987,9 @@ var mapBuyer = (application2) => {
     xlsx_row_default(XLSX.FIELDS[REGISTRATION_NUMBER], buyer[REGISTRATION_NUMBER]),
     xlsx_row_default(String(CONTENT_STRINGS4[WEBSITE4].SUMMARY?.TITLE), buyer[WEBSITE4]),
     xlsx_row_default(XLSX.FIELDS[FIRST_NAME4], `${buyer[FIRST_NAME4]} ${buyer[LAST_NAME4]} ${xlsx_new_line_default}${buyer[POSITION]} ${xlsx_new_line_default}${buyer[EMAIL8]}`),
-    xlsx_row_default(String(CONTENT_STRINGS4[CAN_CONTACT_BUYER].SUMMARY?.TITLE), buyer[CAN_CONTACT_BUYER]),
-    xlsx_row_default(String(CONTENT_STRINGS4[CONNECTED_WITH_BUYER].SUMMARY?.TITLE), buyer[CONNECTED_WITH_BUYER]),
-    xlsx_row_default(String(CONTENT_STRINGS4[TRADED_WITH_BUYER].SUMMARY?.TITLE), buyer[TRADED_WITH_BUYER])
+    xlsx_row_default(String(CONTENT_STRINGS4[CAN_CONTACT_BUYER].SUMMARY?.TITLE), map_yes_no_field_default(buyer[CAN_CONTACT_BUYER])),
+    xlsx_row_default(String(CONTENT_STRINGS4[CONNECTED_WITH_BUYER].SUMMARY?.TITLE), map_yes_no_field_default(buyer[CONNECTED_WITH_BUYER])),
+    xlsx_row_default(String(CONTENT_STRINGS4[TRADED_WITH_BUYER].SUMMARY?.TITLE), map_yes_no_field_default(buyer[TRADED_WITH_BUYER]))
   ];
   return mapped;
 };

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -3889,6 +3889,18 @@ var mapExporterAddress = (address) => {
 };
 var map_address_default = mapExporterAddress;
 
+// generate-xlsx/map-application-to-XLSX/helpers/map-yes-no-field/index.ts
+var mapYesNoField = (answer) => {
+  if (answer === false) {
+    return "No";
+  }
+  if (answer === true) {
+    return "Yes";
+  }
+  return DEFAULT.EMPTY;
+};
+var map_yes_no_field_default = mapYesNoField;
+
 // generate-xlsx/map-application-to-XLSX/map-exporter/index.ts
 var CONTENT_STRINGS3 = {
   ...FIELDS.COMPANY_DETAILS,
@@ -3937,8 +3949,8 @@ var mapExporter = (application2) => {
     xlsx_row_default(XLSX.FIELDS[COMPANY_NAME2], company[COMPANY_NAME2]),
     xlsx_row_default(CONTENT_STRINGS3[COMPANY_INCORPORATED2].SUMMARY?.TITLE, format_date_default(company[COMPANY_INCORPORATED2], "dd-MMM-yy")),
     xlsx_row_default(XLSX.FIELDS[COMPANY_ADDRESS2], map_address_default(company[COMPANY_ADDRESS2])),
-    xlsx_row_default(CONTENT_STRINGS3[TRADING_NAME2].SUMMARY?.TITLE, company[TRADING_NAME2]),
-    xlsx_row_default(CONTENT_STRINGS3[TRADING_ADDRESS2].SUMMARY?.TITLE, company[TRADING_ADDRESS2]),
+    xlsx_row_default(CONTENT_STRINGS3[TRADING_NAME2].SUMMARY?.TITLE, map_yes_no_field_default(company[TRADING_NAME2])),
+    xlsx_row_default(CONTENT_STRINGS3[TRADING_ADDRESS2].SUMMARY?.TITLE, map_yes_no_field_default(company[TRADING_ADDRESS2])),
     xlsx_row_default(XLSX.FIELDS[COMPANY_SIC2], mapSicCodes2(companySicCodes)),
     xlsx_row_default(CONTENT_STRINGS3[FINANCIAL_YEAR_END_DATE2].SUMMARY?.TITLE, format_date_default(company[FINANCIAL_YEAR_END_DATE2], "d MMMM")),
     xlsx_row_default(XLSX.FIELDS[WEBSITE3], company[WEBSITE3]),
@@ -3982,18 +3994,6 @@ var mapBuyer = (application2) => {
   return mapped;
 };
 var map_buyer_default = mapBuyer;
-
-// generate-xlsx/map-application-to-XLSX/helpers/map-yes-no-field/index.ts
-var mapYesNoField = (answer) => {
-  if (answer === false) {
-    return "No";
-  }
-  if (answer === true) {
-    return "Yes";
-  }
-  return DEFAULT.EMPTY;
-};
-var map_yes_no_field_default = mapYesNoField;
 
 // generate-xlsx/map-application-to-XLSX/map-eligibility/index.ts
 var {

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/index.test.ts
@@ -4,6 +4,7 @@ import { XLSX } from '../../../content-strings';
 import { YOUR_BUYER_FIELDS } from '../../../content-strings/fields/insurance/your-buyer';
 import NEW_LINE from '../helpers/xlsx-new-line';
 import xlsxRow from '../helpers/xlsx-row';
+import mapYesNoField from '../helpers/map-yes-no-field';
 import { mockApplication } from '../../../test-mocks';
 
 const CONTENT_STRINGS = {
@@ -29,9 +30,9 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-buyer', () => {
       xlsxRow(XLSX.FIELDS[REGISTRATION_NUMBER], buyer[REGISTRATION_NUMBER]),
       xlsxRow(String(CONTENT_STRINGS[WEBSITE].SUMMARY?.TITLE), buyer[WEBSITE]),
       xlsxRow(XLSX.FIELDS[FIRST_NAME], `${buyer[FIRST_NAME]} ${buyer[LAST_NAME]} ${NEW_LINE}${buyer[POSITION]} ${NEW_LINE}${buyer[EMAIL]}`),
-      xlsxRow(String(CONTENT_STRINGS[CAN_CONTACT_BUYER].SUMMARY?.TITLE), buyer[CAN_CONTACT_BUYER]),
-      xlsxRow(String(CONTENT_STRINGS[CONNECTED_WITH_BUYER].SUMMARY?.TITLE), buyer[CONNECTED_WITH_BUYER]),
-      xlsxRow(String(CONTENT_STRINGS[TRADED_WITH_BUYER].SUMMARY?.TITLE), buyer[TRADED_WITH_BUYER]),
+      xlsxRow(String(CONTENT_STRINGS[CAN_CONTACT_BUYER].SUMMARY?.TITLE), mapYesNoField(buyer[CAN_CONTACT_BUYER])),
+      xlsxRow(String(CONTENT_STRINGS[CONNECTED_WITH_BUYER].SUMMARY?.TITLE), mapYesNoField(buyer[CONNECTED_WITH_BUYER])),
+      xlsxRow(String(CONTENT_STRINGS[TRADED_WITH_BUYER].SUMMARY?.TITLE), mapYesNoField(buyer[TRADED_WITH_BUYER])),
     ];
 
     expect(result).toEqual(expected);

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/index.ts
@@ -3,6 +3,7 @@ import { XLSX } from '../../../content-strings';
 import { YOUR_BUYER_FIELDS } from '../../../content-strings/fields/insurance/your-buyer';
 import xlsxRow from '../helpers/xlsx-row';
 import NEW_LINE from '../helpers/xlsx-new-line';
+import mapYesNoField from '../helpers/map-yes-no-field';
 import { Application } from '../../../types';
 
 const CONTENT_STRINGS = {
@@ -31,9 +32,9 @@ const mapBuyer = (application: Application) => {
     xlsxRow(XLSX.FIELDS[REGISTRATION_NUMBER], buyer[REGISTRATION_NUMBER]),
     xlsxRow(String(CONTENT_STRINGS[WEBSITE].SUMMARY?.TITLE), buyer[WEBSITE]),
     xlsxRow(XLSX.FIELDS[FIRST_NAME], `${buyer[FIRST_NAME]} ${buyer[LAST_NAME]} ${NEW_LINE}${buyer[POSITION]} ${NEW_LINE}${buyer[EMAIL]}`),
-    xlsxRow(String(CONTENT_STRINGS[CAN_CONTACT_BUYER].SUMMARY?.TITLE), buyer[CAN_CONTACT_BUYER]),
-    xlsxRow(String(CONTENT_STRINGS[CONNECTED_WITH_BUYER].SUMMARY?.TITLE), buyer[CONNECTED_WITH_BUYER]),
-    xlsxRow(String(CONTENT_STRINGS[TRADED_WITH_BUYER].SUMMARY?.TITLE), buyer[TRADED_WITH_BUYER]),
+    xlsxRow(String(CONTENT_STRINGS[CAN_CONTACT_BUYER].SUMMARY?.TITLE), mapYesNoField(buyer[CAN_CONTACT_BUYER])),
+    xlsxRow(String(CONTENT_STRINGS[CONNECTED_WITH_BUYER].SUMMARY?.TITLE), mapYesNoField(buyer[CONNECTED_WITH_BUYER])),
+    xlsxRow(String(CONTENT_STRINGS[TRADED_WITH_BUYER].SUMMARY?.TITLE), mapYesNoField(buyer[TRADED_WITH_BUYER])),
   ];
 
   return mapped;

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-exporter/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-exporter/index.test.ts
@@ -58,7 +58,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-exporter', () => {
         };
 
         const expected = [
-          xlsxRow(XLSX.FIELDS[USING_BROKER], broker[USING_BROKER]),
+          xlsxRow(XLSX.FIELDS[USING_BROKER], mapYesNoField(broker[USING_BROKER])),
           xlsxRow(XLSX.FIELDS[BROKER_NAME], broker[BROKER_NAME]),
           xlsxRow(XLSX.FIELDS[ADDRESS_LINE_1], `${expectedAddressAnswer.lineOneAndTwo}${expectedAddressAnswer.other}`),
           xlsxRow(XLSX.FIELDS[EMAIL], broker[EMAIL]),

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-exporter/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-exporter/index.test.ts
@@ -82,7 +82,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-exporter', () => {
 
         const { broker } = mockApplicationNoBroker;
 
-        const expected = [xlsxRow(XLSX.FIELDS[USING_BROKER], broker[USING_BROKER])];
+        const expected = [xlsxRow(XLSX.FIELDS[USING_BROKER], mapYesNoField(broker[USING_BROKER]))];
 
         expect(result).toEqual(expected);
       });

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-exporter/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-exporter/index.test.ts
@@ -9,6 +9,7 @@ import formatDate from '../../../helpers/format-date';
 import formatCurrency from '../helpers/format-currency';
 import NEW_LINE from '../helpers/xlsx-new-line';
 import { mockApplication } from '../../../test-mocks';
+import mapYesNoField from '../helpers/map-yes-no-field';
 
 const CONTENT_STRINGS = {
   ...FIELDS.COMPANY_DETAILS,
@@ -104,8 +105,8 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-exporter', () => {
 
         xlsxRow(XLSX.FIELDS[COMPANY_ADDRESS], mapExporterAddress(company[COMPANY_ADDRESS])),
 
-        xlsxRow(CONTENT_STRINGS[TRADING_NAME].SUMMARY?.TITLE, company[TRADING_NAME]),
-        xlsxRow(CONTENT_STRINGS[TRADING_ADDRESS].SUMMARY?.TITLE, company[TRADING_ADDRESS]),
+        xlsxRow(CONTENT_STRINGS[TRADING_NAME].SUMMARY?.TITLE, mapYesNoField(company[TRADING_NAME])),
+        xlsxRow(CONTENT_STRINGS[TRADING_ADDRESS].SUMMARY?.TITLE, mapYesNoField(company[TRADING_ADDRESS])),
 
         xlsxRow(XLSX.FIELDS[COMPANY_SIC], mapSicCodes(companySicCodes)),
 

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-exporter/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-exporter/index.ts
@@ -6,6 +6,7 @@ import xlsxRow from '../helpers/xlsx-row';
 import mapExporterAddress from './map-address';
 import formatDate from '../../../helpers/format-date';
 import formatCurrency from '../helpers/format-currency';
+import mapYesNoField from '../helpers/map-yes-no-field';
 import NEW_LINE from '../helpers/xlsx-new-line';
 import { Application, ApplicationCompanySicCode } from '../../../types';
 
@@ -89,8 +90,8 @@ const mapExporter = (application: Application) => {
 
     xlsxRow(XLSX.FIELDS[COMPANY_ADDRESS], mapExporterAddress(company[COMPANY_ADDRESS])),
 
-    xlsxRow(CONTENT_STRINGS[TRADING_NAME].SUMMARY?.TITLE, company[TRADING_NAME]),
-    xlsxRow(CONTENT_STRINGS[TRADING_ADDRESS].SUMMARY?.TITLE, company[TRADING_ADDRESS]),
+    xlsxRow(CONTENT_STRINGS[TRADING_NAME].SUMMARY?.TITLE, mapYesNoField(company[TRADING_NAME])),
+    xlsxRow(CONTENT_STRINGS[TRADING_ADDRESS].SUMMARY?.TITLE, mapYesNoField(company[TRADING_ADDRESS])),
 
     xlsxRow(XLSX.FIELDS[COMPANY_SIC], mapSicCodes(companySicCodes)),
 

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-exporter/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-exporter/index.ts
@@ -52,7 +52,7 @@ export const mapSicCodes = (sicCodes: Array<ApplicationCompanySicCode>) => {
 export const mapBroker = (application: Application) => {
   const { broker } = application;
 
-  let mapped = [xlsxRow(XLSX.FIELDS[USING_BROKER], broker[USING_BROKER])];
+  let mapped = [xlsxRow(XLSX.FIELDS[USING_BROKER], mapYesNoField(broker[USING_BROKER]))];
 
   if (broker[USING_BROKER]) {
     const addressAnswer = {


### PR DESCRIPTION
# Issue:
* `hasDifferentTradingName `and `hasDifferentTradingAddress`,  `isUsingBroker`, `canContactBuyer`, `exporterIsConnectedWithBuyer`, `exporterHasTradedWithBuyer `showed true or nothing on XLSX on submission

# Changes made: 
* Used `mapYesNoField` for fields
* Updated tests