### PR TITLE
fix(EMS-2113): No PDF - Eligibility - inactive company exit page

### DIFF
--- a/e2e-tests/content-strings/actions.js
+++ b/e2e-tests/content-strings/actions.js
@@ -23,6 +23,13 @@ export const ACTIONS = {
     },
     TEXT: 'to find out more about your options',
   },
+  FIND_EFM: {
+    LINK: {
+      TEXT: 'Find your nearest export finance manager',
+      HREF: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
+    },
+    TEXT: 'to discuss this.',
+  },
 };
 
 export default ACTIONS;

--- a/e2e-tests/content-strings/pages/insurance/eligibility/index.js
+++ b/e2e-tests/content-strings/pages/insurance/eligibility/index.js
@@ -32,15 +32,12 @@ export const COMPANIES_HOUSE_NUMBER = {
   PAGE_TITLE: 'Enter your Companies House number',
 };
 
-const COMPANIES_HOUSE_EXIT = {
-  PAGE_TITLE: 'You cannot apply for credit insurance',
-  ACTIONS,
-};
-
 export const NO_COMPANIES_HOUSE_NUMBER = {
-  ...COMPANIES_HOUSE_EXIT,
+  PAGE_TITLE: 'You cannot apply for credit insurance',
   ACTIONS: {
-    ...COMPANIES_HOUSE_EXIT.ACTIONS,
+    ELIGIBILITY: ACTIONS.ELIGIBILITY,
+    CONTACT_APPROVED_BROKER: ACTIONS.CONTACT_APPROVED_BROKER,
+    CONTACT_EFM: ACTIONS.CONTACT_EFM,
     UPDATE_COMPANY_DETAILS: {
       TEXT: 'update your company details on',
       LINK: {
@@ -64,8 +61,12 @@ export const COMPANIES_HOUSE_UNAVAILABLE = {
 };
 
 export const COMPANY_NOT_ACTIVE = {
-  ...COMPANIES_HOUSE_EXIT,
+  PAGE_TITLE: 'You need to speak with an export finance manager',
   BODY: "This is because you do not have a UK Companies House registration number for a company that's actively trading.",
+  ACTIONS: {
+    INTRO: 'You can still apply. But you should talk to a export finance manager before you try again.',
+    FIND_EFM: ACTIONS.FIND_EFM,
+  },
 };
 
 export const COMPANY_DETAILS = {

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-not-active/company-not-active.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-not-active/company-not-active.spec.js
@@ -1,9 +1,13 @@
-import { body } from '../../../../../../pages/shared';
+import { body, actions } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { COMPANIES_HOUSE_NUMBER_NOT_ACTIVE } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.COMPANY_NOT_ACTIVE;
+
+const {
+  ACTIONS: { FIND_EFM },
+} = CONTENT_STRINGS;
 
 const {
   START,
@@ -52,22 +56,16 @@ context('Insurance - Eligibility - Company not active - I want to check if I can
     });
 
     describe('actions', () => {
-      it('should render `eligibility` copy and link', () => {
-        cy.checkActionReadAboutEligibility();
+      it('should render an intro', () => {
+        cy.checkText(actions.intro(), CONTENT_STRINGS.ACTIONS.INTRO);
       });
 
-      describe('when clicking `eligibility` link', () => {
-        it('should redirect to an external URL', () => {
-          cy.checkActionReadAboutEligibilityLinkRedirect();
+      it('should render `find your nearest EFM` copy and link', () => {
+        cy.checkActionTalkToYourNearestEFM({
+          expectedText: `${FIND_EFM.LINK.TEXT} ${FIND_EFM.TEXT}`,
+          expectedLinkHref: FIND_EFM.LINK.HREF,
+          expectedLinkText: FIND_EFM.LINK.TEXT
         });
-      });
-
-      it('should render `contact an approved broker` copy and link', () => {
-        cy.checkActionContactApprovedBroker();
-      });
-
-      it('should render `talk to your nearest EFM` copy and link', () => {
-        cy.checkActionTalkToYourNearestEFM({});
       });
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-not-active/company-not-active.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-not-active/company-not-active.spec.js
@@ -64,7 +64,7 @@ context('Insurance - Eligibility - Company not active - I want to check if I can
         cy.checkActionTalkToYourNearestEFM({
           expectedText: `${FIND_EFM.LINK.TEXT} ${FIND_EFM.TEXT}`,
           expectedLinkHref: FIND_EFM.LINK.HREF,
-          expectedLinkText: FIND_EFM.LINK.TEXT
+          expectedLinkText: FIND_EFM.LINK.TEXT,
         });
       });
     });

--- a/src/ui/server/content-strings/actions.ts
+++ b/src/ui/server/content-strings/actions.ts
@@ -23,6 +23,13 @@ export const ACTIONS = {
     },
     TEXT: 'to find out more about your options',
   },
+  FIND_EFM: {
+    LINK: {
+      TEXT: 'Find your nearest export finance manager',
+      HREF: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
+    },
+    TEXT: 'to discuss this.',
+  },
 };
 
 export default ACTIONS;

--- a/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
@@ -32,15 +32,12 @@ const COMPANIES_HOUSE_NUMBER = {
   PAGE_TITLE: 'Enter your Companies House number',
 };
 
-const COMPANIES_HOUSE_EXIT = {
-  PAGE_TITLE: 'You cannot apply for credit insurance',
-  ACTIONS,
-};
-
 const NO_COMPANIES_HOUSE_NUMBER = {
-  ...COMPANIES_HOUSE_EXIT,
+  PAGE_TITLE: 'You cannot apply for credit insurance',
   ACTIONS: {
-    ...COMPANIES_HOUSE_EXIT.ACTIONS,
+    ELIGIBILITY: ACTIONS.ELIGIBILITY,
+    CONTACT_APPROVED_BROKER: ACTIONS.CONTACT_APPROVED_BROKER,
+    CONTACT_EFM: ACTIONS.CONTACT_EFM,
     UPDATE_COMPANY_DETAILS: {
       TEXT: 'update your company details on',
       LINK: {
@@ -64,8 +61,12 @@ const COMPANIES_HOUSE_UNAVAILABLE = {
 };
 
 const COMPANY_NOT_ACTIVE = {
-  ...COMPANIES_HOUSE_EXIT,
+  PAGE_TITLE: 'You need to speak with an export finance manager',
   BODY: "This is because you do not have a UK Companies House registration number for a company that's actively trading.",
+  ACTIONS: {
+    INTRO: 'You can still apply. But you should talk to a export finance manager before you try again.',
+    FIND_EFM: ACTIONS.FIND_EFM,
+  },
 };
 
 const COMPANY_DETAILS = {

--- a/src/ui/templates/insurance/eligibility/companies-house-exit.njk
+++ b/src/ui/templates/insurance/eligibility/companies-house-exit.njk
@@ -26,23 +26,33 @@
 
       <p class="govuk-body" data-cy="body">{{ CONTENT_STRINGS.BODY }}</p>
 
-      <p class="govuk-body" data-cy="actions-intro">{{ CONTENT_STRINGS.ACTIONS.INTRO }}</p>
+      {% if CONTENT_STRINGS.ACTIONS.INTRO %}
+        <p class="govuk-body" data-cy="actions-intro">{{ CONTENT_STRINGS.ACTIONS.INTRO }}</p>
+      {% endif %}
 
-      <ul class="govuk-list govuk-list--bullet">
+      {% if CONTENT_STRINGS.ACTIONS.ELIGIBILITY or CONTENT_STRINGS.ACTIONS.CONTACT_EFM %}
+        <ul class="govuk-list govuk-list--bullet">
 
-        {% if CONTENT_STRINGS.ACTIONS.UPDATE_COMPANY_DETAILS.TEXT %}
-          <li data-cy="action-update-company-details">{{ CONTENT_STRINGS.ACTIONS.UPDATE_COMPANY_DETAILS.TEXT }} <a class="govuk-link" data-cy="action-update-company-details-link" href="{{ CONTENT_STRINGS.ACTIONS.UPDATE_COMPANY_DETAILS.LINK.HREF }}">{{ CONTENT_STRINGS.ACTIONS.UPDATE_COMPANY_DETAILS.LINK.TEXT }}</a></li>
-        {% endif %}
+          {% if CONTENT_STRINGS.ACTIONS.UPDATE_COMPANY_DETAILS.TEXT %}
+            <li data-cy="action-update-company-details">{{ CONTENT_STRINGS.ACTIONS.UPDATE_COMPANY_DETAILS.TEXT }} <a class="govuk-link" data-cy="action-update-company-details-link" href="{{ CONTENT_STRINGS.ACTIONS.UPDATE_COMPANY_DETAILS.LINK.HREF }}">{{ CONTENT_STRINGS.ACTIONS.UPDATE_COMPANY_DETAILS.LINK.TEXT }}</a></li>
+          {% endif %}
 
-        <li data-cy="action-eligibility">{{ CONTENT_STRINGS.ACTIONS.ELIGIBILITY.TEXT }} <a class="govuk-link" data-cy="action-eligibility-link" href="{{ CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.HREF }}">{{ CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.TEXT }}</a></li>
-        <li data-cy="action-approved-broker">
-          <a class="govuk-link" data-cy="action-approved-broker-link" href="{{ CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.LINK.HREF }}">{{ CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.LINK.TEXT }}</a> {{ CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.TEXT }}
-        </li>
+          <li data-cy="action-eligibility">{{ CONTENT_STRINGS.ACTIONS.ELIGIBILITY.TEXT }} <a class="govuk-link" data-cy="action-eligibility-link" href="{{ CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.HREF }}">{{ CONTENT_STRINGS.ACTIONS.ELIGIBILITY.LINK.TEXT }}</a></li>
+          <li data-cy="action-approved-broker">
+            <a class="govuk-link" data-cy="action-approved-broker-link" href="{{ CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.LINK.HREF }}">{{ CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.LINK.TEXT }}</a> {{ CONTENT_STRINGS.ACTIONS.CONTACT_APPROVED_BROKER.TEXT }}
+          </li>
 
-        <li data-cy="action-contact-efm">
-          <a class="govuk-link" data-cy="action-contact-efm-link" href="{{ CONTENT_STRINGS.ACTIONS.CONTACT_EFM.LINK.HREF }}">{{ CONTENT_STRINGS.ACTIONS.CONTACT_EFM.LINK.TEXT }}</a> {{ CONTENT_STRINGS.ACTIONS.CONTACT_EFM.TEXT }}
-        </li>
-      </ul>
+          <li data-cy="action-contact-efm">
+            <a class="govuk-link" data-cy="action-contact-efm-link" href="{{ CONTENT_STRINGS.ACTIONS.CONTACT_EFM.LINK.HREF }}">{{ CONTENT_STRINGS.ACTIONS.CONTACT_EFM.LINK.TEXT }}</a> {{ CONTENT_STRINGS.ACTIONS.CONTACT_EFM.TEXT }}
+          </li>
+        </ul>
+      {% endif %}
+
+      {% if CONTENT_STRINGS.ACTIONS.FIND_EFM %}
+        <p data-cy="action-contact-efm">
+          <a class="govuk-link" data-cy="action-contact-efm-link" href="{{ CONTENT_STRINGS.ACTIONS.FIND_EFM.LINK.HREF }}">{{ CONTENT_STRINGS.ACTIONS.FIND_EFM.LINK.TEXT }}</a> {{ CONTENT_STRINGS.ACTIONS.FIND_EFM.TEXT }}
+        </p>
+      {% endif %}
 
     </div>
   </div>


### PR DESCRIPTION
## Introduction ✏️ 
The "Inactive company" exit page had some incorrect content. This PR now aligns the "inactive company" exit page with the new no PDF design.

## Resolution ✔️ 
- Split up/change companies house exit page content strings.
- Update the companies house exit page to conditionally render some text and "action" list items.
