### PR TITLE
chore(EMS-1814): Improve API test coverage, fix lint warnings & flaky tests

### DIFF
--- a/src/api/.eslintignore
+++ b/src/api/.eslintignore
@@ -1,3 +1,7 @@
+coverage/lcov-report
 generated_reports
 logs
 node_modules
+babel.config.js
+jest.config.js
+

--- a/src/api/custom-resolvers/mutations/account-password-reset/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-password-reset/index.test.ts
@@ -121,6 +121,7 @@ describe('custom-resolvers/account-password-reset', () => {
         data: {
           isBlocked: true,
         },
+        query: 'id isBlocked',
       })) as Account;
 
       result = await accountPasswordReset({}, variables, context);

--- a/src/api/custom-resolvers/mutations/account-password-reset/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-password-reset/index.test.ts
@@ -4,8 +4,9 @@ import createAuthenticationRetryEntry from '../../../helpers/create-authenticati
 import { ACCOUNT, DATE_ONE_MINUTE_IN_THE_PAST } from '../../../constants';
 import accounts from '../../../test-helpers/accounts';
 import { mockAccount } from '../../../test-mocks';
-import { Account, AccountPasswordResetVariables, ApplicationRelationship, SuccessResponse } from '../../../types';
+import { Account, AccountPasswordResetVariables, SuccessResponse } from '../../../types';
 import getKeystoneContext from '../../../test-helpers/get-keystone-context';
+import authRetries from '../../../test-helpers/auth-retries';
 
 const context = getKeystoneContext();
 
