### PR TITLE
fix(EMS-2341): Quote page - update application link

### DIFF
--- a/e2e-tests/content-strings/pages/quote.js
+++ b/e2e-tests/content-strings/pages/quote.js
@@ -1,5 +1,4 @@
 import { LINKS } from '../links';
-import { INSURANCE_ROUTES } from '../../constants/routes/insurance';
 
 const BUYER_BODY = {
   PAGE_TITLE: 'Is your buyer a government or public sector body?',
@@ -100,7 +99,7 @@ const YOUR_QUOTE = {
       CAN_NOW_SUBMIT: 'You can now submit a',
       FULL_APPLICATION: {
         TEXT: 'full application',
-        HREF: INSURANCE_ROUTES.START,
+        HREF: LINKS.EXTERNAL.FULL_APPLICATION,
       },
       TIMEFRAME: 'It takes about 2 weeks to get a decision from UKEF.',
       CAN_GET_HELP: 'You can get help with the application process from export finance managers or brokers.',

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
@@ -32,7 +32,6 @@ const {
     BUYER_COUNTRY_CHANGE,
     YOUR_QUOTE,
   },
-  INSURANCE: { START },
 } = ROUTES;
 
 const {
@@ -233,7 +232,7 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
 
         cy.checkLink(
           yourQuotePage.whatHappensNext.intro.fullApplicationLink(),
-          START,
+          LINKS.EXTERNAL.FULL_APPLICATION,
           CONTENT_STRINGS.WHAT_HAPPENS_NEXT.INTRO.FULL_APPLICATION.TEXT,
         );
       });

--- a/src/ui/server/content-strings/pages/quote.ts
+++ b/src/ui/server/content-strings/pages/quote.ts
@@ -1,5 +1,4 @@
 import { LINKS } from '../links';
-import { INSURANCE_ROUTES } from '../../constants/routes/insurance';
 
 const BUYER_BODY = {
   PAGE_TITLE: 'Is your buyer a government or public sector body?',
@@ -72,7 +71,7 @@ const YOUR_QUOTE = {
       CAN_NOW_SUBMIT: 'You can now submit a',
       FULL_APPLICATION: {
         TEXT: 'full application',
-        HREF: INSURANCE_ROUTES.START,
+        HREF: LINKS.EXTERNAL.FULL_APPLICATION,
       },
       TIMEFRAME: 'It takes about 2 weeks to get a decision from UKEF.',
       CAN_GET_HELP: 'You can get help with the application process from export finance managers or brokers.',


### PR DESCRIPTION
## Introduction :pencil2:
The quote tool has a link to start creating a full application - this was pointing to our own "start insurance" page, however it should point to an external GOV page.

## Resolution :heavy_check_mark:
- Update the "full application" link.

## Miscellaneous :heavy_plus_sign:
- Update a quote E2E test to assert the link via externl links instead of the link in content strings.
