### PR TITLE
style(EMS-2447 2451): Start page, cookies banner, cookies page content improvements

### DIFF
--- a/e2e-tests/commands/analytics/check-cookies-consent-banner-does-not-exist.js
+++ b/e2e-tests/commands/analytics/check-cookies-consent-banner-does-not-exist.js
@@ -5,8 +5,7 @@ const checkCookiesConsentBannerDoesNotExist = () => {
   partials.cookieBanner.hideButton().should('not.exist');
   partials.cookieBanner.cookiesLink().should('not.exist');
 
-  partials.cookieBanner.question.copy1().should('not.exist');
-  partials.cookieBanner.question.copy2().should('not.exist');
+  partials.cookieBanner.question.copy().should('not.exist');
   partials.cookieBanner.question.acceptButton().should('not.exist');
   partials.cookieBanner.question.rejectButton().should('not.exist');
 

--- a/e2e-tests/commands/analytics/check-cookies-consent-banner-is-not-visible.js
+++ b/e2e-tests/commands/analytics/check-cookies-consent-banner-is-not-visible.js
@@ -5,8 +5,7 @@ const checkCookiesConsentBannerIsNotVisible = () => {
   partials.cookieBanner.hideButton().should('not.be.visible');
   partials.cookieBanner.cookiesLink().should('not.be.visible');
 
-  partials.cookieBanner.question.copy1().should('not.exist');
-  partials.cookieBanner.question.copy2().should('not.exist');
+  partials.cookieBanner.question.copy().should('not.exist');
   partials.cookieBanner.question.acceptButton().should('not.exist');
   partials.cookieBanner.question.rejectButton().should('not.exist');
 };

--- a/e2e-tests/commands/analytics/check-cookies-consent-banner-is-visible.js
+++ b/e2e-tests/commands/analytics/check-cookies-consent-banner-is-visible.js
@@ -5,9 +5,7 @@ import { COOKIES_CONSENT } from '../../content-strings';
 const checkCookiesConsentBannerIsVisible = () => {
   partials.cookieBanner.heading().should('exist');
 
-  cy.checkText(partials.cookieBanner.question.copy(), COOKIES_CONSENT.QUESTION.COPY_1);
-
-  cy.checkText(partials.cookieBanner.question.copy2(), COOKIES_CONSENT.QUESTION.COPY_2);
+  cy.checkText(partials.cookieBanner.question.copy(), COOKIES_CONSENT.QUESTION.COPY);
 
   cy.checkText(partials.cookieBanner.question.acceptButton(), COOKIES_CONSENT.QUESTION.ACCEPT_BUTTON);
 

--- a/e2e-tests/commands/analytics/check-cookies-consent-banner-is-visible.js
+++ b/e2e-tests/commands/analytics/check-cookies-consent-banner-is-visible.js
@@ -5,16 +5,12 @@ import { COOKIES_CONSENT } from '../../content-strings';
 const checkCookiesConsentBannerIsVisible = () => {
   partials.cookieBanner.heading().should('exist');
 
-  partials.cookieBanner.question.copy1().should('exist');
-  cy.checkText(partials.cookieBanner.question.copy1(), COOKIES_CONSENT.QUESTION.COPY_1);
+  cy.checkText(partials.cookieBanner.question.copy(), COOKIES_CONSENT.QUESTION.COPY_1);
 
-  partials.cookieBanner.question.copy2().should('exist');
   cy.checkText(partials.cookieBanner.question.copy2(), COOKIES_CONSENT.QUESTION.COPY_2);
 
-  partials.cookieBanner.question.acceptButton().should('exist');
   cy.checkText(partials.cookieBanner.question.acceptButton(), COOKIES_CONSENT.QUESTION.ACCEPT_BUTTON);
 
-  partials.cookieBanner.question.rejectButton().should('exist');
   cy.checkText(partials.cookieBanner.question.rejectButton(), COOKIES_CONSENT.QUESTION.REJECT_BUTTON);
 
   cy.checkLink(

--- a/e2e-tests/content-strings/cookies-consent.js
+++ b/e2e-tests/content-strings/cookies-consent.js
@@ -3,8 +3,7 @@ export const COOKIES_CONSENT = {
   HIDE_BUTTON: 'Hide this message',
   COOKIES_LINK: 'cookies link',
   QUESTION: {
-    COPY_1: 'We use some essential cookies to make this service work.',
-    COPY_2: "We'd also like to use analytics cookies so we can understand how people use this service and make improvements.",
+    COPY: 'We use essential cookies to make this service work. We also use analytics cookies so we can understand how people use this service and make improvements.',
     ACCEPT_BUTTON: 'Accept analytics cookies',
     REJECT_BUTTON: 'Reject analytics cookies',
     VIEW_COOKIES: 'View cookies',

--- a/e2e-tests/content-strings/pages/index.js
+++ b/e2e-tests/content-strings/pages/index.js
@@ -127,7 +127,7 @@ const ACCESSIBILITY_STATEMENT_PAGE = {
 const COOKIES_PAGE = {
   PAGE_TITLE: 'Cookies',
   BODY_1: "UK Export Finance (UKEF) puts small files (known as 'cookies') onto your computer to make this site work.",
-  BODY_2: "Our cookies aren't used to identify you personally.",
+  BODY_2: "Cookies are anonymous and cannot be used to identify you personally.",
   TABLE_HEADINGS: {
     NAME: 'Name',
     PURPOSE: 'Purpose',
@@ -150,11 +150,11 @@ const COOKIES_PAGE = {
     ],
   },
   OPTIONAL_COOKIES: {
-    HEADING: 'Optional Cookies',
+    HEADING: 'Analytics cookies (optional)',
     BODY_1:
-      'With your permission, we use Google Analytics to collect how you use this service and your web performance experience while visiting so we can improve it based on user needs.',
+      'With your permission, we use Google Analytics and Google Tag Manager to collect information about how you use this service. This tells us how well the service works and where we can improve it, so we can provide a better experience for you.',
     BODY_2: 'We do not allow Google to use or share the data about how you use this service.',
-    BODY_3: 'Google Analytics stores anonymised information about:',
+    BODY_3: 'Google Analytics and Google Tag Manager stores anonymised information about:',
     ANALYTICS_INFO_LIST: [
       {
         text: 'how you got to this service',

--- a/e2e-tests/content-strings/pages/index.js
+++ b/e2e-tests/content-strings/pages/index.js
@@ -127,7 +127,7 @@ const ACCESSIBILITY_STATEMENT_PAGE = {
 const COOKIES_PAGE = {
   PAGE_TITLE: 'Cookies',
   BODY_1: "UK Export Finance (UKEF) puts small files (known as 'cookies') onto your computer to make this site work.",
-  BODY_2: "Cookies are anonymous and cannot be used to identify you personally.",
+  BODY_2: 'Cookies are anonymous and cannot be used to identify you personally.',
   TABLE_HEADINGS: {
     NAME: 'Name',
     PURPOSE: 'Purpose',

--- a/e2e-tests/content-strings/pages/insurance/index.js
+++ b/e2e-tests/content-strings/pages/insurance/index.js
@@ -126,6 +126,13 @@ const START = {
     },
     TO_FIND_OUT_MORE: "if you want to know who's eligible and what's covered.",
   },
+  EXTRA_SUPPORT: {
+    INTRO: "Export finance managers can help if you'd like extra support with your application or have questions about credit insurance.",
+    LINK: {
+      TEXT: 'Find your nearest export finance manager.',
+      HREF: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
+    },
+  },
   QUOTE: {
     YOU_CAN: 'You can also',
     LINK: {

--- a/e2e-tests/insurance/cypress/e2e/journeys/start.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/start.spec.js
@@ -1,14 +1,20 @@
 import { insurance } from '../../../../pages';
 import { submitButton } from '../../../../pages/shared';
-import { BUTTONS, PAGES } from '../../../../content-strings';
-import { ROUTES } from '../../../../constants';
+import { BUTTONS, LINKS, PAGES } from '../../../../content-strings';
+import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.START;
+
+const {
+  ACCOUNT,
+  ELIGIBILITY: { CHECK_IF_ELIGIBLE },
+  START,
+} = INSURANCE_ROUTES;
 
 const { startPage } = insurance;
 
 context('Insurance Eligibility - start page', () => {
-  const url = ROUTES.INSURANCE.START;
+  const url = START;
 
   before(() => {
     cy.navigateToUrl(url);
@@ -73,7 +79,7 @@ context('Insurance Eligibility - start page', () => {
 
       cy.checkText(signIn.youCan(), SIGN_IN.YOU_CAN);
 
-      cy.checkLink(signIn.link(), SIGN_IN.LINK.HREF, SIGN_IN.LINK.TEXT);
+      cy.checkLink(signIn.link(), ACCOUNT.SIGN_IN.ROOT, SIGN_IN.LINK.TEXT);
 
       cy.checkText(signIn.toContinueApplication(), SIGN_IN.TO_CONTINUE_APPLICATION);
     });
@@ -84,9 +90,18 @@ context('Insurance Eligibility - start page', () => {
 
       cy.checkText(findOutMore.youCan(), FIND_OUT_MORE.YOU_CAN);
 
-      cy.checkLink(findOutMore.link(), FIND_OUT_MORE.LINK.HREF, FIND_OUT_MORE.LINK.TEXT);
+      cy.checkLink(findOutMore.link(), LINKS.EXTERNAL.GUIDANCE, FIND_OUT_MORE.LINK.TEXT);
 
       cy.checkText(findOutMore.toFindOutMore(), FIND_OUT_MORE.TO_FIND_OUT_MORE);
+    });
+
+    it('renders a "extra support" body text', () => {
+      const { EXTRA_SUPPORT } = CONTENT_STRINGS;
+      const { extraSupport } = startPage;
+
+      cy.checkText(extraSupport.intro(), EXTRA_SUPPORT.INTRO);
+
+      cy.checkLink(extraSupport.link(), LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS, EXTRA_SUPPORT.LINK.TEXT);
     });
 
     it('renders a "get a quote" body text', () => {
@@ -102,12 +117,12 @@ context('Insurance Eligibility - start page', () => {
   });
 
   context('form submission', () => {
-    it(`should redirect to ${ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE}`, () => {
+    it(`should redirect to ${CHECK_IF_ELIGIBLE}`, () => {
       cy.navigateToUrl(url);
 
       submitButton().click();
 
-      const expected = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE}`;
+      const expected = `${Cypress.config('baseUrl')}${CHECK_IF_ELIGIBLE}`;
 
       cy.assertUrl(expected);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/start.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/start.spec.js
@@ -11,6 +11,10 @@ const {
   START,
 } = INSURANCE_ROUTES;
 
+const {
+  EXTERNAL: { GUIDANCE, EXPORT_FINANCE_MANAGERS },
+} = LINKS;
+
 const { startPage } = insurance;
 
 context('Insurance Eligibility - start page', () => {
@@ -90,7 +94,7 @@ context('Insurance Eligibility - start page', () => {
 
       cy.checkText(findOutMore.youCan(), FIND_OUT_MORE.YOU_CAN);
 
-      cy.checkLink(findOutMore.link(), LINKS.EXTERNAL.GUIDANCE, FIND_OUT_MORE.LINK.TEXT);
+      cy.checkLink(findOutMore.link(), GUIDANCE, FIND_OUT_MORE.LINK.TEXT);
 
       cy.checkText(findOutMore.toFindOutMore(), FIND_OUT_MORE.TO_FIND_OUT_MORE);
     });
@@ -101,7 +105,7 @@ context('Insurance Eligibility - start page', () => {
 
       cy.checkText(extraSupport.intro(), EXTRA_SUPPORT.INTRO);
 
-      cy.checkLink(extraSupport.link(), LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS, EXTRA_SUPPORT.LINK.TEXT);
+      cy.checkLink(extraSupport.link(), EXPORT_FINANCE_MANAGERS, EXTRA_SUPPORT.LINK.TEXT);
     });
 
     it('renders a "get a quote" body text', () => {

--- a/e2e-tests/pages/insurance/start.js
+++ b/e2e-tests/pages/insurance/start.js
@@ -23,6 +23,10 @@ const startPage = {
     link: () => cy.get('[data-cy="find-out-more-link"]'),
     toFindOutMore: () => cy.get('[data-cy="find-out-more-to-find-out-more"]'),
   },
+  extraSupport: {
+    intro: () => cy.get('[data-cy="export-support-intro"]'),
+    link: () => cy.get('[data-cy="finance-managers-link"]'),
+  },
   getAQuote: {
     text: () => cy.get('[data-cy="get-a-quote"]'),
     youCan: () => cy.get('[data-cy="get-a-quote-you-can"]'),

--- a/e2e-tests/partials/cookieBanner.js
+++ b/e2e-tests/partials/cookieBanner.js
@@ -3,8 +3,7 @@ const cookieBanner = {
   hideButton: () => cy.get('[data-cy="cookies-banner-hide-button"]'),
   cookiesLink: () => cy.get('[data-cy="cookies-banner-cookies-link"]'),
   question: {
-    copy1: () => cy.get('[data-cy="cookies-question-banner-copy-1"]'),
-    copy2: () => cy.get('[data-cy="cookies-question-banner-copy-2"]'),
+    copy: () => cy.get('[data-cy="cookies-question-banner-copy"]'),
     acceptButton: () => cy.get('[data-cy="cookies-question-banner-accept-button"]'),
     rejectButton: () => cy.get('[data-cy="cookies-question-banner-reject-button"]'),
   },

--- a/e2e-tests/quote/cypress/e2e/journeys/cookies-consent/banner/cookies-consent-accept.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/cookies-consent/banner/cookies-consent-accept.spec.js
@@ -30,8 +30,7 @@ context('Cookies consent - accept', () => {
     });
 
     it('should not render the question banner', () => {
-      partials.cookieBanner.question.copy1().should('not.exist');
-      partials.cookieBanner.question.copy2().should('not.exist');
+      partials.cookieBanner.question.copy().should('not.exist');
       partials.cookieBanner.question.acceptButton().should('not.exist');
       partials.cookieBanner.question.rejectButton().should('not.exist');
     });
@@ -52,7 +51,6 @@ context('Cookies consent - accept', () => {
         COOKIES_CONSENT.COOKIES_LINK,
       );
 
-      partials.cookieBanner.hideButton().should('exist');
       cy.checkText(partials.cookieBanner.hideButton(), COOKIES_CONSENT.HIDE_BUTTON);
     });
 
@@ -80,8 +78,7 @@ context('Cookies consent - accept', () => {
       partials.cookieBanner.hideButton().should('not.be.visible');
       partials.cookieBanner.cookiesLink().should('not.be.visible');
 
-      partials.cookieBanner.question.copy1().should('not.exist');
-      partials.cookieBanner.question.copy2().should('not.exist');
+      partials.cookieBanner.question.copy().should('not.exist');
       partials.cookieBanner.question.acceptButton().should('not.exist');
       partials.cookieBanner.question.rejectButton().should('not.exist');
 
@@ -105,8 +102,7 @@ context('Cookies consent - accept', () => {
       partials.cookieBanner.hideButton().should('not.exist');
       partials.cookieBanner.cookiesLink().should('not.exist');
 
-      partials.cookieBanner.question.copy1().should('not.exist');
-      partials.cookieBanner.question.copy2().should('not.exist');
+      partials.cookieBanner.question.copy().should('not.exist');
       partials.cookieBanner.question.acceptButton().should('not.exist');
       partials.cookieBanner.question.rejectButton().should('not.exist');
 

--- a/e2e-tests/quote/cypress/e2e/journeys/cookies-consent/banner/cookies-consent-reject.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/cookies-consent/banner/cookies-consent-reject.spec.js
@@ -30,8 +30,7 @@ context('Cookies consent - reject', () => {
     });
 
     it('should not render the question banner', () => {
-      partials.cookieBanner.question.copy1().should('not.exist');
-      partials.cookieBanner.question.copy2().should('not.exist');
+      partials.cookieBanner.question.copy().should('not.exist');
       partials.cookieBanner.question.rejectButton().should('not.exist');
       partials.cookieBanner.question.rejectButton().should('not.exist');
     });
@@ -79,8 +78,7 @@ context('Cookies consent - reject', () => {
       partials.cookieBanner.hideButton().should('not.be.visible');
       partials.cookieBanner.cookiesLink().should('not.be.visible');
 
-      partials.cookieBanner.question.copy1().should('not.exist');
-      partials.cookieBanner.question.copy2().should('not.exist');
+      partials.cookieBanner.question.copy().should('not.exist');
       partials.cookieBanner.question.rejectButton().should('not.exist');
       partials.cookieBanner.question.rejectButton().should('not.exist');
 
@@ -104,8 +102,7 @@ context('Cookies consent - reject', () => {
       partials.cookieBanner.hideButton().should('not.exist');
       partials.cookieBanner.cookiesLink().should('not.exist');
 
-      partials.cookieBanner.question.copy1().should('not.exist');
-      partials.cookieBanner.question.copy2().should('not.exist');
+      partials.cookieBanner.question.copy().should('not.exist');
       partials.cookieBanner.question.rejectButton().should('not.exist');
       partials.cookieBanner.question.rejectButton().should('not.exist');
 

--- a/e2e-tests/quote/cypress/e2e/journeys/cookies-consent/banner/cookies-consent.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/cookies-consent/banner/cookies-consent.spec.js
@@ -43,20 +43,14 @@ context('Cookies consent - initial/default', () => {
     });
 
     it('should render copy', () => {
-      partials.cookieBanner.question.copy1().should('exist');
-      cy.checkText(partials.cookieBanner.question.copy1(), COOKIES_CONSENT.QUESTION.COPY_1);
-
-      partials.cookieBanner.question.copy2().should('exist');
-      cy.checkText(partials.cookieBanner.question.copy2(), COOKIES_CONSENT.QUESTION.COPY_2);
+      cy.checkText(partials.cookieBanner.question.copy(), COOKIES_CONSENT.QUESTION.COPY);
     });
 
     it('should render an `accept` button', () => {
-      partials.cookieBanner.question.acceptButton().should('exist');
       cy.checkText(partials.cookieBanner.question.acceptButton(), COOKIES_CONSENT.QUESTION.ACCEPT_BUTTON);
     });
 
     it('should render a `reject` button', () => {
-      partials.cookieBanner.question.rejectButton().should('exist');
       cy.checkText(partials.cookieBanner.question.rejectButton(), COOKIES_CONSENT.QUESTION.REJECT_BUTTON);
     });
 

--- a/e2e-tests/quote/cypress/e2e/journeys/cookies-consent/change-cookies-consent-via-banner-and-cookies-page.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/cookies-consent/change-cookies-consent-via-banner-and-cookies-page.spec.js
@@ -67,8 +67,7 @@ context('Cookies consent - change via banner and cookies page', () => {
       partials.cookieBanner.hideButton().should('not.exist');
       partials.cookieBanner.cookiesLink().should('not.exist');
 
-      partials.cookieBanner.question.copy1().should('not.exist');
-      partials.cookieBanner.question.copy2().should('not.exist');
+      partials.cookieBanner.question.copy().should('not.exist');
       partials.cookieBanner.question.acceptButton().should('not.exist');
       partials.cookieBanner.question.rejectButton().should('not.exist');
     });
@@ -115,8 +114,7 @@ context('Cookies consent - change via banner and cookies page', () => {
       partials.cookieBanner.hideButton().should('not.exist');
       partials.cookieBanner.cookiesLink().should('not.exist');
 
-      partials.cookieBanner.question.copy1().should('not.exist');
-      partials.cookieBanner.question.copy2().should('not.exist');
+      partials.cookieBanner.question.copy().should('not.exist');
       partials.cookieBanner.question.acceptButton().should('not.exist');
       partials.cookieBanner.question.rejectButton().should('not.exist');
     });

--- a/src/ui/server/content-strings/cookies-consent.ts
+++ b/src/ui/server/content-strings/cookies-consent.ts
@@ -3,8 +3,7 @@ export const COOKIES_CONSENT = {
   HIDE_BUTTON: 'Hide this message',
   COOKIES_LINK: 'cookies link',
   QUESTION: {
-    COPY_1: 'We use some essential cookies to make this service work.',
-    COPY_2: "We'd also like to use analytics cookies so we can understand how people use this service and make improvements.",
+    COPY: 'We use essential cookies to make this service work. We also use analytics cookies so we can understand how people use this service and make improvements.',
     ACCEPT_BUTTON: 'Accept analytics cookies',
     REJECT_BUTTON: 'Reject analytics cookies',
     VIEW_COOKIES: 'View cookies',

--- a/src/ui/server/content-strings/pages/index.ts
+++ b/src/ui/server/content-strings/pages/index.ts
@@ -127,7 +127,7 @@ const ACCESSIBILITY_STATEMENT_PAGE = {
 const COOKIES_PAGE = {
   PAGE_TITLE: 'Cookies',
   BODY_1: "UK Export Finance (UKEF) puts small files (known as 'cookies') onto your computer to make this site work.",
-  BODY_2: "Our cookies aren't used to identify you personally.",
+  BODY_2: "Cookies are anonymous and cannot be used to identify you personally.",
   TABLE_HEADINGS: {
     NAME: 'Name',
     PURPOSE: 'Purpose',
@@ -150,11 +150,11 @@ const COOKIES_PAGE = {
     ],
   },
   OPTIONAL_COOKIES: {
-    HEADING: 'Optional Cookies',
+    HEADING: 'Analytics cookies (optional)',
     BODY_1:
-      'With your permission, we use Google Analytics to collect how you use this service and your web performance experience while visiting so we can improve it based on user needs.',
+      'With your permission, we use Google Analytics and Google Tag Manager to collect information about how you use this service. This tells us how well the service works and where we can improve it, so we can provide a better experience for you.',
     BODY_2: 'We do not allow Google to use or share the data about how you use this service.',
-    BODY_3: 'Google Analytics stores anonymised information about:',
+    BODY_3: 'Google Analytics and Google Tag Manager stores anonymised information about:',
     ANALYTICS_INFO_LIST: [
       {
         text: 'how you got to this service',

--- a/src/ui/server/content-strings/pages/index.ts
+++ b/src/ui/server/content-strings/pages/index.ts
@@ -127,7 +127,7 @@ const ACCESSIBILITY_STATEMENT_PAGE = {
 const COOKIES_PAGE = {
   PAGE_TITLE: 'Cookies',
   BODY_1: "UK Export Finance (UKEF) puts small files (known as 'cookies') onto your computer to make this site work.",
-  BODY_2: "Cookies are anonymous and cannot be used to identify you personally.",
+  BODY_2: 'Cookies are anonymous and cannot be used to identify you personally.',
   TABLE_HEADINGS: {
     NAME: 'Name',
     PURPOSE: 'Purpose',

--- a/src/ui/server/content-strings/pages/insurance/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/index.ts
@@ -125,6 +125,13 @@ const START = {
     },
     TO_FIND_OUT_MORE: "if you want to know who's eligible and what's covered.",
   },
+  EXTRA_SUPPORT: {
+    INTRO: "Export finance managers can help if you'd like extra support with your application or have questions about credit insurance.",
+    LINK: {
+      TEXT: 'Find your nearest export finance manager.',
+      HREF: LINKS.EXTERNAL.EXPORT_FINANCE_MANAGERS,
+    },
+  },
   QUOTE: {
     YOU_CAN: 'You can also',
     LINK: {

--- a/src/ui/templates/cookies.njk
+++ b/src/ui/templates/cookies.njk
@@ -29,12 +29,16 @@
 
   <h1 class="govuk-heading-l" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 
-  <p class="govuk-body" data-cy="body-1">{{ CONTENT_STRINGS.BODY_1 }}</p>
-  <p class="govuk-body" data-cy="body-2">{{ CONTENT_STRINGS.BODY_2 }}</p>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters-from-desktop">
+      <p class="govuk-body" data-cy="body-1">{{ CONTENT_STRINGS.BODY_1 }}</p>
+      <p class="govuk-body" data-cy="body-2">{{ CONTENT_STRINGS.BODY_2 }}</p>
 
-  <h2 class="govuk-heading-m" data-cy="essential-cookies-heading">{{ CONTENT_STRINGS.ESSENTIAL_COOKIES.HEADING }}</h2>
+      <h2 class="govuk-heading-m" data-cy="essential-cookies-heading">{{ CONTENT_STRINGS.ESSENTIAL_COOKIES.HEADING }}</h2>
 
-  <p class="govuk-body" data-cy="essential-cookies-intro">{{ CONTENT_STRINGS.ESSENTIAL_COOKIES.INTRO }}</p>
+      <p class="govuk-body" data-cy="essential-cookies-intro">{{ CONTENT_STRINGS.ESSENTIAL_COOKIES.INTRO }}</p>
+    </div>
+  </div>
 
   {{ govukTable({
     firstCellIsHeader: true,

--- a/src/ui/templates/insurance/start.njk
+++ b/src/ui/templates/insurance/start.njk
@@ -62,6 +62,11 @@
           <span data-cy="find-out-more-to-find-out-more">{{ CONTENT_STRINGS.FIND_OUT_MORE.TO_FIND_OUT_MORE }}</span>
         </p>
 
+        <p class="govuk-body" data-cy="extra-support">
+          <span data-cy="export-support-intro">{{ CONTENT_STRINGS.EXTRA_SUPPORT.INTRO }}</span>
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ CONTENT_STRINGS.EXTRA_SUPPORT.LINK.HREF }}" data-cy="finance-managers-link">{{ CONTENT_STRINGS.EXTRA_SUPPORT.LINK.TEXT }}</a>
+        </p>
+
         <p class="govuk-body" data-cy="get-a-quote">
           <span data-cy="get-a-quote-you-can">{{ CONTENT_STRINGS.QUOTE.YOU_CAN }}</span>
           <a class="govuk-link govuk-link--no-visited-state" href="{{ CONTENT_STRINGS.QUOTE.LINK.HREF }}" data-cy="get-a-quote-link">{{ CONTENT_STRINGS.QUOTE.LINK.TEXT }}</a>,

--- a/src/ui/templates/partials/cookies-banner.njk
+++ b/src/ui/templates/partials/cookies-banner.njk
@@ -6,8 +6,7 @@
 {% endset %}
 
 {% set questionBannerHtml %}
-  <p class="govuk-body" data-cy="cookies-question-banner-copy-1">{{ CONTENT_STRINGS.COOKIES_CONSENT.QUESTION.COPY_1 }}</p>
-  <p class="govuk-body" data-cy="cookies-question-banner-copy-2">{{ CONTENT_STRINGS.COOKIES_CONSENT.QUESTION.COPY_2 }}</p>
+  <p class="govuk-body" data-cy="cookies-question-banner-copy">{{ CONTENT_STRINGS.COOKIES_CONSENT.QUESTION.COPY }}</p>
 {% endset %}
 
 {% set acceptHtml %}


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates various pieces of content for the start page, cookies banner and cokies page.

## Resolution :heavy_check_mark:
- Update content strings.
- Add "extra" support content block to the start page.

## Miscellaneous :heavy_plus_sign:
- Update the start page E2E test to assert links via `LINKS`.
- Remove some unnecessary `.should('exist')` checks in cookies E2E tests.