### PR TITLE
chore(deps): Bump express-rate-limit

### DIFF
--- a/src/api/package-lock.json
+++ b/src/api/package-lock.json
@@ -25,7 +25,7 @@
         "date-fns": "^2.30.0",
         "dotenv": "16.3.1",
         "exceljs": "^4.4.0",
-        "express-rate-limit": "^6.11.2",
+        "express-rate-limit": "^7.1.4",
         "jsonwebtoken": "^9.0.2",
         "notifications-node-client": "^7.0.3",
         "otplib": "^12.0.1",
@@ -12263,14 +12263,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.11.2.tgz",
-      "integrity": "sha512-a7uwwfNTh1U60ssiIkuLFWHt4hAC5yxlLGU2VP0X4YNlyEDZAqF4tK3GD3NSitVBrCQmQ0++0uOyFOgC2y4DDw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.1.4.tgz",
+      "integrity": "sha512-mv/6z+EwnWpr+MjGVavMGvM4Tl8S/tHmpl9ZsDfrQeHpYy4Hfr0UYdKEf9OOTe280oIr70yPxLRmQ6MfINfJDw==",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 16"
       },
       "peerDependencies": {
-        "express": "^4 || ^5"
+        "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express/node_modules/body-parser": {

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -38,7 +38,7 @@
     "date-fns": "^2.30.0",
     "dotenv": "16.3.1",
     "exceljs": "^4.4.0",
-    "express-rate-limit": "^6.11.2",
+    "express-rate-limit": "^7.1.4",
     "jsonwebtoken": "^9.0.2",
     "notifications-node-client": "^7.0.3",
     "otplib": "^12.0.1",

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -37,7 +37,7 @@
         "date-fns": "^2.30.0",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
-        "express-rate-limit": "^6.11.2",
+        "express-rate-limit": "^7.1.4",
         "express-session": "^1.17.3",
         "google-libphonenumber": "^3.2.33",
         "govuk-frontend": "^4.7.0",
@@ -6911,14 +6911,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.11.2.tgz",
-      "integrity": "sha512-a7uwwfNTh1U60ssiIkuLFWHt4hAC5yxlLGU2VP0X4YNlyEDZAqF4tK3GD3NSitVBrCQmQ0++0uOyFOgC2y4DDw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.1.4.tgz",
+      "integrity": "sha512-mv/6z+EwnWpr+MjGVavMGvM4Tl8S/tHmpl9ZsDfrQeHpYy4Hfr0UYdKEf9OOTe280oIr70yPxLRmQ6MfINfJDw==",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 16"
       },
       "peerDependencies": {
-        "express": "^4 || ^5"
+        "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express-session": {

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -50,7 +50,7 @@
     "date-fns": "^2.30.0",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "express-rate-limit": "^6.11.2",
+    "express-rate-limit": "^7.1.4",
     "express-session": "^1.17.3",
     "google-libphonenumber": "^3.2.33",
     "govuk-frontend": "^4.7.0",


### PR DESCRIPTION
## Introduction ✏️ 
- Dependabot flagged some dependency updates.

## Resolution ✔️ 
- Update `express-rate-limit`.