### PR TITLE
feat(EMS-2247-2248): No PDF - Business - Credit control data saving

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,6 +214,7 @@ jobs:
             "your-business/company-details/**/*.spec.js",
             "your-business/nature-of-business/**/*.spec.js",
             "your-business/turnover/**/*.spec.js",
+            "your-business/credit-control/**/*.spec.js",
             "your-buyer/**/*.spec.js",
           ]
 

--- a/database/exip.sql
+++ b/database/exip.sql
@@ -707,6 +707,7 @@ CREATE TABLE `Business` (
   `totalEmployeesUK` int DEFAULT NULL,
   `estimatedAnnualTurnover` int DEFAULT NULL,
   `exportsTurnoverPercentage` int DEFAULT NULL,
+  `hasCreditControlProcess` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `Business_application_idx` (`application`),
   CONSTRAINT `Business_application_fkey` FOREIGN KEY (`application`) REFERENCES `Application` (`id`) ON DELETE SET NULL ON UPDATE CASCADE

--- a/database/exip.sql
+++ b/database/exip.sql
@@ -700,9 +700,9 @@ CREATE TABLE `Broker` (
 DROP TABLE IF EXISTS `Business`;
 
 CREATE TABLE `Business` (
-  `id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `application` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `goodsOrServicesSupplied` varchar(1000) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `application` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `goodsOrServicesSupplied` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `totalYearsExporting` int DEFAULT NULL,
   `totalEmployeesUK` int DEFAULT NULL,
   `estimatedAnnualTurnover` int DEFAULT NULL,

--- a/e2e-tests/commands/insurance/complete-and-submit-credit-control-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-credit-control-form.js
@@ -1,11 +1,16 @@
-import { submitButton, yesRadioInput } from '../../pages/shared';
+import { submitButton, noRadioInput, yesRadioInput } from '../../pages/shared';
 
 /**
  * completeAndSubmitCreditControlForm
  * complete and submit the "credit control" form.
+ * @param {Boolean}: hasCreditControlProcess: Flag whether to submit "yes" or "no" radio input
  */
-const completeAndSubmitCreditControlForm = () => {
-  yesRadioInput().click();
+const completeAndSubmitCreditControlForm = ({ hasCreditControlProcess = true }) => {
+  if (hasCreditControlProcess) {
+    yesRadioInput().click();
+  } else {
+    noRadioInput().click();
+  }
 
   submitButton().click();
 };

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
@@ -46,7 +46,7 @@ const completePrepareApplicationMultiplePolicyType = ({
 
   cy.completeAndSubmitNatureOfYourBusiness();
   cy.completeAndSubmitTurnoverForm();
-  cy.completeAndSubmitCreditControlForm();
+  cy.completeAndSubmitCreditControlForm({});
   cy.completeAndSubmitBrokerForm({ usingBroker });
 
   submitButton().click();

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
@@ -48,7 +48,7 @@ const completePrepareYourApplicationSectionSingle = ({
 
   cy.completeAndSubmitNatureOfYourBusiness();
   cy.completeAndSubmitTurnoverForm();
-  cy.completeAndSubmitCreditControlForm();
+  cy.completeAndSubmitCreditControlForm({});
   cy.completeAndSubmitBrokerForm({ usingBroker });
 
   submitButton().click();

--- a/e2e-tests/constants/field-ids/insurance/business/index.js
+++ b/e2e-tests/constants/field-ids/insurance/business/index.js
@@ -19,7 +19,7 @@ export const EXPORTER_BUSINESS = {
     ESTIMATED_ANNUAL_TURNOVER: 'estimatedAnnualTurnover',
     PERCENTAGE_TURNOVER: 'exportsTurnoverPercentage',
   },
-  CREDIT_CONTROL: 'creditControl',
+  HAS_CREDIT_CONTROL: 'hasCreditControlProcess',
   BROKER: {
     LEGEND: 'broker',
     USING_BROKER: 'isUsingBroker',

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -118,7 +118,7 @@ export const ERROR_MESSAGES = {
         BELOW_MINIMUM: 'Your percentage of turnover from exports must be a number between 0 to 100',
         ABOVE_MAXIMUM: 'Your percentage of turnover from exports must be a number between 0 to 100',
       },
-      [FIELD_IDS.INSURANCE.EXPORTER_BUSINESS.CREDIT_CONTROL]: {
+      [FIELD_IDS.INSURANCE.EXPORTER_BUSINESS.HAS_CREDIT_CONTROL]: {
         IS_EMPTY: 'Select if you have a process for dealing with late payments',
       },
       [FIELD_IDS.INSURANCE.EXPORTER_BUSINESS.BROKER.USING_BROKER]: {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/broker/broker-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/broker/broker-page.spec.js
@@ -62,7 +62,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
-      cy.completeAndSubmitCreditControlForm();
+      cy.completeAndSubmitCreditControlForm({});
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
       checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/broker/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/broker/save-and-back.spec.js
@@ -47,7 +47,7 @@ context('Insurance - Your business - Broker page - Save and back', () => {
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
-      cy.completeAndSubmitCreditControlForm();
+      cy.completeAndSubmitCreditControlForm({});
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
       allSectionsUrl = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
@@ -105,7 +105,7 @@ context('Insurance - Your business - Broker page - Save and back', () => {
       // submit turnover form
       submitButton().click();
       // submit credit control form
-      cy.completeAndSubmitCreditControlForm();
+      cy.completeAndSubmitCreditControlForm({});
 
       brokerPage[USING_BROKER].yesRadioInput().should('be.checked');
       cy.checkValue(field(NAME), application.EXPORTER_BROKER[NAME]);
@@ -153,7 +153,7 @@ context('Insurance - Your business - Broker page - Save and back', () => {
         // submit turnover form
         submitButton().click();
         // submit credit control form
-        cy.completeAndSubmitCreditControlForm();
+        cy.completeAndSubmitCreditControlForm({});
 
         brokerPage[USING_BROKER].yesRadioInput().should('be.checked');
         cy.checkValue(field(NAME), application.EXPORTER_BROKER[NAME]);
@@ -192,7 +192,7 @@ context('Insurance - Your business - Broker page - Save and back', () => {
         // submit turnover form
         submitButton().click();
         // submit credit control form
-        cy.completeAndSubmitCreditControlForm();
+        cy.completeAndSubmitCreditControlForm({});
 
         brokerPage[USING_BROKER].noRadioInput().should('be.checked');
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/broker/validation/are-you-using-a-broker-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/broker/validation/are-you-using-a-broker-answer-no.spec.js
@@ -34,7 +34,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
-      cy.completeAndSubmitCreditControlForm();
+      cy.completeAndSubmitCreditControlForm({});
 
       const url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
       checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-all-required-fields.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-all-required-fields.spec.js
@@ -27,7 +27,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
-      cy.completeAndSubmitCreditControlForm();
+      cy.completeAndSubmitCreditControlForm({});
 
       const url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
       checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-no-required-fields.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-no-required-fields.spec.js
@@ -41,7 +41,7 @@ context('Insurance - Your business - Broker Page - As an Exporter I want to conf
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
-      cy.completeAndSubmitCreditControlForm();
+      cy.completeAndSubmitCreditControlForm({});
 
       const url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/broker/validation/broker-email-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/broker/validation/broker-email-validation.spec.js
@@ -45,7 +45,7 @@ context('Insurance - Your business - Broker Page - Validation - Email', () => {
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
-      cy.completeAndSubmitCreditControlForm();
+      cy.completeAndSubmitCreditControlForm({});
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/broker/validation/broker-postcode-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/broker/validation/broker-postcode-validation.spec.js
@@ -47,7 +47,7 @@ context('Insurance - Your business - Broker Page - Validation - Postcode', () =>
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
-      cy.completeAndSubmitCreditControlForm();
+      cy.completeAndSubmitCreditControlForm({});
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-broker.spec.js
@@ -39,7 +39,7 @@ context('Insurance - Your business - Change your answers - Broker - As an export
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
-      cy.completeAndSubmitCreditControlForm();
+      cy.completeAndSubmitCreditControlForm({});
       cy.completeAndSubmitBrokerForm({ usingBroker: true });
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
@@ -49,7 +49,7 @@ context('Insurance - Your business - Change your answers - Company details - As 
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm({});
-      cy.completeAndSubmitCreditControlForm();
+      cy.completeAndSubmitCreditControlForm({});
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-nature-of-your-business.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-nature-of-your-business.spec.js
@@ -34,7 +34,7 @@ context('Insurance - Your business - Change your answers - Nature of your busine
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm({});
-      cy.completeAndSubmitCreditControlForm();
+      cy.completeAndSubmitCreditControlForm({});
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
@@ -31,7 +31,7 @@ context('Insurance - Your business - Change your answers - Turnover - As an expo
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitBrokerForm({});
-      cy.completeAndSubmitCreditControlForm();
+      cy.completeAndSubmitCreditControlForm({});
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-page.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Your Business - Check your answers - As an exporter, I want
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
-      cy.completeAndSubmitCreditControlForm();
+      cy.completeAndSubmitCreditControlForm({});
       cy.completeAndSubmitBrokerForm({});
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
@@ -51,7 +51,7 @@ context('Insurance - Your business - Check your answers - Summary list - your bu
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();
-      cy.completeAndSubmitCreditControlForm();
+      cy.completeAndSubmitCreditControlForm({});
       cy.completeAndSubmitBrokerForm({ usingBroker: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control-answer-no.spec.js
@@ -1,0 +1,60 @@
+import { noRadioInput } from '../../../../../../pages/shared';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+
+const {
+  ROOT,
+  EXPORTER_BUSINESS: {
+    BROKER_ROOT,
+    CREDIT_CONTROL,
+  },
+} = INSURANCE_ROUTES;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Your business - Credit control page - answer `no` - As an Exporter, I want to provide our late payment process  So that UKEF can have clarity on our credit control', () => {
+  let referenceNumber;
+  let url;
+  let brokerUrl;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.startYourBusinessSection();
+      cy.completeAndSubmitCompanyDetails({});
+      cy.completeAndSubmitNatureOfYourBusiness();
+      cy.completeAndSubmitTurnoverForm();
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CREDIT_CONTROL}`;
+      brokerUrl = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('form submission', () => {
+    it(`should redirect to ${BROKER_ROOT}`, () => {
+      cy.navigateToUrl(url);
+
+      cy.completeAndSubmitCreditControlForm({ hasCreditControlProcess: false });
+
+      cy.assertUrl(brokerUrl);
+    });
+  });
+
+  describe('when going back to the page', () => {
+    it('should have the submitted values', () => {
+      cy.navigateToUrl(url);
+
+      noRadioInput().should('be.checked');
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control-answer-no.spec.js
@@ -11,7 +11,7 @@ const {
 
 const baseUrl = Cypress.config('baseUrl');
 
-context('Insurance - Your business - Credit control page - answer `no` - As an Exporter, I want to provide our late payment process  So that UKEF can have clarity on our credit control', () => {
+context('Insurance - Your business - Credit control page - answer `no` - As an Exporter, I want to provide our late payment process So that UKEF can have clarity on our credit control', () => {
   let referenceNumber;
   let url;
   let brokerUrl;

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -1233,7 +1233,8 @@ var lists = {
       totalYearsExporting: (0, import_fields.integer)(),
       totalEmployeesUK: (0, import_fields.integer)(),
       estimatedAnnualTurnover: (0, import_fields.integer)(),
-      exportsTurnoverPercentage: (0, import_fields.integer)()
+      exportsTurnoverPercentage: (0, import_fields.integer)(),
+      hasCreditControlProcess: nullable_checkbox_default()
     },
     hooks: {
       afterOperation: async ({ item, context }) => {

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -970,6 +970,7 @@ type Business {
   totalEmployeesUK: Int
   estimatedAnnualTurnover: Int
   exportsTurnoverPercentage: Int
+  hasCreditControlProcess: Boolean
 }
 
 input BusinessWhereUniqueInput {
@@ -1005,6 +1006,7 @@ input BusinessUpdateInput {
   totalEmployeesUK: Int
   estimatedAnnualTurnover: Int
   exportsTurnoverPercentage: Int
+  hasCreditControlProcess: Boolean
 }
 
 input BusinessUpdateArgs {
@@ -1019,6 +1021,7 @@ input BusinessCreateInput {
   totalEmployeesUK: Int
   estimatedAnnualTurnover: Int
   exportsTurnoverPercentage: Int
+  hasCreditControlProcess: Boolean
 }
 
 type Broker {

--- a/src/api/schema.prisma
+++ b/src/api/schema.prisma
@@ -200,6 +200,7 @@ model Business {
   totalEmployeesUK          Int?
   estimatedAnnualTurnover   Int?
   exportsTurnoverPercentage Int?
+  hasCreditControlProcess   Boolean?
   from_Application_business Application[] @relation("Application_business")
 
   @@index([applicationId])

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -456,6 +456,7 @@ export const lists = {
       totalEmployeesUK: integer(),
       estimatedAnnualTurnover: integer(),
       exportsTurnoverPercentage: integer(),
+      hasCreditControlProcess: nullableCheckbox(),
     },
     hooks: {
       afterOperation: async ({ item, context }) => {

--- a/src/api/test-mocks/mock-application.ts
+++ b/src/api/test-mocks/mock-application.ts
@@ -102,6 +102,7 @@ export const mockBusiness = {
   totalEmployeesUK: 400,
   estimatedAnnualTurnover: 155220,
   exportsTurnoverPercentage: 20,
+  hasCreditControlProcess: true,
 };
 
 export const mockBroker = {

--- a/src/ui/server/constants/field-ids/insurance/business/index.ts
+++ b/src/ui/server/constants/field-ids/insurance/business/index.ts
@@ -20,7 +20,7 @@ const EXPORTER_BUSINESS = {
     ESTIMATED_ANNUAL_TURNOVER: 'estimatedAnnualTurnover',
     PERCENTAGE_TURNOVER: 'exportsTurnoverPercentage',
   },
-  CREDIT_CONTROL: 'creditControl',
+  HAS_CREDIT_CONTROL: 'hasCreditControlProcess',
   BROKER: {
     LEGEND: 'broker',
     USING_BROKER: 'isUsingBroker',

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -122,7 +122,7 @@ export const ERROR_MESSAGES = {
         BELOW_MINIMUM: 'Your percentage of turnover from exports must be a number between 0 to 100',
         ABOVE_MAXIMUM: 'Your percentage of turnover from exports must be a number between 0 to 100',
       },
-      [FIELD_IDS.INSURANCE.EXPORTER_BUSINESS.CREDIT_CONTROL]: {
+      [FIELD_IDS.INSURANCE.EXPORTER_BUSINESS.HAS_CREDIT_CONTROL]: {
         IS_EMPTY: 'Select if you have a process for dealing with late payments',
       },
       [FIELD_IDS.INSURANCE.EXPORTER_BUSINESS.BROKER.USING_BROKER]: {

--- a/src/ui/server/controllers/insurance/business/credit-control/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/credit-control/index.test.ts
@@ -11,7 +11,7 @@ import mapAndSave from '../map-and-save/business';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
 
-const { CREDIT_CONTROL } = BUSINESS_FIELD_IDS;
+const { HAS_CREDIT_CONTROL } = BUSINESS_FIELD_IDS;
 
 const {
   INSURANCE_ROOT,
@@ -36,7 +36,7 @@ describe('controllers/insurance/business/credit-control', () => {
 
   describe('FIELD_ID', () => {
     it('should have the correct ID', () => {
-      const expected = CREDIT_CONTROL;
+      const expected = HAS_CREDIT_CONTROL;
 
       expect(FIELD_ID).toEqual(expected);
     });
@@ -45,7 +45,7 @@ describe('controllers/insurance/business/credit-control', () => {
   describe('PAGE_VARIABLES', () => {
     it('should have correct properties', () => {
       const expected = {
-        FIELD_ID: BUSINESS_FIELD_IDS.CREDIT_CONTROL,
+        FIELD_ID: BUSINESS_FIELD_IDS.HAS_CREDIT_CONTROL,
         PAGE_CONTENT_STRINGS: PAGES.INSURANCE.EXPORTER_BUSINESS.CREDIT_CONTROL,
         SAVE_AND_BACK_URL: '',
       };
@@ -70,6 +70,7 @@ describe('controllers/insurance/business/credit-control', () => {
           BACK_LINK: req.headers.referer,
         }),
         userName: getUserNameFromSession(req.session.user),
+        application: res.locals.application?.business,
       });
     });
 

--- a/src/ui/server/controllers/insurance/business/credit-control/index.ts
+++ b/src/ui/server/controllers/insurance/business/credit-control/index.ts
@@ -6,6 +6,7 @@ import singleInputPageVariables from '../../../../helpers/page-variables/single-
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
 import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
+import mapAndSave from '../map-and-save/business';
 import { Request, Response } from '../../../../../types';
 
 const {
@@ -61,7 +62,7 @@ export const get = (req: Request, res: Response) => {
  * @param {Express.Response} Express response
  * @returns {Express.Response.redirect} Next part of the flow or error page
  */
-export const post = (req: Request, res: Response) => {
+export const post = async (req: Request, res: Response) => {
   try {
     const { application } = res.locals;
 
@@ -85,6 +86,16 @@ export const post = (req: Request, res: Response) => {
         validationErrors,
         submittedValues: payload,
       });
+    }
+
+    /**
+     * No validation errors.
+     * call mapAndSave to call the API.
+     */
+    const saveResponse = await mapAndSave.business(payload, application);
+
+    if (!saveResponse) {
+      return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
     return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${BROKER_ROOT}`);

--- a/src/ui/server/controllers/insurance/business/credit-control/index.ts
+++ b/src/ui/server/controllers/insurance/business/credit-control/index.ts
@@ -15,9 +15,9 @@ const {
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
-const { CREDIT_CONTROL } = BUSINESS_FIELD_IDS;
+const { HAS_CREDIT_CONTROL } = BUSINESS_FIELD_IDS;
 
-export const FIELD_ID = CREDIT_CONTROL;
+export const FIELD_ID = HAS_CREDIT_CONTROL;
 
 export const TEMPLATE = TEMPLATES.INSURANCE.EXPORTER_BUSINESS.CREDIT_CONTROL;
 
@@ -48,6 +48,7 @@ export const get = (req: Request, res: Response) => {
         BACK_LINK: req.headers.referer,
       }),
       userName: getUserNameFromSession(req.session.user),
+      application: application.business,
     });
   } catch (err) {
     console.error('Error getting credit control %O', err);

--- a/src/ui/server/controllers/insurance/business/map-and-save/business/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/business/map-and-save/business/index.api-error.test.ts
@@ -9,7 +9,7 @@ const {
   },
 } = FIELD_IDS.INSURANCE;
 
-describe('controllers/insurance/business/map-and-save/-business - API error', () => {
+describe('controllers/insurance/business/map-and-save/business - API error', () => {
   jest.mock('../../save-data/business');
 
   const mockFormBody = {

--- a/src/ui/server/controllers/insurance/business/map-and-save/business/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/business/map-and-save/business/index.api-error.test.ts
@@ -9,7 +9,7 @@ const {
   },
 } = FIELD_IDS.INSURANCE;
 
-describe('controllers/insurance/business/map-and-save/nature-of-business - API error', () => {
+describe('controllers/insurance/business/map-and-save/-business - API error', () => {
   jest.mock('../../save-data/business');
 
   const mockFormBody = {
@@ -28,7 +28,7 @@ describe('controllers/insurance/business/map-and-save/nature-of-business - API e
     });
 
     it('should return false', async () => {
-      const result = await mapAndSave.natureOfBusiness(mockFormBody, mockApplication);
+      const result = await mapAndSave.business(mockFormBody, mockApplication);
 
       expect(result).toEqual(false);
     });
@@ -40,7 +40,7 @@ describe('controllers/insurance/business/map-and-save/nature-of-business - API e
     });
 
     it('should return false', async () => {
-      const result = await mapAndSave.natureOfBusiness(mockFormBody, mockApplication);
+      const result = await mapAndSave.business(mockFormBody, mockApplication);
 
       expect(result).toEqual(false);
     });

--- a/src/ui/server/controllers/insurance/business/map-and-save/business/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/map-and-save/business/index.test.ts
@@ -1,6 +1,6 @@
 import mapAndSave from '.';
 import save from '../../save-data/business';
-import mapNatureOfBusinessSubmittedData from '../../nature-of-business/map-submitted-data';
+import mapBusinessSubmittedData from '../../map-submitted-data/your-business';
 import { mockApplication } from '../../../../../test-mocks';
 import generateValidationErrors from '../../../../../helpers/validation';
 import { FIELD_IDS } from '../../../../../constants';
@@ -11,7 +11,7 @@ const {
   },
 } = FIELD_IDS.INSURANCE;
 
-describe('controllers/insurance/business/map-and-save/nature-of-business', () => {
+describe('controllers/insurance/business/map-and-save/business', () => {
   jest.mock('../../save-data/business');
 
   let mockFormBody = {
@@ -29,14 +29,14 @@ describe('controllers/insurance/business/map-and-save/nature-of-business', () =>
   describe('when the form has data', () => {
     describe('when the form has validation errors', () => {
       it('should call save.business with application, populated submitted data and validationErrors.errorList', async () => {
-        await mapAndSave.natureOfBusiness(mockFormBody, mockApplication, mockValidationErrors);
+        await mapAndSave.business(mockFormBody, mockApplication, mockValidationErrors);
 
         expect(save.business).toHaveBeenCalledTimes(1);
-        expect(save.business).toHaveBeenCalledWith(mockApplication, mapNatureOfBusinessSubmittedData(mockFormBody), mockValidationErrors?.errorList);
+        expect(save.business).toHaveBeenCalledWith(mockApplication, mapBusinessSubmittedData(mockFormBody), mockValidationErrors?.errorList);
       });
 
       it('should return true', async () => {
-        const result = await mapAndSave.natureOfBusiness(mockFormBody, mockApplication, mockValidationErrors);
+        const result = await mapAndSave.business(mockFormBody, mockApplication, mockValidationErrors);
 
         expect(result).toEqual(true);
       });
@@ -51,15 +51,15 @@ describe('controllers/insurance/business/map-and-save/nature-of-business', () =>
       };
 
       it('should call save.business with application and populated submitted data', async () => {
-        await mapAndSave.natureOfBusiness(mockFormBody, mockApplication);
+        await mapAndSave.business(mockFormBody, mockApplication);
 
         expect(save.business).toHaveBeenCalledTimes(1);
 
-        expect(save.business).toHaveBeenCalledWith(mockApplication, mapNatureOfBusinessSubmittedData(mockFormBody));
+        expect(save.business).toHaveBeenCalledWith(mockApplication, mapBusinessSubmittedData(mockFormBody));
       });
 
       it('should return true', async () => {
-        const result = await mapAndSave.natureOfBusiness(mockFormBody, mockApplication, mockValidationErrors);
+        const result = await mapAndSave.business(mockFormBody, mockApplication, mockValidationErrors);
 
         expect(result).toEqual(true);
       });
@@ -70,7 +70,7 @@ describe('controllers/insurance/business/map-and-save/nature-of-business', () =>
     it('should return true', async () => {
       mockFormBody = { _csrf: '1234' };
 
-      const result = await mapAndSave.natureOfBusiness(mockFormBody, mockApplication, mockValidationErrors);
+      const result = await mapAndSave.business(mockFormBody, mockApplication, mockValidationErrors);
 
       expect(result).toEqual(true);
     });

--- a/src/ui/server/controllers/insurance/business/map-and-save/business/index.ts
+++ b/src/ui/server/controllers/insurance/business/map-and-save/business/index.ts
@@ -1,21 +1,21 @@
 import hasFormData from '../../../../../helpers/has-form-data';
 import { Application, RequestBody, ValidationErrors } from '../../../../../../types';
-import mapNatureOfBusinessSubmittedData from '../../nature-of-business/map-submitted-data';
+import mapBusinessSubmittedData from '../../map-submitted-data/your-business';
 import save from '../../save-data/business';
 
 /**
- * maps nature of business request and calls save function
+ * maps business data and calls save function
  * returns true or false based on response from save function
  * @param {RequestBody} formBody
  * @param {Object} application
  * @param {Object} validationErrors
  * @returns {Boolean}
  */
-const natureOfBusiness = async (formBody: RequestBody, application: Application, validationErrors?: ValidationErrors) => {
+const business = async (formBody: RequestBody, application: Application, validationErrors?: ValidationErrors) => {
   try {
     if (hasFormData(formBody)) {
       // maps through formBody and puts fields in correct format
-      const dataToSave = mapNatureOfBusinessSubmittedData(formBody);
+      const dataToSave = mapBusinessSubmittedData(formBody);
       let saveResponse;
 
       if (validationErrors) {
@@ -38,4 +38,4 @@ const natureOfBusiness = async (formBody: RequestBody, application: Application,
   }
 };
 
-export default { natureOfBusiness };
+export default { business };

--- a/src/ui/server/controllers/insurance/business/map-submitted-data/your-business/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/map-submitted-data/your-business/index.test.ts
@@ -7,7 +7,7 @@ import { stripCommas } from '../../../../../helpers/string';
 const { EXPORTER_BUSINESS } = FIELD_IDS.INSURANCE;
 const { GOODS_OR_SERVICES, YEARS_EXPORTING, EMPLOYEES_UK } = EXPORTER_BUSINESS.NATURE_OF_YOUR_BUSINESS;
 
-describe('controllers/insurance/business/nature-of-business/map-submitted-data', () => {
+describe('controllers/insurance/business/map-submitted-data/your-business', () => {
   describe('when all fields are provided and all number fields contain a comma', () => {
     it('should return the formBody with the commas replaced', () => {
       const mockBody = {

--- a/src/ui/server/controllers/insurance/business/map-submitted-data/your-business/index.ts
+++ b/src/ui/server/controllers/insurance/business/map-submitted-data/your-business/index.ts
@@ -10,7 +10,7 @@ const {
 } = FIELD_IDS.INSURANCE;
 
 /**
- * maps natureOfBusiness formBody and returns fields in correct format
+ * maps business formBody and returns fields in correct format
  * removes commas from numbers entered as commas are valid input
  * @param {RequestBody} formBody
  * @returns {Object} populatedData

--- a/src/ui/server/controllers/insurance/business/nature-of-business/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/index.test.ts
@@ -7,7 +7,7 @@ import insuranceCorePageVariables from '../../../../helpers/page-variables/core/
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
 import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
-import mapAndSave from '../map-and-save/nature-of-business';
+import mapAndSave from '../map-and-save/business';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
@@ -37,7 +37,7 @@ const { NATURE_OF_YOUR_BUSINESS: NATURE_OF_YOUR_BUSINESS_FIELDS } = FIELDS;
 
 const MAXIMUM = 1000;
 
-jest.mock('../map-and-save/nature-of-business');
+jest.mock('../map-and-save/business');
 
 describe('controllers/insurance/business/nature-of-business', () => {
   let req: Request;
@@ -123,7 +123,7 @@ describe('controllers/insurance/business/nature-of-business', () => {
   });
 
   describe('post', () => {
-    mapAndSave.natureOfBusiness = jest.fn(() => Promise.resolve(true));
+    mapAndSave.business = jest.fn(() => Promise.resolve(true));
 
     describe('when there are validation errors', () => {
       it('should render template with validation errors and submitted values', async () => {
@@ -165,7 +165,7 @@ describe('controllers/insurance/business/nature-of-business', () => {
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
 
-      it('should call mapAndSave.natureOfBusiness once with the data from constructPayload function and application', async () => {
+      it('should call mapAndSave.business once with the data from constructPayload function and application', async () => {
         req.body = {
           ...body,
           injection: 1,
@@ -175,9 +175,9 @@ describe('controllers/insurance/business/nature-of-business', () => {
 
         const payload = constructPayload(req.body, FIELD_IDS);
 
-        expect(mapAndSave.natureOfBusiness).toHaveBeenCalledTimes(1);
+        expect(mapAndSave.business).toHaveBeenCalledTimes(1);
 
-        expect(mapAndSave.natureOfBusiness).toHaveBeenCalledWith(payload, mockApplication);
+        expect(mapAndSave.business).toHaveBeenCalledWith(payload, mockApplication);
       });
 
       describe("when the url's last substring is `change`", () => {

--- a/src/ui/server/controllers/insurance/business/nature-of-business/index.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/index.ts
@@ -6,7 +6,7 @@ import insuranceCorePageVariables from '../../../../helpers/page-variables/core/
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
 import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
-import mapAndSave from '../map-and-save/nature-of-business';
+import mapAndSave from '../map-and-save/business';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import isChangeRoute from '../../../../helpers/is-change-route';
 import isCheckAndChangeRoute from '../../../../helpers/is-check-and-change-route';
@@ -124,8 +124,11 @@ const post = async (req: Request, res: Response) => {
       });
     }
 
-    // if no errors, then runs save api call to db
-    const saveResponse = await mapAndSave.natureOfBusiness(payload, application);
+    /**
+     * No validation errors.
+     * call mapAndSave to call the API.
+     */
+    const saveResponse = await mapAndSave.business(payload, application);
 
     if (!saveResponse) {
       return res.redirect(PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/business/nature-of-business/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/save-and-back/index.test.ts
@@ -4,7 +4,7 @@ import { FIELD_IDS } from '..';
 import { ROUTES } from '../../../../../constants';
 import BUSINESS_FIELD_IDS from '../../../../../constants/field-ids/insurance/business';
 import { mockReq, mockRes, mockApplication, mockBusinessNatureOfBusiness } from '../../../../../test-mocks';
-import mapAndSave from '../../map-and-save/nature-of-business';
+import mapAndSave from '../../map-and-save/business';
 import { Request, Response } from '../../../../../../types';
 
 const {
@@ -23,7 +23,7 @@ describe('controllers/insurance/business/nature-of-business/save-and-back', () =
     req = mockReq();
     res = mockRes();
 
-    mapAndSave.natureOfBusiness = updateMapAndSave;
+    mapAndSave.business = updateMapAndSave;
   });
 
   afterAll(() => {
@@ -41,7 +41,7 @@ describe('controllers/insurance/business/nature-of-business/save-and-back', () =
       expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
     });
 
-    it('should call mapAndSave.natureOfBusiness once with data from constructPayload', async () => {
+    it('should call mapAndSave.business once with data from constructPayload', async () => {
       req.body = {
         ...validBody,
         injection: 1,
@@ -69,7 +69,7 @@ describe('controllers/insurance/business/nature-of-business/save-and-back', () =
       expect(res.redirect).toHaveBeenCalledWith(`${INSURANCE_ROOT}/${req.params.referenceNumber}${ALL_SECTIONS}`);
     });
 
-    it('should call mapAndSave.natureOfBusiness once', async () => {
+    it('should call mapAndSave.business once', async () => {
       req.body = {
         [YEARS_EXPORTING]: '5O',
         [EMPLOYEES_UK]: '2000',
@@ -95,11 +95,11 @@ describe('controllers/insurance/business/nature-of-business/save-and-back', () =
   });
 
   describe('api error handling', () => {
-    describe('when mapAndSave.natureOfBusiness returns false', () => {
+    describe('when mapAndSave.business returns false', () => {
       beforeEach(() => {
         req.body = validBody;
         res.locals = mockRes().locals;
-        mapAndSave.natureOfBusiness = jest.fn(() => Promise.resolve(false));
+        mapAndSave.business = jest.fn(() => Promise.resolve(false));
       });
 
       it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
@@ -109,11 +109,11 @@ describe('controllers/insurance/business/nature-of-business/save-and-back', () =
       });
     });
 
-    describe('when mapAndSave.natureOfBusiness fails', () => {
+    describe('when mapAndSave.business fails', () => {
       beforeEach(() => {
         res.locals = mockRes().locals;
         updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
-        mapAndSave.natureOfBusiness = updateMapAndSave;
+        mapAndSave.business = updateMapAndSave;
       });
 
       it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {

--- a/src/ui/server/controllers/insurance/business/nature-of-business/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/save-and-back/index.ts
@@ -1,7 +1,7 @@
 import { TEMPLATES, ROUTES } from '../../../../../constants';
 import { FIELD_IDS } from '..';
 import generateValidationErrors from '../validation';
-import mapAndSave from '../../map-and-save/nature-of-business';
+import mapAndSave from '../../map-and-save/business';
 import constructPayload from '../../../../../helpers/construct-payload';
 import { Request, Response } from '../../../../../../types';
 
@@ -35,7 +35,7 @@ const post = async (req: Request, res: Response) => {
     const validationErrors = generateValidationErrors(payload);
 
     // runs save and go back command
-    const saveResponse = await mapAndSave.natureOfBusiness(payload, application, validationErrors);
+    const saveResponse = await mapAndSave.business(payload, application, validationErrors);
 
     if (!saveResponse) {
       return res.redirect(PROBLEM_WITH_SERVICE);

--- a/src/ui/server/graphql/queries/application.ts
+++ b/src/ui/server/graphql/queries/application.ts
@@ -105,6 +105,7 @@ const applicationQuery = gql`
           totalEmployeesUK
           estimatedAnnualTurnover
           exportsTurnoverPercentage
+          hasCreditControlProcess
         }
         broker {
           id

--- a/src/ui/server/test-mocks/mock-application.ts
+++ b/src/ui/server/test-mocks/mock-application.ts
@@ -80,6 +80,7 @@ export const mockBusiness = {
   totalEmployeesUK: '400',
   estimatedAnnualTurnover: '155220',
   exportsTurnoverPercentage: '20',
+  hasCreditControlProcess: true,
 };
 
 export const mockBroker = {

--- a/src/ui/templates/insurance/your-business/credit-control.njk
+++ b/src/ui/templates/insurance/your-business/credit-control.njk
@@ -27,6 +27,8 @@
     }) }}
   {% endif %}
 
+  <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+
   <form method="POST" id="form" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
@@ -37,26 +39,28 @@
           fieldId: FIELD_ID,
           legendText: CONTENT_STRINGS.PAGE_TITLE,
           hintText: FIELD_HINT,
-          submittedAnswer: submittedValues[FIELD_ID],
+          submittedAnswer: application[FIELD_ID],
           errorMessage: validationErrors.errorList[FIELD_ID]
         }) }}
       </div>
     </div>
 
-    <div class="govuk-grid-column-three-quarters-from-desktop">
-      <div class="govuk-button-group">
-        {{ submitButton.render({
-          text: CONTENT_STRINGS.BUTTONS.CONTINUE
-        }) }}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters-from-desktop">
+        <div class="govuk-button-group">
+          {{ submitButton.render({
+            text: CONTENT_STRINGS.BUTTONS.CONTINUE
+          }) }}
 
-        {{ govukButton({
-          text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-          classes: "govuk-button--secondary",
-          attributes: {
-            'data-cy': 'save-and-back-button',
-            'formaction': SAVE_AND_BACK_URL
-          }
-        }) }}
+          {{ govukButton({
+            text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
+            classes: "govuk-button--secondary",
+            attributes: {
+              'data-cy': 'save-and-back-button',
+              'formaction': SAVE_AND_BACK_URL
+            }
+          }) }}
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Introduction ✏️ 
This PR adds data saving to the "Credit control" form in the "Your business" section of a no-pdf application.


## Resolution ✔️ 
- Update `completeAndSubmitCreditControlForm` cypress to command to submit "yes" or "no" depending on an optional param.
- Rename `CREDIT_CONTROL` field ID to `HAS_CREDIT_CONTROL`
- Add E2E test coverage for submitting the "credit control" form with a "no" answer.
- Update/fix E2E test coverage for the "credit control" page/form, and submitting with a "yes" answer.
- Add `hasCreditControlProcess` field to keystone schema and application fixtures.
- Rename `mapAndSave.natureOfBusiness` to `mapAndSave.business` and move into a directory.
- Update the credit control UI controller to call `mapAndSave.business`.
- Add missing heading caption to the credit control nunjucks template.

## Miscellaneous ➕
- Add missing E2E test path to `test.yml`.
- Minor documentation improvements.