### PR TITLE
feat(EMS-2076): Policy and exports - Redirect to answer pages when changing policy type

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-and-exports-multiple-policy-type.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-and-exports-multiple-policy-type.spec.js
@@ -43,6 +43,8 @@ const getFieldVariables = (fieldId, referenceNumber) => ({
   changeLink: summaryList.field(fieldId).changeLink,
 });
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Change your answers - Policy and exports - multiple contract policy - Summary List', () => {
   let url;
   let referenceNumber;
@@ -57,7 +59,7 @@ context('Insurance - Change your answers - Policy and exports - multiple contrac
       // To get past "Eligibility" check your answers page
       cy.submitCheckYourAnswersForm();
 
-      url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;
+      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-type-change-multiple-to-single-policy-type-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-type-change-multiple-to-single-policy-type-summary-list.spec.js
@@ -1,47 +1,40 @@
 import partials from '../../../../../../../partials';
-import { FIELD_IDS, ROUTES, FIELD_VALUES } from '../../../../../../../constants';
-import { submitButton, saveAndBackButton, summaryList } from '../../../../../../../pages/shared';
-import { LINKS } from '../../../../../../../content-strings';
+import { FIELD_VALUES } from '../../../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
+import { submitButton, summaryList } from '../../../../../../../pages/shared';
 import { typeOfPolicyPage } from '../../../../../../../pages/insurance/policy-and-export';
-import { POLICY_AND_EXPORT_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/policy-and-exports';
 import { createTimestampFromNumbers, formatDate } from '../../../../../../../helpers/date';
 import formatCurrency from '../../../../../../../helpers/format-currency';
 import application from '../../../../../../../fixtures/application';
 
 const {
   ROOT: INSURANCE_ROOT,
-  ALL_SECTIONS,
   POLICY_AND_EXPORTS: {
     TYPE_OF_POLICY_CHECK_AND_CHANGE,
     SINGLE_CONTRACT_POLICY_CHECK_AND_CHANGE,
-    SINGLE_CONTRACT_POLICY,
-    ABOUT_GOODS_OR_SERVICES,
   },
   CHECK_YOUR_ANSWERS,
-} = ROUTES.INSURANCE;
+} = INSURANCE_ROUTES;
 
 const {
-  INSURANCE: {
-    POLICY_AND_EXPORTS: {
-      TYPE_OF_POLICY: { POLICY_TYPE },
-      CONTRACT_POLICY: {
-        SINGLE: { CONTRACT_COMPLETION_DATE, TOTAL_CONTRACT_VALUE },
-      },
+  POLICY_AND_EXPORTS: {
+    TYPE_OF_POLICY: { POLICY_TYPE },
+    CONTRACT_POLICY: {
+      SINGLE: { CONTRACT_COMPLETION_DATE, TOTAL_CONTRACT_VALUE },
     },
   },
-} = FIELD_IDS;
-
-const { CONTRACT_POLICY: { SINGLE: SINGLE_FIELD_STRINGS } } = FIELDS;
+} = INSURANCE_FIELD_IDS;
 
 const { taskList } = partials.insurancePartials;
 
 const task = taskList.submitApplication.tasks.checkAnswers;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Change your answers - Policy and exports - Change multiple to single policy type - Summary List', () => {
-  const baseUrl = Cypress.config('baseUrl');
-  let url;
+  let checkYourAnswersUrl;
   let referenceNumber;
-  let allSectionsUrl;
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
@@ -53,11 +46,8 @@ context('Insurance - Change your answers - Policy and exports - Change multiple 
       // To get past "Eligibility" check your answers page
       cy.submitCheckYourAnswersForm();
 
-      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY}`;
-
-      cy.assertUrl(url);
-
-      allSectionsUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+      checkYourAnswersUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY}`;
+      cy.assertUrl(checkYourAnswersUrl);
     });
   });
 
@@ -69,102 +59,65 @@ context('Insurance - Change your answers - Policy and exports - Change multiple 
     cy.deleteApplication(referenceNumber);
   });
 
