### PR TITLE
chore(EMS-722): Split up Companies house summary list assertions

### DIFF
--- a/src/ui/server/helpers/summary-lists/companies-house/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/companies-house/index.test.ts
@@ -15,43 +15,61 @@ const {
 
 describe('server/helpers/summary-lists/companies-house', () => {
   describe('generateFields', () => {
-    it('should populate field groups when provided with companyDetails', () => {
-      const isApplicationData = true;
-      const result = generateFields(mockCompany, isApplicationData);
+    const isApplicationData = true;
+    const result = generateFields(mockCompany, isApplicationData);
 
-      const expected = [
-        fieldGroupItem({
-          field: getFieldById(FIELDS, COMPANY_NUMBER),
-          data: mockCompany,
-        }),
-        fieldGroupItem({
-          field: getFieldById(FIELDS, COMPANY_NAME),
-          data: mockCompany,
-        }),
-        fieldGroupItem(
-          {
-            field: getFieldById(FIELDS, COMPANY_ADDRESS),
-            data: mockCompany,
-          },
-          generateMultipleFieldHtml(mockCompany[COMPANY_ADDRESS]),
-        ),
-        fieldGroupItem(
-          {
-            field: getFieldById(FIELDS, COMPANY_INCORPORATED),
-            data: mockCompany,
-          },
-          formatDate(mockCompany[COMPANY_INCORPORATED]),
-        ),
-        fieldGroupItem(
-          {
-            field: getFieldById(FIELDS, COMPANY_SIC),
-            data: mockCompany,
-          },
-          generateSicCodesValue(mockCompany, isApplicationData),
-        ),
-      ];
+    it(`it should populate a ${COMPANY_NUMBER} field`, () => {
+      const expected = fieldGroupItem({
+        field: getFieldById(FIELDS, COMPANY_NUMBER),
+        data: mockCompany,
+      });
 
-      expect(result).toEqual(expected);
+      expect(result[0]).toEqual(expected);
+    });
+
+    it(`it should populate a ${COMPANY_NAME} field`, () => {
+      const expected = fieldGroupItem({
+        field: getFieldById(FIELDS, COMPANY_NAME),
+        data: mockCompany,
+      });
+
+      expect(result[1]).toEqual(expected);
+    });
+
+    it(`it should populate a ${COMPANY_ADDRESS} field`, () => {
+      const expected = fieldGroupItem(
+        {
+          field: getFieldById(FIELDS, COMPANY_ADDRESS),
+          data: mockCompany,
+        },
+        generateMultipleFieldHtml(mockCompany[COMPANY_ADDRESS]),
+      );
+
+      expect(result[2]).toEqual(expected);
+    });
+
+    it(`it should populate a ${COMPANY_INCORPORATED} field`, () => {
+      const expected = fieldGroupItem(
+        {
+          field: getFieldById(FIELDS, COMPANY_INCORPORATED),
+          data: mockCompany,
+        },
+        formatDate(mockCompany[COMPANY_INCORPORATED]),
+      );
+
+      expect(result[3]).toEqual(expected);
+    });
+
+    it(`it should populate a ${COMPANY_SIC} field`, () => {
+      const expected = fieldGroupItem(
+        {
+          field: getFieldById(FIELDS, COMPANY_SIC),
+          data: mockCompany,
+        },
+        generateSicCodesValue(mockCompany, isApplicationData),
+      );
+
+      expect(result[4]).toEqual(expected);
     });
   });
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR improves the Companies house summary list unit tests.

## Resolution :heavy_check_mark:
- Split up each summary list field assertion into its own test, making debugging easier.
