### PR TITLE
feat(EMS-2064): Policy contact - special characters, various tech improvements

### DIFF
--- a/e2e-tests/commands/insurance/complete-and-submit-different-name-on-policy-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-different-name-on-policy-form.js
@@ -1,6 +1,6 @@
 import { INSURANCE_FIELD_IDS } from '../../constants/field-ids/insurance';
 import { submitButton, input } from '../../pages/shared';
-import application from '../../fixtures/application';
+import mockApplication from '../../fixtures/application';
 
 const {
   POLICY_AND_EXPORTS: {
@@ -15,15 +15,20 @@ const {
   },
 } = INSURANCE_FIELD_IDS;
 
-const { POLICY_CONTACT } = application;
+const { POLICY_CONTACT } = mockApplication;
 
 /**
  * completeAndSubmitDifferentNameOnPolicyForm
  * Runs through the different name on policy form in the "policy" section
+ * @param {String} First name
+ * @param {String} Last name
  */
-const completeAndSubmitDifferentNameOnPolicyForm = () => {
-  cy.keyboardInput(input.field(FIRST_NAME).input(), POLICY_CONTACT[FIRST_NAME]);
-  cy.keyboardInput(input.field(LAST_NAME).input(), POLICY_CONTACT[LAST_NAME]);
+const completeAndSubmitDifferentNameOnPolicyForm = ({
+  firstName = POLICY_CONTACT[FIRST_NAME],
+  lastName = POLICY_CONTACT[LAST_NAME],
+}) => {
+  cy.keyboardInput(input.field(FIRST_NAME).input(), firstName);
+  cy.keyboardInput(input.field(LAST_NAME).input(), lastName);
 
   cy.keyboardInput(input.field(EMAIL).input(), POLICY_CONTACT[EMAIL]);
 

--- a/e2e-tests/commands/insurance/complete-and-submit-name-on-policy-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-name-on-policy-form.js
@@ -19,9 +19,9 @@ const { POLICY_CONTACT } = application;
  * completes and submits name on policy form
  * if sameName selected, then clicks radio and fills in conditional field
  * if not sameName then only clicks other name radio
- * @param {Boolean} sameName - if name is the same name as owner - default false
+ * @param {Boolean} sameName - if name is the same name as owner - default true
  */
-const completeAndSubmitNameOnPolicyForm = ({ sameName = false }) => {
+const completeAndSubmitNameOnPolicyForm = ({ sameName = true }) => {
   if (sameName) {
     input.field(SAME_NAME).input().click();
     cy.keyboardInput(input.field(POSITION).input(), POLICY_CONTACT[POSITION]);

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
@@ -12,11 +12,13 @@ const task = taskList.prepareApplication.tasks.policyTypeAndExports;
  * @param {Object} Object with flags on how to complete specific parts of the application
  * - usingBroker: Should submit "yes" or "no" to "using a broker". Defaults to "no".
  * - policyAndExportsMaximumValue: should submit an application with the maximum value of 500000
+ * - differentPolicyContact: Should submit an application with a different policy contact to the owner
  * - referenceNumber: Application reference number
  */
 const completePrepareApplicationMultiplePolicyType = ({
   usingBroker,
   policyAndExportsMaximumValue = false,
+  differentPolicyContact,
   referenceNumber,
 }) => {
   task.link().click();
@@ -24,7 +26,11 @@ const completePrepareApplicationMultiplePolicyType = ({
   cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
   cy.completeAndSubmitMultipleContractPolicyForm({ policyAndExportsMaximumValue });
   cy.completeAndSubmitAboutGoodsOrServicesForm();
-  cy.completeAndSubmitNameOnPolicyForm({});
+  cy.completeAndSubmitNameOnPolicyForm({ sameName: !differentPolicyContact });
+
+  if (differentPolicyContact) {
+    cy.completeAndSubmitDifferentNameOnPolicyForm({});
+  }
 
   submitButton().click();
 

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
@@ -24,7 +24,7 @@ const completePrepareApplicationMultiplePolicyType = ({
   cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
   cy.completeAndSubmitMultipleContractPolicyForm({ policyAndExportsMaximumValue });
   cy.completeAndSubmitAboutGoodsOrServicesForm();
-  cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+  cy.completeAndSubmitNameOnPolicyForm({});
 
   submitButton().click();
 

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
@@ -12,13 +12,15 @@ const task = taskList.prepareApplication.tasks.policyTypeAndExports;
  * @param {Object} Object with flags on how to complete specific parts of the application
  * - exporterHasTradedWithBuyer: Should submit "yes" to "have traded with buyer before" in the "working with buyer" form. Defaults to "yes".
  * - usingBroker: Should submit "yes" or "no" to "using a broker". Defaults to "no".
- * - policyAndExportsMaximumValue: should submit an application with the maximum value of 500000
+ * - policyAndExportsMaximumValue: Should submit an application with the maximum value of 500000
+ * - differentPolicyContact: Should submit an application with a different policy contact to the owner
  * - referenceNumber: Application reference number
  */
 const completePrepareYourApplicationSectionSingle = ({
   exporterHasTradedWithBuyer,
   usingBroker,
   policyAndExportsMaximumValue = false,
+  differentPolicyContact,
   referenceNumber,
 }) => {
   task.link().click();
@@ -26,7 +28,11 @@ const completePrepareYourApplicationSectionSingle = ({
   cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
   cy.completeAndSubmitSingleContractPolicyForm({ policyAndExportsMaximumValue });
   cy.completeAndSubmitAboutGoodsOrServicesForm();
-  cy.completeAndSubmitNameOnPolicyForm({});
+  cy.completeAndSubmitNameOnPolicyForm({ sameName: !differentPolicyContact });
+
+  if (differentPolicyContact) {
+    cy.completeAndSubmitDifferentNameOnPolicyForm({});
+  }
 
   submitButton().click();
 

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
@@ -26,7 +26,7 @@ const completePrepareYourApplicationSectionSingle = ({
   cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
   cy.completeAndSubmitSingleContractPolicyForm({ policyAndExportsMaximumValue });
   cy.completeAndSubmitAboutGoodsOrServicesForm();
-  cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+  cy.completeAndSubmitNameOnPolicyForm({});
 
   submitButton().click();
 

--- a/e2e-tests/commands/insurance/complete-sign-in-and-submit-an-application.js
+++ b/e2e-tests/commands/insurance/complete-sign-in-and-submit-an-application.js
@@ -23,6 +23,7 @@ const completeSignInAndSubmitAnApplication = ({
   exportingWithCodeOfConduct,
   policyAndExportsMaximumValue = false,
   usingBroker,
+  differentPolicyContact = false,
 }) => {
   completeSignInAndGoToApplication({}).then(({ referenceNumber }) => {
     if (policyType === APPLICATION.POLICY_TYPE.MULTIPLE) {
@@ -31,6 +32,7 @@ const completeSignInAndSubmitAnApplication = ({
         policyAndExportsMaximumValue,
         referenceNumber,
         usingBroker,
+        differentPolicyContact,
       });
     } else {
       cy.completePrepareApplicationSinglePolicyType({
@@ -38,6 +40,7 @@ const completeSignInAndSubmitAnApplication = ({
         policyAndExportsMaximumValue,
         referenceNumber,
         usingBroker,
+        differentPolicyContact,
       });
     }
     cy.completeAndSubmitCheckYourAnswers();

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/submit-an-application-different-name-on-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/submit-an-application-different-name-on-policy.spec.js
@@ -1,0 +1,25 @@
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+
+const { APPLICATION_SUBMITTED } = INSURANCE_ROUTES;
+
+context('Insurance - submit an application - Single policy type, with a different `name on policy`', () => {
+  let referenceNumber;
+
+  before(() => {
+    cy.completeSignInAndSubmitAnApplication({ differentPolicyContact: true }).then((refNumber) => {
+      referenceNumber = refNumber;
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  it(`should successfully submit the application and redirect to ${APPLICATION_SUBMITTED}`, () => {
+    cy.assertApplicationSubmittedUrl(referenceNumber);
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-about-goods-or-services.spec.js
@@ -38,7 +38,7 @@ context('Insurance - Policy and exports - Change your answers - About goods or s
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitAboutGoodsOrServicesForm();
-      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitNameOnPolicyForm({});
 
       url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       cy.assertUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-change-policy-type-multiple-to-single.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-change-policy-type-multiple-to-single.spec.js
@@ -51,7 +51,7 @@ context('Insurance - Policy and exports - Change your answers - Policy type - mu
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
       cy.completeAndSubmitMultipleContractPolicyForm({});
       cy.completeAndSubmitAboutGoodsOrServicesForm();
-      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitNameOnPolicyForm({});
 
       checkYourAnswersUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       changeLinkHref = `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_CHANGE}`;
@@ -109,7 +109,7 @@ context('Insurance - Policy and exports - Change your answers - Policy type - mu
         // proceed to "name on policy"
         submitButton().click();
         // proceed to "check your answers"
-        cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+        cy.completeAndSubmitNameOnPolicyForm({});
 
         const expectedUrl = `${checkYourAnswersUrl}#heading`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-change-policy-type-single-to-multiple.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-change-policy-type-single-to-multiple.spec.js
@@ -54,7 +54,7 @@ context('Insurance - Policy and exports - Change your answers - Policy type - si
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitAboutGoodsOrServicesForm();
-      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitNameOnPolicyForm({});
 
       checkYourAnswersUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       changeLinkHref = `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_CHANGE}`;
@@ -113,7 +113,7 @@ context('Insurance - Policy and exports - Change your answers - Policy type - si
         // proceed to "name on policy"
         submitButton().click();
         // proceed to "check your answers"
-        cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+        cy.completeAndSubmitNameOnPolicyForm({});
 
         const expectedUrl = `${checkYourAnswersUrl}#heading`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-multiple-contract-policy.spec.js
@@ -45,7 +45,7 @@ context('Insurance - Policy and exports - Change your answers - Multiple contrac
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
       cy.completeAndSubmitMultipleContractPolicyForm({});
       cy.completeAndSubmitAboutGoodsOrServicesForm();
-      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitNameOnPolicyForm({});
 
       url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       cy.assertUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-single-contract-policy.spec.js
@@ -45,7 +45,7 @@ context('Insurance - Policy and exports - Change your answers - Single contract 
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitAboutGoodsOrServicesForm();
-      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitNameOnPolicyForm({});
 
       url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       cy.assertUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/check-your-answers/check-your-answers-summary-list/summary-list-multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/check-your-answers/check-your-answers-summary-list/summary-list-multiple-contract-policy.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Policy and exports - Check your answers - Summary list - mu
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
       cy.completeAndSubmitMultipleContractPolicyForm({});
       cy.completeAndSubmitAboutGoodsOrServicesForm();
-      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitNameOnPolicyForm({});
 
       url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.CHECK_YOUR_ANSWERS}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/check-your-answers/check-your-answers-summary-list/summary-list-single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/check-your-answers/check-your-answers-summary-list/summary-list-single-contract-policy.spec.js
@@ -39,7 +39,7 @@ context('Insurance - Policy and exports - Check your answers - Summary list - si
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitAboutGoodsOrServicesForm();
-      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitNameOnPolicyForm({});
 
       url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.CHECK_YOUR_ANSWERS}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/check-your-answers/check-your-answers.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/check-your-answers/check-your-answers.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Policy and exports - Check your answers - As an exporter, I
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitAboutGoodsOrServicesForm();
-      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitNameOnPolicyForm({});
 
       url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${POLICY_AND_EXPORTS.CHECK_YOUR_ANSWERS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/complete-policy-and-exports-as-multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/complete-policy-and-exports-as-multiple-contract-policy.spec.js
@@ -26,7 +26,7 @@ context('Insurance - Policy and exports - Complete the entire section as a multi
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
       cy.completeAndSubmitMultipleContractPolicyForm({});
       cy.completeAndSubmitAboutGoodsOrServicesForm();
-      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitNameOnPolicyForm({});
 
       // go back to the all sections page
       saveAndBackButton().click();

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/complete-policy-and-exports-as-single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/complete-policy-and-exports-as-single-contract-policy.spec.js
@@ -26,7 +26,7 @@ context('Insurance - Policy and exports - Complete the entire section as a singl
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitAboutGoodsOrServicesForm();
-      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitNameOnPolicyForm({});
 
       // go back to the all sections page
       saveAndBackButton().click();

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/different-name-on-policy/different-name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/different-name-on-policy/different-name-on-policy-page.spec.js
@@ -13,7 +13,9 @@ import { ACCOUNT_FIELDS } from '../../../../../../content-strings/fields/insuran
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
-import application from '../../../../../../fixtures/application';
+import mockApplication from '../../../../../../fixtures/application';
+
+const { POLICY_CONTACT } = mockApplication;
 
 const { taskList } = partials.insurancePartials;
 
@@ -55,7 +57,7 @@ context('Insurance - Policy and exports - Different name on Policy page - I want
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitAboutGoodsOrServicesForm();
-      cy.completeAndSubmitNameOnPolicyForm({});
+      cy.completeAndSubmitNameOnPolicyForm({ sameName: false });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${DIFFERENT_NAME_ON_POLICY}`;
 
@@ -146,7 +148,6 @@ context('Insurance - Policy and exports - Different name on Policy page - I want
     });
 
     it('should should have submitted values when navigating back to page', () => {
-      const { POLICY_CONTACT } = application;
       cy.navigateToUrl(url);
 
       cy.checkValue(input.field(FIRST_NAME), POLICY_CONTACT[FIRST_NAME]);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/different-name-on-policy/different-name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/different-name-on-policy/different-name-on-policy-page.spec.js
@@ -141,7 +141,7 @@ context('Insurance - Policy and exports - Different name on Policy page - I want
     it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
       cy.navigateToUrl(url);
 
-      cy.completeAndSubmitDifferentNameOnPolicyForm();
+      cy.completeAndSubmitDifferentNameOnPolicyForm({});
 
       const expectedUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       cy.assertUrl(expectedUrl);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/different-name-on-policy/validation/different-name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/different-name-on-policy/validation/different-name-on-policy-validation.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Policy and exports - Different name on Policy page - Valida
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitAboutGoodsOrServicesForm();
-      cy.completeAndSubmitNameOnPolicyForm({});
+      cy.completeAndSubmitNameOnPolicyForm({ sameName: false });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${DIFFERENT_NAME_ON_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/name-on-policy/name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/name-on-policy/name-on-policy-page.spec.js
@@ -128,7 +128,7 @@ context('Insurance - Policy and exports - Name on Policy page - I want to enter 
       it(`should redirect to ${CHECK_YOUR_ANSWERS} when ${SAME_NAME} is selected`, () => {
         cy.navigateToUrl(url);
 
-        cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+        cy.completeAndSubmitNameOnPolicyForm({});
 
         const expectedUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
         cy.assertUrl(expectedUrl);
@@ -150,7 +150,7 @@ context('Insurance - Policy and exports - Name on Policy page - I want to enter 
       it(`should redirect to ${DIFFERENT_NAME_ON_POLICY} when ${OTHER_NAME} is selected`, () => {
         cy.navigateToUrl(url);
 
-        cy.completeAndSubmitNameOnPolicyForm({});
+        cy.completeAndSubmitNameOnPolicyForm({ sameName: false });
 
         const expectedUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${DIFFERENT_NAME_ON_POLICY}`;
         cy.assertUrl(expectedUrl);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/name-on-policy/name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/name-on-policy/name-on-policy-page.spec.js
@@ -99,11 +99,13 @@ context('Insurance - Policy and exports - Name on Policy page - I want to enter 
 
       const nameAndEmail = `${account[FIRST_NAME]} ${account[LAST_NAME]} (${account[EMAIL]})`;
       cy.checkText(input.field(SAME_NAME).label(), nameAndEmail);
+    });
 
+    it(`should NOT display conditional "${POSITION}" section without selecting the "same name" radio`, () => {
       input.field(POSITION).input().should('not.be.visible');
     });
 
-    it(`renders ${POSITION} input if ${SAME_NAME} is selected'`, () => {
+    it(`should display conditional "${POSITION}" section when selecting the "yes" radio`, () => {
       input.field(SAME_NAME).input().click();
 
       input.field(POSITION).input().should('be.visible');

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/name-on-policy/validation/name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/name-on-policy/validation/name-on-policy-validation.spec.js
@@ -105,7 +105,7 @@ context('Insurance - Policy and exports - Name on policy - Validation', () => {
     });
 
     it('should not display validation error and redirect to the next page', () => {
-      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitNameOnPolicyForm({});
 
       partials.errorSummaryListItems().should('not.exist');
 
@@ -120,7 +120,7 @@ context('Insurance - Policy and exports - Name on policy - Validation', () => {
     });
 
     it('should not display validation error and redirect to the next page', () => {
-      cy.completeAndSubmitNameOnPolicyForm({});
+      cy.completeAndSubmitNameOnPolicyForm({ sameName: false });
 
       partials.errorSummaryListItems().should('not.exist');
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/single-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/single-contract-policy/save-and-back.spec.js
@@ -36,12 +36,14 @@ const {
 
 const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Policy and exports - Single contract policy page - Save and go back', () => {
   let referenceNumber;
   let url;
 
   const date = new Date();
-  const futureDate = add(date, { months: 3 });
+  const futureDate = add(date, { years: 1 });
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
@@ -51,7 +53,7 @@ context('Insurance - Policy and exports - Single contract policy page - Save and
 
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
 
-      url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
+      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
 
       cy.assertUrl(url);
     });
@@ -73,7 +75,7 @@ context('Insurance - Policy and exports - Single contract policy page - Save and
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
-      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+      const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       cy.assertUrl(expected);
     });
@@ -100,7 +102,7 @@ context('Insurance - Policy and exports - Single contract policy page - Save and
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
-      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+      const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       cy.assertUrl(expected);
     });
@@ -133,7 +135,7 @@ context('Insurance - Policy and exports - Single contract policy page - Save and
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
-      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+      const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       cy.assertUrl(expected);
     });
@@ -170,7 +172,7 @@ context('Insurance - Policy and exports - Single contract policy page - Save and
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
-      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+      const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       cy.assertUrl(expected);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
@@ -39,6 +39,8 @@ const {
   },
 } = ERROR_MESSAGES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Policy and exports - Single contract policy page - form validation - contract completion date', () => {
   let referenceNumber;
   let url;
@@ -51,7 +53,7 @@ context('Insurance - Policy and exports - Single contract policy page - form val
 
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
 
-      url = `${Cypress.config('baseUrl')}${INSURANCE.ROOT}/${referenceNumber}${INSURANCE.POLICY_AND_EXPORTS.SINGLE_CONTRACT_POLICY}`;
+      url = `${baseUrl}${INSURANCE.ROOT}/${referenceNumber}${INSURANCE.POLICY_AND_EXPORTS.SINGLE_CONTRACT_POLICY}`;
 
       cy.assertUrl(url);
     });
@@ -209,7 +211,7 @@ context('Insurance - Policy and exports - Single contract policy page - form val
 
   describe(`when ${REQUESTED_START_DATE} is also provided`, () => {
     const date = new Date();
-    const startDate = add(date, { months: 3 });
+    const startDate = add(date, { years: 1 });
 
     beforeEach(() => {
       cy.navigateToUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/submit-name-fields-with-special-characters/different-name-on-policy-name-fields-with-special-characters.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/submit-name-fields-with-special-characters/different-name-on-policy-name-fields-with-special-characters.spec.js
@@ -1,0 +1,79 @@
+import { INSURANCE_FIELD_IDS } from '../../../../../constants/field-ids/insurance';
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+import { FIELD_VALUES } from '../../../../../constants/field-values';
+import { input, backLink } from '../../../../../pages/shared';
+import partials from '../../../../../partials';
+import mockAccount from '../../../../../fixtures/account';
+import mockNameWithSpecialCharacters from '../../../../../fixtures/name-with-special-characters';
+
+const {
+  ACCOUNT: { FIRST_NAME, LAST_NAME },
+} = INSURANCE_FIELD_IDS;
+
+const {
+  ROOT: INSURANCE_ROOT,
+  POLICY_AND_EXPORTS: { DIFFERENT_NAME_ON_POLICY },
+} = INSURANCE_ROUTES;
+
+const {
+  taskList: {
+    prepareApplication: { tasks },
+  },
+} = partials.insurancePartials;
+
+const mockAccountSpecialCharacters = {
+  ...mockAccount,
+  [FIRST_NAME]: mockNameWithSpecialCharacters(mockAccount[FIRST_NAME]),
+  [LAST_NAME]: mockNameWithSpecialCharacters(mockAccount[LAST_NAME]),
+};
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Name fields - `Policy contact` name fields should render special characters without character codes after submission', () => {
+  let referenceNumber;
+  let differentNamOnPolicyUrl;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      // go to the page we want to test.
+      tasks.policyTypeAndExports.link().click();
+
+      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitSingleContractPolicyForm({});
+      cy.completeAndSubmitAboutGoodsOrServicesForm();
+      cy.completeAndSubmitNameOnPolicyForm({ sameName: false });
+
+      differentNamOnPolicyUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${DIFFERENT_NAME_ON_POLICY}`;
+    });
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe("'policy and exports - policy contact' page", () => {
+    describe('when submitting name fields with special characters and going back to the page', () => {
+      beforeEach(() => {
+        cy.saveSession();
+
+        cy.navigateToUrl(differentNamOnPolicyUrl);
+
+        cy.completeAndSubmitDifferentNameOnPolicyForm({
+          [FIRST_NAME]: mockAccountSpecialCharacters[FIRST_NAME],
+          [LAST_NAME]: mockAccountSpecialCharacters[LAST_NAME],
+        });
+
+        backLink().click();
+
+        cy.assertUrl(differentNamOnPolicyUrl);
+      });
+
+      it('should render special characters in the first and last name fields', () => {
+        cy.checkValue(input.field(FIRST_NAME), mockAccountSpecialCharacters[FIRST_NAME]);
+        cy.checkValue(input.field(LAST_NAME), mockAccountSpecialCharacters[LAST_NAME]);
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-header-and-page-fields.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-header-and-page-fields.spec.js
@@ -33,8 +33,9 @@ const mockAccountSpecialCharacters = {
   [LAST_NAME]: mockNameWithSpecialCharacters(mockAccount[LAST_NAME]),
 };
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Name fields - Header and page fields should render special characters without character codes after submission', () => {
-  const baseUrl = Cypress.config('baseUrl');
   let referenceNumber;
   let allSectionsUrl;
 

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -2021,7 +2021,7 @@ var application = {
   /**
    * application.submittedEmail
    * Send "application submitted" email to an account
-   * @param {Object} ApplicationSubmissionEmailVariables
+   * @param {ApplicationSubmissionEmailVariables} ApplicationSubmissionEmailVariables
    * @returns {Object} callNotify response
    */
   submittedEmail: async (variables) => {
@@ -2041,7 +2041,7 @@ var application = {
    * Read CSV file, generate a file buffer
    * Send "application submitted" email to the underwriting team with a link to CSV
    * We send a file buffer to Notify and Notify generates a unique URL that is then rendered in the email.
-   * @param {Object} ApplicationSubmissionEmailVariables
+   * @param {ApplicationSubmissionEmailVariables}
    * @returns {Object} callNotify response
    */
   underwritingTeam: async (variables, filePath, templateId) => {

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -3211,15 +3211,15 @@ var delete_application_by_reference_number_default = deleteApplicationByReferenc
 var import_types2 = __toESM(require("@keystone-6/core/types"));
 
 // helpers/map-sic-codes/index.ts
-var mapSicCodes = (company, sicCodes, industrySectorNames) => {
+var mapSicCodes = (company, sicCodes, industrySectorNames2) => {
   const mapped = [];
   if (!sicCodes?.length) {
     return mapped;
   }
   sicCodes.forEach((code, index) => {
     let industrySectorName = "";
-    if (industrySectorNames && industrySectorNames[index]) {
-      industrySectorName = industrySectorNames[index];
+    if (industrySectorNames2 && industrySectorNames2[index]) {
+      industrySectorName = industrySectorNames2[index];
     }
     const codeToAdd = {
       sicCode: code,
@@ -3239,7 +3239,7 @@ var mapSicCodes = (company, sicCodes, industrySectorNames) => {
 var updateCompanyAndCompanyAddress = async (root, variables, context) => {
   try {
     console.info("Updating application company and company address for %s", variables.companyId);
-    const { address, sicCodes, industrySectorNames, oldSicCodes, ...company } = variables.data;
+    const { address, sicCodes, industrySectorNames: industrySectorNames2, oldSicCodes, ...company } = variables.data;
     if (company?.companyNumber && !company?.financialYearEndDate) {
       company.financialYearEndDate = null;
     }
@@ -3251,7 +3251,7 @@ var updateCompanyAndCompanyAddress = async (root, variables, context) => {
       where: { id: variables.companyAddressId },
       data: address
     });
-    const mappedSicCodes = mapSicCodes(updatedCompany, sicCodes, industrySectorNames);
+    const mappedSicCodes = mapSicCodes(updatedCompany, sicCodes, industrySectorNames2);
     if (company && oldSicCodes && oldSicCodes.length) {
       await context.db.CompanySicCode.deleteMany({
         where: oldSicCodes
@@ -4666,15 +4666,15 @@ var create_full_timestamp_from_day_month_default = createFullTimestampFromDayAnd
 
 // helpers/map-sic-code-descriptions/index.ts
 var mapSicCodeDescriptions = (sicCodes, sectors) => {
-  const industrySectorNames = [];
+  const industrySectorNames2 = [];
   if (!sicCodes?.length || !sectors?.length) {
-    return industrySectorNames;
+    return industrySectorNames2;
   }
   sicCodes.forEach((sicCode) => {
     const sicCodeSector = sectors.find((sector) => sector.ukefIndustryId === sicCode);
-    industrySectorNames.push(sicCodeSector?.ukefIndustryName);
+    industrySectorNames2.push(sicCodeSector?.ukefIndustryName);
   });
-  return industrySectorNames;
+  return industrySectorNames2;
 };
 var map_sic_code_descriptions_default = mapSicCodeDescriptions;
 
@@ -4714,7 +4714,7 @@ var headers = {
   "Content-Type": "application/json",
   [String(APIM_MDM_KEY2)]: APIM_MDM_VALUE2
 };
-var getIndustrySectorNames = {
+var industrySectorNames = {
   get: async () => {
     try {
       console.info("Calling industry sector API");
@@ -4745,7 +4745,7 @@ var getIndustrySectorNames = {
     }
   }
 };
-var industry_sector_default = getIndustrySectorNames;
+var industry_sector_default = industrySectorNames;
 
 // integrations/companies-house/index.ts
 var import_axios3 = __toESM(require("axios"));
@@ -4794,14 +4794,14 @@ var getCompaniesHouseInformation = async (root, variables) => {
         success: false
       };
     }
-    const industrySectorNames = await industry_sector_default.get();
-    if (!industrySectorNames.success || industrySectorNames.apiError) {
+    const industrySectors = await industry_sector_default.get();
+    if (!industrySectors.success || industrySectors.apiError) {
       return {
         apiError: true,
         success: false
       };
     }
-    const mappedResponse = mapCompaniesHouseFields(response.data, industrySectorNames.data);
+    const mappedResponse = mapCompaniesHouseFields(response.data, industrySectors.data);
     return {
       ...mappedResponse,
       success: true

--- a/src/api/emails/application/index.ts
+++ b/src/api/emails/application/index.ts
@@ -7,7 +7,7 @@ const application = {
   /**
    * application.submittedEmail
    * Send "application submitted" email to an account
-   * @param {Object} ApplicationSubmissionEmailVariables
+   * @param {ApplicationSubmissionEmailVariables} ApplicationSubmissionEmailVariables
    * @returns {Object} callNotify response
    */
   submittedEmail: async (variables: ApplicationSubmissionEmailVariables): Promise<EmailResponse> => {
@@ -32,7 +32,7 @@ const application = {
    * Read CSV file, generate a file buffer
    * Send "application submitted" email to the underwriting team with a link to CSV
    * We send a file buffer to Notify and Notify generates a unique URL that is then rendered in the email.
-   * @param {Object} ApplicationSubmissionEmailVariables
+   * @param {ApplicationSubmissionEmailVariables}
    * @returns {Object} callNotify response
    */
   underwritingTeam: async (variables: ApplicationSubmissionEmailVariables, filePath: string, templateId: string): Promise<EmailResponse> => {

--- a/src/api/emails/documents/index.ts
+++ b/src/api/emails/documents/index.ts
@@ -4,7 +4,7 @@ import { ApplicationSubmissionEmailVariables, EmailResponse } from '../../types'
 /**
  * documentsEmail
  * Send "we need some documents from you" email to an account
- * @param {Object} ApplicationSubmissionEmailVariables
+ * @param {ApplicationSubmissionEmailVariables}
  * @param {Boolean} Flag for sending anti-bribery/trading history template
  * @returns {Object} callNotify response
  */

--- a/src/api/emails/send-application-submitted-emails/index.ts
+++ b/src/api/emails/send-application-submitted-emails/index.ts
@@ -7,7 +7,7 @@ import { SuccessResponse, ApplicationSubmissionEmailVariables, Application } fro
 /**
  * applicationSubmittedEmails.send
  * Send "application submitted" emails
- * @param {Object} Application
+ * @param {Application}
  * @param {String} Path to XLSX file for underwriting team email
  * @returns {Object} Object with success flag and emailRecipient
  */

--- a/src/api/generate-xlsx/index.ts
+++ b/src/api/generate-xlsx/index.ts
@@ -7,7 +7,7 @@ import { Application } from '../types';
 /**
  * XLSX
  * Generate an XLSX file with exceljs
- * @param {Object} Application
+ * @param {Application}
  * @returns {String} File path
  */
 const XLSX = (application: Application): Promise<string> => {

--- a/src/api/generate-xlsx/map-application-to-XLSX/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/index.ts
@@ -11,7 +11,7 @@ import { Application } from '../../types';
 /**
  * mapApplicationToXLSX
  * Map application fields into an array of objects for XLSX generation
- * @param {Object} Application
+ * @param {Application}
  * @returns {Array} Array of objects for XLSX generation
  */
 const mapApplicationToXLSX = (application: Application) => {

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/index.ts
@@ -19,7 +19,7 @@ const {
 /**
  * mapBuyer
  * Map an application's buyer fields into an array of objects for XLSX generation
- * @param {Object} Application
+ * @param {Application}
  * @returns {Array} Array of objects for XLSX generation
  */
 const mapBuyer = (application: Application) => {

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-eligibility/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-eligibility/index.ts
@@ -20,7 +20,7 @@ const {
 /**
  * mapEligibility
  * Map an application's eligibility fields into an array of objects for XLSX generation
- * @param {Object} Application
+ * @param {Application}
  * @returns {Array} Array of objects for XLSX generation
  */
 const mapEligibility = (application: Application) => {

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-exporter-contact-details/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-exporter-contact-details/index.ts
@@ -13,7 +13,7 @@ const {
 /**
  * mapExporterContactDetails
  * Map an application's exporter/policy contact details fields into an array of objects for XLSX generation
- * @param {Object} Application
+ * @param {Application}
  * @returns {Array} Array of objects for XLSX generation
  */
 const mapExporterContactDetails = (application: Application) => {

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-exporter/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-exporter/index.ts
@@ -46,7 +46,7 @@ export const mapSicCodes = (sicCodes: Array<ApplicationCompanySicCode>) => {
 /**
  * mapBroker
  * Map an application's broker fields into an array of objects for XLSX generation
- * @param {Object} Application
+ * @param {Application}
  * @returns {Array} Array of objects for XLSX generation
  */
 export const mapBroker = (application: Application) => {
@@ -74,7 +74,7 @@ export const mapBroker = (application: Application) => {
 /**
  * mapExporter
  * Map an application's exporter fields into an array of objects for XLSX generation
- * @param {Object} Application
+ * @param {Application}
  * @returns {Array} Array of objects for XLSX generation
  */
 const mapExporter = (application: Application) => {

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-key-information/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-key-information/index.ts
@@ -13,7 +13,7 @@ const { FIRST_NAME, LAST_NAME, EMAIL } = ACCOUNT;
 /**
  * mapKeyInformation
  * Map key information for an application
- * @param {Object} Application
+ * @param {Application}
  * @returns {Array} Array of objects for XLSX generation
  */
 const mapKeyInformation = (application: Application) => {

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-policy-and-export/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-policy-and-export/index.ts
@@ -76,7 +76,7 @@ export const mapPolicyAndExportOutro = (application: Application) => {
 /**
  * mapPolicyAndExport
  * Map an application's policy fields into an array of objects for XLSX generation
- * @param {Object} Application
+ * @param {Application}
  * @returns {Array} Array of objects for XLSX generation
  */
 const mapPolicyAndExport = (application: Application) => {

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-secondary-key-information/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-secondary-key-information/index.ts
@@ -28,7 +28,7 @@ const {
 /**
  * mapSecondaryKeyInformation
  * Map secondary key information for an application
- * @param {Object} Application
+ * @param {Application}
  * @returns {Array} Array of objects for XLSX generation
  */
 const mapSecondaryKeyInformation = (application: Application) => {

--- a/src/api/generate-xlsx/styled-columns/index.ts
+++ b/src/api/generate-xlsx/styled-columns/index.ts
@@ -28,7 +28,7 @@ export const worksheetRowHeights = (titleRowIndexes: Array<number>, rowIndexes: 
 /**
  * styledColumns
  * Add custom styles to each worksheet cell
- * @param {Object} Application
+ * @param {Application}
  * @param {ExcelJS.Worksheet} ExcelJS worksheet
  * @returns {ExcelJS.Worksheet} ExcelJS worksheet
  */

--- a/src/api/helpers/get-application-submitted-email-template-ids/index.ts
+++ b/src/api/helpers/get-application-submitted-email-template-ids/index.ts
@@ -10,7 +10,7 @@ const {
 /**
  * getApplicationSubmittedEmailTemplateIds
  * Get "application submitted" email template IDs team depending on submitted answers
- * @param {Object} Application
+ * @param {Application}
  * @returns {Object} Email template IDs for application owner/account and UKEF underwriting team
  */
 const getApplicationSubmittedEmailTemplateIds = (application: Application) => {

--- a/src/api/helpers/get-populated-application/index.ts
+++ b/src/api/helpers/get-populated-application/index.ts
@@ -10,7 +10,7 @@ export const generateErrorMessage = (section: string, applicationId: number) =>
  * getPopulatedApplication
  * Get data associated with an application
  * @param {Object} KeystoneJS context API
- * @param {Object} Application
+ * @param {Application}
  * @returns {Object} Populated application
  */
 const getPopulatedApplication = async (context: Context, application: KeystoneApplication): Promise<Application> => {

--- a/src/ui/server/controllers/insurance/check-your-answers/save-data/index.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/save-data/index.ts
@@ -6,7 +6,7 @@ import { Application, RequestBody } from '../../../../../types';
  * sectionReview
  * Update an application's section review
  * This is used for any save functionality in the Check your answers section of an application
- * @param {Object} Application
+ * @param {Application}
  * @param {Express.Request.body} Form data
  * @returns {Object} Saved data
  */

--- a/src/ui/server/controllers/insurance/declarations/save-data/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/save-data/index.ts
@@ -7,7 +7,7 @@ import { Application, RequestBody } from '../../../../../types';
  * declarations
  * Update an application's declaration
  * This is used for any save functionality in the Declarations section of an application
- * @param {Object} Application
+ * @param {Application}
  * @param {Express.Request.body} Form data
  * @returns {Object} Saved data
  */

--- a/src/ui/server/controllers/insurance/export-contract/call-map-and-save/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/call-map-and-save/index.ts
@@ -5,7 +5,7 @@ import { Application, RequestBody, ValidationErrors } from '../../../../../types
  * callMapAndSave
  * Call the "map and save" function with or without validation errors
  * @param {RequestBody} Form body
- * @param {Object} Application
+ * @param {Application}
  * @param {Object} Form Validation errors
  * @returns {Boolean}
  */

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/index.ts
@@ -6,7 +6,7 @@ import { Application, RequestBody, ValidationErrors } from '../../../../../types
  * mapAndSave
  * Map and save any valid export contract fields
  * @param {Express.Request.body} Express request body
- * @param {Object} Application
+ * @param {Application}
  * @param {Object} Validation errors
  * @returns {Boolean}
  */

--- a/src/ui/server/controllers/insurance/export-contract/save-data/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/index.ts
@@ -7,7 +7,7 @@ import { Application, RequestBody } from '../../../../../types';
  * exportContract
  * Strip invalid fields from submitted form data and update the application.
  * This is used for any save functionality in the Export contract section of the application.
- * @param {Object} Application
+ * @param {Application}
  * @param {Express.Request.body} Form data
  * @param {Object} Field error list
  * @returns {Object} Saved data

--- a/src/ui/server/controllers/insurance/policy-and-export/call-map-and-save/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/call-map-and-save/index.ts
@@ -5,7 +5,7 @@ import { Application, RequestBody, ValidationErrors } from '../../../../../types
  * callMapAndSave
  * Call the "map and save" function with or without validation errors
  * @param {RequestBody} Form body
- * @param {Object} Application
+ * @param {Application}
  * @param {Object} Form Validation errors
  * @returns {Boolean}
  */

--- a/src/ui/server/controllers/insurance/policy-and-export/different-name-on-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/different-name-on-policy/index.test.ts
@@ -7,6 +7,7 @@ import { POLICY_AND_EXPORTS_FIELDS as FIELDS, ACCOUNT_FIELDS } from '../../../..
 import ACCOUNT_FIELD_IDS from '../../../../constants/field-ids/insurance/account';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapNameFields from '../../../../helpers/mappings/map-name-fields';
 import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/policy-contact';
@@ -104,7 +105,10 @@ describe('controllers/insurance/policy-and-export/different-name-on-policy', () 
         ...pageVariables(refNumber),
         userName: getUserNameFromSession(req.session.user),
         application: mockApplication,
-        submittedValues: mockApplication.policyContact,
+        submittedValues: {
+          ...mockApplication.policyContact,
+          ...mapNameFields(mockApplication).policyContact,
+        },
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);

--- a/src/ui/server/controllers/insurance/policy-and-export/different-name-on-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/different-name-on-policy/index.ts
@@ -6,6 +6,7 @@ import { POLICY_AND_EXPORTS_FIELDS as FIELDS, ACCOUNT_FIELDS } from '../../../..
 import ACCOUNT_FIELD_IDS from '../../../../constants/field-ids/insurance/account';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapNameFields from '../../../../helpers/mappings/map-name-fields';
 import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import { Request, Response } from '../../../../../types';
@@ -82,7 +83,10 @@ export const get = (req: Request, res: Response) => {
     ...pageVariables(refNumber),
     userName: getUserNameFromSession(req.session.user),
     application,
-    submittedValues: application.policyContact,
+    submittedValues: {
+      ...application.policyContact,
+      ...mapNameFields(application).policyContact,
+    },
   });
 };
 

--- a/src/ui/server/controllers/insurance/policy-and-export/map-and-save/policy-contact/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/map-and-save/policy-contact/index.ts
@@ -7,7 +7,7 @@ import { Application, RequestBody, ValidationErrors } from '../../../../../../ty
  * mapAndSave policyContact
  * Map and save any valid policyContact fields
  * @param {Express.Request.body} Express request body
- * @param {Object} Application
+ * @param {Application}
  * @param {Object} Validation errors
  * @returns {Boolean}
  */

--- a/src/ui/server/controllers/insurance/policy-and-export/map-and-save/policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/map-and-save/policy/index.ts
@@ -7,7 +7,7 @@ import { Application, RequestBody, ValidationErrors } from '../../../../../../ty
  * mapAndSave
  * Map and save any valid  policy fields
  * @param {Express.Request.body} Express request body
- * @param {Object} Application
+ * @param {Application}
  * @param {Object} Validation errors
  * @returns {Boolean}
  */

--- a/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/contract-completion-date.test.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/single-contract-policy/validation/rules/contract-completion-date.test.ts
@@ -132,7 +132,12 @@ describe('controllers/insurance/policy-and-export/single-contract-policy/validat
 
   describe(`when ${REQUESTED_START_DATE} is also provided`, () => {
     const date = new Date();
-    const futureDate = add(date, { months: 3 });
+
+    // Add 1 day
+    const initFutureDate = new Date(date.setDate(date.getDate() + 1));
+
+    // Add 1 year
+    const futureDate = new Date(initFutureDate.setFullYear(getYear(initFutureDate) + 1));
 
     const requestedStartDateFields = {
       [`${REQUESTED_START_DATE}-day`]: getDate(futureDate),

--- a/src/ui/server/helpers/application-is-complete/index.ts
+++ b/src/ui/server/helpers/application-is-complete/index.ts
@@ -11,7 +11,7 @@ const {
 /**
  * applicationIsComplete
  * Check if the application is complete
- * @param {Object} Application
+ * @param {Application}
  * @returns {Boolean}
  */
 const applicationIsComplete = (application: ApplicationFlat) => {

--- a/src/ui/server/helpers/can-access-submit-your-application-routes/index.ts
+++ b/src/ui/server/helpers/can-access-submit-your-application-routes/index.ts
@@ -8,7 +8,7 @@ import { Application } from '../../../types';
  * canAccessSubmitYourApplicationRoutes
  * Check if an application has submitted previous fields/sections required before accessing the "submit your application" group/sections/routes.
  * The "submit your application" group includes all routes for "check your answers" and "declarations".
- * @param {Object} Application
+ * @param {Application}
  * @param {String} Current URL
  * @returns {Boolean}
  */

--- a/src/ui/server/helpers/can-submit-application/index.ts
+++ b/src/ui/server/helpers/can-submit-application/index.ts
@@ -11,7 +11,7 @@ import { Application } from '../../../types';
  * - Has a draft status
  * - Is submitting before the submission deadline
  * - Has not been submitted before
- * @param {Object} Application
+ * @param {Application}
  * @returns {Boolean}
  */
 const canSubmitApplication = (application: Application): boolean => {

--- a/src/ui/server/helpers/flatten-application-data/index.ts
+++ b/src/ui/server/helpers/flatten-application-data/index.ts
@@ -4,7 +4,7 @@ import { Application, ApplicationFlat } from '../../../types';
 /**
  * flattenApplicationData
  * Transform an application into a single level object
- * @param {Object} Application
+ * @param {Application}
  * @returns {Object} Application as a single level object
  */
 const flattenApplicationData = (application: Application): ApplicationFlat => {

--- a/src/ui/server/helpers/mappings/map-application-to-form-fields/index.ts
+++ b/src/ui/server/helpers/mappings/map-application-to-form-fields/index.ts
@@ -24,7 +24,7 @@ const {
 /**
  * mapApplicationToFormFields
  * Generate an object with application data mappings for UI form fields and summary lists.
- * @param {Object} Application
+ * @param {Application}
  * @returns {Object} Mapped application for UI consumption
  */
 const mapApplicationToFormFields = (application?: Application): object => {

--- a/src/ui/server/helpers/mappings/map-applications/index.ts
+++ b/src/ui/server/helpers/mappings/map-applications/index.ts
@@ -8,7 +8,7 @@ import { Application } from '../../../../types';
 /**
  * mapApplication
  * Map an application for display in the dashboard
- * @param {Object} Application
+ * @param {Application}
  * @returns {Object} Mapped application
  */
 export const mapApplication = (application: Application) => {

--- a/src/ui/server/helpers/mappings/map-applications/map-value.ts
+++ b/src/ui/server/helpers/mappings/map-applications/map-value.ts
@@ -18,7 +18,7 @@ const {
 /**
  * mapValue
  * Map an application's "insurance value" depending on the policy type, for display in the dashboard
- * @param {Object} Application
+ * @param {Application}
  * @returns {String} Formatted insured amount or empty dash
  */
 const mapValue = (application: Application) => {

--- a/src/ui/server/helpers/mappings/map-name-fields/index.test.ts
+++ b/src/ui/server/helpers/mappings/map-name-fields/index.test.ts
@@ -4,6 +4,7 @@ import replaceCharacterCodesWithCharacters from '../../replace-character-codes-w
 import { mockApplication } from '../../../test-mocks';
 
 const {
+  ACCOUNT: { FIRST_NAME, LAST_NAME },
   YOUR_BUYER: {
     COMPANY_OR_ORGANISATION: { NAME: BUYER_NAME, FIRST_NAME: BUYER_CONTACT_FIRST_NAME, LAST_NAME: BUYER_CONTACT_LAST_NAME },
   },
@@ -20,6 +21,11 @@ const mockApplicationWithCharacterCodes = {
     [BUYER_NAME]: mockStringWithCharacterCodes,
     [BUYER_CONTACT_FIRST_NAME]: mockStringWithCharacterCodes,
     [BUYER_CONTACT_LAST_NAME]: mockStringWithCharacterCodes,
+  },
+  policyContact: {
+    ...mockApplication.policyContact,
+    [FIRST_NAME]: mockStringWithCharacterCodes,
+    [LAST_NAME]: mockStringWithCharacterCodes,
   },
 };
 

--- a/src/ui/server/helpers/mappings/map-name-fields/index.ts
+++ b/src/ui/server/helpers/mappings/map-name-fields/index.ts
@@ -3,6 +3,7 @@ import replaceCharacterCodesWithCharacters from '../../replace-character-codes-w
 import { Application } from '../../../../types';
 
 const {
+  ACCOUNT: { FIRST_NAME, LAST_NAME },
   YOUR_BUYER: {
     COMPANY_OR_ORGANISATION: { NAME: BUYER_NAME, FIRST_NAME: BUYER_CONTACT_FIRST_NAME, LAST_NAME: BUYER_CONTACT_LAST_NAME },
   },
@@ -15,7 +16,7 @@ const {
  * @returns {Object} Application with name field characters
  */
 const mapNameFields = (application: Application): Application => {
-  const { buyer } = application;
+  const { buyer, policyContact } = application;
 
   if (buyer?.[BUYER_NAME]) {
     const fieldValue = buyer[BUYER_NAME];
@@ -33,6 +34,18 @@ const mapNameFields = (application: Application): Application => {
     const fieldValue = buyer[BUYER_CONTACT_LAST_NAME];
 
     buyer[BUYER_CONTACT_LAST_NAME] = replaceCharacterCodesWithCharacters(fieldValue);
+  }
+
+  if (policyContact?.[FIRST_NAME]) {
+    const fieldValue = policyContact[FIRST_NAME];
+
+    policyContact[FIRST_NAME] = replaceCharacterCodesWithCharacters(fieldValue);
+  }
+
+  if (policyContact?.[LAST_NAME]) {
+    const fieldValue = policyContact[LAST_NAME];
+
+    policyContact[LAST_NAME] = replaceCharacterCodesWithCharacters(fieldValue);
   }
 
   return application;

--- a/src/ui/server/helpers/mappings/map-name-fields/index.ts
+++ b/src/ui/server/helpers/mappings/map-name-fields/index.ts
@@ -12,7 +12,7 @@ const {
 /**
  * mapNameFields
  * Replace character codes in name fields with characters
- * @param {Object} Application
+ * @param {Application}
  * @returns {Object} Application with name field characters
  */
 const mapNameFields = (application: Application): Application => {

--- a/src/ui/server/helpers/required-fields/index.ts
+++ b/src/ui/server/helpers/required-fields/index.ts
@@ -10,7 +10,7 @@ const {
 
 /**
  * Required fields for an application
- * @param {Object} Application
+ * @param {Application}
  * @returns {Array} Required field IDs
  */
 const requiredFields = (application: ApplicationFlat) => [

--- a/src/ui/templates/insurance/policy-and-exports/name-on-policy.njk
+++ b/src/ui/templates/insurance/policy-and-exports/name-on-policy.njk
@@ -36,11 +36,11 @@
   </div>
 
    {{ govukHint({
-      text: CONTENT_STRINGS.HINT,
-      attributes: {
-      "data-cy": FIELDS.NAME_ON_POLICY.ID + "-hint"
-      }
-    }) }}
+    text: CONTENT_STRINGS.HINT,
+    attributes: {
+    "data-cy": FIELDS.NAME_ON_POLICY.ID + "-hint"
+    }
+  }) }}
 
 
   <form method="POST" id="form" novalidate>


### PR DESCRIPTION
## Introduction ✏️ 
- The "Different policy contact" form's first/last name fields would render encoded special characters, instead of them being decoded/how the user entered the characers.
- An E2E and UI test were failing due to a date construction / the current date.

## Resolution ✔️ 
- Update `mapNameFields` to map `policyContact` first/last name.
- Update  the "different name on policy" GET controller to consume `mapNameFields`.
- Change the way a date is constructed in a "contract completion date" E2E  and unit test.

## Miscellaneous ➕
- Update various cypress commands in order to add test coverage for submitting an application with a different policy contact.
- Replace all instances of `@param {Object} Application` with `@param {Application}`.
- Fix an indentation issue.