### PR TITLE
fix(EMS-806): Task list - remove link from eligibility task

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/all-sections.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/all-sections.spec.js
@@ -53,7 +53,7 @@ context('Insurance - All sections - new application', () => {
       });
 
       describe('tasks', () => {
-        it('should render a `check eligibility` task with `completed` status', () => {
+        it('should render a `check eligibility` task with `completed` status, no link', () => {
           cy.navigateToUrl(url);
 
           const task = taskList.initialChecks.tasks.eligibility;
@@ -65,9 +65,9 @@ context('Insurance - All sections - new application', () => {
             expectedText,
           );
 
-          const expectedStatus = TASKS.STATUS.COMPLETED;
+          cy.checkText(task.status(), TASKS.STATUS.COMPLETED);
 
-          cy.checkText(task.status(), expectedStatus);
+          task.link().should('not.exist');
         });
       });
     });
@@ -98,9 +98,7 @@ context('Insurance - All sections - new application', () => {
             expectedText,
           );
 
-          const expectedStatus = TASKS.STATUS.NOT_STARTED_YET;
-
-          cy.checkText(task.status(), expectedStatus);
+          cy.checkText(task.status(), TASKS.STATUS.NOT_STARTED_YET);
         });
 
         it('should render a `your business` task with link and `not started` status', () => {
@@ -115,8 +113,7 @@ context('Insurance - All sections - new application', () => {
             expectedText,
           );
 
-          const expectedStatus = TASKS.STATUS.NOT_STARTED_YET;
-          cy.checkText(task.status(), expectedStatus);
+          cy.checkText(task.status(), TASKS.STATUS.NOT_STARTED_YET);
         });
 
         it('should render a `your buyer` task with link and `not started` status', () => {
@@ -131,8 +128,7 @@ context('Insurance - All sections - new application', () => {
             expectedText,
           );
 
-          const expectedStatus = TASKS.STATUS.NOT_STARTED_YET;
-          cy.checkText(task.status(), expectedStatus);
+          cy.checkText(task.status(), TASKS.STATUS.NOT_STARTED_YET);
         });
       });
     });