@@ -22,28 +23,16 @@ describe('custom-resolvers/account-password-reset', () => {
   let account: Account;
   let result: SuccessResponse;
   let variables: AccountPasswordResetVariables;
-  let authRetries;
 
   beforeEach(async () => {
     await accounts.deleteAll(context);
 
-    // wipe the AuthenticationRetry table so we have a clean slate.
-    authRetries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
-
-    await context.query.AuthenticationRetry.deleteMany({
-      where: authRetries,
-    });
-
     // wipe the Authentication table so we have a clean slate.
-    let authEntries = await context.query.Authentication.findMany();
+    const authEntries = await context.query.Authentication.findMany();
 
     await context.query.Authentication.deleteMany({
       where: authEntries,
     });
-
-    authEntries = await context.query.Authentication.findMany();
-
-    expect(authEntries.length).toEqual(0);
 
     account = await accounts.create({ context });
 
@@ -51,9 +40,9 @@ describe('custom-resolvers/account-password-reset', () => {
     await createAuthenticationRetryEntry(context, account.id);
 
     // get the latest AuthenticationRetry entries
-    authRetries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
+    const retries = await authRetries.findAll(context);
 
-    expect(authRetries.length).toEqual(1);
+    expect(retries.length).toEqual(1);
 
     variables = {
       token: String(mockAccount.passwordResetHash),
@@ -68,11 +57,7 @@ describe('custom-resolvers/account-password-reset', () => {
   afterAll(async () => {
     jest.resetAllMocks();
 
-    const entries = await context.query.Authentication.findMany();
-
-    await context.query.Authentication.deleteMany({
-      where: entries,
-    });
+    await authRetries.deleteAll(context);
   });
 
   test('it should return success=true', () => {
@@ -85,9 +70,9 @@ describe('custom-resolvers/account-password-reset', () => {
 
   test(`it should wipe the account's retry entires`, async () => {
     // get the latest retries
-    authRetries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
+    const retries = await authRetries.findAll(context);
 
-    expect(authRetries.length).toEqual(0);
+    expect(retries.length).toEqual(0);
   });
 
   test('it should add an authentication entry', async () => {
@@ -202,7 +187,6 @@ describe('custom-resolvers/account-password-reset', () => {
   describe('when the provided password matches the existing account password', () => {
     test('it should return success=false and hasBeenUsedBefore=true', async () => {
       // update the account to have default test password (MOCK_ACCOUNT_PASSWORD)
-
       await context.query.Account.updateOne({
         where: { id: account.id },
         data: mockAccount,

--- a/src/api/custom-resolvers/mutations/account-sign-in/account-checks/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/account-checks/index.test.ts
@@ -46,7 +46,7 @@ describe('custom-resolvers/account-sign-in/account-checks', () => {
 
   let result: AccountSignInResponse;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     await accounts.deleteAll(context);
 
     // wipe the AuthenticationRetry table so we have a clean slate.

--- a/src/api/custom-resolvers/mutations/account-sign-in/account-checks/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/account-checks/index.test.ts
@@ -9,8 +9,9 @@ import generate from '../../../../helpers/generate-otp';
 import getFullNameString from '../../../../helpers/get-full-name-string';
 import sendEmail from '../../../../emails';
 import accounts from '../../../../test-helpers/accounts';
+import authRetries from '../../../../test-helpers/auth-retries';
 import { mockAccount, mockOTP, mockSendEmailResponse, mockUrlOrigin } from '../../../../test-mocks';
-import { Account, AccountSignInResponse, ApplicationRelationship } from '../../../../types';
+import { Account, AccountSignInResponse } from '../../../../types';
 import { Context } from '.keystone/types'; // eslint-disable-line
 
 const dbUrl = String(process.env.DATABASE_URL);
@@ -22,7 +23,6 @@ const context = getContext(config, PrismaModule) as Context;
 
 describe('custom-resolvers/account-sign-in/account-checks', () => {
   let account: Account;
-  let retries: Array<ApplicationRelationship>;
 
   jest.mock('../../../../emails');
   jest.mock('../../../../helpers/generate-otp');
@@ -48,13 +48,6 @@ describe('custom-resolvers/account-sign-in/account-checks', () => {
 
   beforeEach(async () => {
     await accounts.deleteAll(context);
-
-    // wipe the AuthenticationRetry table so we have a clean slate.
-    retries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
-
-    await context.query.AuthenticationRetry.deleteMany({
-      where: retries,
-    });
 
     // create an account
     account = await accounts.create({ context });
@@ -154,11 +147,7 @@ describe('custom-resolvers/account-sign-in/account-checks', () => {
         jest.resetAllMocks();
 
         // wipe the AuthenticationRetry table so we have a clean slate.
-        retries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
-
-        await context.query.AuthenticationRetry.deleteMany({
-          where: retries,
-        });
+        await authRetries.deleteAll(context);
 
         const oneMinuteInThePast = DATE_ONE_MINUTE_IN_THE_PAST();
 

--- a/src/api/custom-resolvers/mutations/delete-an-account/index.test.ts
+++ b/src/api/custom-resolvers/mutations/delete-an-account/index.test.ts
@@ -1,6 +1,7 @@
 import deleteAnAccount from '.';
 import createAuthenticationRetryEntry from '../../../helpers/create-authentication-retry-entry';
 import accounts from '../../../test-helpers/accounts';
+import authRetries from '../../../test-helpers/auth-retries';
 import { mockAccount } from '../../../test-mocks';
 import { Account, SuccessResponse } from '../../../types';
 import getKeystoneContext from '../../../test-helpers/get-keystone-context';
@@ -38,18 +39,14 @@ describe('custom-resolvers/delete-an-account', () => {
       account = await accounts.create({ context });
 
       // wipe the table so we have a clean slate.
-      retries = await context.query.AuthenticationRetry.findMany();
-
-      await context.query.AuthenticationRetry.deleteMany({
-        where: retries,
-      });
+      await authRetries.deleteAll(context);
 
       // create new retry entires
       await createAuthenticationRetryEntry(context, account.id);
       await createAuthenticationRetryEntry(context, account.id);
 
       // get the latest retries to make sure we only have 2 entries
-      retries = await context.query.AuthenticationRetry.findMany();
+      retries = await authRetries.findAll(context);
 
       expect(retries.length).toEqual(2);
     });
@@ -57,7 +54,7 @@ describe('custom-resolvers/delete-an-account', () => {
     test('it should delete the retries', async () => {
       result = await deleteAnAccount({}, variables, context);
 
-      retries = await context.query.AuthenticationRetry.findMany();
+      retries = await authRetries.findAll(context);
 
       expect(retries.length).toEqual(0);
     });

--- a/src/api/custom-resolvers/mutations/delete-application-by-reference-number/index.test.ts
+++ b/src/api/custom-resolvers/mutations/delete-application-by-reference-number/index.test.ts
@@ -1,0 +1,50 @@
+import deleteApplicationByReferenceNumber from '.';
+import applications from '../../../test-helpers/applications';
+import { Application, SuccessResponse } from '../../../types';
+import getKeystoneContext from '../../../test-helpers/get-keystone-context';
+
+const context = getKeystoneContext();
+
+describe('custom-resolvers/delete-application-by-reference-number', () => {
+  let application: Application;
+  let result: SuccessResponse;
+
+  const variables = {
+    referenceNumber: 0,
+  };
+
+  beforeAll(async () => {
+    application = (await applications.create({
+      context,
+      data: {},
+    })) as Application;
+  });
+
+  test('it should return success=true', async () => {
+    variables.referenceNumber = application.referenceNumber;
+
+    result = await deleteApplicationByReferenceNumber({}, variables, context);
+
+    const expected = {
+      success: true,
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  describe('when an application is not found', () => {
+    it('should return success=false', async () => {
+      const referenceNumberDoesNotExist = 0;
+
+      variables.referenceNumber = referenceNumberDoesNotExist;
+
+      result = await deleteApplicationByReferenceNumber({}, variables, context);
+
+      const expected = {
+        success: false,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/src/api/custom-resolvers/mutations/delete-application-by-reference-number/index.ts
+++ b/src/api/custom-resolvers/mutations/delete-application-by-reference-number/index.ts
@@ -21,24 +21,26 @@ const deleteApplicationByReferenceNumber = async (
 
     const { referenceNumber } = variables;
 
-    const application = (await context.db.Application.findMany({
+    const applications = (await context.db.Application.findMany({
       where: {
         referenceNumber: { equals: referenceNumber },
       },
     })) as Application;
 
-    const [{ id }] = application;
+    if (applications.length) {
+      const [{ id }] = applications;
 
-    const deleteResponse = await context.db.Application.deleteOne({
-      where: {
-        id,
-      },
-    });
+      const deleteResponse = await context.db.Application.deleteOne({
+        where: {
+          id,
+        },
+      });
 
-    if (deleteResponse.id) {
-      return {
-        success: true,
-      };
+      if (deleteResponse?.id) {
+        return {
+          success: true,
+        };
+      }
     }
 
     return {

--- a/src/api/custom-resolvers/mutations/index.ts
+++ b/src/api/custom-resolvers/mutations/index.ts
@@ -9,7 +9,7 @@ import addAndGetOTP from './add-and-get-OTP';
 import sendEmailPasswordResetLink from './send-email-password-reset-link';
 import accountPasswordReset from './account-password-reset';
 import sendEmailReactivateAccountLink from './send-email-reactivate-account-link';
-import deleteApplicationByReferenceNumber from './delete-application-by-refrence-number';
+import deleteApplicationByReferenceNumber from './delete-application-by-reference-number';
 import updateCompanyAndCompanyAddress from './update-company-and-company-address';
 import submitApplication from './submit-application';
 import createFeedbackAndSendEmail from './create-feedback';

--- a/src/api/custom-resolvers/mutations/submit-application/index.test.ts
+++ b/src/api/custom-resolvers/mutations/submit-application/index.test.ts
@@ -7,6 +7,7 @@ import { createFullApplication } from '../../../test-helpers';
 import { mockSendEmailResponse } from '../../../test-mocks';
 import { Application, SubmitApplicationVariables, SuccessResponse } from '../../../types';
 import getKeystoneContext from '../../../test-helpers/get-keystone-context';
+import applications from '../../../test-helpers/applications';
 
 const context = getKeystoneContext();
 
@@ -102,10 +103,9 @@ describe('custom-resolvers/submit-application', () => {
   describe('when an application is not found', () => {
     it('should return success=false', async () => {
       // create a new application so we can get a valid ID format
-      const newApplication = (await context.query.Application.createOne({
-        query: 'id',
-        data: {},
-      })) as Application;
+      const applicationData = {};
+
+      const newApplication = (await applications.create({ context, data: applicationData })) as Application;
 
       variables = {
         applicationId: newApplication.id,

--- a/src/api/custom-resolvers/mutations/verify-account-email-address/index.test.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-email-address/index.test.ts
@@ -3,6 +3,7 @@ import verifyAccountEmailAddress from '.';
 import { ACCOUNT, FIELD_IDS, DATE_ONE_MINUTE_IN_THE_PAST } from '../../../constants';
 import encryptPassword from '../../../helpers/encrypt-password';
 import accounts from '../../../test-helpers/accounts';
+import authRetries from '../../../test-helpers/auth-retries';
 import { mockAccount } from '../../../test-mocks';
 import { Account, VerifyEmailAddressResponse, VerifyEmailAddressVariables } from '../../../types';
 import getKeystoneContext from '../../../test-helpers/get-keystone-context';
@@ -38,6 +39,7 @@ describe('custom-resolvers/verify-account-email-address', () => {
   });
 
   beforeEach(async () => {
+    await authRetries.deleteAll(context);
     await accounts.deleteAll(context);
 
     /**
@@ -96,7 +98,7 @@ describe('custom-resolvers/verify-account-email-address', () => {
   });
 
   test('should remove all entries for the account in the AuthenticationRetry table', async () => {
-    const retries = await context.query.AuthenticationRetry.findMany();
+    const retries = await authRetries.findAll(context);
 
     expect(retries.length).toEqual(0);
   });

--- a/src/api/custom-resolvers/mutations/verify-account-reactivation-token/index.test.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-reactivation-token/index.test.ts
@@ -3,6 +3,7 @@ import verifyAccountReactivationToken from '.';
 import createAuthenticationRetryEntry from '../../../helpers/create-authentication-retry-entry';
 import { ACCOUNT, FIELD_IDS, DATE_ONE_MINUTE_IN_THE_PAST } from '../../../constants';
 import accounts from '../../../test-helpers/accounts';
+import authRetries from '../../../test-helpers/auth-retries';
 import { mockAccount } from '../../../test-mocks';
 import { Account, SuccessResponse, VerifyAccountReactivationTokenVariables } from '../../../types';
 import getKeystoneContext from '../../../test-helpers/get-keystone-context';
@@ -39,13 +40,6 @@ describe('custom-resolvers/verify-account-reactivation-token', () => {
   beforeEach(async () => {
     await accounts.deleteAll(context);
 
-    // wipe the AuthenticationRetry table so we have a clean slate.
-    let retries = await context.query.AuthenticationRetry.findMany();
-
-    await context.query.AuthenticationRetry.deleteMany({
-      where: retries,
-    });
-
     /**
      * Create an account that:
      * - is unverified
@@ -76,7 +70,7 @@ describe('custom-resolvers/verify-account-reactivation-token', () => {
     await createAuthenticationRetryEntry(context, account.id);
 
     // get the latest retries to ensure we have a retry entry
-    retries = await context.query.AuthenticationRetry.findMany();
+    const retries = await authRetries.findAll(context);
 
     expect(retries.length).toEqual(1);
 
@@ -113,7 +107,7 @@ describe('custom-resolvers/verify-account-reactivation-token', () => {
   });
 
   test('should remove all entries for the account in the AuthenticationRetry table', async () => {
-    const retries = await context.query.AuthenticationRetry.findMany();
+    const retries = await authRetries.findAll(context);
 
     expect(retries.length).toEqual(0);
   });

--- a/src/api/custom-resolvers/mutations/verify-account-sign-in-code/index.test.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-sign-in-code/index.test.ts
@@ -5,7 +5,8 @@ import getAccountById from '../../../helpers/get-account-by-id';
 import generate from '../../../helpers/generate-otp';
 import generateOTPAndUpdateAccount from '../../../helpers/generate-otp-and-update-account';
 import accounts from '../../../test-helpers/accounts';
-import { Account, ApplicationRelationship, VerifyAccountSignInCodeVariables, VerifyAccountSignInCodeResponse } from '../../../types';
+import authRetries from '../../../test-helpers/auth-retries';
+import { Account, VerifyAccountSignInCodeVariables, VerifyAccountSignInCodeResponse } from '../../../types';
 import getKeystoneContext from '../../../test-helpers/get-keystone-context';
 
 const context = getKeystoneContext();
@@ -19,7 +20,6 @@ const {
 describe('custom-resolvers/verify-account-sign-in-code', () => {
   let account: Account;
   let updatedAccount: Account;
-  let retries: Array<ApplicationRelationship>;
   let variables: VerifyAccountSignInCodeVariables;
   let result: VerifyAccountSignInCodeResponse;
 
@@ -36,12 +36,7 @@ describe('custom-resolvers/verify-account-sign-in-code', () => {
   beforeEach(async () => {
     account = await accounts.create({ context });
 
-    // wipe the AuthenticationRetry table so we have a clean slate.
-    retries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
-
-    await context.query.AuthenticationRetry.deleteMany({
-      where: retries,
-    });
+    await authRetries.deleteAll(context);
 
     // generate OTP and update the account
     const { securityCode } = await generateOTPAndUpdateAccount(context, account.id);
@@ -78,8 +73,7 @@ describe('custom-resolvers/verify-account-sign-in-code', () => {
   });
 
   test(`it should wipe the account's retry entires`, async () => {
-    // get the latest retries
-    retries = (await context.query.AuthenticationRetry.findMany()) as Array<ApplicationRelationship>;
+    const retries = await authRetries.findAll(context);
 
     expect(retries.length).toEqual(0);
   });

--- a/src/api/emails/send-application-submitted-emails/index.test.ts
+++ b/src/api/emails/send-application-submitted-emails/index.test.ts
@@ -226,18 +226,83 @@ describe('emails/send-email-application-submitted', () => {
   });
 
   describe('error handling', () => {
-    beforeEach(() => {
-      sendEmail.application.submittedEmail = jest.fn(() => Promise.reject(mockSendEmailResponse));
+    describe('when sendEmail.application.submittedEmail returns success=false', () => {
+      beforeEach(() => {
+        sendEmail.application.submittedEmail = jest.fn(() =>
+          Promise.resolve({
+            ...mockSendEmailResponse,
+            success: false,
+          }),
+        );
+      });
+
+      test('should throw an error', async () => {
+        try {
+          await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
+        } catch (err) {
+          const expected = new Error('Sending application submitted emails Error: Sending application submitted email to owner/account');
+
+          expect(err).toEqual(expected);
+        }
+      });
     });
 
-    test('should throw an error', async () => {
-      try {
-        await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
-      } catch (err) {
-        const expected = new Error(`Sending application submitted emails ${mockSendEmailResponse}`);
+    describe('when sendEmail.application.underwritingTeam returns success=false', () => {
+      beforeEach(() => {
+        sendEmail.application.underwritingTeam = jest.fn(() =>
+          Promise.resolve({
+            ...mockSendEmailResponse,
+            success: false,
+          }),
+        );
+      });
 
-        expect(err).toEqual(expected);
-      }
+      test('should throw an error', async () => {
+        try {
+          await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
+        } catch (err) {
+          const expected = new Error('Sending application submitted emails Error: Sending application submitted email to underwriting team');
+
+          expect(err).toEqual(expected);
+        }
+      });
+    });
+
+    describe('when sendEmail.documentsEmail returns success=false', () => {
+      beforeEach(() => {
+        sendEmail.documentsEmail = jest.fn(() =>
+          Promise.resolve({
+            ...mockSendEmailResponse,
+            success: false,
+          }),
+        );
+      });
+
+      test('should throw an error', async () => {
+        try {
+          await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
+        } catch (err) {
+          const expected = new Error(`Sending application submitted emails Error: Sending application documents emails ${mockSendEmailResponse}`);
+
+          expect(err).toEqual(expected);
+        }
+      });
+    });
+
+    describe('when sendEmail.application.submittedEmail fails', () => {
+      beforeEach(() => {
+        sendEmail.application.submittedEmail = jest.fn(() => Promise.reject(mockSendEmailResponse));
+      });
+
+      test('should throw an error', async () => {
+        try {
+          await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
+        } catch (err) {
+          const expected = new Error(`Sending application submitted emails ${mockSendEmailResponse}`);
+
+          expect(err).toEqual(expected);
+        }
+      });
     });
   });
 });

--- a/src/api/helpers/create-authentication-entry/index.test.ts
+++ b/src/api/helpers/create-authentication-entry/index.test.ts
@@ -20,46 +20,10 @@ describe('helpers/create-authentication-entry', () => {
   let result;
 
   beforeAll(async () => {
-    // wipe the table so we have a clean slate.
-    const entries = await context.query.Authentication.findMany();
-
-    await context.query.Authentication.deleteMany({
-      where: entries,
-    });
-
-    expect(entries.length).toEqual(0);
-
     account = await accounts.create({ context });
-
-    const authEntry = {
-      account: {
-        connect: {
-          id: account.id,
-        },
-      },
-      salt: mockAccount.salt,
-      hash: mockAccount.hash,
-    };
-
-    result = await createAuthenticationEntry(context, authEntry);
   });
 
-  afterAll(async () => {
-    // wipe the table so we have a clean slate.
-    const entries = await context.query.Authentication.findMany();
-
-    await context.query.Authentication.deleteMany({
-      where: entries,
-    });
-  });
-
-  test('it should create a new entry', async () => {
-    const entries = await context.query.Authentication.findMany();
-
-    expect(entries.length).toEqual(1);
-  });
-
-  test('it should return the entry with a timestamp', async () => {
+  test('it should create a new entry and return the entry with a timestamp', async () => {
     const authEntry = {
       account: {
         connect: {

--- a/src/api/helpers/create-authentication-retry-entry/index.test.ts
+++ b/src/api/helpers/create-authentication-retry-entry/index.test.ts
@@ -4,6 +4,7 @@ import * as PrismaModule from '.prisma/client'; // eslint-disable-line import/no
 import createAuthenticationRetryEntry from '.';
 import baseConfig from '../../keystone';
 import accounts from '../../test-helpers/accounts';
+import authRetries from '../../test-helpers/auth-retries';
 import { Account } from '../../types';
 import { Context } from '.keystone/types'; // eslint-disable-line
 
@@ -21,19 +22,11 @@ describe('helpers/create-authentication-retry-entry', () => {
     account = await accounts.create({ context });
 
     // wipe the AuthenticationRetry table so we have a clean slate.
-    const retries = await context.query.AuthenticationRetry.findMany();
-
-    await context.query.AuthenticationRetry.deleteMany({
-      where: retries,
-    });
+    await authRetries.deleteAll(context);
   });
 
   afterAll(async () => {
-    const retries = await context.query.AuthenticationRetry.findMany();
-
-    await context.query.AuthenticationRetry.deleteMany({
-      where: retries,
-    });
+    await authRetries.deleteAll(context);
   });
 
   it('should create a new AuthenticationRetry entry associated with the provided account ID', async () => {

--- a/src/api/helpers/get-authentication-retries-by-account-id/index.test.ts
+++ b/src/api/helpers/get-authentication-retries-by-account-id/index.test.ts
@@ -5,6 +5,7 @@ import getAuthenticationRetriesByAccountId from '.';
 import createAuthenticationRetryEntry from '../create-authentication-retry-entry';
 import baseConfig from '../../keystone';
 import accounts from '../../test-helpers/accounts';
+import authRetries from '../../test-helpers/auth-retries';
 import { mockAccount } from '../../test-mocks';
 import { Account } from '../../types';
 import { Context } from '.keystone/types'; // eslint-disable-line
@@ -21,11 +22,7 @@ describe('helpers/get-authentication-retries-by-account-id', () => {
 
   beforeEach(async () => {
     // wipe the table so we have a clean slate.
-    const authRetries = await context.query.AuthenticationRetry.findMany();
-
-    await context.query.AuthenticationRetry.deleteMany({
-      where: authRetries,
-    });
+    await authRetries.deleteAll(context);
 
     const unblockedAccount = {
       ...mockAccount,

--- a/src/api/helpers/update-application/index.test.ts
+++ b/src/api/helpers/update-application/index.test.ts
@@ -5,6 +5,7 @@ import updateApplication from '.';
 import baseConfig from '../../keystone';
 import { Application } from '../../types';
 import { Context } from '.keystone/types'; // eslint-disable-line
+import applications from '../../test-helpers/applications';
 
 const dbUrl = String(process.env.DATABASE_URL);
 const config = { ...baseConfig, db: { ...baseConfig.db, url: dbUrl } };
@@ -18,10 +19,9 @@ describe('helpers/update-application', () => {
 
   beforeEach(async () => {
     // create a new application
-    application = (await context.query.Application.createOne({
-      data: {},
-      query: 'id updatedAt',
-    })) as Application;
+    const applicationData = {};
+
+    application = (await applications.create({ context, data: applicationData })) as Application;
   });
 
   it('should update the updatedAt timestamp', async () => {

--- a/src/api/integrations/companies-house/index.test.ts
+++ b/src/api/integrations/companies-house/index.test.ts
@@ -1,0 +1,63 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import companiesHouse from '.';
+import mockCompany from '../../test-mocks/mock-company';
+
+const companiesHouseURL = process.env.COMPANIES_HOUSE_API_URL;
+
+const { companyNumber } = mockCompany;
+
+describe('integrations/companies-house', () => {
+  describe('when a 200 status and data is returned', () => {
+    test('it should return success=true and data', async () => {
+      const mock = new MockAdapter(axios);
+
+      const mockResponse = mockCompany;
+
+      mock.onGet(`${companiesHouseURL}/company/${companyNumber}`).reply(200, mockResponse);
+
+      const result = await companiesHouse.get(companyNumber);
+
+      const expected = {
+        success: true,
+        data: mockResponse,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when no data is returned', () => {
+    test('it should return success=false', async () => {
+      const mock = new MockAdapter(axios);
+
+      mock.onGet(`${companiesHouseURL}/company/${companyNumber}`).reply(200);
+
+      const result = await companiesHouse.get(companyNumber);
+
+      const expected = {
+        success: false,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a 200 status is not returned', () => {
+    test('it should throw an error', async () => {
+      const mock = new MockAdapter(axios);
+
+      mock.onGet(`${companiesHouseURL}/company/${companyNumber}`).reply(500);
+
+      try {
+        await companiesHouse.get(companyNumber);
+      } catch (err) {
+        const expectedError = 'Calling Companies House API. Unable to search for company Error: Request failed with status code 500';
+
+        const expected = new Error(expectedError);
+
+        expect(err).toEqual(expected);
+      }
+    });
+  });
+});

--- a/src/api/integrations/companies-house/index.ts
+++ b/src/api/integrations/companies-house/index.ts
@@ -4,8 +4,8 @@ import { CompaniesHouseAPIResponse } from '../../types';
 
 dotenv.config();
 
-const username: any = process.env.COMPANIES_HOUSE_API_KEY;
-const companiesHouseURL: any = process.env.COMPANIES_HOUSE_API_URL;
+const username = String(process.env.COMPANIES_HOUSE_API_KEY);
+const companiesHouseURL = String(process.env.COMPANIES_HOUSE_API_URL);
 
 /**
  * companiesHouse
@@ -34,8 +34,8 @@ const companiesHouse = {
       }
 
       return {
-        data: response.data,
         success: true,
+        data: response.data,
       };
     } catch (err) {
       console.error('Error calling Companies House API %O', err);

--- a/src/api/integrations/industry-sector/index.test.ts
+++ b/src/api/integrations/industry-sector/index.test.ts
@@ -1,0 +1,65 @@
+import dotenv from 'dotenv';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import getIndustrySectorNames from '.';
+import { EXTERNAL_API_ENDPOINTS } from '../../constants';
+import mockIndustrySectors from '../../test-mocks/mock-industry-sectors';
+
+dotenv.config();
+
+const { APIM_MDM_URL } = process.env;
+const { MULESOFT_MDM_EA } = EXTERNAL_API_ENDPOINTS;
+
+describe('integrations/industry-sector', () => {
+  describe('when a 200 status and data is returned', () => {
+    test('it should return success=true and data', async () => {
+      const mock = new MockAdapter(axios);
+
+      const mockResponseData = mockIndustrySectors;
+
+      mock.onGet(`${APIM_MDM_URL}${MULESOFT_MDM_EA.INDUSTRY_SECTORS}`).reply(200, mockResponseData);
+
+      const result = await getIndustrySectorNames.get();
+
+      const expected = {
+        success: true,
+        data: mockResponseData,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when no data is returned', () => {
+    test('it should return success=false', async () => {
+      const mock = new MockAdapter(axios);
+
+      mock.onGet(`${APIM_MDM_URL}${MULESOFT_MDM_EA.INDUSTRY_SECTORS}`).reply(200);
+
+      const result = await getIndustrySectorNames.get();
+
+      const expected = {
+        success: false,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a 200 status is not returned', () => {
+    test('it should return success=false and apiError=true', async () => {
+      const mock = new MockAdapter(axios);
+
+      mock.onGet(`${APIM_MDM_URL}${MULESOFT_MDM_EA.INDUSTRY_SECTORS}`).reply(500);
+
+      const result = await getIndustrySectorNames.get();
+
+      const expected = {
+        success: false,
+        apiError: true,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/src/api/integrations/industry-sector/index.ts
+++ b/src/api/integrations/industry-sector/index.ts
@@ -4,10 +4,13 @@ import { EXTERNAL_API_ENDPOINTS } from '../../constants';
 
 dotenv.config();
 
+const { APIM_MDM_URL, APIM_MDM_KEY, APIM_MDM_VALUE } = process.env;
+
 const { MULESOFT_MDM_EA } = EXTERNAL_API_ENDPOINTS;
+
 const headers = {
   'Content-Type': 'application/json',
-  [String(process.env.APIM_MDM_KEY)]: process.env.APIM_MDM_VALUE,
+  [String(APIM_MDM_KEY)]: APIM_MDM_VALUE,
 };
 
 /**
@@ -22,7 +25,7 @@ const getIndustrySectorNames = {
 
       const response = await axios({
         method: 'get',
-        url: `${process.env.APIM_MDM_URL}${MULESOFT_MDM_EA.INDUSTRY_SECTORS}`,
+        url: `${APIM_MDM_URL}${MULESOFT_MDM_EA.INDUSTRY_SECTORS}`,
         headers,
         validateStatus(status) {
           const acceptableStatus = [200, 404];
@@ -38,14 +41,14 @@ const getIndustrySectorNames = {
       }
 
       return {
-        data: response.data,
         success: true,
+        data: response.data,
       };
     } catch (err) {
       console.error('Error calling industry sector API %O', err);
       return {
-        apiError: true,
         success: false,
+        apiError: true,
       };
     }
   },

--- a/src/api/integrations/notify/index.test.ts
+++ b/src/api/integrations/notify/index.test.ts
@@ -1,0 +1,48 @@
+// @ts-ignore
+import notificationsClient from 'notifications-node-client';
+import notify from '.';
+
+jest.mock('notifications-node-client');
+
+const mockTemplateId = 'mock-template-id';
+const mockSendToEmailAddress = 'mock@email.com';
+const mockVariables = {};
+
+describe('integrations/notify', () => {
+  describe('when the call is successful', () => {
+    beforeEach(() => {
+      notificationsClient.NotifyClient = () => ({
+        prepareUpload: jest.fn(),
+        sendEmail: jest.fn(() => Promise.resolve()),
+      });
+    });
+
+    test('it should return success=true and emailRecipient', async () => {
+      const result = await notify.sendEmail(mockTemplateId, mockSendToEmailAddress, mockVariables);
+
+      const expected = {
+        success: true,
+        emailRecipient: mockSendToEmailAddress,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when the call is NOT successful', () => {
+    beforeEach(() => {
+      notificationsClient.NotifyClient = () => ({
+        prepareUpload: jest.fn(),
+        sendEmail: jest.fn(() => Promise.reject()),
+      });
+    });
+
+    test('it should throw an error', async () => {
+      try {
+        await notify.sendEmail(mockTemplateId, mockSendToEmailAddress, mockVariables);
+      } catch (err) {
+        expect(err).toEqual('Error calling Notify API. Unable to send email');
+      }
+    });
+  });
+});

--- a/src/api/integrations/notify/index.ts
+++ b/src/api/integrations/notify/index.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 // @ts-ignore
 import { NotifyClient } from 'notifications-node-client';
-import { NotifyPeronsalisation } from '../../types';
+import { NotifyPersonalisation } from '../../types';
 
 dotenv.config();
 
@@ -22,7 +22,7 @@ const notify = {
     try {
       console.info('Calling Notify API. templateId: %s', templateId);
 
-      const personalisation = variables as NotifyPeronsalisation;
+      const personalisation = variables as NotifyPersonalisation;
 
       if (file) {
         personalisation.linkToFile = await notifyClient.prepareUpload(file, { confirmEmailBeforeDownload: true });

--- a/src/api/jest.config.js
+++ b/src/api/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  clearMocks: true,
+  collectCoverage: true,
+  collectCoverageFrom: [
+    'custom-resolvers/**/*.{ts,}',
+    'emails/**/*.{ts,}',
+    'generate-xlsx/**/*.{ts,}',
+    'integrations/**/*.{ts,}',
+    'middleware/**/*.{ts,}',
+    'server/generate-quote/*.{ts,}',
+  ],
+  testTimeout: 60000,
+};

--- a/src/api/package-lock.json
+++ b/src/api/package-lock.json
@@ -23,6 +23,7 @@
         "dotenv": "16.3.1",
         "exceljs": "^4.3.0",
         "express-rate-limit": "^6.8.1",
+        "jest-mock-extended": "^3.0.5",
         "jsonwebtoken": "^9.0.1",
         "notifications-node-client": "^7.0.3",
         "otplib": "^12.0.1",
@@ -46,7 +47,8 @@
         "eslint-plugin-import": "^2.28.0",
         "eslint-plugin-prettier": "5.0.0",
         "jest": "^29.6.2",
-        "prettier": "^3.0.1"
+        "prettier": "^3.0.1",
+        "ts-jest": "^29.1.1"
       },
       "engines": {
         "node": ">=18",
@@ -8212,6 +8214,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -13509,6 +13523,18 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-mock-extended": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-3.0.5.tgz",
+      "integrity": "sha512-/eHdaNPUAXe7f65gHH5urc8SbRVWjYxBqmCgax2uqOBJy8UUcCBMN1upj1eZ8y/i+IqpyEm4Kq0VKss/GCCTdw==",
+      "dependencies": {
+        "ts-essentials": "^7.0.3"
+      },
+      "peerDependencies": {
+        "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0",
+        "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -14716,6 +14742,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
       "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA=="
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -14937,6 +14969,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -18514,6 +18552,14 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-essentials": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
+      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
+      "peerDependencies": {
+        "typescript": ">=3.7.0"
+      }
+    },
     "node_modules/ts-invariant": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
@@ -18523,6 +18569,91 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz",
+      "integrity": "sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.3",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "^7.5.3",
+        "yargs-parser": "^21.0.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/types": "^29.0.0",
+        "babel-jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/ts-jest/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ts-pattern": {

--- a/src/api/package-lock.json
+++ b/src/api/package-lock.json
@@ -19,11 +19,11 @@
         "@keystone-6/fields-document": "^8.0.0",
         "@types/express": "^4.17.17",
         "axios": "^1.4.0",
+        "axios-mock-adapter": "^1.21.5",
         "date-fns": "^2.30.0",
         "dotenv": "16.3.1",
         "exceljs": "^4.3.0",
         "express-rate-limit": "^6.8.1",
-        "jest-mock-extended": "^3.0.5",
         "jsonwebtoken": "^9.0.1",
         "notifications-node-client": "^7.0.3",
         "otplib": "^12.0.1",
@@ -7826,6 +7826,18 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/axios-mock-adapter": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.5.tgz",
+      "integrity": "sha512-5NI1V/VK+8+JeTF8niqOowuysA4b8mGzdlMN/QnTnoXbYh4HZSNiopsDclN2g/m85+G++IrEtUdZaQ3GnaMsSA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.17.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
@@ -12201,6 +12213,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -13521,18 +13555,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-mock-extended": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-3.0.5.tgz",
-      "integrity": "sha512-/eHdaNPUAXe7f65gHH5urc8SbRVWjYxBqmCgax2uqOBJy8UUcCBMN1upj1eZ8y/i+IqpyEm4Kq0VKss/GCCTdw==",
-      "dependencies": {
-        "ts-essentials": "^7.0.3"
-      },
-      "peerDependencies": {
-        "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0",
-        "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/jest-pnp-resolver": {
@@ -18550,14 +18572,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
-      }
-    },
-    "node_modules/ts-essentials": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
-      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
-      "peerDependencies": {
-        "typescript": ">=3.7.0"
       }
     },
     "node_modules/ts-invariant": {

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -13,7 +13,7 @@
     "dev": "keystone dev",
     "start": "keystone start",
     "build": "keystone build",
-    "test": "jest --runInBand --testTimeout=60000 --coverage"
+    "test": "jest --runInBand --coverage --config=jest.config.js"
   },
   "repository": {
     "type": "git",
@@ -63,6 +63,7 @@
     "eslint-plugin-import": "^2.28.0",
     "eslint-plugin-prettier": "5.0.0",
     "jest": "^29.6.2",
-    "prettier": "^3.0.1"
+    "prettier": "^3.0.1",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -36,6 +36,7 @@
     "@keystone-6/fields-document": "^8.0.0",
     "@types/express": "^4.17.17",
     "axios": "^1.4.0",
+    "axios-mock-adapter": "^1.21.5",
     "date-fns": "^2.30.0",
     "dotenv": "16.3.1",
     "exceljs": "^4.3.0",

--- a/src/api/test-helpers/accounts.ts
+++ b/src/api/test-helpers/accounts.ts
@@ -1,4 +1,5 @@
 import { Context } from '.keystone/types'; // eslint-disable-line
+import authRetries from './auth-retries';
 import { mockAccount } from '../test-mocks';
 import { Account, TestHelperAccountCreate } from '../types';
 
@@ -11,6 +12,8 @@ import { Account, TestHelperAccountCreate } from '../types';
 const deleteAll = async (context: Context) => {
   try {
     console.info('Getting and deleting accounts (test helpers)');
+
+    await authRetries.deleteAll(context);
 
     const accounts = await context.query.Account.findMany();
 

--- a/src/api/test-helpers/applications.ts
+++ b/src/api/test-helpers/applications.ts
@@ -13,7 +13,7 @@ const create = async ({ context, data }: TestHelperApplicationCreate) => {
 
     const application = (await context.query.Application.createOne({
       data,
-      query: 'id referenceNumber',
+      query: 'id referenceNumber updatedAt',
     })) as Application;
 
     return application;

--- a/src/api/test-helpers/applications.ts
+++ b/src/api/test-helpers/applications.ts
@@ -1,0 +1,30 @@
+import { Context } from '.keystone/types'; // eslint-disable-line
+import { Application, TestHelperApplicationCreate } from '../types';
+
+/**
+ * create application test helper
+ * Create an application with mock application data and any provied custom application data.
+ * @param {Object} KeystoneJS context API, application data, deleteApplications flag
+ * @returns {Object} Created application
+ */
+const create = async ({ context, data }: TestHelperApplicationCreate) => {
+  try {
+    console.info('Creating an application (test helpers)');
+
+    const application = (await context.query.Application.createOne({
+      data,
+      query: 'id referenceNumber',
+    })) as Application;
+
+    return application;
+  } catch (err) {
+    console.error(err);
+    return err;
+  }
+};
+
+const applications = {
+  create,
+};
+
+export default applications;

--- a/src/api/test-helpers/auth-retries.ts
+++ b/src/api/test-helpers/auth-retries.ts
@@ -1,0 +1,50 @@
+import { Context } from '.keystone/types'; // eslint-disable-line
+
+/**
+ * findAll test helper
+ * Get all auth retries and delete them.
+ * @param {Object} KeystoneJS context API
+ * @returns {Array} Auth retries
+ */
+const findAll = async (context: Context) => {
+  try {
+    console.info('Getting auth retries (test helpers)');
+
+    const retries = await context.query.AuthenticationRetry.findMany();
+
+    return retries;
+  } catch (err) {
+    console.error(err);
+    throw new Error(`Getting auth retries (test helpers) ${err}`);
+  }
+};
+
+/**
+ * deleteAll test helper
+ * Delete all auth retries
+ * @param {Object} KeystoneJS context API
+ * @returns {Array} Deleted auth retries
+ */
+const deleteAll = async (context: Context) => {
+  try {
+    console.info('Deleting auth retries (test helpers)');
+
+    const retries = await findAll(context);
+
+    const deleted = await context.query.AuthenticationRetry.deleteMany({
+      where: retries,
+    });
+
+    return deleted;
+  } catch (err) {
+    console.error(err);
+    return err;
+  }
+};
+
+const authRetries = {
+  findAll,
+  deleteAll,
+};
+
+export default authRetries;

--- a/src/api/tsconfig.json
+++ b/src/api/tsconfig.json
@@ -33,6 +33,6 @@
     "allowJs": true,
     "importHelpers": true
   },
-  "include": ["**/*.ts", ".eslintrc.js"],
+  "include": ["**/*.ts", "**/*.tsx", ".eslintrc.js", "babel.config.js", "jest.config.js"],
   "exclude": ["node_modules", "logs"]
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -251,7 +251,7 @@ interface Currency {
   isoCode: string;
 }
 
-interface NotifyPeronsalisation {
+interface NotifyPersonalisation {
   linkToFile?: string;
 }
 
@@ -509,7 +509,7 @@ export {
   GetCompaniesHouseInformationVariables,
   GetAccountPasswordResetTokenVariables,
   AccountPasswordResetTokenResponse,
-  NotifyPeronsalisation,
+  NotifyPersonalisation,
   InsuranceFeedbackVariables,
   IndustrySector,
   SicCode,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,4 +1,4 @@
-import { AccountUpdateInput, CompanyUpdateInput, Context } from '.keystone/types'; // eslint-disable-line
+import { ApplicationCreateInput, AccountUpdateInput, CompanyUpdateInput, Context } from '.keystone/types'; // eslint-disable-line
 
 interface SuccessResponse {
   success: boolean;
@@ -434,15 +434,18 @@ interface IndustrySector {
   ukefIndustryName: string;
 }
 
-interface TestHelperAccountCreate {
+interface TestHelperCreate {
   context: Context;
+  companyId?: string;
+}
+
+interface TestHelperAccountCreate extends TestHelperCreate {
   data?: Account;
   deleteAccounts?: boolean;
 }
 
-interface TestHelperCreate {
-  context: Context;
-  companyId?: string;
+interface TestHelperApplicationCreate extends TestHelperCreate {
+  data: ApplicationCreateInput;
 }
 
 interface XLSXTitleRowIndexes {
@@ -514,6 +517,7 @@ export {
   SubmitApplicationVariables,
   SuccessResponse,
   TestHelperAccountCreate,
+  TestHelperApplicationCreate,
   TestHelperCreate,
   UpdateCompanyAndCompanyAddressVariables,
   XLSXTitleRowIndexes,


### PR DESCRIPTION
This PR adds some missing API unit tests coverage and fixes some linting warnings/"silent errors".

## Changes
- Add babel config, jest config and lcov-report directories to `.eslintignore`.
- Add test coverage for:
  - `deleteApplicationByReferenceNumber` GQL mutation.
  - Companies house API call.
  - Industry sector API call.
  - Notify API call.
- Create jest config file so that we can define where to collect coverage from.
- Create "application" and "auth retry" test helpers.
- Fix various typos, simplify some usages of environment variables to avoid having to use `any` type.
- Fix some flaky tests.