-  const fieldId = POLICY_TYPE;
+  let fieldId = POLICY_TYPE;
 
   describe('when clicking the `change` link', () => {
     beforeEach(() => {
-      cy.navigateToUrl(url);
+      cy.navigateToUrl(checkYourAnswersUrl);
+
+      summaryList.field(POLICY_TYPE).changeLink().click();
     });
 
-    it(`should redirect to ${TYPE_OF_POLICY_CHECK_AND_CHANGE}`, () => {
-      cy.navigateToUrl(url);
-      summaryList.field(fieldId).changeLink().click();
-
+    it(`should redirect to ${TYPE_OF_POLICY_CHECK_AND_CHANGE} with heading anchor`, () => {
       const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY_CHECK_AND_CHANGE}#heading`;
 
       cy.assertUrl(expected);
     });
   });
 
-  describe('form submission with a new answer', () => {
-    beforeEach(() => {
-      cy.navigateToUrl(url);
+  describe('after submitting a new policy type (single) and completing (now required) fields for a single policy', () => {
+    it(`should redirect to ${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY}`, () => {
+      cy.navigateToUrl(checkYourAnswersUrl);
 
       summaryList.field(fieldId).changeLink().click();
 
       typeOfPolicyPage[fieldId].single.input().click();
-
       submitButton().click();
-    });
 
-    it(`should redirect to ${SINGLE_CONTRACT_POLICY}`, () => {
-      const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}#heading`;
-
-      cy.assertUrl(expected);
-    });
-  });
-
-  describe(`after completing (now required) fields in ${SINGLE_CONTRACT_POLICY} and proceeding to ${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY}`, () => {
-    beforeEach(() => {
-      cy.navigateToUrl(`${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}#heading`);
-
-      // complete the form/now required fields for a single contract policy
       cy.completeAndSubmitSingleContractPolicyForm({});
 
-      cy.assertUrl(`${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}#heading`);
+      const expectedUrl = `${checkYourAnswersUrl}#heading`;
 
-      // go back to "all sections"
-      saveAndBackButton().click();
-
-      cy.assertUrl(allSectionsUrl);
+      cy.assertUrl(expectedUrl);
     });
 
-    it(`should render the new answer when navigating back to ${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY} from ${ALL_SECTIONS}`, () => {
-      cy.navigateToUrl(allSectionsUrl);
-      cy.assertUrl(allSectionsUrl);
-
-      // go into the "insurance - check your answers" section
-      task.link().click();
-
-      // submit check your answers - eligibility
-      submitButton().click();
-
-      cy.assertUrl(url);
-
-      const expected = FIELD_VALUES.POLICY_TYPE.SINGLE;
-      cy.assertSummaryListRowValueNew(summaryList, fieldId, expected);
-    });
-
-    describe('Updated summary list', () => {
+    describe('should render new answers and change links for new single policy fields', () => {
       beforeEach(() => {
-        cy.navigateToUrl(url);
+        cy.navigateToUrl(checkYourAnswersUrl);
       });
 
-      it('should render the new answers and `change` links to the newly submitted fields', () => {
-        const newDate = application.POLICY_AND_EXPORTS[CONTRACT_COMPLETION_DATE];
-
-        const expectedDate = formatDate(createTimestampFromNumbers(newDate.day, newDate.month, newDate.year));
-
-        cy.assertSummaryListRowValueNew(summaryList, CONTRACT_COMPLETION_DATE, expectedDate);
-
-        cy.checkText(
-          summaryList.field(CONTRACT_COMPLETION_DATE).changeLink(),
-          `${LINKS.CHANGE} ${SINGLE_FIELD_STRINGS[CONTRACT_COMPLETION_DATE].SUMMARY.TITLE}`,
-        );
-
-        const expectedTotalContractValue = formatCurrency(application.POLICY_AND_EXPORTS[TOTAL_CONTRACT_VALUE]);
-
-        cy.assertSummaryListRowValueNew(summaryList, TOTAL_CONTRACT_VALUE, expectedTotalContractValue);
-
-        cy.checkText(
-          summaryList.field(TOTAL_CONTRACT_VALUE).changeLink(),
-          `${LINKS.CHANGE} ${SINGLE_FIELD_STRINGS[TOTAL_CONTRACT_VALUE].SUMMARY.TITLE}`,
-        );
+      it(POLICY_TYPE, () => {
+        cy.assertSummaryListRowValueNew(summaryList, POLICY_TYPE, FIELD_VALUES.POLICY_TYPE.SINGLE);
       });
 
-      it(`'total contract value' summary list row change link should redirect to ${SINGLE_CONTRACT_POLICY_CHECK_AND_CHANGE}`, () => {
+      it(CONTRACT_COMPLETION_DATE, () => {
+        fieldId = CONTRACT_COMPLETION_DATE;
+        const newAnswer = application.POLICY_AND_EXPORTS[fieldId];
+
+        const expectedDate = formatDate(createTimestampFromNumbers(newAnswer.day, newAnswer.month, newAnswer.year));
+
+        cy.assertSummaryListRowValueNew(summaryList, fieldId, expectedDate);
+      });
+
+      it(`${TOTAL_CONTRACT_VALUE} with different change link`, () => {
+        fieldId = TOTAL_CONTRACT_VALUE;
+
+        const expectedTotalContractValue = formatCurrency(application.POLICY_AND_EXPORTS[fieldId]);
+
+        cy.assertSummaryListRowValueNew(summaryList, fieldId, expectedTotalContractValue);
+
+        // check the change link
         summaryList.field(TOTAL_CONTRACT_VALUE).changeLink().click();
-
         cy.assertChangeAnswersPageUrl(referenceNumber, SINGLE_CONTRACT_POLICY_CHECK_AND_CHANGE, TOTAL_CONTRACT_VALUE, 'label');
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-type-change-single-to-multiple-policy-type-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-type-change-single-to-multiple-policy-type-summary-list.spec.js
@@ -1,50 +1,43 @@
 import partials from '../../../../../../../partials';
-import { FIELD_IDS, ROUTES, FIELD_VALUES } from '../../../../../../../constants';
-import { submitButton, saveAndBackButton, summaryList } from '../../../../../../../pages/shared';
-import { LINKS } from '../../../../../../../content-strings';
+import { FIELD_VALUES } from '../../../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
+import { submitButton, summaryList } from '../../../../../../../pages/shared';
 import { typeOfPolicyPage } from '../../../../../../../pages/insurance/policy-and-export';
-import { POLICY_AND_EXPORT_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/policy-and-exports';
 import formatCurrency from '../../../../../../../helpers/format-currency';
 import application from '../../../../../../../fixtures/application';
 
 const {
-  ROOT: INSURANCE_ROOT,
-  ALL_SECTIONS,
+  ROOT,
   POLICY_AND_EXPORTS: {
     TYPE_OF_POLICY_CHECK_AND_CHANGE,
     MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE,
-    MULTIPLE_CONTRACT_POLICY,
-    ABOUT_GOODS_OR_SERVICES,
   },
   CHECK_YOUR_ANSWERS,
-} = ROUTES.INSURANCE;
+} = INSURANCE_ROUTES;
 
 const {
-  INSURANCE: {
-    POLICY_AND_EXPORTS: {
-      TYPE_OF_POLICY: { POLICY_TYPE },
-      CONTRACT_POLICY: {
-        MULTIPLE: {
-          TOTAL_MONTHS_OF_COVER,
-          TOTAL_SALES_TO_BUYER,
-          MAXIMUM_BUYER_WILL_OWE,
-        },
+  POLICY_AND_EXPORTS: {
+    TYPE_OF_POLICY: { POLICY_TYPE },
+    CONTRACT_POLICY: {
+      MULTIPLE: {
+        TOTAL_MONTHS_OF_COVER,
+        TOTAL_SALES_TO_BUYER,
+        MAXIMUM_BUYER_WILL_OWE,
       },
     },
   },
-} = FIELD_IDS;
-
-const { CONTRACT_POLICY: { MULTIPLE: MULTIPLE_FIELD_STRINGS } } = FIELDS;
+} = INSURANCE_FIELD_IDS;
 
 const { taskList } = partials.insurancePartials;
 
 const task = taskList.submitApplication.tasks.checkAnswers;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Change your answers - Policy and exports - Change single to multiple policy type - Summary List', () => {
-  const baseUrl = Cypress.config('baseUrl');
-  let url;
+  let checkYourAnswersUrl;
   let referenceNumber;
-  let allSectionsUrl;
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
@@ -56,11 +49,8 @@ context('Insurance - Change your answers - Policy and exports - Change single to
       // To get past "Eligibility" check your answers page
       cy.submitCheckYourAnswersForm();
 
-      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY}`;
-
-      cy.assertUrl(url);
-
-      allSectionsUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY}`;
+      cy.assertUrl(checkYourAnswersUrl);
     });
   });
 
@@ -72,108 +62,72 @@ context('Insurance - Change your answers - Policy and exports - Change single to
     cy.deleteApplication(referenceNumber);
   });
 
-  const fieldId = POLICY_TYPE;
+  let fieldId = POLICY_TYPE;
 
   describe('when clicking the `change` link', () => {
     beforeEach(() => {
-      cy.navigateToUrl(url);
+      cy.navigateToUrl(checkYourAnswersUrl);
+
+      summaryList.field(fieldId).changeLink().click();
     });
 
-    it(`should redirect to ${TYPE_OF_POLICY_CHECK_AND_CHANGE}`, () => {
-      cy.navigateToUrl(url);
-      summaryList.field(fieldId).changeLink().click();
-
-      const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY_CHECK_AND_CHANGE}#heading`;
+    it(`should redirect to ${TYPE_OF_POLICY_CHECK_AND_CHANGE} with heading anchor`, () => {
+      const expected = `${baseUrl}${ROOT}/${referenceNumber}${TYPE_OF_POLICY_CHECK_AND_CHANGE}#heading`;
 
       cy.assertUrl(expected);
     });
   });
 
-  describe('form submission with a new answer', () => {
-    beforeEach(() => {
-      cy.navigateToUrl(url);
+  describe('after submitting a new policy type (multiple) and completing (now required) fields for a multiple policy', () => {
+    it(`should redirect to ${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY}`, () => {
+      cy.navigateToUrl(checkYourAnswersUrl);
 
       summaryList.field(fieldId).changeLink().click();
 
       typeOfPolicyPage[fieldId].multiple.input().click();
       submitButton().click();
-    });
 
-    it(`should redirect to ${MULTIPLE_CONTRACT_POLICY}`, () => {
-      const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}#heading`;
-
-      cy.assertUrl(expected);
-    });
-  });
-
-  describe(`after completing (now required) fields in ${MULTIPLE_CONTRACT_POLICY} and proceeding to ${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY}`, () => {
-    beforeEach(() => {
-      cy.navigateToUrl(`${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}#heading`);
-
-      // complete the form/now required fields for a multiple contract policy
       cy.completeAndSubmitMultipleContractPolicyForm({});
 
-      cy.assertUrl(`${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}#heading`);
+      const expectedUrl = `${checkYourAnswersUrl}#heading`;
 
-      // go back to "all sections"
-      saveAndBackButton().click();
-
-      cy.assertUrl(allSectionsUrl);
+      cy.assertUrl(expectedUrl);
     });
 
-    it(`should render the new answer when navigating back to ${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY} from ${ALL_SECTIONS}`, () => {
-      cy.navigateToUrl(allSectionsUrl);
-      cy.assertUrl(allSectionsUrl);
-
-      // go into the "insurance - check your answers" section
-      task.link().click();
-
-      // submit check your answers - eligibility
-      submitButton().click();
-
-      cy.assertUrl(url);
-
-      const expected = FIELD_VALUES.POLICY_TYPE.MULTIPLE;
-      cy.assertSummaryListRowValueNew(summaryList, fieldId, expected);
-    });
-
-    describe('Updated summary list', () => {
+    describe('should render new answers and change links for new multiple policy fields', () => {
       beforeEach(() => {
-        cy.navigateToUrl(url);
+        cy.navigateToUrl(checkYourAnswersUrl);
       });
 
-      it('should render the new answers and `change` links to the newly submitted fields', () => {
-        const expectedTotalMonthsOfCover = `${String(application.POLICY_AND_EXPORTS[TOTAL_MONTHS_OF_COVER])} months`;
-
-        cy.assertSummaryListRowValueNew(summaryList, TOTAL_MONTHS_OF_COVER, expectedTotalMonthsOfCover);
-
-        cy.checkText(
-          summaryList.field(TOTAL_MONTHS_OF_COVER).changeLink(),
-          `${LINKS.CHANGE} ${MULTIPLE_FIELD_STRINGS[TOTAL_MONTHS_OF_COVER].SUMMARY.TITLE}`,
-        );
-
-        const expectedTotalSalesToBuyer = formatCurrency(application.POLICY_AND_EXPORTS[TOTAL_SALES_TO_BUYER]);
-
-        cy.assertSummaryListRowValueNew(summaryList, TOTAL_SALES_TO_BUYER, expectedTotalSalesToBuyer);
-
-        cy.checkText(
-          summaryList.field(TOTAL_SALES_TO_BUYER).changeLink(),
-          `${LINKS.CHANGE} ${MULTIPLE_FIELD_STRINGS[TOTAL_SALES_TO_BUYER].SUMMARY.TITLE}`,
-        );
-
-        const expectedMaximumBuyerWillOwe = formatCurrency(application.POLICY_AND_EXPORTS[MAXIMUM_BUYER_WILL_OWE]);
-
-        cy.assertSummaryListRowValueNew(summaryList, MAXIMUM_BUYER_WILL_OWE, expectedMaximumBuyerWillOwe);
-
-        cy.checkText(
-          summaryList.field(MAXIMUM_BUYER_WILL_OWE).changeLink(),
-          `${LINKS.CHANGE} ${MULTIPLE_FIELD_STRINGS[MAXIMUM_BUYER_WILL_OWE].SUMMARY.TITLE}`,
-        );
+      it(POLICY_TYPE, () => {
+        cy.assertSummaryListRowValueNew(summaryList, POLICY_TYPE, FIELD_VALUES.POLICY_TYPE.SINGLE);
       });
 
-      it(`'maximum buyer will owe' summary list row change link should redirect to ${MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE}`, () => {
+      it(TOTAL_MONTHS_OF_COVER, () => {
+        fieldId = TOTAL_MONTHS_OF_COVER;
+
+        const expectedValue = `${application.POLICY_AND_EXPORTS[fieldId]} months`;
+
+        cy.assertSummaryListRowValueNew(summaryList, fieldId, expectedValue);
+      });
+
+      it(TOTAL_SALES_TO_BUYER, () => {
+        fieldId = TOTAL_SALES_TO_BUYER;
+
+        const expectedValue = formatCurrency(application.POLICY_AND_EXPORTS[fieldId]);
+
+        cy.assertSummaryListRowValueNew(summaryList, fieldId, expectedValue);
+      });
+
+      it(`${MAXIMUM_BUYER_WILL_OWE} with different change link`, () => {
+        fieldId = MAXIMUM_BUYER_WILL_OWE;
+
+        const expectedMaximumBuyerWillOwe = formatCurrency(application.POLICY_AND_EXPORTS[fieldId]);
+
+        cy.assertSummaryListRowValueNew(summaryList, fieldId, expectedMaximumBuyerWillOwe);
+
+        // check the change link
         summaryList.field(MAXIMUM_BUYER_WILL_OWE).changeLink().click();
-
         cy.assertChangeAnswersPageUrl(referenceNumber, MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE, MAXIMUM_BUYER_WILL_OWE, 'label');
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-type-change-single-to-multiple-policy-type-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy-and-exports/change-your-answers/change-your-answers-policy-type-change-single-to-multiple-policy-type-summary-list.spec.js
@@ -100,7 +100,7 @@ context('Insurance - Change your answers - Policy and exports - Change single to
       });
 
       it(POLICY_TYPE, () => {
-        cy.assertSummaryListRowValueNew(summaryList, POLICY_TYPE, FIELD_VALUES.POLICY_TYPE.SINGLE);
+        cy.assertSummaryListRowValueNew(summaryList, POLICY_TYPE, FIELD_VALUES.POLICY_TYPE.MULTIPLE);
       });
 
       it(TOTAL_MONTHS_OF_COVER, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-about-goods-or-services.spec.js
@@ -22,8 +22,9 @@ const {
 } = FIELD_IDS;
 
 const { taskList } = partials.insurancePartials;
-
 const task = taskList.prepareApplication.tasks.policyTypeAndExports;
+
+const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Policy and exports - Change your answers - About goods or services- As an exporter, I want to change my answers to the type of policy and exports section', () => {
   let referenceNumber;
@@ -37,7 +38,7 @@ context('Insurance - Policy and exports - Change your answers - About goods or s
 
       cy.completePolicyAndExportSection({});
 
-      url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       cy.assertUrl(url);
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-change-policy-type-multiple-to-single.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-change-policy-type-multiple-to-single.spec.js
@@ -1,45 +1,44 @@
 import { submitButton, summaryList } from '../../../../../../pages/shared';
 import { typeOfPolicyPage } from '../../../../../../pages/insurance/policy-and-export';
 import partials from '../../../../../../partials';
-import { FIELD_IDS, FIELD_VALUES, ROUTES } from '../../../../../../constants';
+import { FIELD_VALUES } from '../../../../../../constants';
+import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { LINKS } from '../../../../../../content-strings';
 import { POLICY_AND_EXPORT_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy-and-exports';
-import { INSURANCE_ROOT } from '../../../../../../constants/routes/insurance';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { createTimestampFromNumbers, formatDate } from '../../../../../../helpers/date';
 import formatCurrency from '../../../../../../helpers/format-currency';
 import application from '../../../../../../fixtures/application';
 
 const {
+  ROOT,
   POLICY_AND_EXPORTS: {
     CHECK_YOUR_ANSWERS,
     TYPE_OF_POLICY_CHANGE,
     SINGLE_CONTRACT_POLICY_CHANGE,
-    SINGLE_CONTRACT_POLICY,
-    ABOUT_GOODS_OR_SERVICES,
   },
-} = ROUTES.INSURANCE;
+} = INSURANCE_ROUTES;
 
 const {
-  INSURANCE: {
-    POLICY_AND_EXPORTS: {
-      TYPE_OF_POLICY: { POLICY_TYPE },
-      CONTRACT_POLICY: {
-        SINGLE: { CONTRACT_COMPLETION_DATE, TOTAL_CONTRACT_VALUE },
-      },
+  POLICY_AND_EXPORTS: {
+    TYPE_OF_POLICY: { POLICY_TYPE },
+    CONTRACT_POLICY: {
+      SINGLE: { CONTRACT_COMPLETION_DATE, TOTAL_CONTRACT_VALUE },
     },
   },
-} = FIELD_IDS;
+} = INSURANCE_FIELD_IDS;
 
 const { CONTRACT_POLICY: { SINGLE: SINGLE_FIELD_STRINGS } } = FIELDS;
 
 const { taskList } = partials.insurancePartials;
-
 const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Policy and exports - Change your answers - Policy type - multiple to single', () => {
-  const baseUrl = Cypress.config('baseUrl');
   let referenceNumber;
   let checkYourAnswersUrl;
+  let typeOfPolicyUrl;
   let changeLinkHref;
 
   before(() => {
@@ -50,8 +49,11 @@ context('Insurance - Policy and exports - Change your answers - Policy type - mu
 
       cy.completePolicyAndExportSection({ policyType: FIELD_VALUES.POLICY_TYPE.MULTIPLE });
 
-      checkYourAnswersUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
-      changeLinkHref = `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_CHANGE}`;
+      const applicationRouteUrl = `${ROOT}/${referenceNumber}`;
+
+      checkYourAnswersUrl = `${baseUrl}${applicationRouteUrl}${CHECK_YOUR_ANSWERS}`;
+      typeOfPolicyUrl = `${baseUrl}${applicationRouteUrl}${TYPE_OF_POLICY_CHANGE}`;
+      changeLinkHref = `${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_CHANGE}`;
 
       cy.assertUrl(checkYourAnswersUrl);
     });
@@ -66,58 +68,47 @@ context('Insurance - Policy and exports - Change your answers - Policy type - mu
   });
 
   describe('when clicking the `change` link', () => {
-    it(`should redirect to ${TYPE_OF_POLICY_CHANGE}`, () => {
+    beforeEach(() => {
       cy.navigateToUrl(checkYourAnswersUrl);
 
       summaryList.field(POLICY_TYPE).changeLink().click();
+    });
 
-      const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY_CHANGE}#heading`;
+    it(`should redirect to ${TYPE_OF_POLICY_CHANGE} with heading anchor`, () => {
+      const expectedUrl = `${typeOfPolicyUrl}#heading`;
 
-      cy.assertUrl(expected);
+      cy.assertUrl(expectedUrl);
     });
   });
 
-  describe('form submission with a new answer', () => {
+  describe('after submitting a new policy type (single) and completing (now required) fields for a single policy', () => {
     beforeEach(() => {
       cy.navigateToUrl(checkYourAnswersUrl);
 
       summaryList.field(POLICY_TYPE).changeLink().click();
 
       typeOfPolicyPage[POLICY_TYPE].single.input().click();
-
       submitButton().click();
+
+      cy.completeAndSubmitSingleContractPolicyForm({});
     });
 
-    it(`should redirect to ${SINGLE_CONTRACT_POLICY}`, () => {
-      const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}#heading`;
+    it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+      const expectedUrl = `${checkYourAnswersUrl}#heading`;
 
-      cy.assertUrl(expected);
+      cy.assertUrl(expectedUrl);
     });
 
-    describe(`after completing (now required) fields in ${SINGLE_CONTRACT_POLICY} and proceeding to ${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY}`, () => {
+    describe('should render new answers and change links for new single policy fields', () => {
       beforeEach(() => {
-        cy.navigateToUrl(`${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}#heading`);
-
-        // complete the form/now required fields for a multiple contract policy
-        cy.completeAndSubmitSingleContractPolicyForm({});
-
-        cy.assertUrl(`${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}#heading`);
-
-        // proceed to "name on policy"
-        submitButton().click();
-        // proceed to "check your answers"
-        cy.completeAndSubmitNameOnPolicyForm({});
-
-        const expectedUrl = `${checkYourAnswersUrl}#heading`;
-
-        cy.assertUrl(expectedUrl);
+        cy.navigateToUrl(checkYourAnswersUrl);
       });
 
-      it(`should render the new answer for ${POLICY_TYPE}`, () => {
+      it(POLICY_TYPE, () => {
         cy.assertSummaryListRowValueNew(summaryList, POLICY_TYPE, FIELD_VALUES.POLICY_TYPE.SINGLE);
       });
 
-      it(`should render the new answer and 'change' links for ${CONTRACT_COMPLETION_DATE}`, () => {
+      it(CONTRACT_COMPLETION_DATE, () => {
         const fieldId = CONTRACT_COMPLETION_DATE;
         const newAnswer = application.POLICY_AND_EXPORTS[fieldId];
 
@@ -132,7 +123,7 @@ context('Insurance - Policy and exports - Change your answers - Policy type - mu
         );
       });
 
-      it(`should render the new answer and 'change' links for ${TOTAL_CONTRACT_VALUE}`, () => {
+      it(TOTAL_CONTRACT_VALUE, () => {
         const fieldId = TOTAL_CONTRACT_VALUE;
 
         const expectedTotalContractValue = formatCurrency(application.POLICY_AND_EXPORTS[fieldId]);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-change-policy-type-single-to-multiple.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-change-policy-type-single-to-multiple.spec.js
@@ -1,37 +1,35 @@
 import { submitButton, summaryList } from '../../../../../../pages/shared';
 import { typeOfPolicyPage } from '../../../../../../pages/insurance/policy-and-export';
 import partials from '../../../../../../partials';
-import { FIELD_IDS, FIELD_VALUES, ROUTES } from '../../../../../../constants';
+import { FIELD_VALUES } from '../../../../../../constants';
 import { LINKS } from '../../../../../../content-strings';
 import { POLICY_AND_EXPORT_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy-and-exports';
-import { INSURANCE_ROOT } from '../../../../../../constants/routes/insurance';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import formatCurrency from '../../../../../../helpers/format-currency';
 import application from '../../../../../../fixtures/application';
 
 const {
+  ROOT,
   POLICY_AND_EXPORTS: {
     CHECK_YOUR_ANSWERS,
     TYPE_OF_POLICY_CHANGE,
     MULTIPLE_CONTRACT_POLICY_CHANGE,
-    MULTIPLE_CONTRACT_POLICY,
-    ABOUT_GOODS_OR_SERVICES,
   },
-} = ROUTES.INSURANCE;
+} = INSURANCE_ROUTES;
 
 const {
-  INSURANCE: {
-    POLICY_AND_EXPORTS: {
-      TYPE_OF_POLICY: { POLICY_TYPE },
-      CONTRACT_POLICY: {
-        MULTIPLE: {
-          TOTAL_MONTHS_OF_COVER,
-          TOTAL_SALES_TO_BUYER,
-          MAXIMUM_BUYER_WILL_OWE,
-        },
+  POLICY_AND_EXPORTS: {
+    TYPE_OF_POLICY: { POLICY_TYPE },
+    CONTRACT_POLICY: {
+      MULTIPLE: {
+        TOTAL_MONTHS_OF_COVER,
+        TOTAL_SALES_TO_BUYER,
+        MAXIMUM_BUYER_WILL_OWE,
       },
     },
   },
-} = FIELD_IDS;
+} = INSURANCE_FIELD_IDS;
 
 const { CONTRACT_POLICY: { MULTIPLE: MULTIPLE_FIELD_STRINGS } } = FIELDS;
 
@@ -39,10 +37,12 @@ const { taskList } = partials.insurancePartials;
 
 const task = taskList.prepareApplication.tasks.policyTypeAndExports;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Policy and exports - Change your answers - Policy type - single to multiple', () => {
-  const baseUrl = Cypress.config('baseUrl');
   let referenceNumber;
   let checkYourAnswersUrl;
+  let typeOfPolicyUrl;
   let changeLinkHref;
 
   before(() => {
@@ -53,8 +53,11 @@ context('Insurance - Policy and exports - Change your answers - Policy type - si
 
       cy.completePolicyAndExportSection({});
 
-      checkYourAnswersUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
-      changeLinkHref = `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_CHANGE}`;
+      const applicationRouteUrl = `${ROOT}/${referenceNumber}`;
+
+      checkYourAnswersUrl = `${baseUrl}${applicationRouteUrl}${CHECK_YOUR_ANSWERS}`;
+      typeOfPolicyUrl = `${baseUrl}${applicationRouteUrl}${TYPE_OF_POLICY_CHANGE}`;
+      changeLinkHref = `${applicationRouteUrl}${MULTIPLE_CONTRACT_POLICY_CHANGE}`;
 
       cy.assertUrl(checkYourAnswersUrl);
     });
@@ -75,14 +78,14 @@ context('Insurance - Policy and exports - Change your answers - Policy type - si
       summaryList.field(POLICY_TYPE).changeLink().click();
     });
 
-    it(`should redirect to ${TYPE_OF_POLICY_CHANGE}`, () => {
-      const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY_CHANGE}#heading`;
+    it(`should redirect to ${TYPE_OF_POLICY_CHANGE} with heading anchor`, () => {
+      const expectedUrl = `${typeOfPolicyUrl}#heading`;
 
-      cy.assertUrl(expected);
+      cy.assertUrl(expectedUrl);
     });
   });
 
-  describe('form submission with a new answer', () => {
+  describe('after submitting a new policy type (multiple) and completing (now required) fields for a multiple policy', () => {
     beforeEach(() => {
       cy.navigateToUrl(checkYourAnswersUrl);
 
@@ -90,38 +93,26 @@ context('Insurance - Policy and exports - Change your answers - Policy type - si
 
       typeOfPolicyPage[POLICY_TYPE].multiple.input().click();
       submitButton().click();
+
+      cy.completeAndSubmitMultipleContractPolicyForm({});
     });
 
-    it(`should redirect to ${MULTIPLE_CONTRACT_POLICY}`, () => {
-      const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}#heading`;
+    it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+      const expectedUrl = `${checkYourAnswersUrl}#heading`;
 
-      cy.assertUrl(expected);
+      cy.assertUrl(expectedUrl);
     });
 
-    describe(`after completing (now required) fields in ${MULTIPLE_CONTRACT_POLICY} and proceeding to ${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY}`, () => {
+    describe('should render new answers and change links for new multiple policy fields', () => {
       beforeEach(() => {
-        cy.navigateToUrl(`${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}#heading`);
-
-        // complete the form/now required fields for a multiple contract policy
-        cy.completeAndSubmitMultipleContractPolicyForm({});
-
-        cy.assertUrl(`${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}#heading`);
-
-        // proceed to "name on policy"
-        submitButton().click();
-        // proceed to "check your answers"
-        cy.completeAndSubmitNameOnPolicyForm({});
-
-        const expectedUrl = `${checkYourAnswersUrl}#heading`;
-
-        cy.assertUrl(expectedUrl);
+        cy.navigateToUrl(checkYourAnswersUrl);
       });
 
-      it(`should render the new answer for ${POLICY_TYPE}`, () => {
+      it(POLICY_TYPE, () => {
         cy.assertSummaryListRowValueNew(summaryList, POLICY_TYPE, FIELD_VALUES.POLICY_TYPE.MULTIPLE);
       });
 
-      it(`should render the new answers and 'change' links for ${TOTAL_MONTHS_OF_COVER}`, () => {
+      it(TOTAL_MONTHS_OF_COVER, () => {
         const fieldId = TOTAL_MONTHS_OF_COVER;
 
         const expectedTotalMonthsOfCover = `${application.POLICY_AND_EXPORTS[fieldId]} months`;
@@ -135,7 +126,7 @@ context('Insurance - Policy and exports - Change your answers - Policy type - si
         );
       });
 
-      it(`should render the new answer and 'change' link for ${TOTAL_SALES_TO_BUYER}`, () => {
+      it(TOTAL_SALES_TO_BUYER, () => {
         const fieldId = TOTAL_SALES_TO_BUYER;
 
         const expectedTotalSalesToBuyer = formatCurrency(application.POLICY_AND_EXPORTS[fieldId]);
@@ -149,7 +140,7 @@ context('Insurance - Policy and exports - Change your answers - Policy type - si
         );
       });
 
-      it(`should render the new answer and 'change' link for ${MAXIMUM_BUYER_WILL_OWE}`, () => {
+      it(MAXIMUM_BUYER_WILL_OWE, () => {
         const fieldId = MAXIMUM_BUYER_WILL_OWE;
 
         const expectedMaximumBuyerWillOwe = formatCurrency(application.POLICY_AND_EXPORTS[fieldId]);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-multiple-contract-policy.spec.js
@@ -1,36 +1,38 @@
 import { field, submitButton, summaryList } from '../../../../../../pages/shared';
 import { multipleContractPolicyPage } from '../../../../../../pages/insurance/policy-and-export';
 import partials from '../../../../../../partials';
-import { FIELD_IDS, FIELD_VALUES, ROUTES } from '../../../../../../constants';
-import { INSURANCE_ROOT } from '../../../../../../constants/routes/insurance';
+import { FIELD_VALUES } from '../../../../../../constants';
+import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { createTimestampFromNumbers, formatDate } from '../../../../../../helpers/date';
 import formatCurrency from '../../../../../../helpers/format-currency';
 import application from '../../../../../../fixtures/application';
 import currencies from '../../../../../../fixtures/currencies';
 
 const {
+  ROOT,
   POLICY_AND_EXPORTS: {
     CHECK_YOUR_ANSWERS,
     MULTIPLE_CONTRACT_POLICY_CHANGE,
   },
-} = ROUTES.INSURANCE;
+} = INSURANCE_ROUTES;
 
 const {
-  INSURANCE: {
-    POLICY_AND_EXPORTS: {
-      CONTRACT_POLICY: {
-        REQUESTED_START_DATE,
-        CREDIT_PERIOD_WITH_BUYER,
-        POLICY_CURRENCY_CODE,
-        MULTIPLE: { TOTAL_MONTHS_OF_COVER, TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE },
-      },
+  POLICY_AND_EXPORTS: {
+    CONTRACT_POLICY: {
+      REQUESTED_START_DATE,
+      CREDIT_PERIOD_WITH_BUYER,
+      POLICY_CURRENCY_CODE,
+      MULTIPLE: { TOTAL_MONTHS_OF_COVER, TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE },
     },
   },
-} = FIELD_IDS;
+} = INSURANCE_FIELD_IDS;
 
 const { taskList, policyCurrencyCodeFormField } = partials.insurancePartials;
 
 const task = taskList.prepareApplication.tasks.policyTypeAndExports;
+
+const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Policy and exports - Change your answers - Multiple contract policy - As an exporter, I want to change my answers to the type of policy and exports section', () => {
   let referenceNumber;
@@ -44,7 +46,7 @@ context('Insurance - Policy and exports - Change your answers - Multiple contrac
 
       cy.completePolicyAndExportSection({ policyType: FIELD_VALUES.POLICY_TYPE.MULTIPLE });
 
-      url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       cy.assertUrl(url);
     });
   });
@@ -57,7 +59,7 @@ context('Insurance - Policy and exports - Change your answers - Multiple contrac
     cy.deleteApplication(referenceNumber);
   });
 
-  describe('single policy type answers', () => {
+  describe('multiple policy type answers', () => {
     describe(REQUESTED_START_DATE, () => {
       const fieldId = REQUESTED_START_DATE;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy-and-exports/change-your-answers/change-your-answers-single-contract-policy.spec.js
@@ -1,35 +1,36 @@
 import { field, submitButton, summaryList } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
-import { FIELD_IDS, ROUTES } from '../../../../../../constants';
-import { INSURANCE_ROOT } from '../../../../../../constants/routes/insurance';
+import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { createTimestampFromNumbers, formatDate } from '../../../../../../helpers/date';
 import formatCurrency from '../../../../../../helpers/format-currency';
 import application from '../../../../../../fixtures/application';
 import currencies from '../../../../../../fixtures/currencies';
 
 const {
+  ROOT,
   POLICY_AND_EXPORTS: {
     CHECK_YOUR_ANSWERS,
     SINGLE_CONTRACT_POLICY_CHANGE,
   },
-} = ROUTES.INSURANCE;
+} = INSURANCE_ROUTES;
 
 const {
-  INSURANCE: {
-    POLICY_AND_EXPORTS: {
-      CONTRACT_POLICY: {
-        REQUESTED_START_DATE,
-        CREDIT_PERIOD_WITH_BUYER,
-        POLICY_CURRENCY_CODE,
-        SINGLE: { CONTRACT_COMPLETION_DATE, TOTAL_CONTRACT_VALUE },
-      },
+  POLICY_AND_EXPORTS: {
+    CONTRACT_POLICY: {
+      REQUESTED_START_DATE,
+      CREDIT_PERIOD_WITH_BUYER,
+      POLICY_CURRENCY_CODE,
+      SINGLE: { CONTRACT_COMPLETION_DATE, TOTAL_CONTRACT_VALUE },
     },
   },
-} = FIELD_IDS;
+} = INSURANCE_FIELD_IDS;
 
 const { taskList, policyCurrencyCodeFormField } = partials.insurancePartials;
 
 const task = taskList.prepareApplication.tasks.policyTypeAndExports;
+
+const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Policy and exports - Change your answers - Single contract policy - As an exporter, I want to change my answers to the type of policy and exports section', () => {
   let referenceNumber;
@@ -43,7 +44,7 @@ context('Insurance - Policy and exports - Change your answers - Single contract 
 
       cy.completePolicyAndExportSection({});
 
-      url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       cy.assertUrl(url);
     });
   });

--- a/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy-and-export/type-of-policy/index.ts
@@ -115,7 +115,7 @@ export const post = async (req: Request, res: Response) => {
 
     /**
      * If the route is a "change" route,
-     * redirect to the appropriate "change" route (single or multiple policy route)
+     * redirect to the appropriate "change" route (single or multiple policy route).
      */
     if (isChangeRoute(req.originalUrl)) {
       if (isSinglePolicyType(payload[FIELD_ID])) {
@@ -129,11 +129,9 @@ export const post = async (req: Request, res: Response) => {
 
     /**
      * If the route is a "check and change" route,
-     * redirect to the application's "check your answers - policy type" (single or multiple policy route)
+     * redirect to the application's "check your answers - policy type" (single or multiple) route.
      */
     if (isCheckAndChangeRoute(req.originalUrl)) {
-      // return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`);
-
       if (isSinglePolicyType(payload[FIELD_ID])) {
         return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_CHECK_AND_CHANGE}`);
       }


### PR DESCRIPTION
## Introduction ✏️ 
This PR simplifies the policy and export user flow, when a user changes the policy type from "single" to "multiple" and vice versa.

Previously, after changing a policy type, a user would have to complete the entire policy and export section when only 1 additional form is required.

Now, when the 1 additional form is submitted, we redirect the user back to the relevant "check your answers" page.


## Resolution ✔️ 
- Update the UI's "type of policy" controller to, depending on `req.originalUrl`:
  - Redirect to "single/multiple policy page" with an additional `/change` in the URL.
  - Redirect to an application's "check your answers - policy type".
- Update E2E tests.

## Miscellaneous ➕
- Various destructuring improvements.
- Simplify some E2E test coverage.
- Add some missing test coverage.