### PR TITLE
fix(EMS-2316-2318): No PDF - missing guidance text, PDF link

### DIFF
--- a/e2e-tests/content-strings/pages/insurance/business/index.js
+++ b/e2e-tests/content-strings/pages/insurance/business/index.js
@@ -25,7 +25,7 @@ export const COMPANIES_HOUSE_NUMBER = {
 export const COMPANY_DETAILS = {
   ...SHARED,
   PAGE_TITLE: 'Your company details',
-  TABLE_HEADING: 'Your company',
+  BODY: 'This information comes from Companies House.',
 };
 
 export const COMPANIES_HOUSE_UNAVAILABLE = {

--- a/e2e-tests/content-strings/pages/insurance/eligibility/index.js
+++ b/e2e-tests/content-strings/pages/insurance/eligibility/index.js
@@ -33,7 +33,7 @@ export const LONG_TERM_COVER = {
       INTRO: "You can still apply, but you'll need to do so through",
       LINK: {
         TEXT: 'this PDF form instead',
-        HREF: LINKS.EXTERNAL.NBI_FORM,
+        HREF: LINKS.EXTERNAL.PROPOSAL_FORM,
       },
     },
     CONTACT_EFM: {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
@@ -1,6 +1,7 @@
 import { companyDetails } from '../../../../../../pages/your-business';
 import partials from '../../../../../../partials';
 import {
+  body,
   field,
   saveAndBackButton,
   yesRadioInput,
@@ -78,6 +79,10 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
 
     it('renders a heading caption', () => {
       cy.checkText(partials.headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
+    });
+
+    it('should render body text', () => {
+      cy.checkText(body(), CONTENT_STRINGS.BODY);
     });
 
     describe('companies house summary list', () => {

--- a/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
@@ -33,7 +33,7 @@ const LONG_TERM_COVER = {
       INTRO: "You can still apply, but you'll need to do so through",
       LINK: {
         TEXT: 'this PDF form instead',
-        HREF: LINKS.EXTERNAL.NBI_FORM,
+        HREF: LINKS.EXTERNAL.PROPOSAL_FORM,
       },
     },
     CONTACT_EFM: {

--- a/src/ui/server/content-strings/pages/insurance/your-business/company/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/your-business/company/index.ts
@@ -1,5 +1,6 @@
 const COMPANY_DETAILS = {
   PAGE_TITLE: 'Your company details',
+  BODY: 'This information comes from Companies House.',
   HAS_DIFFERENT_TRADING_NAME: 'Do you use a different trading name for this company?',
   TRADING_ADDRESS: 'Do you trade from a different address to your registered office address for this company?',
   WEBSITE: 'Enter your company website, if you have one (optional)',

--- a/src/ui/templates/insurance/your-business/company-details.njk
+++ b/src/ui/templates/insurance/your-business/company-details.njk
@@ -41,7 +41,10 @@
         <span class="govuk-caption-xl" data-cy="heading-caption">
           {{ CONTENT_STRINGS.HEADING_CAPTION }}
         </span>
+
         <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
+
+        <p class="govuk-body" data-cy="body">{{ CONTENT_STRINGS.BODY }}</p>
 
         {{ govukSummaryList({
           classes: 'govuk-!-margin-bottom-9',


### PR DESCRIPTION
## Introduction ✏️ 
- "Your business - company details" had some missing intro/body text.
- "Long term cover" exit page had an incorrect "PDF" link.

## Resolution ✔️ 
- Add missing intro/body text.
- Update the "PDF" link used in the "Long term cover" exit page.