@@ -158,8 +154,7 @@ context('Insurance - All sections - new application', () => {
 
           task.link().should('not.exist');
 
-          const expectedStatus = TASKS.STATUS.CANNOT_START;
-          cy.checkText(task.status(), expectedStatus);
+          cy.checkText(task.status(), TASKS.STATUS.CANNOT_START);
         });
 
         it('should render a `declarations and submit` task with no link and `cannot start yet` status', () => {
@@ -170,8 +165,7 @@ context('Insurance - All sections - new application', () => {
 
           task.link().should('not.exist');
 
-          const expectedStatus = TASKS.STATUS.CANNOT_START;
-          cy.checkText(task.status(), expectedStatus);
+          cy.checkText(task.status(), TASKS.STATUS.CANNOT_START);
         });
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/all-sections.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/all-sections.spec.js
@@ -8,6 +8,8 @@ const { taskList } = partials.insurancePartials;
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ALL_SECTIONS;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - All sections - new application', () => {
   let referenceNumber;
   let url;
@@ -16,7 +18,7 @@ context('Insurance - All sections - new application', () => {
     cy.completeSignInAndGoToApplication().then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`;
+      url = `${baseUrl}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`;
 
       cy.assertUrl(url);
     });
@@ -51,17 +53,15 @@ context('Insurance - All sections - new application', () => {
       });
 
       describe('tasks', () => {
-        it('should render a `check eligibility` task with link and `completed` status', () => {
+        it('should render a `check eligibility` task with `completed` status', () => {
           cy.navigateToUrl(url);
 
           const task = taskList.initialChecks.tasks.eligibility;
 
-          const expectedHref = '#';
           const expectedText = TASKS.LIST.INITIAL_CHECKS.TASKS.ELIGIBILITY;
 
-          cy.checkLink(
-            task.link(),
-            expectedHref,
+          cy.checkText(
+            task.text(),
             expectedText,
           );
 

--- a/e2e-tests/partials/insurance/taskList.js
+++ b/e2e-tests/partials/insurance/taskList.js
@@ -11,6 +11,7 @@ const taskList = {
     groupHeading: () => cy.get(`[data-cy="task-list-group-heading-${INITIAL_CHECKS.HEADING}"]`),
     tasks: {
       eligibility: {
+        link: () => cy.get(`[data-cy="task-list-group-${INITIAL_CHECKS.HEADING}-task-${INITIAL_CHECKS.TASKS.ELIGIBILITY}-link"]`),
         text: () => cy.get(`[data-cy="task-list-group-${INITIAL_CHECKS.HEADING}-task-${INITIAL_CHECKS.TASKS.ELIGIBILITY}"]`),
         status: () => cy.get(`[data-cy="task-list-group-${INITIAL_CHECKS.HEADING}-task-${INITIAL_CHECKS.TASKS.ELIGIBILITY}-status"]`),
       },

--- a/e2e-tests/partials/insurance/taskList.js
+++ b/e2e-tests/partials/insurance/taskList.js
@@ -11,7 +11,7 @@ const taskList = {
     groupHeading: () => cy.get(`[data-cy="task-list-group-heading-${INITIAL_CHECKS.HEADING}"]`),
     tasks: {
       eligibility: {
-        link: () => cy.get(`[data-cy="task-list-group-${INITIAL_CHECKS.HEADING}-task-${INITIAL_CHECKS.TASKS.ELIGIBILITY}-link"]`),
+        text: () => cy.get(`[data-cy="task-list-group-${INITIAL_CHECKS.HEADING}-task-${INITIAL_CHECKS.TASKS.ELIGIBILITY}"]`),
         status: () => cy.get(`[data-cy="task-list-group-${INITIAL_CHECKS.HEADING}-task-${INITIAL_CHECKS.TASKS.ELIGIBILITY}-status"]`),
       },
     },

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/initial-checks.test.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/initial-checks.test.ts
@@ -11,7 +11,6 @@ describe('server/helpers/task-list/initial-checks', () => {
 
     const expected = [
       {
-        href: '#',
         title: INITIAL_CHECKS.TASKS.ELIGIBILITY,
         id: TASK_IDS.INITIAL_CHECKS.ELIGIBILITY,
         fields: requiredFields(),

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/initial-checks.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/initial-checks.ts
@@ -11,7 +11,6 @@ const { INITIAL_CHECKS } = TASKS.LIST;
  */
 const createInitialChecksTasks = (): Array<TaskListDataTask> => [
   {
-    href: '#',
     title: INITIAL_CHECKS.TASKS.ELIGIBILITY,
     id: TASK_IDS.INITIAL_CHECKS.ELIGIBILITY,
     fields: requiredFields(),

--- a/src/ui/server/helpers/task-list/index.ts
+++ b/src/ui/server/helpers/task-list/index.ts
@@ -2,6 +2,25 @@ import { taskStatus, taskLink } from './task-helpers';
 import { TaskListData, TaskListDataTask, TaskListGroup, ApplicationFlat } from '../../../types';
 
 /**
+ * mapTask
+ * @param {TaskListDataTask} Task list groups and tasks
+ * @param {ApplicationFlat} Submitted application data
+ * @returns {Object} Tasks with status and optional href
+ */
+export const mapTask = (task: TaskListDataTask, submittedData: ApplicationFlat) => {
+  const mapped = {
+    ...task,
+    status: taskStatus(task, submittedData),
+  };
+
+  if (task.href) {
+    mapped.href = taskLink(task.href, mapped.status);
+  }
+
+  return mapped;
+};
+
+/**
  * generateTaskStatusesAndLinks
  * @param {Array} taskListData Task list groups and tasks
  * @param {Object} submittedData Submitted application data
@@ -11,15 +30,7 @@ export const generateTaskStatusesAndLinks = (taskListData: TaskListData, submitt
   const tasksList = taskListData.map((group) => {
     return {
       ...group,
-      tasks: group.tasks.map((task) => {
-        const status = taskStatus(task, submittedData);
-
-        return {
-          ...task,
-          status,
-          href: taskLink(task.href, status),
-        };
-      }),
+      tasks: group.tasks.map((task) => mapTask(task, submittedData)),
     };
   }) as TaskListData;
 

--- a/src/ui/server/helpers/task-list/task-helpers.test.ts
+++ b/src/ui/server/helpers/task-list/task-helpers.test.ts
@@ -174,10 +174,10 @@ describe('server/helpers/task-helpers', () => {
     });
 
     describe(`when the task has a status of ${TASKS.STATUS.CANNOT_START}`, () => {
-      it('should return null', () => {
+      it('should return an empty string', () => {
         const result = taskLink(mockTaskLink, TASKS.STATUS.CANNOT_START);
 
-        expect(result).toEqual(null);
+        expect(result).toEqual('');
       });
     });
   });

--- a/src/ui/server/helpers/task-list/task-helpers.ts
+++ b/src/ui/server/helpers/task-list/task-helpers.ts
@@ -38,7 +38,7 @@ export const getAllTasksFieldsInAGroup = (group: TaskListDataGroup): Array<strin
 
 /**
  * areTaskDependenciesMet
- * @param {Array} dependencies Array of depedency ids
+ * @param {Array} dependencies Array of dependency ids
  * @param {Object} submittedData Submitted application data
  * @returns {Boolean}
  */
@@ -104,4 +104,4 @@ export const taskStatus = (task: TaskListDataTask, submittedData: ApplicationFla
  * @param {String} status Status of the task
  * @returns {String} Task link if the status is not `cannot start`
  */
-export const taskLink = (link: string, status: string): string | null => (status === TASKS.STATUS.CANNOT_START ? null : link);
+export const taskLink = (link: string, status: string): string => (status === TASKS.STATUS.CANNOT_START ? '' : link);

--- a/src/ui/types/task-list.ts
+++ b/src/ui/types/task-list.ts
@@ -1,5 +1,5 @@
 interface TaskListDataTask {
-  href: string;
+  href?: string;
   title: string;
   id: string;
   fields: Array<string>;


### PR DESCRIPTION
## Introduction ✏️ 
This PR fixes an issue where the "eligibility" task in the "initial checks" group of an application's task list would display an empty link ("#").

## Resolution ✔️ 
- Remove "href" definition in `createInitialChecksTasks`.
- Update `generateTaskStatusesAndLinks` task mapping logic to optionally add a href to a task.
- Update `taskLink` function to return an empty string instead of null.
- Make a tasks href an optional type.

## Miscellaneous ➕
- Extract task mapping logic into its own function, `mapTask`.
- Fixed a typo.
- Simplified some E2E task assertions.