### PR TITLE
fix(escape): escaping environment variables with double quotes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ env:
   environment: "qa"
   timezone: "Europe/London"
   NODE_ENV: ${{ secrets.NODE_ENV }}
-  TLS_CERTIFICATE: ${{ secrets.TLS_CERTIFICATE }}
-  TLS_KEY: ${{ secrets.TLS_KEY }}
+  TLS_CERTIFICATE: "${{ secrets.TLS_CERTIFICATE }}"
+  TLS_KEY: "${{ secrets.TLS_KEY }}"
   DATABASE_PORT: ${{ vars.DATABASE_PORT }}
   API_PORT: ${{ vars.API_PORT }}
   UI_PORT: ${{ vars.UI_PORT }}
@@ -129,8 +129,8 @@ jobs:
       - name: API
         working-directory: ./
         env:
-          TLS_CERTIFICATE: ${{ secrets.TLS_CERTIFICATE }}
-          TLS_KEY: ${{ secrets.TLS_KEY }}
+          TLS_CERTIFICATE: "${{ secrets.TLS_CERTIFICATE }}"
+          TLS_KEY: "${{ secrets.TLS_KEY }}"
           DATABASE_PORT: ${{ vars.DATABASE_PORT }}
           API_PORT: ${{ vars.API_PORT }}
           UI_PORT: ${{ vars.UI_PORT }}

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -4890,13 +4890,14 @@ var extendGraphqlSchema = (schema) => (0, import_schema.mergeSchemas)({
 });
 
 // keystone.ts
