### PR TITLE
fix(EMS-2331 2364): No PDF - Companies house unavailable, policy start page copy updates

### DIFF
--- a/e2e-tests/content-strings/pages/insurance/business/index.js
+++ b/e2e-tests/content-strings/pages/insurance/business/index.js
@@ -28,18 +28,6 @@ export const COMPANY_DETAILS = {
   BODY: 'This information comes from Companies House.',
 };
 
-export const COMPANIES_HOUSE_UNAVAILABLE = {
-  ...SHARED,
-  PAGE_TITLE: 'You cannot search for your Companies House registration number right now',
-  ERROR_REASON: 'This is due to technical issues with the Companies House search',
-  TRY_AGAIN_PREFIX: 'You can',
-  TRY_AGAIN: 'try again in a few minutes.',
-  CONTINUE_PREFIX: 'Or you can continue filling in',
-  CONTINUE_LINK: 'other sections of your application,',
-  CONTINUE_SUFFIX: 'until this problem is resolved',
-  INFORMATION: '(You may lose any information you entered on the previous page.)',
-};
-
 export const CONTACT = {
   ...SHARED,
   PAGE_TITLE: 'Your contact details',

--- a/e2e-tests/content-strings/pages/insurance/eligibility/index.js
+++ b/e2e-tests/content-strings/pages/insurance/eligibility/index.js
@@ -74,7 +74,7 @@ export const NO_COMPANIES_HOUSE_NUMBER = {
 
 export const COMPANIES_HOUSE_UNAVAILABLE = {
   PAGE_TITLE: 'You cannot search for your Companies House registration number right now',
-  ERROR_REASON: 'This is due to technical issues with the Companies House search',
+  ERROR_REASON: 'This is due to technical issues with the Companies House search.',
   TRY_AGAIN_PREFIX: 'You can',
   TRY_AGAIN: 'try again in a few minutes.',
   CONTINUE_PREFIX: 'Or you can continue filling in',

--- a/e2e-tests/content-strings/pages/insurance/policy/index.js
+++ b/e2e-tests/content-strings/pages/insurance/policy/index.js
@@ -8,9 +8,9 @@ const ROOT = {
   LIST: {
     INTRO: 'This section will cover',
     ITEMS: [
-      'what type of policy you need(single or multiple)',
+      'what type of policy you need (single or multiple)',
       'whose name should be on the policy',
-      'whether you need cover during the pre - credit period',
+      'whether you need cover during the pre-credit period',
       'any other companies that may need to be covered in your policy',
     ],
   },

--- a/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
@@ -74,7 +74,7 @@ const NO_COMPANIES_HOUSE_NUMBER = {
 
 const COMPANIES_HOUSE_UNAVAILABLE = {
   PAGE_TITLE: 'You cannot search for your Companies House registration number right now',
-  ERROR_REASON: 'This is due to technical issues with the Companies House search',
+  ERROR_REASON: 'This is due to technical issues with the Companies House search.',
   TRY_AGAIN_PREFIX: 'You can',
   TRY_AGAIN: 'try again in a few minutes.',
   CONTINUE_PREFIX: 'Or you can continue filling in',

--- a/src/ui/server/content-strings/pages/insurance/policy/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/policy/index.ts
@@ -8,9 +8,9 @@ const ROOT = {
   LIST: {
     INTRO: 'This section will cover',
     ITEMS: [
-      'what type of policy you need(single or multiple)',
+      'what type of policy you need (single or multiple)',
       'whose name should be on the policy',
-      'whether you need cover during the pre - credit period',
+      'whether you need cover during the pre-credit period',
       'any other companies that may need to be covered in your policy',
     ],
   },

--- a/src/ui/server/content-strings/pages/insurance/your-business/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/your-business/index.ts
@@ -27,17 +27,6 @@ const EXPORTER_BUSINESS = {
     ...SHARED,
     ...COMPANY_DETAILS,
   },
-  COMPANIES_HOUSE_UNAVAILABLE: {
-    ...SHARED,
-    PAGE_TITLE: 'You cannot search for your Companies House registration number right now',
-    ERROR_REASON: 'This is due to technical issues with the Companies House search',
-    TRY_AGAIN_PREFIX: 'You can',
-    TRY_AGAIN: 'try again in a few minutes.',
-    CONTINUE_PREFIX: 'Or you can continue filling in',
-    CONTINUE_LINK: 'other sections of your application,',
-    CONTINUE_SUFFIX: 'until this problem is resolved',
-    INFORMATION: '(You may lose any information you entered on the previous page.)',
-  },
   ALTERNATIVE_TRADING_ADDRESS: {
     ...SHARED,
     PAGE_TITLE: 'Alternative trading address',


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes some copy issues in the "policy start" and "Companies house unavailable" pages.

## Resolution :heavy_check_mark:
- Update content strings.

## Miscellaneous :heavy_plus_sign:
- Remove unused `COMPANIES_HOUSE_UNAVAILABLE` content strings; Seems to have been leftover after moving Companies House into the eligibility flow.