### PR TITLE
fix(alert-condition): condition updated to average 99 over 5 minutes

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -748,19 +748,19 @@ jobs:
             az monitor metrics alert condition create \
             --type static \
             --dimension "_where_ OriginGroup includes ui" \
-            --aggregation Minimum \
+            --aggregation Average \
             --metric OriginHealthPercentage \
-            --operator LessThan \
-            --threshold 100 \
+            --operator LessThanOrEqual \
+            --threshold 99 \
             --num-periods 1 \
-            --num-violations 1 \
+            --num-violations 5 \
             --sensitivity High
 
             # Alert
             az monitor metrics alert create \
             --name alert-healthcheck-${{ env.PRODUCT }}-${{ env.TARGET }}-${{ vars.VERSION }} \
             --description "1 minute health check" \
-            --condition  "min 'OriginHealthPercentage' < 100.0 where OriginGroup includes ui" \
+            --condition  "avg 'OriginHealthPercentage' <= 99.0 where OriginGroup includes ui" \
             --scope $(az afd profile list --query [].id -o tsv) \
             --action $(az monitor action-group list --query [].id -o tsv) \
             --auto-mitigate true \


### PR DESCRIPTION
## Introduction ✏️ 
Rectify alert condition to avoid constant alert condition trigger, ensure availability is always over `99%`.

## Resolution ✔️ 
* Aggregation set to `Average`.
* Operator set to `Less then or equal to`.
* Operand set to `99%`.
* Timeframe set to `5 minute`.

## Note 🗒️ 
* If the average origin health dips below `99%` over 5 minutes duration on every 1 minute check then an alert group will be triggered. It has not been set to `100%` due to occasional rate-limiter threshold exceed thus reducing the average to `99.8%`.