-var { NODE_ENV: NODE_ENV2, API_PORT, DATABASE_URL } = process.env;
+var { NODE_ENV: NODE_ENV2, PORT, API_PORT, DATABASE_URL } = process.env;
 var isDevEnvironment2 = NODE_ENV2 === "development";
 var isProdEnvironment = NODE_ENV2 === "production";
 var keystone_default = withAuth(
   (0, import_core3.config)({
     server: {
-      port: Number(API_PORT),
+      // Azure requires `PORT` whilst GHA requires `API_PORT`
+      port: Number(PORT) || Number(API_PORT),
       extendExpressApp: (app) => {
         app.use(check_api_key_default);
         if (isProdEnvironment) {

--- a/src/ui/server/helpers/sanitise-environment/index.test.ts
+++ b/src/ui/server/helpers/sanitise-environment/index.test.ts
@@ -8,9 +8,9 @@ describe('helper/sanitise-environment/sanitise', () => {
     expect(result).toBe(input);
   });
 
-  // Replaces all occurrences of `\\\\n` with `\n` in the input string
-  it('should replace all occurrences of `\\\\n` with `\n` in the input string', () => {
-    const input = 'Hello\\\\nWorld\\\\n';
+  // Replaces all occurrences of `\\\n` with `\n` in the input string
+  it('should replace all occurrences of `\\\n` with `\n` in the input string', () => {
+    const input = 'Hello\\\nWorld\\\n';
     const result = sanitise(input);
     expect(result).toBe('Hello\nWorld\n');
   });
@@ -22,23 +22,23 @@ describe('helper/sanitise-environment/sanitise', () => {
     expect(result).toBe('');
   });
 
-  // Returns the input string if it does not contain `\\\\n`
-  it('should return the input string if it does not contain `\\\\n`', () => {
+  // Returns the input string if it does not contain `\\\n`
+  it('should return the input string if it does not contain `\\\n`', () => {
     const input = 'Hello World';
     const result = sanitise(input);
     expect(result).toBe(input);
   });
 
-  // Returns the input string with `\\\\n` replaced by `\n` even if there are multiple occurrences in the string
-  it('should return the input string with `\\\\n` replaced by `\n` even if there are multiple occurrences in the string', () => {
-    const input = 'Hello\\\\nWorld\\\\n!';
+  // Returns the input string with `\\\n` replaced by `\n` even if there are multiple occurrences in the string
+  it('should return the input string with `\\\n` replaced by `\n` even if there are multiple occurrences in the string', () => {
+    const input = 'Hello\\\nWorld\\\n!';
     const result = sanitise(input);
     expect(result).toBe('Hello\nWorld\n!');
   });
 
   // Handles input strings with leading and trailing spaces correctly
   it('should handle input strings with leading and trailing spaces correctly', () => {
-    const input = '   Hello\\\\nWorld   ';
+    const input = '   Hello\\\nWorld   ';
     const result = sanitise(input);
     expect(result).toBe('   Hello\nWorld   ');
   });

--- a/src/ui/server/helpers/sanitise-environment/index.test.ts
+++ b/src/ui/server/helpers/sanitise-environment/index.test.ts
@@ -1,45 +1,105 @@
 import { sanitise } from '.';
 
 describe('helper/sanitise-environment/sanitise', () => {
-  // Returns the input string if it is undefined
   it('should return the input string if it is undefined', () => {
     const input = undefined;
     const result = sanitise(input);
     expect(result).toBe(input);
   });
 
-  // Replaces all occurrences of `\\\n` with `\n` in the input string
   it('should replace all occurrences of `\\\n` with `\n` in the input string', () => {
     const input = 'Hello\\\nWorld\\\n';
     const result = sanitise(input);
     expect(result).toBe('Hello\nWorld\n');
   });
 
-  // Returns an empty string if the input string is an empty string
   it('should return an empty string if the input string is an empty string', () => {
     const input = '';
     const result = sanitise(input);
     expect(result).toBe('');
   });
 
-  // Returns the input string if it does not contain `\\\n`
   it('should return the input string if it does not contain `\\\n`', () => {
     const input = 'Hello World';
     const result = sanitise(input);
     expect(result).toBe(input);
   });
 
-  // Returns the input string with `\\\n` replaced by `\n` even if there are multiple occurrences in the string
   it('should return the input string with `\\\n` replaced by `\n` even if there are multiple occurrences in the string', () => {
     const input = 'Hello\\\nWorld\\\n!';
     const result = sanitise(input);
     expect(result).toBe('Hello\nWorld\n!');
   });
 
-  // Handles input strings with leading and trailing spaces correctly
   it('should handle input strings with leading and trailing spaces correctly', () => {
     const input = '   Hello\\\nWorld   ';
     const result = sanitise(input);
     expect(result).toBe('   Hello\nWorld   ');
+  });
+
+  it('should replace all occurrences of `\\n` with `\n` in the input string', () => {
+    const input = 'Hello\\nWorld\\n';
+    const result = sanitise(input);
+    expect(result).toBe('Hello\nWorld\n');
+  });
+
+  it('should return an empty string if the input string is an empty string', () => {
+    const input = '';
+    const result = sanitise(input);
+    expect(result).toBe('');
+  });
+
+  it('should return the input string if it does not contain `\\n`', () => {
+    const input = 'Hello World';
+    const result = sanitise(input);
+    expect(result).toBe(input);
+  });
+
+  it('should return the input string with `\\n` replaced by `\n` even if there are multiple occurrences in the string', () => {
+    const input = 'Hello\\nWorld\\n!';
+    const result = sanitise(input);
+    expect(result).toBe('Hello\nWorld\n!');
+  });
+
+  it('should handle input strings with leading and trailing spaces correctly', () => {
+    const input = '   Hello\\nWorld   ';
+    const result = sanitise(input);
+    expect(result).toBe('   Hello\nWorld   ');
+  });
+
+  it('should replace all occurrences of `\\\\n` with `\n` in the input string', () => {
+    const input = 'Hello\\\\nWorld\\\\n';
+    const result = sanitise(input);
+    expect(result).toBe('Hello\nWorld\n');
+  });
+
+  it('should return an empty string if the input string is an empty string', () => {
+    const input = '';
+    const result = sanitise(input);
+    expect(result).toBe('');
+  });
+
+  it('should return the input string if it does not contain `\\\\n`', () => {
+    const input = 'Hello World';
+    const result = sanitise(input);
+    expect(result).toBe(input);
+  });
+
+  it('should return the input string with `\\\\n` replaced by `\n` even if there are multiple occurrences in the string', () => {
+    const input = 'Hello\\\\nWorld\\\\n!';
+    const result = sanitise(input);
+    expect(result).toBe('Hello\nWorld\n!');
+  });
+
+  it('should handle input strings with leading and trailing spaces correctly', () => {
+    const input = '   Hello\\\\nWorld   ';
+    const result = sanitise(input);
+    expect(result).toBe('   Hello\nWorld   ');
+  });
+
+  it('should handle input strings with leading and trailing spaces correctly and with multiple escape characters', () => {
+    const input = '   Hello\\\\nThere\nWorld\\n!   ';
+    const result = sanitise(input);
+    expect(result).toBe('   Hello\nThere\nWorld\n!   ');
   });
 });

--- a/src/ui/server/helpers/sanitise-environment/index.ts
+++ b/src/ui/server/helpers/sanitise-environment/index.ts
@@ -1,11 +1,17 @@
-/**
- * Sanitises an environment variable string by replacing occurrences of all the sequence
- * '\\n' with a newline character ('\n').
- * Note the triple back-slash are for escaping the escaped back-slash.
- * @param string - The input string that needs to be sanitised.
- * @returns The sanitised version of the input string.
- * @example `ABC\\nCBA` will be sanitised to
- * `ABC
- * CBA`
- */
-export const sanitise = (string?: string): string | undefined => (string ? string.replace(/\\n|\\\n|\\\\n/g, '\n') : string);
+export const sanitise = (string?: string): string | undefined => {
+  /**
+   * Sanitises the input string by replacing occurrences of the sequence '\\n' with a newline character ('\n').
+   *
+   * @param string - The input string to be sanitised.
+   * @returns The sanitised version of the input string, or undefined if no input string is provided.
+   *
+   * @example
+   * const input = 'ABC\\nCBA';
+   * const output = sanitise(input);
+   * console.log(output);
+   * // Output:
+   * // ABC
+   * // CBA
+   */
+  return string ? string.replace(/\\n|\\\n|\\\\n/g, '\n') : string;
+};

--- a/src/ui/server/helpers/sanitise-environment/index.ts
+++ b/src/ui/server/helpers/sanitise-environment/index.ts
@@ -8,4 +8,4 @@
  * `ABC
  * CBA`
  */
-export const sanitise = (string?: string): string | undefined => (string ? string.replace(/\\\n/g, '\n') : string);
+export const sanitise = (string?: string): string | undefined => (string ? string.replace(/\\n|\\\n|\\\\n/g, '\n') : string);

--- a/src/ui/server/helpers/sanitise-environment/index.ts
+++ b/src/ui/server/helpers/sanitise-environment/index.ts
@@ -1,10 +1,11 @@
 /**
  * Sanitises an environment variable string by replacing occurrences of all the sequence
- * '\\n' with a newline character ('\n'). Note this function has also replace escaped backslash (\).
+ * '\\n' with a newline character ('\n').
+ * Note the triple back-slash are for escaping the escaped back-slash.
  * @param string - The input string that needs to be sanitised.
  * @returns The sanitised version of the input string.
  * @example `ABC\\nCBA` will be sanitised to
  * `ABC
  * CBA`
  */
-export const sanitise = (string: string | undefined): string | undefined => (string ? string.replace(/\\\\n/g, '\n') : string);
+export const sanitise = (string?: string): string | undefined => (string ? string.replace(/\\\n/g, '\n') : string);


### PR DESCRIPTION
## Introduction
Ensure double quotes environment variables successfully escapes `\\n|\\\n|\\\\n`.

## Resolution
* Updated RegEx with values in double quotes.
* Function argument data type fix