### PR TITLE
chore(EMS-2414): Add enctype to all forms

### DIFF
--- a/e2e-tests/commands/core-page-checks.js
+++ b/e2e-tests/commands/core-page-checks.js
@@ -1,5 +1,10 @@
 import { BUTTONS, LINKS, ORGANISATION } from '../content-strings';
-import { backLink as backLinkSelector, heading, submitButton } from '../pages/shared';
+import {
+  backLink as backLinkSelector,
+  form,
+  heading,
+  submitButton,
+} from '../pages/shared';
 
 // const lighthouseAudit = (lightHouseThresholds = {}) => {
 //   cy.lighthouse({
@@ -58,9 +63,9 @@ const checkPageTitleAndHeading = (pageTitle) => {
  * @param {String} pageTitle - Expected page title
  * @param {String} currentHref - Expected page HREF
  * @param {String} backLink - Expected "back" HREF
- * @param {Boolean} assertSubmitButton - Should check submit button (some pages don't have a submit button)
+ * @param {Boolean} hasAForm - Flag for if a page has a form, to check check form attributes and submit button (some paged do not have a form)
  * @param {String} submitButtonCopy - Expected submit button copy
- * @param {Boolean} assertBackLink - Should check "back" link (some pages don't have a back link)
+ * @param {Boolean} assertBackLink - Should check "back" link (some pages do not have a back link)
  * @param {Boolean} isInsurancePage - If page is an insurance page or otherwise
  * @param {Boolean} assertServiceHeading - Should check service heading is for insurance or quote
  * @param {Object} lightHouseThresholds - Custom expected lighthouse thresholds
@@ -69,7 +74,7 @@ const corePageChecks = ({
   pageTitle,
   currentHref,
   backLink,
-  assertSubmitButton = true,
+  hasAForm = true,
   submitButtonCopy = BUTTONS.CONTINUE,
   assertBackLink = true,
   assertAuthenticatedHeader = true,
@@ -109,9 +114,15 @@ const corePageChecks = ({
   // check page title and heading
   checkPageTitleAndHeading(pageTitle);
 
-  if (assertSubmitButton) {
-    // check submit button
-    submitButton().should('exist');
+  /**
+   * If the page has a form,
+   * 1) Assert form attributes
+   * 2) Assert submit button.
+   */
+  if (hasAForm) {
+    form().should('have.attr', 'method', 'POST');
+    form().should('have.attr', 'enctype', 'application/x-www-form-urlencoded');
+    form().should('have.attr', 'novalidate');
 
     cy.checkText(submitButton(), submitButtonCopy);
   }

--- a/e2e-tests/insurance/cypress/e2e/journeys/accessibility-statement-signed-in.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/accessibility-statement-signed-in.spec.js
@@ -28,7 +28,7 @@ context('Accessibility statement page - Insurance - Signed in', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ACCESSIBILITY_STATEMENT,
       backLink: dashboardUrl,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: true,
       isInsurancePage: true,
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/accessibility-statement.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/accessibility-statement.spec.js
@@ -49,7 +49,7 @@ context('Accessibility statement page - Insurance', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.ACCESSIBILITY_STATEMENT,
       backLink: startRoute,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: false,
       isInsurancePage: true,
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/confirm-email/confirm-email-verification-expired-link.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/confirm-email/confirm-email-verification-expired-link.spec.js
@@ -77,7 +77,7 @@ context('Insurance - Account - Create - Confirm email page - expired token - As 
         pageTitle: CONTENT_STRINGS.PAGE_TITLE,
         currentHref: verificationUrl,
         backLink: `${CONFIRM_EMAIL}?id=${account.id}`,
-        assertSubmitButton: false,
+        hasAForm: false,
         assertAuthenticatedHeader: false,
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/confirm-email/confirm-email-verification-invalid-link.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/confirm-email/confirm-email-verification-invalid-link.spec.js
@@ -42,7 +42,7 @@ context('Insurance - Account - Create - Confirm email page - invalid link - As a
         currentHref: verifyEmailUrl,
         assertBackLink: false,
         assertAuthenticatedHeader: false,
-        assertSubmitButton: false,
+        hasAForm: false,
       });
 
       cy.checkText(

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/confirm-email/confirm-email.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/confirm-email/confirm-email.spec.js
@@ -52,7 +52,7 @@ context('Insurance - Account - Create - Confirm email page - As an Exporter I wa
         pageTitle: CONTENT_STRINGS.PAGE_TITLE,
         currentHref: `${CONFIRM_EMAIL}?id=${account.id}`,
         backLink: YOUR_DETAILS,
-        assertSubmitButton: false,
+        hasAForm: false,
         assertAuthenticatedHeader: false,
         lightHouseThresholds: {
           performance: 69,

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/resend-confirm-email/resend-confirm-email.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/resend-confirm-email/resend-confirm-email.spec.js
@@ -51,7 +51,7 @@ context('Insurance - Account - Create - Resend confirm email page - As an Export
         pageTitle: CONTENT_STRINGS.PAGE_TITLE,
         currentHref: url,
         backLink: `${CONFIRM_EMAIL}?id=${account.id}`,
-        assertSubmitButton: false,
+        hasAForm: false,
         assertAuthenticatedHeader: false,
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/manage/account-manage.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/manage/account-manage.spec.js
@@ -85,7 +85,7 @@ context('Insurance - Account - Manage - As an Exporter, I want the service to ha
           currentHref: MANAGE,
           backLink: DASHBOARD,
           assertBackLink: true,
-          assertSubmitButton: false,
+          hasAForm: false,
           assertAuthenticatedHeader: true,
         });
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/expired-link/account-password-reset-expired-link.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/expired-link/account-password-reset-expired-link.spec.js
@@ -94,7 +94,7 @@ context('Insurance - Account - Password reset - expired link page', () => {
         currentHref: EXPIRED_LINK,
         assertBackLink: false,
         assertAuthenticatedHeader: false,
-        assertSubmitButton: false,
+        hasAForm: false,
       });
 
       cy.checkText(linkExpiredPage.passwordNotReset(), CONTENT_STRINGS.PASSWORD_NOT_RESET);

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/link-sent/account-password-reset-link-sent.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/link-sent/account-password-reset-link-sent.spec.js
@@ -60,7 +60,7 @@ context('Insurance - Account - Password reset - link sent page - As an Exporter,
         currentHref: LINK_SENT,
         backLink: PASSWORD_RESET_ROOT,
         assertAuthenticatedHeader: false,
-        assertSubmitButton: false,
+        hasAForm: false,
       });
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/success/account-password-reset-success.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/success/account-password-reset-success.spec.js
@@ -62,7 +62,7 @@ context('Insurance - Account - Password reset - success page - I want to reset m
           currentHref: successUrl,
           assertBackLink: false,
           assertAuthenticatedHeader: false,
-          assertSubmitButton: false,
+          hasAForm: false,
         });
 
         cy.checkLink(

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/reactivated/account-reactivated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/reactivated/account-reactivated.spec.js
@@ -54,7 +54,7 @@ context('Insurance - Account - Reactivated page', () => {
         currentHref: REACTIVATED_ROOT,
         assertBackLink: false,
         assertAuthenticatedHeader: false,
-        assertSubmitButton: false,
+        hasAForm: false,
       });
 
       cy.checkText(

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-out/account-signed-out.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-out/account-signed-out.spec.js
@@ -30,7 +30,7 @@ context('Insurance - Account - Signed out -  As an Exporter I want the system to
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: SIGNED_OUT,
       assertBackLink: false,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: false,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/suspended/account-suspended.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/suspended/account-suspended.spec.js
@@ -48,7 +48,7 @@ context('Insurance - Account - Suspended page - As an Exporter, I want to reacti
         currentHref: accountSuspendedUrl,
         assertBackLink: false,
         assertAuthenticatedHeader: false,
-        assertSubmitButton: false,
+        hasAForm: false,
       });
 
       cy.checkText(suspendedPage.body(), CONTENT_STRINGS.BODY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/suspended/email-sent/account-suspended-email-sent.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/suspended/email-sent/account-suspended-email-sent.spec.js
@@ -56,7 +56,7 @@ context('Insurance - Account - Suspended - Email sent page - As an Exporter, I w
           currentHref: EMAIL_SENT,
           backLink: `${SUSPENDED_ROOT}?id=${account.id}`,
           assertAuthenticatedHeader: false,
-          assertSubmitButton: false,
+          hasAForm: false,
         });
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/suspended/link-invalid/account-suspended-invalid-link.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/suspended/link-invalid/account-suspended-invalid-link.spec.js
@@ -39,7 +39,7 @@ context('Insurance - Account - Suspended - Verify email - Visit with an invalid 
         currentHref: verifyEmailUrl,
         assertBackLink: false,
         assertAuthenticatedHeader: false,
-        assertSubmitButton: false,
+        hasAForm: false,
       });
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/all-sections.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/all-sections.spec.js
@@ -37,7 +37,7 @@ context('Insurance - All sections - new application', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.ALL_SECTIONS}`,
       backLink: ROUTES.INSURANCE.ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertBackLink: false,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/application-submitted.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/application-submitted.spec.js
@@ -42,7 +42,7 @@ context('Insurance - application submitted page', () => {
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${APPLICATION_SUBMITTED}`,
       backLink: `${INSURANCE_ROOT}/${referenceNumber}${HOW_YOUR_DATA_WILL_BE_USED}`,
       assertBackLink: false,
-      assertSubmitButton: false,
+      hasAForm: false,
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/apply-offline-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/apply-offline-page.spec.js
@@ -44,7 +44,7 @@ context('Insurance - apply offline exit page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: APPLY_OFFLINE,
       backLink: BUYER_COUNTRY,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: false,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/need-to-start-new-application/need-to-start-new-application-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/need-to-start-new-application/need-to-start-new-application-page.spec.js
@@ -62,7 +62,7 @@ context('Insurance - Check your answers - Need to start new application page', (
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: url,
       backLink: eligibilityUrl,
-      assertSubmitButton: false,
+      hasAForm: false,
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/complete-other-sections.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/complete-other-sections.spec.js
@@ -42,7 +42,7 @@ context('Insurance - Complete other sections page', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${COMPLETE_OTHER_SECTIONS}`,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertBackLink: false,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/contact-us.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/contact-us.spec.js
@@ -28,7 +28,7 @@ context('Contact us page - Insurance', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.INSURANCE.CONTACT_US,
       backLink: ROUTES.INSURANCE.START,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: false,
       isInsurancePage: true,
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/cookies-saved.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/cookies-saved.spec.js
@@ -38,7 +38,7 @@ context('Cookies saved page - Insurance', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: COOKIES_SAVED,
       backLink: COOKIES,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: false,
       isInsurancePage: true,
       assertCookies: false,

--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard.spec.js
@@ -57,7 +57,7 @@ context('Insurance - Dashboard - new application - As an Exporter, I want to acc
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: DASHBOARD,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertBackLink: false,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-page.spec.js
@@ -44,7 +44,7 @@ context('Insurance Eligibility - Cannot apply exit page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: CANNOT_APPLY,
       backLink: BUYER_COUNTRY,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: false,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/feedback/feedback-confirmation-page-signed-in.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/feedback/feedback-confirmation-page-signed-in.spec.js
@@ -25,11 +25,17 @@ context('Insurance - Feedback confirmation page - Signed in', () => {
 
   it('renders core page elements', () => {
     cy.corePageChecks({
+      hasAForm: false,
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: url,
-      submitButtonCopy: BUTTONS.BACK_TO_SERVICE,
       assertAuthenticatedHeader: true,
       assertBackLink: false,
     });
+  });
+
+  it('renders a "submit button"/link', () => {
+    cy.navigateToUrl(url);
+
+    cy.checkText(submitButton(), BUTTONS.BACK_TO_SERVICE);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/feedback/feedback-confirmation-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/feedback/feedback-confirmation-page.spec.js
@@ -28,9 +28,9 @@ context('Insurance - Feedback Confirmation page', () => {
 
   it('renders core page elements', () => {
     cy.corePageChecks({
+      hasAForm: false,
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: url,
-      submitButtonCopy: BUTTONS.BACK_TO_SERVICE,
       assertAuthenticatedHeader: false,
       assertBackLink: false,
     });
@@ -43,6 +43,12 @@ context('Insurance - Feedback Confirmation page', () => {
 
     it('should render text confirming feedback', () => {
       cy.checkText(feedbackConfirmation.feedbackConfirmation(), CONTENT_STRINGS.FEEDBACK_TEXT);
+    });
+
+    it('renders a "submit button"/link', () => {
+      cy.navigateToUrl(url);
+
+      cy.checkText(submitButton(), BUTTONS.BACK_TO_SERVICE);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/no-access-application-submitted/no-access-application-submitted.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/no-access-application-submitted/no-access-application-submitted.spec.js
@@ -51,7 +51,7 @@ context('Insurance - no access to application when application is submitted', ()
       cy.corePageChecks({
         pageTitle: CONTENT_STRINGS.PAGE_TITLE,
         currentHref: NO_ACCESS_APPLICATION_SUBMITTED,
-        assertSubmitButton: false,
+        hasAForm: false,
         backLink: expectedUrl,
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/no-access-to-application/no-access-to-application.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/no-access-to-application/no-access-to-application.spec.js
@@ -50,7 +50,7 @@ context('Insurance - no access to application page - signed out', () => {
       cy.corePageChecks({
         pageTitle: CONTENT_STRINGS.PAGE_TITLE,
         currentHref: NO_ACCESS_TO_APPLICATION,
-        assertSubmitButton: false,
+        hasAForm: false,
         assertBackLink: false,
         assertAuthenticatedHeader: false,
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/page-not-found-when-signed-out.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/page-not-found-when-signed-out.spec.js
@@ -18,7 +18,7 @@ context('Insurance - page not found - signed out', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: invalidUrl,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertBackLink: false,
       assertAuthenticatedHeader: false,
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/page-not-found.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/page-not-found.spec.js
@@ -19,7 +19,7 @@ context('Insurance - page not found', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: invalidUrl,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertBackLink: false,
       assertAuthenticatedHeader: true,
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/problem-with-service.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/problem-with-service.spec.js
@@ -20,7 +20,7 @@ context('Problem with service page - Insurance', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: url,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: false,
       assertBackLink: false,
       isInsurancePage: true,

--- a/e2e-tests/insurance/cypress/e2e/journeys/speak-to-ukef-efm.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/speak-to-ukef-efm.spec.js
@@ -49,7 +49,7 @@ context('Insurance - speak to UKEF EFM exit page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: SPEAK_TO_UKEF_EFM,
       backLink: INSURED_PERIOD,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: false,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/companies-house-number/companies-house-unavailable/companies-house-unavailable-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/companies-house-number/companies-house-unavailable/companies-house-unavailable-page.spec.js
@@ -42,7 +42,7 @@ context("Insurance - Your business - Companies house unavailable page - I want t
       currentHref: `${ROOT}/${referenceNumber}${COMPANIES_HOUSE_UNAVAILABLE}`,
       backLink: null,
       assertBackLink: false,
-      assertSubmitButton: false,
+      hasAForm: false,
     });
   });
 

--- a/e2e-tests/pages/shared/index.js
+++ b/e2e-tests/pages/shared/index.js
@@ -7,6 +7,7 @@ import ukGoodsOrServicesPage from './ukGoodsOrServices';
 import field from './field';
 
 const backLink = () => cy.get('[data-cy="back-link"]');
+const form = () => cy.get('[data-cy="form"]');
 const heading = () => cy.get('[data-cy="heading"]');
 const headingCaption = () => cy.get('[data-cy="heading-caption"]');
 const yesNoRadioHint = () => cy.get('[data-cy="yes-no-input-hint"]');
@@ -35,6 +36,7 @@ const singleInputField = (fieldId) => ({
 
 export {
   backLink,
+  form,
   heading,
   headingCaption,
   yesNoRadioHint,

--- a/e2e-tests/quote/cypress/e2e/journeys/page-not-found.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/page-not-found.spec.js
@@ -16,7 +16,7 @@ context('404 Page not found', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: '/test',
-      assertSubmitButton: false,
+      hasAForm: false,
       assertBackLink: false,
       assertAuthenticatedHeader: false,
       isInsurancePage: false,

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/accessibility-statement.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/accessibility-statement.spec.js
@@ -44,7 +44,7 @@ context('Accessibility statement page - Quote', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.ACCESSIBILITY_STATEMENT,
       backLink: ROUTES.QUOTE.BUYER_COUNTRY,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: false,
       isInsurancePage: false,
     });

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
@@ -38,7 +38,7 @@ context('Cannot apply exit page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: CANNOT_APPLY,
       backLink: UK_GOODS_OR_SERVICES,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: false,
       isInsurancePage: false,
       lightHouseThresholds: {

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/contact-us.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/contact-us.spec.js
@@ -28,7 +28,7 @@ context('Contact us page - Quote', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.CONTACT_US,
       backLink: ROUTES.QUOTE.BUYER_COUNTRY,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: false,
       isInsurancePage: false,
     });

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/cookies-saved.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/cookies-saved.spec.js
@@ -38,7 +38,7 @@ context('Cookies saved page - Quote', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: COOKIES_SAVED,
       backLink: COOKIES,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: false,
       isInsurancePage: false,
       assertCookies: false,

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
@@ -30,7 +30,7 @@ context('Get a quote via email exit page', () => {
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: ROUTES.QUOTE.GET_A_QUOTE_BY_EMAIL,
       backLink: ROUTES.QUOTE.BUYER_COUNTRY,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: false,
       isInsurancePage: false,
       lightHouseThresholds: {

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/page-not-found.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/page-not-found.spec.js
@@ -18,7 +18,7 @@ context('Quote - page not found', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: invalidUrl,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertBackLink: false,
       assertAuthenticatedHeader: false,
       isInsurancePage: false,

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/problem-with-service.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/problem-with-service.spec.js
@@ -20,7 +20,7 @@ context('Problem with service page - Quote', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: url,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertAuthenticatedHeader: false,
       assertBackLink: false,
       isInsurancePage: false,

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/your-quote/your-quote-single-policy.spec.js
@@ -73,7 +73,7 @@ context('Get a quote/your quote page (single policy) - as an exporter, I want to
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: url,
-      assertSubmitButton: false,
+      hasAForm: false,
       assertBackLink: false,
       assertAuthenticatedHeader: false,
       isInsurancePage: false,

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -99,7 +99,8 @@ var import_dotenv = __toESM(require("dotenv"));
 
 // constants/field-ids/shared/index.ts
 var SHARED = {
-  POLICY_TYPE: "policyType"
+  POLICY_TYPE: "policyType",
+  NAME: "name"
 };
 var shared_default = SHARED;
 
@@ -4914,7 +4915,7 @@ var getSupportedCurrencies = (currencies) => {
 };
 var mapCurrencies = (currencies) => {
   const supportedCurrencies = getSupportedCurrencies(currencies);
-  const sorted = sort_array_alphabetically_default(supportedCurrencies, "name");
+  const sorted = sort_array_alphabetically_default(supportedCurrencies, FIELD_IDS.NAME);
   return sorted;
 };
 var map_currencies_default = mapCurrencies;

--- a/src/ui/templates/cookies.njk
+++ b/src/ui/templates/cookies.njk
@@ -116,7 +116,7 @@
     dataCy: 'analytics-info-list'
   }) }}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/cookies.njk
+++ b/src/ui/templates/cookies.njk
@@ -116,7 +116,7 @@
     dataCy: 'analytics-info-list'
   }) }}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/create/your-details.njk
+++ b/src/ui/templates/insurance/account/create/your-details.njk
@@ -29,7 +29,7 @@
 
   <p data-cy="intro">{{ CONTENT_STRINGS.INTRO }}</p>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/create/your-details.njk
+++ b/src/ui/templates/insurance/account/create/your-details.njk
@@ -29,7 +29,7 @@
 
   <p data-cy="intro">{{ CONTENT_STRINGS.INTRO }}</p>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/password-reset/expired-link.njk
+++ b/src/ui/templates/insurance/account/password-reset/expired-link.njk
@@ -16,7 +16,7 @@
 
       <p class="govuk-body" data-cy="if-you-would-like">{{ CONTENT_STRINGS.IF_YOU_WOULD_LIKE }}</p>
 
-      <form method="POST" id="form" novalidate>
+      <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/password-reset/expired-link.njk
+++ b/src/ui/templates/insurance/account/password-reset/expired-link.njk
@@ -16,7 +16,7 @@
 
       <p class="govuk-body" data-cy="if-you-would-like">{{ CONTENT_STRINGS.IF_YOU_WOULD_LIKE }}</p>
 
-      <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+      <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/password-reset/new-password.njk
+++ b/src/ui/templates/insurance/account/password-reset/new-password.njk
@@ -31,7 +31,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/password-reset/new-password.njk
+++ b/src/ui/templates/insurance/account/password-reset/new-password.njk
@@ -31,7 +31,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/password-reset/password-reset.njk
+++ b/src/ui/templates/insurance/account/password-reset/password-reset.njk
@@ -31,7 +31,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/password-reset/password-reset.njk
+++ b/src/ui/templates/insurance/account/password-reset/password-reset.njk
@@ -31,7 +31,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/sign-in/enter-code.njk
+++ b/src/ui/templates/insurance/account/sign-in/enter-code.njk
@@ -49,7 +49,7 @@
 
   <p data-cy="intro">{{ CONTENT_STRINGS.INTRO }}</p>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/sign-in/enter-code.njk
+++ b/src/ui/templates/insurance/account/sign-in/enter-code.njk
@@ -49,7 +49,7 @@
 
   <p data-cy="intro">{{ CONTENT_STRINGS.INTRO }}</p>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/sign-in/request-new-code.njk
+++ b/src/ui/templates/insurance/account/sign-in/request-new-code.njk
@@ -24,7 +24,7 @@
 
       <p data-cy="intro">{{ CONTENT_STRINGS.INTRO }}</p>
 
-      <form method="POST" id="form" novalidate>
+      <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/sign-in/request-new-code.njk
+++ b/src/ui/templates/insurance/account/sign-in/request-new-code.njk
@@ -24,7 +24,7 @@
 
       <p data-cy="intro">{{ CONTENT_STRINGS.INTRO }}</p>
 
-      <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+      <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/sign-in/sign-in.njk
+++ b/src/ui/templates/insurance/account/sign-in/sign-in.njk
@@ -73,7 +73,7 @@
 
   <p data-cy="intro">{{ CONTENT_STRINGS.INTRO }}</p>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/sign-in/sign-in.njk
+++ b/src/ui/templates/insurance/account/sign-in/sign-in.njk
@@ -73,7 +73,7 @@
 
   <p data-cy="intro">{{ CONTENT_STRINGS.INTRO }}</p>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/suspended/expired-link.njk
+++ b/src/ui/templates/insurance/account/suspended/expired-link.njk
@@ -14,7 +14,7 @@
 
       <p class="govuk-body" data-cy="body">{{ CONTENT_STRINGS.BODY }}</p>
 
-      <form method="POST" id="form" novalidate>
+      <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/suspended/expired-link.njk
+++ b/src/ui/templates/insurance/account/suspended/expired-link.njk
@@ -14,7 +14,7 @@
 
       <p class="govuk-body" data-cy="body">{{ CONTENT_STRINGS.BODY }}</p>
 
-      <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+      <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/suspended/suspended.njk
+++ b/src/ui/templates/insurance/account/suspended/suspended.njk
@@ -11,7 +11,7 @@
 
   <p class="govuk-body" data-cy="body">{{ CONTENT_STRINGS.BODY }} </p>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/account/suspended/suspended.njk
+++ b/src/ui/templates/insurance/account/suspended/suspended.njk
@@ -11,7 +11,7 @@
 
   <p class="govuk-body" data-cy="body">{{ CONTENT_STRINGS.BODY }} </p>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/check-your-answers/check-your-answers.njk
+++ b/src/ui/templates/insurance/check-your-answers/check-your-answers.njk
@@ -51,7 +51,7 @@
     rows: SUMMARY_LIST
   }) }}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/check-your-answers/check-your-answers.njk
+++ b/src/ui/templates/insurance/check-your-answers/check-your-answers.njk
@@ -51,7 +51,7 @@
     rows: SUMMARY_LIST
   }) }}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/declarations/anti-bribery.njk
+++ b/src/ui/templates/insurance/declarations/anti-bribery.njk
@@ -49,7 +49,7 @@
     CONTENT: CONTENT_STRINGS.EXPANDABLE
   }) }}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/declarations/anti-bribery.njk
+++ b/src/ui/templates/insurance/declarations/anti-bribery.njk
@@ -49,7 +49,7 @@
     CONTENT: CONTENT_STRINGS.EXPANDABLE
   }) }}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/declarations/anti-bribery/code-of-conduct.njk
+++ b/src/ui/templates/insurance/declarations/anti-bribery/code-of-conduct.njk
@@ -29,7 +29,7 @@
 
   <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/declarations/anti-bribery/code-of-conduct.njk
+++ b/src/ui/templates/insurance/declarations/anti-bribery/code-of-conduct.njk
@@ -29,7 +29,7 @@
 
   <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/declarations/anti-bribery/exporting-with-code-of-conduct.njk
+++ b/src/ui/templates/insurance/declarations/anti-bribery/exporting-with-code-of-conduct.njk
@@ -29,7 +29,7 @@
 
   <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/declarations/anti-bribery/exporting-with-code-of-conduct.njk
+++ b/src/ui/templates/insurance/declarations/anti-bribery/exporting-with-code-of-conduct.njk
@@ -29,7 +29,7 @@
 
   <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/declarations/confidentiality.njk
+++ b/src/ui/templates/insurance/declarations/confidentiality.njk
@@ -83,7 +83,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/declarations/confidentiality.njk
+++ b/src/ui/templates/insurance/declarations/confidentiality.njk
@@ -83,7 +83,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/account-to-apply-online.njk
+++ b/src/ui/templates/insurance/eligibility/account-to-apply-online.njk
@@ -27,7 +27,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/account-to-apply-online.njk
+++ b/src/ui/templates/insurance/eligibility/account-to-apply-online.njk
@@ -27,7 +27,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/check-if-eligible.njk
+++ b/src/ui/templates/insurance/eligibility/check-if-eligible.njk
@@ -28,7 +28,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/check-if-eligible.njk
+++ b/src/ui/templates/insurance/eligibility/check-if-eligible.njk
@@ -28,7 +28,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/companies-house-number.njk
+++ b/src/ui/templates/insurance/eligibility/companies-house-number.njk
@@ -26,7 +26,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/companies-house-number.njk
+++ b/src/ui/templates/insurance/eligibility/companies-house-number.njk
@@ -26,7 +26,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/eligible-to-apply-online.njk
+++ b/src/ui/templates/insurance/eligibility/eligible-to-apply-online.njk
@@ -34,7 +34,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/eligible-to-apply-online.njk
+++ b/src/ui/templates/insurance/eligibility/eligible-to-apply-online.njk
@@ -34,7 +34,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/insured-amount.njk
+++ b/src/ui/templates/insurance/eligibility/insured-amount.njk
@@ -26,7 +26,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/insured-amount.njk
+++ b/src/ui/templates/insurance/eligibility/insured-amount.njk
@@ -26,7 +26,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/insured-period.njk
+++ b/src/ui/templates/insurance/eligibility/insured-period.njk
@@ -26,7 +26,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/insured-period.njk
+++ b/src/ui/templates/insurance/eligibility/insured-period.njk
@@ -26,7 +26,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/letter-of-credit.njk
+++ b/src/ui/templates/insurance/eligibility/letter-of-credit.njk
@@ -26,7 +26,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/letter-of-credit.njk
+++ b/src/ui/templates/insurance/eligibility/letter-of-credit.njk
@@ -26,7 +26,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/other-parties.njk
+++ b/src/ui/templates/insurance/eligibility/other-parties.njk
@@ -27,7 +27,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/other-parties.njk
+++ b/src/ui/templates/insurance/eligibility/other-parties.njk
@@ -27,7 +27,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/pre-credit-period.njk
+++ b/src/ui/templates/insurance/eligibility/pre-credit-period.njk
@@ -28,7 +28,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/pre-credit-period.njk
+++ b/src/ui/templates/insurance/eligibility/pre-credit-period.njk
@@ -28,7 +28,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/uk-goods-or-services.njk
+++ b/src/ui/templates/insurance/eligibility/uk-goods-or-services.njk
@@ -27,7 +27,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/eligibility/uk-goods-or-services.njk
+++ b/src/ui/templates/insurance/eligibility/uk-goods-or-services.njk
@@ -27,7 +27,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/feedback.njk
+++ b/src/ui/templates/insurance/feedback.njk
@@ -36,7 +36,7 @@
   <h1 class="govuk-heading-l" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" novalidate>
+    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/feedback.njk
+++ b/src/ui/templates/insurance/feedback.njk
@@ -36,7 +36,7 @@
   <h1 class="govuk-heading-l" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+    <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/policy/about-goods-or-services.njk
+++ b/src/ui/templates/insurance/policy/about-goods-or-services.njk
@@ -36,7 +36,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/policy/about-goods-or-services.njk
+++ b/src/ui/templates/insurance/policy/about-goods-or-services.njk
@@ -36,7 +36,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/policy/check-your-answers.njk
+++ b/src/ui/templates/insurance/policy/check-your-answers.njk
@@ -30,7 +30,7 @@
     rows: SUMMARY_LIST
   }) }}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/policy/check-your-answers.njk
+++ b/src/ui/templates/insurance/policy/check-your-answers.njk
@@ -30,7 +30,7 @@
     rows: SUMMARY_LIST
   }) }}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/policy/different-name-on-policy.njk
+++ b/src/ui/templates/insurance/policy/different-name-on-policy.njk
@@ -34,7 +34,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" novalidate>
+    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/policy/different-name-on-policy.njk
+++ b/src/ui/templates/insurance/policy/different-name-on-policy.njk
@@ -34,7 +34,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+    <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/policy/multiple-contract-policy.njk
+++ b/src/ui/templates/insurance/policy/multiple-contract-policy.njk
@@ -39,7 +39,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/policy/multiple-contract-policy.njk
+++ b/src/ui/templates/insurance/policy/multiple-contract-policy.njk
@@ -39,7 +39,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/policy/name-on-policy.njk
+++ b/src/ui/templates/insurance/policy/name-on-policy.njk
@@ -43,7 +43,7 @@
   }) }}
 
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     {% set positionHTML %}

--- a/src/ui/templates/insurance/policy/name-on-policy.njk
+++ b/src/ui/templates/insurance/policy/name-on-policy.njk
@@ -43,7 +43,7 @@
   }) }}
 
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     {% set positionHTML %}

--- a/src/ui/templates/insurance/policy/single-contract-policy.njk
+++ b/src/ui/templates/insurance/policy/single-contract-policy.njk
@@ -41,7 +41,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/policy/single-contract-policy.njk
+++ b/src/ui/templates/insurance/policy/single-contract-policy.njk
@@ -41,7 +41,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/policy/type-of-policy.njk
+++ b/src/ui/templates/insurance/policy/type-of-policy.njk
@@ -26,7 +26,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/policy/type-of-policy.njk
+++ b/src/ui/templates/insurance/policy/type-of-policy.njk
@@ -26,7 +26,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/start.njk
+++ b/src/ui/templates/insurance/start.njk
@@ -37,7 +37,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/start.njk
+++ b/src/ui/templates/insurance/start.njk
@@ -37,7 +37,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/your-business/broker.njk
+++ b/src/ui/templates/insurance/your-business/broker.njk
@@ -104,7 +104,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+    <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/your-business/broker.njk
+++ b/src/ui/templates/insurance/your-business/broker.njk
@@ -104,7 +104,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" novalidate>
+    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/your-business/check-your-answers.njk
+++ b/src/ui/templates/insurance/your-business/check-your-answers.njk
@@ -30,7 +30,7 @@
     rows: SUMMARY_LIST
   }) }}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/your-business/check-your-answers.njk
+++ b/src/ui/templates/insurance/your-business/check-your-answers.njk
@@ -30,7 +30,7 @@
     rows: SUMMARY_LIST
   }) }}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/your-business/companies_house_number.njk
+++ b/src/ui/templates/insurance/your-business/companies_house_number.njk
@@ -30,7 +30,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" novalidate>
+    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/your-business/companies_house_number.njk
+++ b/src/ui/templates/insurance/your-business/companies_house_number.njk
@@ -30,7 +30,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+    <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/your-business/company-details.njk
+++ b/src/ui/templates/insurance/your-business/company-details.njk
@@ -34,7 +34,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" novalidate>
+    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/your-business/company-details.njk
+++ b/src/ui/templates/insurance/your-business/company-details.njk
@@ -34,7 +34,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+    <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/your-business/contact.njk
+++ b/src/ui/templates/insurance/your-business/contact.njk
@@ -34,7 +34,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" novalidate>
+    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/your-business/contact.njk
+++ b/src/ui/templates/insurance/your-business/contact.njk
@@ -34,7 +34,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+    <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/your-business/nature-of-your-business.njk
+++ b/src/ui/templates/insurance/your-business/nature-of-your-business.njk
@@ -33,7 +33,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+    <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/your-business/nature-of-your-business.njk
+++ b/src/ui/templates/insurance/your-business/nature-of-your-business.njk
@@ -33,7 +33,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" novalidate>
+    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/your-business/turnover.njk
+++ b/src/ui/templates/insurance/your-business/turnover.njk
@@ -33,7 +33,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+    <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/your-business/turnover.njk
+++ b/src/ui/templates/insurance/your-business/turnover.njk
@@ -33,7 +33,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <form method="POST" id="form" novalidate>
+    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">

--- a/src/ui/templates/insurance/your-buyer/check-your-answers.njk
+++ b/src/ui/templates/insurance/your-buyer/check-your-answers.njk
@@ -30,7 +30,7 @@
     rows: SUMMARY_LIST
   }) }}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/your-buyer/check-your-answers.njk
+++ b/src/ui/templates/insurance/your-buyer/check-your-answers.njk
@@ -30,7 +30,7 @@
     rows: SUMMARY_LIST
   }) }}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
+++ b/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
@@ -42,7 +42,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     <div class="govuk-grid-row">

--- a/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
+++ b/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
@@ -42,7 +42,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" novalidate="novalidate">
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     <div class="govuk-grid-row">

--- a/src/ui/templates/insurance/your-buyer/working-with-buyer.njk
+++ b/src/ui/templates/insurance/your-buyer/working-with-buyer.njk
@@ -35,7 +35,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     <div class="govuk-grid-row">

--- a/src/ui/templates/insurance/your-buyer/working-with-buyer.njk
+++ b/src/ui/templates/insurance/your-buyer/working-with-buyer.njk
@@ -35,7 +35,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" novalidate="novalidate">
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     <div class="govuk-grid-row">

--- a/src/ui/templates/partials/cookies-banner.njk
+++ b/src/ui/templates/partials/cookies-banner.njk
@@ -61,7 +61,7 @@
 {% endif %}
 
 {% if not cookieConsentDecision %}
-  <form method="POST" action="/cookies-consent" novalidate>
+  <form method="POST" action="/cookies-consent" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/quote/buyer-body.njk
+++ b/src/ui/templates/quote/buyer-body.njk
@@ -26,7 +26,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/quote/buyer-body.njk
+++ b/src/ui/templates/quote/buyer-body.njk
@@ -26,7 +26,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/quote/check-your-answers.njk
+++ b/src/ui/templates/quote/check-your-answers.njk
@@ -34,7 +34,7 @@
     rows: SUMMARY_LIST.POLICY.ROWS
   }) }}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/quote/check-your-answers.njk
+++ b/src/ui/templates/quote/check-your-answers.njk
@@ -34,7 +34,7 @@
     rows: SUMMARY_LIST.POLICY.ROWS
   }) }}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/quote/policy-type.njk
+++ b/src/ui/templates/quote/policy-type.njk
@@ -29,7 +29,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
 
-      <form method="POST" id="form" novalidate>
+      <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/quote/policy-type.njk
+++ b/src/ui/templates/quote/policy-type.njk
@@ -29,7 +29,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
 
-      <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+      <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/quote/tell-us-about-your-policy.njk
+++ b/src/ui/templates/quote/tell-us-about-your-policy.njk
@@ -41,7 +41,7 @@
       </div>
     </div>
 
-    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+    <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/quote/tell-us-about-your-policy.njk
+++ b/src/ui/templates/quote/tell-us-about-your-policy.njk
@@ -41,7 +41,7 @@
       </div>
     </div>
 
-    <form method="POST" id="form" novalidate>
+    <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/quote/uk-goods-or-services.njk
+++ b/src/ui/templates/quote/uk-goods-or-services.njk
@@ -27,7 +27,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/quote/uk-goods-or-services.njk
+++ b/src/ui/templates/quote/uk-goods-or-services.njk
@@ -27,7 +27,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/shared-pages/buyer-country.njk
+++ b/src/ui/templates/shared-pages/buyer-country.njk
@@ -27,7 +27,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     <input type="hidden" name="{{ HIDDEN_FIELD_ID }}" id="{{ HIDDEN_FIELD_ID }}" value="{{ submittedValues[HIDDEN_FIELD_ID].name }}">
 

--- a/src/ui/templates/shared-pages/buyer-country.njk
+++ b/src/ui/templates/shared-pages/buyer-country.njk
@@ -27,7 +27,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     <input type="hidden" name="{{ HIDDEN_FIELD_ID }}" id="{{ HIDDEN_FIELD_ID }}" value="{{ submittedValues[HIDDEN_FIELD_ID].name }}">
 

--- a/src/ui/templates/shared-pages/declaration.njk
+++ b/src/ui/templates/shared-pages/declaration.njk
@@ -44,7 +44,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/shared-pages/declaration.njk
+++ b/src/ui/templates/shared-pages/declaration.njk
@@ -44,7 +44,7 @@
     </div>
   </div>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/shared-pages/exporter-location.njk
+++ b/src/ui/templates/shared-pages/exporter-location.njk
@@ -25,7 +25,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/shared-pages/exporter-location.njk
+++ b/src/ui/templates/shared-pages/exporter-location.njk
@@ -25,7 +25,7 @@
     }) }}
   {% endif %}
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/shared-pages/need-to-start-again.njk
+++ b/src/ui/templates/shared-pages/need-to-start-again.njk
@@ -11,7 +11,7 @@
 
   <p class="govuk-body" data-cy="reason">{{ CONTENT_STRINGS.REASON }}</p>
 
-  <form method="POST" id="form" novalidate>
+  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/src/ui/templates/shared-pages/need-to-start-again.njk
+++ b/src/ui/templates/shared-pages/need-to-start-again.njk
@@ -11,7 +11,7 @@
 
   <p class="govuk-body" data-cy="reason">{{ CONTENT_STRINGS.REASON }}</p>
 
-  <form method="POST" id="form" enctype="application/x-www-form-urlencoded" novalidate>
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates all forms to include an `enctype` attribute with a value of `application/x-www-form-urlencoded`.

Note that we do not currently have any file upload functionality, so the `enctype` attribute does not need to differ.

## Resolution :heavy_check_mark:
- Update all instances of html forms.

## Miscellaneous :heavy_plus_sign:
- Replace all unused form ID attributes with `data-cy`.
- Update E2E `corePageChecks` to have a `hasAForm` parameter, instead of `assertSubmitButton` and check form attributes.