### PR TITLE
fix(EMS-2083-2084-2089): Name on policy - Bug fixes

### DIFF
--- a/e2e-tests/content-strings/fields/insurance/policy/index.js
+++ b/e2e-tests/content-strings/fields/insurance/policy/index.js
@@ -169,14 +169,14 @@ export const POLICY_FIELDS = {
       },
     },
     [NAME_ON_POLICY.POSITION]: {
-      LABEL: "What's your position at the company",
+      LABEL: "What's your position at the company?",
       SUMMARY: {
         TITLE: 'Position at company',
       },
     },
     [NAME_ON_POLICY.NAME]: {
       SUMMARY: {
-        TITLE: 'Name on policy',
+        TITLE: 'Name on the policy',
       },
     },
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
@@ -4,6 +4,7 @@ import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
+import { POLICY_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
 import account from '../../../../../../../fixtures/account';
 
 const { taskList } = partials.insurancePartials;
@@ -105,6 +106,10 @@ context('Insurance - Policy - Name on policy - Validation', () => {
     it(`should render the ${SAME_NAME} radio text`, () => {
       const nameAndEmail = `${account[FIRST_NAME]} ${account[LAST_NAME]} (${account[EMAIL]})`;
       cy.checkText(field(SAME_NAME).label(), nameAndEmail);
+    });
+
+    it(`should render the ${OTHER_NAME} radio text`, () => {
+      cy.checkText(field(OTHER_NAME).label(), FIELDS.NAME_ON_POLICY.OPTIONS.OTHER_NAME.TEXT);
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
@@ -1,30 +1,34 @@
 import { field } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import { FIELD_IDS, FIELD_VALUES, ROUTES } from '../../../../../../../constants';
+import { FIELD_VALUES } from '../../../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
+import account from '../../../../../../../fixtures/account';
 
 const { taskList } = partials.insurancePartials;
 
 const {
-  INSURANCE: {
-    ROOT: INSURANCE_ROOT,
-    POLICY: {
-      CHECK_YOUR_ANSWERS,
-      DIFFERENT_NAME_ON_POLICY,
-      NAME_ON_POLICY,
-    },
+  ROOT: INSURANCE_ROOT,
+  POLICY: {
+    CHECK_YOUR_ANSWERS,
+    DIFFERENT_NAME_ON_POLICY,
+    NAME_ON_POLICY,
   },
-} = ROUTES;
+} = INSURANCE_ROUTES;
 
 const {
-  INSURANCE: {
-    POLICY: {
-      NAME_ON_POLICY: {
-        NAME, POSITION, SAME_NAME, OTHER_NAME,
-      },
+  POLICY: {
+    NAME_ON_POLICY: {
+      NAME, POSITION, SAME_NAME, OTHER_NAME,
     },
   },
-} = FIELD_IDS;
+  ACCOUNT: {
+    FIRST_NAME,
+    LAST_NAME,
+    EMAIL,
+  },
+} = INSURANCE_FIELD_IDS;
 
 const NAME_ON_POLICY_ERRORS = ERROR_MESSAGES.INSURANCE.POLICY.NAME_ON_POLICY;
 
@@ -80,11 +84,11 @@ context('Insurance - Policy - Name on policy - Validation', () => {
   describe(`${POSITION} not entered`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
+
+      field(SAME_NAME).input().click();
     });
 
     it('should display validation error', () => {
-      field(SAME_NAME).input().click();
-
       const expectedErrorsCount = 1;
       const expectedErrorMessage = NAME_ON_POLICY_ERRORS[POSITION].IS_EMPTY;
 
@@ -96,6 +100,11 @@ context('Insurance - Policy - Name on policy - Validation', () => {
         expectedErrorMessage,
         false,
       );
+    });
+
+    it(`should render the ${SAME_NAME} radio text`, () => {
+      const nameAndEmail = `${account[FIRST_NAME]} ${account[LAST_NAME]} (${account[EMAIL]})`;
+      cy.checkText(field(SAME_NAME).label(), nameAndEmail);
     });
   });
 

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -3914,7 +3914,7 @@ var XLSX = {
   SECTION_TITLES: {
     KEY_INFORMATION: "Key information",
     EXPORTER_CONTACT_DETAILS: "Exporter contact details",
-    POLICY: "Type of policy",
+    POLICY: "Type of policy and exports",
     EXPORTER_BUSINESS: "About your business",
     BUYER: "Your buyer",
     ELIGIBILITY: "Eligibility"

--- a/src/ui/server/content-strings/fields/insurance/policy/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy/index.ts
@@ -162,14 +162,14 @@ export const POLICY_FIELDS = {
       },
     },
     [NAME_ON_POLICY.POSITION]: {
-      LABEL: "What's your position at the company",
+      LABEL: "What's your position at the company?",
       SUMMARY: {
         TITLE: 'Position at company',
       },
     },
     [NAME_ON_POLICY.NAME]: {
       SUMMARY: {
-        TITLE: 'Name on policy',
+        TITLE: 'Name on the policy',
       },
     },
   },

--- a/src/ui/server/controllers/insurance/policy/name-on-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/name-on-policy/index.test.ts
@@ -227,6 +227,12 @@ describe('controllers/insurance/policy/name-on-policy', () => {
         await post(req, res);
 
         const payload = constructPayload(req.body, FIELD_IDS);
+        const nameOfOwner = getNameEmailPositionFromOwnerAndPolicy(mockApplication.owner, mockApplication.policyContact);
+
+        const submittedValues = {
+          ...nameOfOwner,
+          ...payload,
+        };
 
         const expectedVariables = {
           ...insuranceCorePageVariables({
@@ -236,7 +242,7 @@ describe('controllers/insurance/policy/name-on-policy', () => {
           ...pageVariables(refNumber),
           userName: getUserNameFromSession(req.session.user),
           application: mockApplication,
-          submittedValues: payload,
+          submittedValues,
           validationErrors: generateValidationErrors(payload),
         };
 

--- a/src/ui/server/controllers/insurance/policy/name-on-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy/name-on-policy/index.ts
@@ -105,7 +105,7 @@ export const post = async (req: Request, res: Response) => {
   if (validationErrors) {
     /**
      * have to get name of owner to render radio (radio uses name and email of owner)
-     * combine with payload to ensure name shows on radio and submitted value before validatione error
+     * combine submitted answers with the payload to ensure that the name shows on the radio
      */
     const nameOfOwner = getNameEmailPositionFromOwnerAndPolicy(application.owner, application.policyContact);
 

--- a/src/ui/server/controllers/insurance/policy/name-on-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy/name-on-policy/index.ts
@@ -103,6 +103,17 @@ export const post = async (req: Request, res: Response) => {
   const validationErrors = generateValidationErrors(payload);
 
   if (validationErrors) {
+    /**
+     * have to get name of owner to render radio (radio uses name and email of owner)
+     * combine with payload to ensure name shows on radio and submitted value before validatione error
+     */
+    const nameOfOwner = getNameEmailPositionFromOwnerAndPolicy(application.owner, application.policyContact);
+
+    const submittedValues = {
+      ...nameOfOwner,
+      ...payload,
+    };
+
     return res.render(TEMPLATE, {
       ...insuranceCorePageVariables({
         PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.NAME_ON_POLICY,
@@ -111,7 +122,7 @@ export const post = async (req: Request, res: Response) => {
       ...pageVariables(refNumber),
       userName: getUserNameFromSession(req.session.user),
       application,
-      submittedValues: payload,
+      submittedValues,
       validationErrors,
     });
   }


### PR DESCRIPTION
## Introduction ✏️ 
This PR fixes various bugs on name on policy page / summary list
[EMS-2083](https://ukef-dtfs.atlassian.net/browse/EMS-2083) - Missing question mark at end of label
[EMS-2084](https://ukef-dtfs.atlassian.net/browse/EMS-2084) - Owner name and radio would disappear if validation error
[EMS-2089](https://ukef-dtfs.atlassian.net/browse/EMS-2089) - Summary list was missing `the`



## Resolution ✔️ 
* Fixed typo bugs
* fixed radio disappearing by combining name from owner and payload when rendering template in post controller
* Updated and added e2e test and unit test