### PR TITLE
fix(EMS-2033): typo - utlity should be utility

### DIFF
--- a/e2e-tests/content-strings/pages.js
+++ b/e2e-tests/content-strings/pages.js
@@ -11,7 +11,7 @@ const BUYER_BODY_PAGE = {
   DETAILS: {
     INTRO: 'What counts as a government or public sector body?',
     BODY_1: 'This means a formally established organisation that is, at least in part, publicly funded to deliver a public or government service.',
-    BODY_2: 'For example, a central government department, a local authority or a public utlity company.',
+    BODY_2: 'For example, a central government department, a local authority or a public utility company.',
   },
 };
 

--- a/src/ui/server/content-strings/pages.ts
+++ b/src/ui/server/content-strings/pages.ts
@@ -11,7 +11,7 @@ const BUYER_BODY_PAGE = {
   DETAILS: {
     INTRO: 'What counts as a government or public sector body?',
     BODY_1: 'This means a formally established organisation that is, at least in part, publicly funded to deliver a public or government service.',
-    BODY_2: 'For example, a central government department, a local authority or a public utlity company.',
+    BODY_2: 'For example, a central government department, a local authority or a public utility company.',
   },
 };
 


### PR DESCRIPTION
## Introduction ✏️ 
The quote tool has a typo in the "buyer type" page - second page of the flow. "utlity" should be "utility"

## Resolution ✔️ 
- Update copy.