### PR TITLE
fix(EMS-1159): Dashboard pagination - Fix issue where "total pages" count would not round up

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-16-applications.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-16-applications.spec.js
@@ -1,0 +1,89 @@
+import pagination from '../../../../../../partials/pagination';
+import { MAX_APPLICATIONS_PER_PAGE } from '../../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+
+const { DASHBOARD } = INSURANCE_ROUTES;
+
+const baseUrl = Cypress.config('baseUrl');
+
+const totalApplications = MAX_APPLICATIONS_PER_PAGE + 1;
+const totalPages = 2;
+
+const dashboardUrl = `${baseUrl}${DASHBOARD}`;
+
+context(`Insurance - Dashboard - pagination - ${totalApplications} applications`, () => {
+  let applications;
+
+  before(() => {
+    cy.completeSignInAndGoToDashboard().then(({ accountId }) => {
+      cy.createApplications(accountId, totalApplications).then((createdApplications) => {
+        applications = createdApplications;
+      });
+
+      cy.navigateToUrl(dashboardUrl);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplications(applications);
+  });
+
+  describe('page tests', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(dashboardUrl);
+    });
+
+    it('should render 2 pagination list items with links', () => {
+      pagination.listItems().should('have.length', totalPages);
+
+      cy.assertPaginationItemLink({ index: 0 });
+      cy.assertPaginationItemLink({ index: 1 });
+    });
+
+    it('should have the correct pagination state', () => {
+      cy.assertPaginationState({
+        totalPages,
+        index: 0,
+        expectedPageNumber: 1,
+        previousLinkShouldExist: false,
+        expectedUrl: `${baseUrl}${DASHBOARD}`,
+      });
+    });
+  });
+
+  describe('when clicking on the `next` pagination link', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(dashboardUrl);
+
+      pagination.nextLink().click();
+    });
+
+    it('should have the correct pagination state', () => {
+      cy.assertPaginationState({
+        totalPages,
+        index: 2,
+        expectedPageNumber: 2,
+        nextLinkShouldExist: false,
+      });
+    });
+  });
+
+  describe('when clicking on page 2 pagination link', () => {
+    it('should have the correct pagination state', () => {
+      cy.navigateToUrl(dashboardUrl);
+
+      pagination.listItemLink(1).click();
+
+      cy.assertPaginationState({
+        totalPages,
+        index: 2,
+        expectedPageNumber: 2,
+        nextLinkShouldExist: false,
+      });
+    });
+  });
+});

--- a/src/ui/server/helpers/pagination/get-total-pages/index.test.ts
+++ b/src/ui/server/helpers/pagination/get-total-pages/index.test.ts
@@ -7,7 +7,7 @@ describe('server/helpers/pagination/get-total-pages', () => {
       const mockTotalApplications = MAX_APPLICATIONS_PER_PAGE + 1;
       const result = getTotalPages(mockTotalApplications);
 
-      const expected = Math.round(mockTotalApplications / MAX_APPLICATIONS_PER_PAGE);
+      const expected = Math.ceil(mockTotalApplications / MAX_APPLICATIONS_PER_PAGE);
 
       expect(result).toEqual(expected);
     });

--- a/src/ui/server/helpers/pagination/get-total-pages/index.ts
+++ b/src/ui/server/helpers/pagination/get-total-pages/index.ts
@@ -4,7 +4,7 @@ import { MAX_APPLICATIONS_PER_PAGE } from '../../../constants';
  * getTotalPages
  * Get the total amount of pages for pagination.
  * 1 page should have a maximum of MAX_APPLICATIONS_PER_PAGE
- * Therefore, divide and round the total of applications/pages
+ * Therefore, divide and round the total of applications/pages up to the nearest number.
  * @param {Number} Total amount of applications
  * @returns {Number}
  */
@@ -12,7 +12,7 @@ export const getTotalPages = (totalApplications: number) => {
   let totalPages = 1;
 
   if (totalApplications > MAX_APPLICATIONS_PER_PAGE) {
-    totalPages = Math.round(totalApplications / MAX_APPLICATIONS_PER_PAGE);
+    totalPages = Math.ceil(totalApplications / MAX_APPLICATIONS_PER_PAGE);
   }
 
   return totalPages;


### PR DESCRIPTION
This PR fixes an issue where the dasboard pagination would not diplay if the total amount of applications is just over the maximum amount allowed per page, for example if there are ~16-19 applications, pagination would not display because the total pages functionality was not rounding **_up_** to the nearest number.

## Changes
- Update `getTotalPages` function to use `Math.ceil` instead of `Math.round`, therefore it'll always round up.
- Add E2E test coverage for pagination when there are 16 applications.