### PR TITLE
feat(EMS-2399): No PDF - About goods or services - content updates

### DIFF
--- a/e2e-tests/content-strings/fields/insurance/export-contract/index.js
+++ b/e2e-tests/content-strings/fields/insurance/export-contract/index.js
@@ -7,7 +7,7 @@ const {
 export const EXPORT_CONTRACT_FIELDS = {
   ABOUT_GOODS_OR_SERVICES: {
     [ABOUT_GOODS_OR_SERVICES.DESCRIPTION]: {
-      LABEL: "Describe the goods or services you want to insure and explain how they'll be used by the buyer",
+      LABEL: "Describe the goods or services you're exporting and explain how they'll be used by the buyer",
       HINT: {
         INTRO: 'For example:',
         LIST: [
@@ -15,6 +15,7 @@ export const EXPORT_CONTRACT_FIELDS = {
           'construction materials to build commercial property',
           'educational services such as teacher training',
         ],
+        OUTRO: "We may contact you to get more information if you're exporting goods or services that might have an impact on the environment.",
       },
       MAXIMUM: 1000,
       SUMMARY: {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
@@ -85,7 +85,7 @@ context('Insurance - Export contract - About goods or services page - Final dest
       cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
     });
 
-    it(`renders ${DESCRIPTION} label, hint, prefix and input`, () => {
+    it(`renders ${DESCRIPTION} label, hint and input`, () => {
       const fieldId = DESCRIPTION;
       const field = aboutGoodsOrServicesPage[fieldId];
 
@@ -98,6 +98,8 @@ context('Insurance - Export contract - About goods or services page - Final dest
       cy.checkText(field.hint.list.item2(), FIELDS.ABOUT_GOODS_OR_SERVICES[fieldId].HINT.LIST[1]);
 
       cy.checkText(field.hint.list.item3(), FIELDS.ABOUT_GOODS_OR_SERVICES[fieldId].HINT.LIST[2]);
+
+      cy.checkText(field.hint.outro(), FIELDS.ABOUT_GOODS_OR_SERVICES[fieldId].HINT.OUTRO);
 
       field.textarea().should('exist');
     });

--- a/e2e-tests/pages/insurance/export-contract/aboutGoodsOrServices.js
+++ b/e2e-tests/pages/insurance/export-contract/aboutGoodsOrServices.js
@@ -17,6 +17,7 @@ const aboutGoodsOrServices = {
         item2: () => cy.get(`[data-cy="${DESCRIPTION}-hint-list-item-2"]`),
         item3: () => cy.get(`[data-cy="${DESCRIPTION}-hint-list-item-3"]`),
       },
+      outro: () => cy.get(`[data-cy="${DESCRIPTION}-hint-outro"]`),
     },
   },
 };

--- a/src/ui/server/content-strings/fields/insurance/export-contract/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/export-contract/index.ts
@@ -7,7 +7,7 @@ const {
 export const EXPORT_CONTRACT_FIELDS = {
   ABOUT_GOODS_OR_SERVICES: {
     [ABOUT_GOODS_OR_SERVICES.DESCRIPTION]: {
-      LABEL: "Describe the goods or services you want to insure and explain how they'll be used by the buyer",
+      LABEL: "Describe the goods or services you're exporting and explain how they'll be used by the buyer",
       HINT: {
         INTRO: 'For example:',
         LIST: [
@@ -15,6 +15,7 @@ export const EXPORT_CONTRACT_FIELDS = {
           'construction materials to build commercial property',
           'educational services such as teacher training',
         ],
+        OUTRO: "We may contact you to get more information if you're exporting goods or services that might have an impact on the environment.",
       },
       MAXIMUM: 1000,
       SUMMARY: {

--- a/src/ui/templates/insurance/export-contract/about-goods-or-services.njk
+++ b/src/ui/templates/insurance/export-contract/about-goods-or-services.njk
@@ -46,14 +46,15 @@
       <div class="govuk-grid-column-two-thirds-from-desktop">
 
         {% set descriptionHintHtml %}
+          <p class="govuk-hint" data-cy="{{ FIELDS.DESCRIPTION.ID }}-hint-intro">{{ FIELDS.DESCRIPTION.HINT.INTRO }}</p>
 
-        <p class="govuk-hint" data-cy="{{ FIELDS.DESCRIPTION.ID }}-hint-intro">{{ FIELDS.DESCRIPTION.HINT.INTRO }}</p>
+          <ul class="govuk-list govuk-list--bullet">
+            {% for item in FIELDS.DESCRIPTION.HINT.LIST %}
+              <li class="govuk-hint" data-cy="{{ FIELDS.DESCRIPTION.ID }}-hint-list-item-{{ loop.index }}">{{ item }}</li>
+            {% endfor %}
+          </ul>
 
-        <ul class="govuk-list govuk-list--bullet">
-          {% for item in FIELDS.DESCRIPTION.HINT.LIST %}
-            <li class="govuk-hint" data-cy="{{ FIELDS.DESCRIPTION.ID }}-hint-list-item-{{ loop.index }}">{{ item }}</li>
-          {% endfor %}
-        </ul>
+          <p class="govuk-hint" data-cy="{{ FIELDS.DESCRIPTION.ID }}-hint-outro">{{ FIELDS.DESCRIPTION.HINT.OUTRO }}</p>
         {% endset %}
 
         {{ govukCharacterCount({


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the content strings for "About goods or services" fields so that they are aligned with the latest no PDF design.

## Resolution :heavy_check_mark:
- Update content strings.
- Update E2E test.
