### PR TITLE
fix(EMS-2206): Application submission - XLSX eligibility yes/no answers

### DIFF
--- a/src/api/generate-xlsx/map-application-to-XLSX/map-eligibility/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-eligibility/index.test.ts
@@ -26,7 +26,7 @@ const { MORE_THAN_2_YEARS } = COVER_PERIOD;
 const { MORE_THAN_500K } = TOTAL_CONTRACT_VALUE;
 
 describe('api/generate-xlsx/map-application-to-xlsx/map-eligibility', () => {
-  it('should return an array of mapped buyer fields', () => {
+  it('should return an array of mapped eligibility fields', () => {
     const result = mapEligibility(mockApplication);
 
     const { eligibility, policy } = mockApplication;

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-eligibility/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-eligibility/index.ts
@@ -32,7 +32,7 @@ const { MORE_THAN_500K } = TOTAL_CONTRACT_VALUE;
  */
 const mapEligibility = (application: Application) => {
   const { eligibility, policy } = application;
-
+  
   const mapped = [
     xlsxRow(XLSX.SECTION_TITLES.ELIGIBILITY, ''),
     xlsxRow(CONTENT_STRINGS[BUYER_COUNTRY].SUMMARY?.TITLE, eligibility[BUYER_COUNTRY].name),

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-eligibility/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-eligibility/index.ts
@@ -32,7 +32,7 @@ const { MORE_THAN_500K } = TOTAL_CONTRACT_VALUE;
  */
 const mapEligibility = (application: Application) => {
   const { eligibility, policy } = application;
-  
+
   const mapped = [
     xlsxRow(XLSX.SECTION_TITLES.ELIGIBILITY, ''),
     xlsxRow(CONTENT_STRINGS[BUYER_COUNTRY].SUMMARY?.TITLE, eligibility[BUYER_COUNTRY].name),

--- a/src/ui/server/helpers/map-cover-period-id/index.test.ts
+++ b/src/ui/server/helpers/map-cover-period-id/index.test.ts
@@ -3,19 +3,19 @@ import { COVER_PERIOD } from '../../constants';
 
 describe('server/helpers/map-credit-period-id', () => {
   describe('when the provided answer is a true boolean', () => {
-    it(`should return "${COVER_PERIOD.LESS_THAN_2_YEARS.DB_ID}"`, () => {
+    it(`should return "${COVER_PERIOD.MORE_THAN_2_YEARS.DB_ID}"`, () => {
       const result = mapTotalContractValue(true);
 
-      const expected = COVER_PERIOD.LESS_THAN_2_YEARS.DB_ID;
+      const expected = COVER_PERIOD.MORE_THAN_2_YEARS.DB_ID;
       expect(result).toEqual(expected);
     });
   });
 
   describe('when the provided answer is a false boolean', () => {
-    it(`should return "${COVER_PERIOD.MORE_THAN_2_YEARS.DB_ID}"`, () => {
+    it(`should return "${COVER_PERIOD.LESS_THAN_2_YEARS.DB_ID}"`, () => {
       const result = mapTotalContractValue(false);
 
-      const expected = COVER_PERIOD.MORE_THAN_2_YEARS.DB_ID;
+      const expected = COVER_PERIOD.LESS_THAN_2_YEARS.DB_ID;
       expect(result).toEqual(expected);
     });
   });

--- a/src/ui/server/helpers/map-cover-period-id/index.ts
+++ b/src/ui/server/helpers/map-cover-period-id/index.ts
@@ -5,6 +5,6 @@ import { COVER_PERIOD } from '../../constants';
  * @param {Boolean} answer: cover period answer
  * @returns {Number} cover period DB ID
  */
-export const mapCoverPeriodId = (answer: boolean) => (answer ? COVER_PERIOD.LESS_THAN_2_YEARS.DB_ID : COVER_PERIOD.MORE_THAN_2_YEARS.DB_ID);
+export const mapCoverPeriodId = (answer: boolean) => (answer ? COVER_PERIOD.MORE_THAN_2_YEARS.DB_ID : COVER_PERIOD.LESS_THAN_2_YEARS.DB_ID);
 
 export default mapCoverPeriodId;

--- a/src/ui/server/helpers/map-total-contract-value/index.test.ts
+++ b/src/ui/server/helpers/map-total-contract-value/index.test.ts
@@ -3,19 +3,19 @@ import { TOTAL_CONTRACT_VALUE } from '../../constants';
 
 describe('server/helpers/map-total-contract-value', () => {
   describe('when the provided answer is a true boolean', () => {
-    it(`should return "${TOTAL_CONTRACT_VALUE.LESS_THAN_500K.DB_ID}"`, () => {
+    it(`should return "${TOTAL_CONTRACT_VALUE.MORE_THAN_500K.DB_ID}"`, () => {
       const result = mapTotalContractValue(true);
 
-      const expected = TOTAL_CONTRACT_VALUE.LESS_THAN_500K.DB_ID;
+      const expected = TOTAL_CONTRACT_VALUE.MORE_THAN_500K.DB_ID;
       expect(result).toEqual(expected);
     });
   });
 
   describe('when the provided answer is a false boolean', () => {
-    it(`should return "${TOTAL_CONTRACT_VALUE.MORE_THAN_500K.DB_ID}"`, () => {
+    it(`should return "${TOTAL_CONTRACT_VALUE.LESS_THAN_500K.DB_ID}"`, () => {
       const result = mapTotalContractValue(false);
 
-      const expected = TOTAL_CONTRACT_VALUE.MORE_THAN_500K.DB_ID;
+      const expected = TOTAL_CONTRACT_VALUE.LESS_THAN_500K.DB_ID;
       expect(result).toEqual(expected);
     });
   });

--- a/src/ui/server/helpers/map-total-contract-value/index.ts
+++ b/src/ui/server/helpers/map-total-contract-value/index.ts
@@ -5,6 +5,6 @@ import { TOTAL_CONTRACT_VALUE } from '../../constants';
  * @param {Boolean} answer: total contract value answer
  * @returns {Number} Total contract value DB ID
  */
-export const mapTotalContractValue = (answer: boolean) => (answer ? TOTAL_CONTRACT_VALUE.LESS_THAN_500K.DB_ID : TOTAL_CONTRACT_VALUE.MORE_THAN_500K.DB_ID);
+export const mapTotalContractValue = (answer: boolean) => (answer ? TOTAL_CONTRACT_VALUE.MORE_THAN_500K.DB_ID : TOTAL_CONTRACT_VALUE.LESS_THAN_500K.DB_ID);
 
 export default mapTotalContractValue;


### PR DESCRIPTION
## Introduction ✏️ 
2x "yes/no" answer fields in the XLSX generated on application submission were incorrectly mapped after some recent data chagnes.

## Resolution ✔️ 
* Swap the UI mappings for `mapCoverPeriodId` and `mapTotalContractValue`.

## Miscellaneous ➕
- Fixed some typos.