### PR TITLE
fix(EMS-2088): Application submission - XLSX mapping

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -4239,7 +4239,7 @@ var {
   COMPANIES_HOUSE_NUMBER: COMPANIES_HOUSE_NUMBER2
 } = insurance_default.ELIGIBILITY;
 var mapEligibility = (application2) => {
-  const { eligibility } = application2;
+  const { eligibility, policy } = application2;
   const mapped = [
     xlsx_row_default(XLSX.SECTION_TITLES.ELIGIBILITY, ""),
     xlsx_row_default(FIELDS_ELIGIBILITY[BUYER_COUNTRY2].SUMMARY?.TITLE, eligibility[BUYER_COUNTRY2].name),
@@ -4249,7 +4249,7 @@ var mapEligibility = (application2) => {
     xlsx_row_default(FIELDS_ELIGIBILITY[WANT_COVER_OVER_MAX_PERIOD2].SUMMARY?.TITLE, map_yes_no_field_default(eligibility[WANT_COVER_OVER_MAX_PERIOD2])),
     xlsx_row_default(FIELDS_ELIGIBILITY[OTHER_PARTIES_INVOLVED2].SUMMARY?.TITLE, map_yes_no_field_default(eligibility[OTHER_PARTIES_INVOLVED2])),
     xlsx_row_default(FIELDS_ELIGIBILITY[LETTER_OF_CREDIT2].SUMMARY?.TITLE, map_yes_no_field_default(eligibility[LETTER_OF_CREDIT2])),
-    xlsx_row_default(FIELDS_ELIGIBILITY[PRE_CREDIT_PERIOD2].SUMMARY?.TITLE, map_yes_no_field_default(eligibility[PRE_CREDIT_PERIOD2])),
+    xlsx_row_default(FIELDS_ELIGIBILITY[PRE_CREDIT_PERIOD2].SUMMARY?.TITLE, map_yes_no_field_default(policy[PRE_CREDIT_PERIOD2])),
     xlsx_row_default(FIELDS_ELIGIBILITY[COMPANIES_HOUSE_NUMBER2].SUMMARY?.TITLE, map_yes_no_field_default(eligibility[COMPANIES_HOUSE_NUMBER2]))
   ];
   return mapped;

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-eligibility/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-eligibility/index.test.ts
@@ -22,7 +22,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-eligibility', () => {
   it('should return an array of mapped buyer fields', () => {
     const result = mapEligibility(mockApplication);
 
-    const { eligibility } = mockApplication;
+    const { eligibility, policy } = mockApplication;
 
     const expected = [
       xlsxRow(XLSX.SECTION_TITLES.ELIGIBILITY, ''),
@@ -33,7 +33,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-eligibility', () => {
       xlsxRow(CONTENT_STRINGS[WANT_COVER_OVER_MAX_PERIOD].SUMMARY?.TITLE, mapYesNoField(eligibility[WANT_COVER_OVER_MAX_PERIOD])),
       xlsxRow(CONTENT_STRINGS[OTHER_PARTIES_INVOLVED].SUMMARY?.TITLE, mapYesNoField(eligibility[OTHER_PARTIES_INVOLVED])),
       xlsxRow(CONTENT_STRINGS[LETTER_OF_CREDIT].SUMMARY?.TITLE, mapYesNoField(eligibility[LETTER_OF_CREDIT])),
-      xlsxRow(CONTENT_STRINGS[PRE_CREDIT_PERIOD].SUMMARY?.TITLE, mapYesNoField(eligibility[PRE_CREDIT_PERIOD])),
+      xlsxRow(CONTENT_STRINGS[PRE_CREDIT_PERIOD].SUMMARY?.TITLE, mapYesNoField(policy[PRE_CREDIT_PERIOD])),
       xlsxRow(CONTENT_STRINGS[COMPANIES_HOUSE_NUMBER].SUMMARY?.TITLE, mapYesNoField(eligibility[COMPANIES_HOUSE_NUMBER])),
     ];
 

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-eligibility/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-eligibility/index.ts
@@ -24,7 +24,7 @@ const {
  * @returns {Array} Array of objects for XLSX generation
  */
 const mapEligibility = (application: Application) => {
-  const { eligibility } = application;
+  const { eligibility, policy } = application;
 
   const mapped = [
     xlsxRow(XLSX.SECTION_TITLES.ELIGIBILITY, ''),
@@ -35,7 +35,7 @@ const mapEligibility = (application: Application) => {
     xlsxRow(CONTENT_STRINGS[WANT_COVER_OVER_MAX_PERIOD].SUMMARY?.TITLE, mapYesNoField(eligibility[WANT_COVER_OVER_MAX_PERIOD])),
     xlsxRow(CONTENT_STRINGS[OTHER_PARTIES_INVOLVED].SUMMARY?.TITLE, mapYesNoField(eligibility[OTHER_PARTIES_INVOLVED])),
     xlsxRow(CONTENT_STRINGS[LETTER_OF_CREDIT].SUMMARY?.TITLE, mapYesNoField(eligibility[LETTER_OF_CREDIT])),
-    xlsxRow(CONTENT_STRINGS[PRE_CREDIT_PERIOD].SUMMARY?.TITLE, mapYesNoField(eligibility[PRE_CREDIT_PERIOD])),
+    xlsxRow(CONTENT_STRINGS[PRE_CREDIT_PERIOD].SUMMARY?.TITLE, mapYesNoField(policy[PRE_CREDIT_PERIOD])),
     xlsxRow(CONTENT_STRINGS[COMPANIES_HOUSE_NUMBER].SUMMARY?.TITLE, mapYesNoField(eligibility[COMPANIES_HOUSE_NUMBER])),
   ];
 


### PR DESCRIPTION
## Introduction ✏️ 
After some data changes (moving a field from `eligibility` into `policy`), one field/row in the XLSX that's generated on application submission is no longer mapped correctly.

## Resolution ✔️ 
- Update "map policy" function to reference the correct object.