### PR TITLE
fix(EMS-2407): No PDF - Remove policy type intro. Minor tech improvements

### DIFF
--- a/e2e-tests/content-strings/pages/insurance/policy/index.js
+++ b/e2e-tests/content-strings/pages/insurance/policy/index.js
@@ -20,7 +20,6 @@ const ROOT = {
 const TYPE_OF_POLICY = {
   ...SHARED,
   PAGE_TITLE: 'What type of policy do you need?',
-  INTRO: 'You can change this before you accept and pay for any policy.',
 };
 
 const SINGLE_CONTRACT_POLICY = {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/type-of-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/type-of-policy.spec.js
@@ -1,7 +1,6 @@
 import {
   field,
   headingCaption,
-  intro,
   submitButton,
   saveAndBackButton,
 } from '../../../../../../pages/shared';
@@ -84,10 +83,6 @@ context('Insurance - Policy - Type of policy page - As an exporter, I want to en
 
     it('renders a heading caption', () => {
       cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
-    });
-
-    it('renders an intro paragraph', () => {
-      cy.checkText(intro(), CONTENT_STRINGS.INTRO);
     });
 
     it('renders `single` radio input with label and hint text list', () => {

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
@@ -12,6 +12,7 @@ const {
   QUOTE: { BUYER_COUNTRY, BUYER_BODY },
 } = ROUTES;
 
+const supportedCountryName = COUNTRY_QUOTE_SUPPORT.ONLINE.NAME;
 const baseUrl = Cypress.config('baseUrl');
 
 context('Buyer country page - as an exporter, I want to check if UKEF issue credit insurance cover for where my buyer is based', () => {
@@ -92,10 +93,12 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue cred
     });
 
     describe('when submitting with a supported country', () => {
-      beforeEach(() => {
-        cy.keyboardInput(countryInput.field(FIELD_ID).input(), COUNTRY_QUOTE_SUPPORT.ONLINE.NAME);
+      const field = countryInput.field(FIELD_ID);
 
-        const results = countryInput.field(FIELD_ID).results();
+      beforeEach(() => {
+        cy.keyboardInput(field.input(), supportedCountryName);
+
+        const results = field.results();
         results.first().click();
 
         submitButton().click();
@@ -110,11 +113,9 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue cred
       it('should prepopulate the field when going back to the page via back link', () => {
         cy.clickBackLink();
 
-        const expectedValue = COUNTRY_QUOTE_SUPPORT.ONLINE.NAME;
+        cy.checkValue(field, supportedCountryName);
 
-        cy.checkValue(countryInput.field(FIELD_ID), expectedValue);
-
-        cy.checkText(countryInput.field(FIELD_ID).results(), expectedValue);
+        cy.checkText(field.results(), supportedCountryName);
       });
     });
   });

--- a/src/api/package-lock.json
+++ b/src/api/package-lock.json
@@ -8113,7 +8113,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -9208,7 +9208,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9775,7 +9775,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -9802,7 +9802,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -14932,7 +14932,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
       "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -15170,7 +15170,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -21042,7 +21042,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -21446,7 +21446,7 @@
       "version": "1.69.5",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
       "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/src/ui/server/content-strings/pages/insurance/policy/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/policy/index.ts
@@ -20,7 +20,6 @@ const ROOT = {
 const TYPE_OF_POLICY = {
   ...SHARED,
   PAGE_TITLE: 'What type of policy do you need?',
-  INTRO: 'You can change this before you accept and pay for any policy.',
 };
 
 const SINGLE_CONTRACT_POLICY = {

--- a/src/ui/server/helpers/companies-house-search/validation/rules/companiesHouseNumber.ts
+++ b/src/ui/server/helpers/companies-house-search/validation/rules/companiesHouseNumber.ts
@@ -16,9 +16,9 @@ const { ELIGIBILITY } = ERROR_MESSAGES.INSURANCE;
  * - only contains letters and/or numbers
  * - has a length greater than 6
  */
-const joiFunc = Joi.string();
+const joiString = Joi.string();
 
-const schema = () => joiFunc.alphanum().trim().min(6).required();
+const schema = () => joiString.alphanum().trim().min(6).required();
 
 /**
  * validates companies house input

--- a/src/ui/templates/insurance/policy/type-of-policy.njk
+++ b/src/ui/templates/insurance/policy/type-of-policy.njk
@@ -38,7 +38,6 @@
           <span class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading" id="heading" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
           </span>
-          <p class="govuk-body" data-cy="intro">{{ CONTENT_STRINGS.INTRO }}</p>
         {% endset %}
 
         {% set singlePolicyTypeHintHtml %}


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where the "policy type" page had an intro that is no longer required for no PDF.

## Resolution :heavy_check_mark:
- Remove intro from "policy type" page.

## Miscellaneous :heavy_plus_sign:
- Update an E2E test to use more consts/variables (mentioned in another PR).
- Rename a `Joi.string()` const name (mentioned in another PR).
