### PR TITLE
feat(EMS-2100-2106-2261): No PDF - Eligibility - Exporter location and exit page content updates

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -59,7 +59,7 @@ export const ERROR_MESSAGES = {
         IS_EMPTY: `Select whether you want to be insured for longer than ${ELIGIBILITY.MAX_COVER_PERIOD_YEARS} years`,
       },
       [FIELD_IDS.INSURANCE.ELIGIBILITY.HAS_COMPANIES_HOUSE_NUMBER]: {
-        IS_EMPTY: 'Select whether you have a UK Companies House registration number or not',
+        IS_EMPTY: 'Select whether you have a UK Companies House number and whether your company is actively trading',
       },
       [FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER]: {
         IS_EMPTY: 'Enter a recognised Companies House number',

--- a/e2e-tests/content-strings/fields/index.js
+++ b/e2e-tests/content-strings/fields/index.js
@@ -31,6 +31,7 @@ export const FIELDS = {
     },
   },
   [FIELD_IDS.ELIGIBILITY.VALID_EXPORTER_LOCATION]: {
+    HINT: 'UKEF provides credit insurance for payments from overseas territories.',
     SUMMARY: {
       TITLE: 'Your company',
     },

--- a/e2e-tests/content-strings/pages/index.js
+++ b/e2e-tests/content-strings/pages/index.js
@@ -10,7 +10,7 @@ const BUYER_COUNTRY = {
 };
 
 const EXPORTER_LOCATION = {
-  PAGE_TITLE: 'Are you exporting from a business base inside the UK, Channel Islands or Isle of Man?',
+  PAGE_TITLE: 'Are you exporting from the UK, Channel Islands or Isle of Man?',
 };
 
 const UK_GOODS_OR_SERVICES = {
@@ -21,7 +21,7 @@ const CANNOT_APPLY = {
   PAGE_TITLE: 'You cannot apply for UKEF export insurance',
   REASON: {
     INTRO: 'This is because',
-    UNSUPPORTED_COMPANY_COUNTRY: 'your company is not based in the UK, Channel Islands or Isle of Man.',
+    UNSUPPORTED_COMPANY_COUNTRY: "you're not exporting from a business base in the UK, Channel Islands or Isle of Man.We can only provide cover for UK businesses.",
     UNSUPPORTED_BUYER_COUNTRY_1: 'your buyer is based in',
     UNSUPPORTED_BUYER_COUNTRY_2: 'which we cannot provide cover for.',
     NOT_ENOUGH_UK_GOODS_OR_SERVICES: 'your export contract value is not made up from at least 20% UK goods or services.',

--- a/e2e-tests/content-strings/pages/quote.js
+++ b/e2e-tests/content-strings/pages/quote.js
@@ -34,7 +34,7 @@ const CANNOT_APPLY = {
   PAGE_TITLE: 'You cannot apply for UKEF export insurance',
   REASON: {
     INTRO: 'This is because',
-    UNSUPPORTED_COMPANY_COUNTRY: 'your company is not based in the UK, Channel Islands or Isle of Man.',
+    UNSUPPORTED_COMPANY_COUNTRY: "you're not exporting from a business base in the UK, Channel Islands or Isle of Man.We can only provide cover for UK businesses.",
     UNSUPPORTED_BUYER_COUNTRY_1: 'your buyer is based in',
     UNSUPPORTED_BUYER_COUNTRY_2: 'which we cannot provide cover for.',
     NOT_ENOUGH_UK_GOODS_OR_SERVICES: 'your export contract value is not made up from at least 20% UK goods or services.',

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-page.spec.js
@@ -65,6 +65,10 @@ context('Insurance Eligibility - Cannot apply exit page', () => {
     it('should render `contact an approved broker` copy and link', () => {
       cy.checkActionContactApprovedBroker();
     });
+
+    it('should render `talk to your nearest EFM` copy and link', () => {
+      cy.checkActionTalkToYourNearestEFM();
+    });
   });
 
   describe('when clicking `eligibility` link', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
@@ -1,7 +1,12 @@
 import {
-  yesRadio, yesRadioInput, noRadio, submitButton,
+  yesRadio,
+  yesRadioInput,
+  yesNoRadioHint,
+  noRadio,
+  submitButton,
 } from '../../../../../../pages/shared';
 import { PAGES, ERROR_MESSAGES } from '../../../../../../content-strings';
+import { FIELDS } from '../../../../../../content-strings/fields';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -42,6 +47,10 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
       backLink: CHECK_IF_ELIGIBLE,
       assertAuthenticatedHeader: false,
     });
+  });
+
+  it('renders a hint', () => {
+    cy.checkText(yesNoRadioHint(), FIELDS[FIELD_ID].HINT);
   });
 
   it('renders `yes` radio button', () => {

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
@@ -59,6 +59,10 @@ context('Cannot apply exit page', () => {
     it('should render `contact an approved broker` copy and link', () => {
       cy.checkActionContactApprovedBroker();
     });
+
+    it('should render `talk to your nearest EFM` copy and link', () => {
+      cy.checkActionTalkToYourNearestEFM();
+    });
   });
 
   describe('when clicking `eligibility` link', () => {

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
@@ -1,9 +1,11 @@
 import {
   yesRadio,
+  yesNoRadioHint,
   noRadio,
   submitButton,
 } from '../../../../../../pages/shared';
 import { PAGES, ERROR_MESSAGES } from '../../../../../../content-strings';
+import { FIELDS } from '../../../../../../content-strings/fields';
 import { ROUTES, FIELD_IDS, FIELD_VALUES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../../commands/forms';
 import { completeAndSubmitBuyerBodyForm } from '../../../../../../commands/quote/forms';
@@ -43,6 +45,10 @@ context('Exporter location page - as an exporter, I want to check if my company 
       assertAuthenticatedHeader: false,
       isInsurancePage: false,
     });
+  });
+
+  it('renders a hint', () => {
+    cy.checkText(yesNoRadioHint(), FIELDS[FIELD_ID].HINT);
   });
 
   it('renders `yes` radio button', () => {

--- a/src/ui/server/content-strings/actions.ts
+++ b/src/ui/server/content-strings/actions.ts
@@ -16,6 +16,13 @@ export const ACTIONS = {
     },
     TEXT: 'who may be able to help you get insurance from the private sector, if you`ve not tried already',
   },
+  CONTACT_EFM: {
+    LINK: {
+      TEXT: 'talk to your nearest export finance manager',
+      HREF: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
+    },
+    TEXT: 'to find out more about your options',
+  },
 };
 
 export default ACTIONS;

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -63,7 +63,7 @@ export const ERROR_MESSAGES = {
         IS_EMPTY: `Select whether you want to be insured for longer than ${ELIGIBILITY.MAX_COVER_PERIOD_YEARS} years`,
       },
       [FIELD_IDS.INSURANCE.ELIGIBILITY.HAS_COMPANIES_HOUSE_NUMBER]: {
-        IS_EMPTY: 'Select whether you have a UK Companies House registration number or not',
+        IS_EMPTY: 'Select whether you have a UK Companies House number and whether your company is actively trading',
       },
       [FIELD_IDS.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER]: {
         IS_EMPTY: 'Enter a recognised Companies House number',

--- a/src/ui/server/content-strings/fields/index.ts
+++ b/src/ui/server/content-strings/fields/index.ts
@@ -28,6 +28,7 @@ export const FIELDS = {
     },
   },
   [FIELD_IDS.ELIGIBILITY.VALID_EXPORTER_LOCATION]: {
+    HINT: 'UKEF provides credit insurance for payments from overseas territories.',
     SUMMARY: {
       TITLE: 'Your company',
     },

--- a/src/ui/server/content-strings/pages/index.ts
+++ b/src/ui/server/content-strings/pages/index.ts
@@ -10,7 +10,7 @@ const BUYER_COUNTRY = {
 };
 
 const EXPORTER_LOCATION = {
-  PAGE_TITLE: 'Are you exporting from a business base inside the UK, Channel Islands or Isle of Man?',
+  PAGE_TITLE: 'Are you exporting from the UK, Channel Islands or Isle of Man?',
 };
 
 const UK_GOODS_OR_SERVICES = {
@@ -21,7 +21,8 @@ const CANNOT_APPLY = {
   PAGE_TITLE: 'You cannot apply for UKEF export insurance',
   REASON: {
     INTRO: 'This is because',
-    UNSUPPORTED_COMPANY_COUNTRY: 'your company is not based in the UK, Channel Islands or Isle of Man.',
+    UNSUPPORTED_COMPANY_COUNTRY:
+      "you're not exporting from a business base in the UK, Channel Islands or Isle of Man.We can only provide cover for UK businesses.",
     UNSUPPORTED_BUYER_COUNTRY_1: 'your buyer is based in',
     UNSUPPORTED_BUYER_COUNTRY_2: 'which we cannot provide cover for.',
     NOT_ENOUGH_UK_GOODS_OR_SERVICES: 'your export contract value is not made up from at least 20% UK goods or services.',

--- a/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
@@ -33,16 +33,7 @@ const COMPANIES_HOUSE_NUMBER = {
 
 const COMPANIES_HOUSE_EXIT = {
   PAGE_TITLE: 'You cannot apply for credit insurance',
-  ACTIONS: {
-    ...ACTIONS,
-    CONTACT_EFM: {
-      LINK: {
-        TEXT: 'talk to your nearest export finance manager',
-        HREF: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
-      },
-      TEXT: 'to find out more about your options',
-    },
-  },
+  ACTIONS,
 };
 
 const NO_COMPANIES_HOUSE_NUMBER = {

--- a/src/ui/server/controllers/insurance/eligibility/exporter-location/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/exporter-location/index.test.ts
@@ -1,5 +1,6 @@
 import { FIELD_ID, PAGE_VARIABLES, TEMPLATE, get, post } from '.';
 import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
+import { FIELDS_ELIGIBILITY as FIELDS } from '../../../../content-strings/fields/insurance/eligibility';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
@@ -30,6 +31,7 @@ describe('controllers/insurance/eligibility/exporter-location', () => {
     it('should have correct properties', () => {
       const expected = {
         FIELD_ID: FIELD_IDS.ELIGIBILITY.VALID_EXPORTER_LOCATION,
+        FIELD: FIELDS[FIELD_ID],
         PAGE_CONTENT_STRINGS: PAGES.EXPORTER_LOCATION,
       };
 

--- a/src/ui/server/controllers/insurance/eligibility/exporter-location/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/exporter-location/index.ts
@@ -1,4 +1,5 @@
 import { PAGES, ERROR_MESSAGES } from '../../../../content-strings';
+import { FIELDS_ELIGIBILITY as FIELDS } from '../../../../content-strings/fields/insurance/eligibility';
 import { FIELD_IDS, ROUTES, TEMPLATES } from '../../../../constants';
 import { objectHasProperty } from '../../../../helpers/object';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
@@ -12,6 +13,7 @@ export const FIELD_ID = FIELD_IDS.ELIGIBILITY.VALID_EXPORTER_LOCATION;
 
 export const PAGE_VARIABLES = {
   FIELD_ID,
+  FIELD: FIELDS[FIELD_ID],
   PAGE_CONTENT_STRINGS: PAGES.EXPORTER_LOCATION,
 };
 

--- a/src/ui/templates/cannot-apply.njk
+++ b/src/ui/templates/cannot-apply.njk
@@ -28,6 +28,9 @@
     <li data-cy="action-approved-broker">
       <a class="govuk-link" data-cy="action-approved-broker-link"href="{{ CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.LINK.HREF }}">{{ CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.LINK.TEXT }}</a> {{ CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.TEXT }}
     </li>
+    <li data-cy="action-contact-efm">
+      <a class="govuk-link" data-cy="action-contact-efm-link" href="{{ CONTENT_STRINGS.ACTIONS.CONTACT_EFM.LINK.HREF }}">{{ CONTENT_STRINGS.ACTIONS.CONTACT_EFM.LINK.TEXT }}</a> {{ CONTENT_STRINGS.ACTIONS.CONTACT_EFM.TEXT }}
+    </li>
   </ul>
  
 {% endblock %}

--- a/src/ui/templates/shared-pages/exporter-location.njk
+++ b/src/ui/templates/shared-pages/exporter-location.njk
@@ -35,6 +35,7 @@
         {{ yesNoRadioButtons.render({
           fieldId: FIELD_ID,
           legendText: CONTENT_STRINGS.PAGE_TITLE,
+          hintText: FIELD_HINT,
           submittedAnswer: submittedValues[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]
         }) }}


### PR DESCRIPTION
## Introduction ✏️ 
This PR updates the "exporter location" and exit page in the "eligibility" flow, for both the quote tool and No PDF/insurance eligibility.

## Resolution ✔️ 
- Add a hint to "exporter location" field content strings and form.
- Update "exporter location"  page title/label.
- Update the `UNSUPPORTED_COMPANY_COUNTRY` content string, used in the exit page
- Extract the UI's `CONTACT_EFM` action string into the shared `ACTIONS` content strings, since its now shared.
- Add `CONTACT_EFM` action to the "cannot appy" exit page template.
- Update E2E tests.
- Fix/update an error message for the "do you have a companies house number" question.