### PR TITLE
fix(EMS-2453): Buyer country field - styling issue, DRY autocomplete component

### DIFF
--- a/src/ui/templates/components/accessible-autocomplete-select.njk
+++ b/src/ui/templates/components/accessible-autocomplete-select.njk
@@ -1,0 +1,28 @@
+{% from 'govuk/components/button/macro.njk' import govukButton %}
+
+{% macro render(params) %}
+
+  {# {% set text = params.text %}
+  {% set isStartButton = params.isStartButton %}
+  {% set classes = params.classes %}
+  {% set href = params.href %} #}
+
+  {% set fieldId = params.fieldId %}
+  {% set countries = params.countries %}
+  {% set integrity = params.integrity %}
+ 
+  <select class="govuk-select" id="{{ fieldId }}" name="{{ fieldId }}">
+    <option value="" disabled selected></option>
+
+    {% for country in countries %}
+      {% if country.selected %}
+        <option value="{{ country.text }}" selected>{{ country.text }}</option>
+      {% else %}
+        <option value="{{ country.text }}">{{ country.text }}</option>
+      {% endif %}
+    {% endfor %}
+  </select>
+
+  <script src="/assets/js/accessibleAutocomplete.js" type="text/javascript" integrity="{{ integrity }}" crossorigin="anonymous"></script>
+
+{% endmacro %}

--- a/src/ui/templates/components/accessible-autocomplete-select.njk
+++ b/src/ui/templates/components/accessible-autocomplete-select.njk
@@ -2,11 +2,6 @@
 
 {% macro render(params) %}
 
-  {# {% set text = params.text %}
-  {% set isStartButton = params.isStartButton %}
-  {% set classes = params.classes %}
-  {% set href = params.href %} #}
-
   {% set fieldId = params.fieldId %}
   {% set countries = params.countries %}
   {% set integrity = params.integrity %}

--- a/src/ui/templates/insurance/export-contract/about-goods-or-services.njk
+++ b/src/ui/templates/insurance/export-contract/about-goods-or-services.njk
@@ -6,6 +6,7 @@
 {% from "govuk/components/label/macro.njk" import govukLabel %}
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
 {% from 'govuk/components/button/macro.njk' import govukButton %}
+{% import '../../components/accessible-autocomplete-select.njk' as accessibleAutoCompleteSelect %}
 {% import '../../components/submit-button.njk' as submitButton %}
 
 {% block pageTitle %}
@@ -88,7 +89,7 @@
             {% set class = "govuk-form-group" %}
 
             {% if validationErrors.errorList[FIELDS.FINAL_DESTINATION.ID] %}
-              {% set class = "govuk-form-group govuk-form-group--error-message" %}
+              {% set class = "govuk-form-group govuk-form-group--error" %}
             {% endif %}
 
             <div class="{{ class }}">
@@ -111,19 +112,11 @@
 
               <div class="govuk-grid-row">
                 <div class="govuk-grid-column-one-half-from-desktop">
-
-                  <select class="govuk-select" id="{{ FIELDS.FINAL_DESTINATION.ID }}" name="{{ FIELDS.FINAL_DESTINATION.ID }}">
-                    <option value="" disabled selected></option>
-
-                    {% for country in countries %}
-                      {% if country.selected %}
-                        <option value="{{ country.text }}" selected>{{ country.text }}</option>
-                      {% else %}
-                        <option value="{{ country.text }}">{{ country.text }}</option>
-                      {% endif %}
-                    {% endfor %}
-                  </select>
-
+                  {{ accessibleAutoCompleteSelect.render({
+                    fieldId: FIELDS.FINAL_DESTINATION.ID,
+                    countries: countries,
+                    integrity: SRI.ACCESSIBILITY
+                  }) }}
                 </div>
               </div>
             </div>
@@ -161,7 +154,5 @@
     </div>
 
   </form>
-
-  <script src="/assets/js/accessibleAutocomplete.js" type="text/javascript" integrity="{{ SRI.ACCESSIBILITY }}" crossorigin="anonymous"></script>
 
 {% endblock %}

--- a/src/ui/templates/shared-pages/buyer-country.njk
+++ b/src/ui/templates/shared-pages/buyer-country.njk
@@ -4,6 +4,7 @@
 {% from 'govuk/components/label/macro.njk' import govukLabel %}
 {% from "govuk/components/hint/macro.njk" import govukHint %}
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
+{% import '../components/accessible-autocomplete-select.njk' as accessibleAutoCompleteSelect %}
 {% import '../components/submit-button.njk' as submitButton %}
 
 {% block pageTitle %}
@@ -31,38 +32,37 @@
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     <input type="hidden" name="{{ HIDDEN_FIELD_ID }}" id="{{ HIDDEN_FIELD_ID }}" value="{{ submittedValues[HIDDEN_FIELD_ID].name }}">
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds-from-desktop">
+    {% set class = "govuk-form-group" %}
 
-        {{ govukLabel({
-          for: FIELD_ID_COUNTRY,
-          classes: "govuk-heading-l",
-          html: "<h1 class='govuk-heading-l' id='heading'><label for='" + FIELD_ID + "'>" + CONTENT_STRINGS.PAGE_TITLE + "</label></h1>",
-          attributes: {
-            "data-cy": DATA_CY.HEADING
-          }
-        }) }}
+    {% if validationErrors.errorList[FIELD_ID] %}
+      {% set class = "govuk-form-group govuk-form-group--error" %}
+    {% endif %}
 
-        {{ govukHint({
-          id: FIELD_ID + "-hint",
-          text: FIELD_HINT,
-          attributes: {
-            "data-cy": FIELD_ID + "-hint"
-          }
-        }) }}
+    <div class="{{ class }}">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+
+          {{ govukLabel({
+            for: FIELD_ID_COUNTRY,
+            classes: "govuk-heading-l",
+            html: "<h1 class='govuk-heading-l' id='heading'><label for='" + FIELD_ID + "'>" + CONTENT_STRINGS.PAGE_TITLE + "</label></h1>",
+            attributes: {
+              "data-cy": DATA_CY.HEADING
+            }
+          }) }}
+
+          {{ govukHint({
+            id: FIELD_ID + "-hint",
+            text: FIELD_HINT,
+            attributes: {
+              "data-cy": FIELD_ID + "-hint"
+            }
+          }) }}
+        </div>
       </div>
-    </div>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half-from-desktop">
-
-        {% set class = "govuk-form-group" %}
-
-        {% if validationErrors.errorList[FIELD_ID] %}
-          {% set class = "govuk-form-group govuk-form-group--error-message" %}
-        {% endif %}
-
-        <div class="{{ class }}">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half-from-desktop">
           {{ govukErrorMessage({
             text: validationErrors.errorList[FIELD_ID].text,
             attributes: {
@@ -70,20 +70,14 @@
             }
           }) }}
 
-          <select class="govuk-select" id="{{ FIELD_ID }}" name="{{ FIELD_ID }}">
-            <option value="" disabled selected></option>
-
-            {% for country in countries %}
-              {% if country.selected %}
-                <option value="{{ country.text }}" selected>{{ country.text }}</option>
-              {% else %}
-                <option value="{{ country.text }}">{{ country.text }}</option>
-              {% endif %}
-            {% endfor %}
-          </select>
+          {{ accessibleAutoCompleteSelect.render({
+            fieldId: FIELD_ID,
+            countries: countries,
+            integrity: SRI.ACCESSIBILITY
+          }) }}
         </div>
-
       </div>
+
     </div>
 
     {{ submitButton.render({
@@ -91,7 +85,5 @@
     }) }}
 
   </form>
-
-  <script src="/assets/js/accessibleAutocomplete.js" type="text/javascript" integrity="{{ SRI.ACCESSIBILITY }}" crossorigin="anonymous"></script>
 
 {% endblock %}


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue with all "buyer country" fields, where a red border would be displayed/wrapped around the form input and label.

## Resolution :heavy_check_mark:
- Update invalid class name.
- Ensure the class name/div is wrapping the appropriate elements.

## Miscellaneous :heavy_plus_sign:
- Create a DRY, resuable component for the autocomplete script and select options, `accessibleAutoCompleteSelect`.
