### PR TITLE
fix(cypress): added CSP headers to cypress configuration

### DIFF
--- a/e2e-tests/insurance/cypress.config.js
+++ b/e2e-tests/insurance/cypress.config.js
@@ -32,16 +32,15 @@ const cypressConfig = defineConfig({
       MOCK_ACCOUNT_PASSWORD: process.env.MOCK_ACCOUNT_PASSWORD,
       API_KEY: process.env.API_KEY,
     },
+    experimentalCspAllowList: ['child-src', 'frame-src', 'form-action', 'script-src', 'script-src-elem'],
     // eslint-disable-next-line
     setupNodeEvents(on, config) {
-      // eslint-disable-next-line
-      on('before:browser:launch', (browser = {}, launchOptions) => {
+      on('before:browser:launch', (browser, launchOptions) => {
         prepareAudit(launchOptions);
       });
 
       on('task', {
         lighthouse: lighthouse(),
-        // pa11y: pa11y(console.log.bind(console)),
         pa11y: pa11y(),
       });
     },

--- a/e2e-tests/quote/cypress.config.js
+++ b/e2e-tests/quote/cypress.config.js
@@ -32,16 +32,15 @@ const cypressConfig = defineConfig({
       MOCK_ACCOUNT_PASSWORD: process.env.MOCK_ACCOUNT_PASSWORD,
       API_KEY: process.env.API_KEY,
     },
+    experimentalCspAllowList: ['child-src', 'frame-src', 'form-action', 'script-src', 'script-src-elem'],
     // eslint-disable-next-line
     setupNodeEvents(on, config) {
-      // eslint-disable-next-line
-      on('before:browser:launch', (browser = {}, launchOptions) => {
+      on('before:browser:launch', (browser, launchOptions) => {
         prepareAudit(launchOptions);
       });
 
       on('task', {
         lighthouse: lighthouse(),
-        // pa11y: pa11y(console.log.bind(console)),
         pa11y: pa11y(),
       });
     },

--- a/e2e-tests/switch-between-services/cypress.config.js
+++ b/e2e-tests/switch-between-services/cypress.config.js
@@ -32,16 +32,15 @@ const cypressConfig = defineConfig({
       MOCK_ACCOUNT_PASSWORD: process.env.MOCK_ACCOUNT_PASSWORD,
       API_KEY: process.env.API_KEY,
     },
+    experimentalCspAllowList: ['child-src', 'frame-src', 'form-action', 'script-src', 'script-src-elem'],
     // eslint-disable-next-line
     setupNodeEvents(on, config) {
-      // eslint-disable-next-line
-      on('before:browser:launch', (browser = {}, launchOptions) => {
+      on('before:browser:launch', (browser, launchOptions) => {
         prepareAudit(launchOptions);
       });
 
       on('task', {
         lighthouse: lighthouse(),
-        // pa11y: pa11y(console.log.bind(console)),
         pa11y: pa11y(),
       });
     },


### PR DESCRIPTION
## Introduction
By default Cypress discards any CSP headers, ensure they are adhered to.

## Resolution
* Added `experimentalCspAllowList`.

## Miscellaneous
* Lint fixes