### PR TITLE
chore(e2e): Improve "prepare application" cypress commands

### DIFF
--- a/e2e-tests/commands/insurance/complete-business-section.js
+++ b/e2e-tests/commands/insurance/complete-business-section.js
@@ -3,11 +3,12 @@ import { submitButton } from '../../pages/shared';
 /**
  * completeBusinessSection
  * Complete the "business" section
+ * @param {Boolean} viaTaskList: Start the "business" section from the task list.
  * @param {Boolean} differentTradingAddress: Should submit "yes" to "trade from a different address" in the "company details" form.
  * @param {Boolean} submitCheckYourAnswers: Click policy "check your answers" submit button
  */
-const completeBusinessSection = ({ differentTradingAddress = false, submitCheckYourAnswers = false }) => {
-  cy.startYourBusinessSection({});
+const completeBusinessSection = ({ viaTaskList, differentTradingAddress = false, submitCheckYourAnswers = false }) => {
+  cy.startYourBusinessSection({ viaTaskList });
 
   cy.completeAndSubmitCompanyDetails({ differentTradingAddress });
 

--- a/e2e-tests/commands/insurance/complete-business-section.js
+++ b/e2e-tests/commands/insurance/complete-business-section.js
@@ -1,0 +1,27 @@
+import { submitButton } from '../../pages/shared';
+
+/**
+ * completeBusinessSection
+ * Complete the "business" section
+ * @param {Boolean} differentTradingAddress: Should submit "yes" to "trade from a different address" in the "company details" form.
+ * @param {Boolean} submitCheckYourAnswers: Click policy "check your answers" submit button
+ */
+const completeBusinessSection = ({ differentTradingAddress = false, submitCheckYourAnswers = false }) => {
+  cy.startYourBusinessSection({});
+
+  cy.completeAndSubmitCompanyDetails({ differentTradingAddress });
+
+  if (differentTradingAddress) {
+    cy.completeAndSubmitAlternativeTradingAddressForm();
+  }
+
+  cy.completeAndSubmitNatureOfYourBusiness();
+  cy.completeAndSubmitTurnoverForm();
+  cy.completeAndSubmitCreditControlForm({});
+
+  if (submitCheckYourAnswers) {
+    submitButton().click();
+  }
+};
+
+export default completeBusinessSection;

--- a/e2e-tests/commands/insurance/complete-buyer-section.js
+++ b/e2e-tests/commands/insurance/complete-buyer-section.js
@@ -1,8 +1,9 @@
 import { submitButton } from '../../pages/shared';
 
 /**
- * completeExportContractSection
- * Complete the "Export contract" section
+ * completeBuyerSection
+ * Complete the "Buyer" section
+ * @param {Boolean} viaTaskList: Start the "buyer" section from the task list.
  * @param {Boolean} exporterHasTradedWithBuyer: Submit "yes" to "have traded with buyer before" in the "working with buyer" form.
  * @param {Boolean} submitCheckYourAnswers: Click buyer "check your answers" submit button
  */

--- a/e2e-tests/commands/insurance/complete-buyer-section.js
+++ b/e2e-tests/commands/insurance/complete-buyer-section.js
@@ -1,0 +1,21 @@
+import { submitButton } from '../../pages/shared';
+
+/**
+ * completeExportContractSection
+ * Complete the "Export contract" section
+ * @param {Boolean} exporterHasTradedWithBuyer: Submit "yes" to "have traded with buyer before" in the "working with buyer" form.
+ * @param {Boolean} submitCheckYourAnswers: Click buyer "check your answers" submit button
+ */
+const completeBuyerSection = ({ viaTaskList, exporterHasTradedWithBuyer, submitCheckYourAnswers = false }) => {
+  cy.startInsuranceYourBuyerSection({ viaTaskList });
+
+  cy.completeAndSubmitCompanyOrOrganisationForm({});
+  cy.completeAndSubmitConnectionToTheBuyerForm({});
+  cy.completeAndSubmitWorkingWithBuyerForm({ exporterHasTradedWithBuyer });
+
+  if (submitCheckYourAnswers) {
+    submitButton().click();
+  }
+};
+
+export default completeBuyerSection;

--- a/e2e-tests/commands/insurance/complete-export-contract-section.js
+++ b/e2e-tests/commands/insurance/complete-export-contract-section.js
@@ -3,6 +3,7 @@ import { submitButton } from '../../pages/shared';
 /**
  * completeExportContractSection
  * Complete the "Export contract" section
+ * @param {Boolean} viaTaskList: Start the "export contract" section from the task list.
  * @param {Boolean} submitCheckYourAnswers: Click export contract "check your answers" submit button
  */
 const completeExportContractSection = ({ viaTaskList, submitCheckYourAnswers = false }) => {

--- a/e2e-tests/commands/insurance/complete-export-contract-section.js
+++ b/e2e-tests/commands/insurance/complete-export-contract-section.js
@@ -1,11 +1,18 @@
+import { submitButton } from '../../pages/shared';
+
 /**
  * completeExportContractSection
- * complete the export contract section
+ * Complete the "Export contract" section
+ * @param {Boolean} submitCheckYourAnswers: Click export contract "check your answers" submit button
  */
-const completeExportContractSection = () => {
-  cy.startInsuranceExportContractSection();
+const completeExportContractSection = ({ viaTaskList, submitCheckYourAnswers = false }) => {
+  cy.startInsuranceExportContractSection({ viaTaskList });
 
   cy.completeAndSubmitAboutGoodsOrServicesForm({});
+
+  if (submitCheckYourAnswers) {
+    submitButton().click();
+  }
 };
 
 export default completeExportContractSection;

--- a/e2e-tests/commands/insurance/complete-policy-section.js
+++ b/e2e-tests/commands/insurance/complete-policy-section.js
@@ -6,6 +6,7 @@ const { SINGLE } = FIELD_VALUES.POLICY_TYPE;
 /**
  * completePolicySection
  * Complete the "policy" section
+ * @param {Boolean} viaTaskList: Start the "policy" section from the task list.
  * @param {String} policyType: If single or multiple policy - defaults to single
  * @param {Boolean} policyMaximumValue: If the value should be the maximum amount
  * @param {Boolean} sameName: If sameName on policy - defaults to true

--- a/e2e-tests/commands/insurance/complete-policy-section.js
+++ b/e2e-tests/commands/insurance/complete-policy-section.js
@@ -1,24 +1,33 @@
+import { submitButton } from '../../pages/shared';
 import { FIELD_VALUES } from '../../constants';
 
 const { SINGLE } = FIELD_VALUES.POLICY_TYPE;
 
 /**
  * completePolicySection
- * completes policy section
- * handles policyType and if sameName on policy
- * @param {String} policyType - if single or multiple policy - defaults to single
- * @param {Boolean} sameName - if sameName on policy - defaults to true
- * @param {Boolean} usingBroker - if usingBroker on policy - defaults to false
+ * Complete the "policy" section
+ * @param {String} policyType: If single or multiple policy - defaults to single
+ * @param {Boolean} policyMaximumValue: If the value should be the maximum amount
+ * @param {Boolean} sameName: If sameName on policy - defaults to true
+ * @param {Boolean} usingBroker: If usingBroker on policy - defaults to false
+ * @param {Boolean} submitCheckYourAnswers: Click policy "check your answers" submit button
  */
-const completePolicySection = ({ policyType = SINGLE, sameName = true, usingBroker = false }) => {
-  cy.startInsurancePolicySection();
+const completePolicySection = ({
+  viaTaskList,
+  policyType = SINGLE,
+  policyMaximumValue = false,
+  sameName = true,
+  usingBroker = false,
+  submitCheckYourAnswers = false,
+}) => {
+  cy.startInsurancePolicySection({ viaTaskList });
 
   cy.completeAndSubmitPolicyTypeForm(policyType);
 
   if (policyType === SINGLE) {
-    cy.completeAndSubmitSingleContractPolicyForm({});
+    cy.completeAndSubmitSingleContractPolicyForm({ policyMaximumValue });
   } else {
-    cy.completeAndSubmitMultipleContractPolicyForm({});
+    cy.completeAndSubmitMultipleContractPolicyForm({ policyMaximumValue });
   }
 
   cy.completeAndSubmitNameOnPolicyForm({ sameName });
@@ -28,6 +37,10 @@ const completePolicySection = ({ policyType = SINGLE, sameName = true, usingBrok
   }
 
   cy.completeAndSubmitBrokerForm({ usingBroker });
+
+  if (submitCheckYourAnswers) {
+    submitButton().click();
+  }
 };
 
 export default completePolicySection;

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
@@ -6,6 +6,7 @@ const { POLICY_TYPE } = FIELD_VALUES;
  * completePrepareApplicationMultiplePolicyType
  * Runs through the full prepare your application journey for multiple policy type
  * @param {Object} Object with flags on how to complete specific parts of the application
+ * - differentTradingAddress: Should submit "yes" to "trade from a different address" in the "company details" form.
  * - exporterHasTradedWithBuyer: Should submit "yes" to "have traded with buyer before" in the "working with buyer" form.
  * - usingBroker: Should submit "yes" or "no" to "using a broker". Defaults to "no".
  * - policyMaximumValue: should submit an application with the maximum value of 500000

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
@@ -1,68 +1,42 @@
-import { submitButton, startNowLink } from '../../pages/shared';
 import { FIELD_VALUES } from '../../constants';
+
+const { POLICY_TYPE } = FIELD_VALUES;
 
 /**
  * completePrepareApplicationMultiplePolicyType
  * Runs through the full prepare your application journey for multiple policy type
  * @param {Object} Object with flags on how to complete specific parts of the application
- * - differentTradingAddress: Should submit "yes" to "trade from a different address" in the "your business - company details" form. Defaults to false.
+ * - exporterHasTradedWithBuyer: Should submit "yes" to "have traded with buyer before" in the "working with buyer" form.
  * - usingBroker: Should submit "yes" or "no" to "using a broker". Defaults to "no".
  * - policyMaximumValue: should submit an application with the maximum value of 500000
  * - differentPolicyContact: Should submit an application with a different policy contact to the owner
+ * - submitCheckYourAnswers: Should click each section's "check your answers" submit button
  */
 const completePrepareApplicationMultiplePolicyType = ({
   differentTradingAddress = false,
-  usingBroker,
+  exporterHasTradedWithBuyer = false,
+  differentPolicyContact = false,
   policyMaximumValue = false,
-  differentPolicyContact,
+  usingBroker = false,
+  submitCheckYourAnswers = true,
 }) => {
-  cy.startInsurancePolicySection();
+  cy.completeBusinessSection({ differentTradingAddress, submitCheckYourAnswers });
 
-  cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
-  cy.completeAndSubmitMultipleContractPolicyForm({ policyMaximumValue });
-  cy.completeAndSubmitNameOnPolicyForm({ sameName: !differentPolicyContact });
+  cy.completeBuyerSection({
+    viaTaskList: false,
+    exporterHasTradedWithBuyer,
+    submitCheckYourAnswers,
+  });
 
-  if (differentPolicyContact) {
-    cy.completeAndSubmitDifferentNameOnPolicyForm({});
-  }
+  cy.completePolicySection({
+    policyType: POLICY_TYPE.MULTIPLE,
+    sameName: !differentPolicyContact,
+    policyMaximumValue,
+    submitCheckYourAnswers,
+    usingBroker,
+  });
 
-  cy.completeAndSubmitBrokerForm({ usingBroker });
-
-  // submit "policy and exports - check your answers" form
-  submitButton().click();
-
-  // start "export contract" section
-  startNowLink().click();
-
-  cy.completeAndSubmitAboutGoodsOrServicesForm({});
-
-  // submit "export contract - check your answers" form
-  submitButton().click();
-
-  cy.startYourBusinessSection();
-
-  cy.completeAndSubmitCompanyDetails({ differentTradingAddress });
-
-  if (differentTradingAddress) {
-    cy.completeAndSubmitAlternativeTradingAddressForm();
-  }
-
-  cy.completeAndSubmitNatureOfYourBusiness();
-  cy.completeAndSubmitTurnoverForm();
-  cy.completeAndSubmitCreditControlForm({});
-
-  // submit "your business - check your answers" form
-  submitButton().click();
-
-  // start "your buyer" section
-  startNowLink().click();
-
-  cy.completeAndSubmitCompanyOrOrganisationForm({});
-  cy.completeAndSubmitConnectionToTheBuyerForm({});
-  cy.completeAndSubmitWorkingWithBuyerForm({});
-
-  // submit "your buyer - check your answers" forM
-  submitButton().click();
+  cy.completeExportContractSection({ viaTaskList: false, submitCheckYourAnswers });
 };
 
 export default completePrepareApplicationMultiplePolicyType;

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
@@ -1,5 +1,6 @@
-import { submitButton, startNowLink } from '../../pages/shared';
 import { FIELD_VALUES } from '../../constants';
+
+const { POLICY_TYPE } = FIELD_VALUES;
 
 /**
  * completePrepareYourApplicationSectionSingle
@@ -10,60 +11,33 @@ import { FIELD_VALUES } from '../../constants';
  * - usingBroker: Should submit "yes" or "no" to "using a broker". Defaults to "no".
  * - policyMaximumValue: Should submit an application with the maximum value of 500000
  * - differentPolicyContact: Should submit an application with a different policy contact to the owner
+ * - submitCheckYourAnswers: Should click each section's "check your answers" submit button
  */
-const completePrepareYourApplicationSectionSingle = ({
+const completePrepareApplicationSinglePolicyType = ({
   differentTradingAddress = false,
   exporterHasTradedWithBuyer,
   usingBroker,
   policyMaximumValue = false,
   differentPolicyContact,
+  submitCheckYourAnswers = true,
 }) => {
-  cy.startInsurancePolicySection();
+  cy.completeBusinessSection({ differentTradingAddress, submitCheckYourAnswers });
 
-  cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
-  cy.completeAndSubmitSingleContractPolicyForm({ policyMaximumValue });
-  cy.completeAndSubmitNameOnPolicyForm({ sameName: !differentPolicyContact });
+  cy.completeBuyerSection({
+    viaTaskList: false,
+    exporterHasTradedWithBuyer,
+    submitCheckYourAnswers,
+  });
 
-  if (differentPolicyContact) {
-    cy.completeAndSubmitDifferentNameOnPolicyForm({});
-  }
+  cy.completePolicySection({
+    policyType: POLICY_TYPE.SINGLE,
+    sameName: !differentPolicyContact,
+    policyMaximumValue,
+    submitCheckYourAnswers,
+    usingBroker,
+  });
 
-  cy.completeAndSubmitBrokerForm({ usingBroker });
-
-  // submit "policy and exports - check your answers" form
-  submitButton().click();
-
-  // start "export contract" section
-  startNowLink().click();
-
-  cy.completeAndSubmitAboutGoodsOrServicesForm({});
-
-  // submit "export contract - check your answers" form
-  submitButton().click();
-
-  cy.startYourBusinessSection();
-
-  cy.completeAndSubmitCompanyDetails({ differentTradingAddress });
-
-  if (differentTradingAddress) {
-    cy.completeAndSubmitAlternativeTradingAddressForm();
-  }
-
-  cy.completeAndSubmitNatureOfYourBusiness();
-  cy.completeAndSubmitTurnoverForm();
-  cy.completeAndSubmitCreditControlForm({});
-
-  // submit "your business - check your answers" form
-  submitButton().click();
-
-  // start "your buyer" section
-  startNowLink().click();
-
-  cy.completeAndSubmitCompanyOrOrganisationForm({});
-  cy.completeAndSubmitConnectionToTheBuyerForm({});
-  cy.completeAndSubmitWorkingWithBuyerForm({ exporterHasTradedWithBuyer });
-
-  submitButton().click();
+  cy.completeExportContractSection({ viaTaskList: false, submitCheckYourAnswers });
 };
 
-export default completePrepareYourApplicationSectionSingle;
+export default completePrepareApplicationSinglePolicyType;

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
@@ -6,7 +6,7 @@ const { POLICY_TYPE } = FIELD_VALUES;
  * completePrepareYourApplicationSectionSingle
  * Runs through the full prepare your application journey for a single policy type
  * @param {Object} Object with flags on how to complete specific parts of the application
- * - differentTradingAddress: Should submit "yes" to "trade from a different address" in the "your business - company details" form. Defaults to false.
+ * - differentTradingAddress: Should submit "yes" to "trade from a different address" in the "company details" form. Defaults to false.
  * - exporterHasTradedWithBuyer: Should submit "yes" to "have traded with buyer before" in the "working with buyer" form. Defaults to "yes".
  * - usingBroker: Should submit "yes" or "no" to "using a broker". Defaults to "no".
  * - policyMaximumValue: Should submit an application with the maximum value of 500000

--- a/e2e-tests/commands/insurance/start-insurance-export-contract-section.js
+++ b/e2e-tests/commands/insurance/start-insurance-export-contract-section.js
@@ -10,9 +10,13 @@ const task = taskList.prepareApplication.tasks.exportContract;
  * Start the "export contract" section of an application.
  * 1) Click the "export contract" task list item.
  * 2) Click the "start now" link in the "export contract" start page.
+ * @param {Boolean} viaTaskList: Start the "export contract" section from the task list.
  */
-const startInsuranceExportContractSection = () => {
-  task.link().click();
+const startInsuranceExportContractSection = ({ viaTaskList = true }) => {
+  if (viaTaskList) {
+    task.link().click();
+  }
+
   startNowLink().click();
 };
 

--- a/e2e-tests/commands/insurance/start-insurance-policy-section.js
+++ b/e2e-tests/commands/insurance/start-insurance-policy-section.js
@@ -10,9 +10,13 @@ const task = taskList.prepareApplication.tasks.policy;
  * Start the "insurance policy" section of an application.
  * 1) Click the "insurance policy" task list item.
  * 2) Click the "start now" link in the "insurance policy" start page.
+ * @param {Boolean} viaTaskList: Start the "insurance policy" section from the task list.
  */
-const startInsurancePolicySection = () => {
-  task.link().click();
+const startInsurancePolicySection = ({ viaTaskList = true }) => {
+  if (viaTaskList) {
+    task.link().click();
+  }
+
   startNowLink().click();
 };
 

--- a/e2e-tests/commands/insurance/start-your-business-section.js
+++ b/e2e-tests/commands/insurance/start-your-business-section.js
@@ -10,9 +10,13 @@ const task = taskList.prepareApplication.tasks.business;
  * Start the "your business" section of an application.
  * 1) Click the "your business" task list item.
  * 2) Click the "start now" link in the "your business" start page.
+ * @param {Boolean} viaTaskList: Start the "your business" section from the task list.
  */
-const startYourBusinessSection = () => {
-  task.link().click();
+const startYourBusinessSection = ({ viaTaskList = true }) => {
+  if (viaTaskList) {
+    task.link().click();
+  }
+
   startNowLink().click();
 };
 

--- a/e2e-tests/commands/insurance/start-your-buyer-section.js
+++ b/e2e-tests/commands/insurance/start-your-buyer-section.js
@@ -10,9 +10,13 @@ const task = taskList.prepareApplication.tasks.buyer;
  * Start the "your buyer" section of an application.
  * 1) Click the "your buyer" task list item.
  * 2) Click the "start now" link in the "your buyer" start page.
+ * @param {Boolean} viaTaskList: Start the "your buyer" section from the task list.
  */
-const startInsuranceYourBuyerSection = () => {
-  task.link().click();
+const startInsuranceYourBuyerSection = ({ viaTaskList = true }) => {
+  if (viaTaskList) {
+    task.link().click();
+  }
+
   startNowLink().click();
 };
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/complete-prepare-application-tasks.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/complete-prepare-application-tasks.spec.js
@@ -56,7 +56,9 @@ context('Insurance - Complete `prepare your application` tasks', () => {
       cy.checkText(prepareApplication.tasks.policy.status(), COMPLETED);
     });
 
-    // TODO - export contract
+    it(`renders a 'export contract' task with a status of ${COMPLETED}`, () => {
+      cy.checkText(prepareApplication.tasks.exportContract.status(), COMPLETED);
+    });
   });
 
   describe('`submit application` tasks', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/complete-prepare-application-tasks.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/complete-prepare-application-tasks.spec.js
@@ -44,10 +44,6 @@ context('Insurance - Complete `prepare your application` tasks', () => {
   });
 
   describe('`prepare application` tasks', () => {
-    it(`renders a 'type of policy' task with a status of ${COMPLETED}`, () => {
-      cy.checkText(prepareApplication.tasks.policy.status(), COMPLETED);
-    });
-
     it(`renders a 'your business' task with a status of ${COMPLETED}`, () => {
       cy.checkText(prepareApplication.tasks.business.status(), COMPLETED);
     });
@@ -55,6 +51,12 @@ context('Insurance - Complete `prepare your application` tasks', () => {
     it(`renders a 'your buyer' task with a status of ${COMPLETED}`, () => {
       cy.checkText(prepareApplication.tasks.buyer.status(), COMPLETED);
     });
+
+    it(`renders a 'type of policy' task with a status of ${COMPLETED}`, () => {
+      cy.checkText(prepareApplication.tasks.policy.status(), COMPLETED);
+    });
+
+    // TODO - export contract
   });
 
   describe('`submit application` tasks', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-populated-application.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-populated-application.spec.js
@@ -62,7 +62,7 @@ context('Insurance - Dashboard - populated application', () => {
       table.body.row(referenceNumber).submittedLink().click();
 
       // go to the 'your buyer' section via task list
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       // complete and submit the form
       cy.completeAndSubmitCompanyOrOrganisationForm({});
@@ -97,7 +97,7 @@ context('Insurance - Dashboard - populated application', () => {
       table.body.row(referenceNumber).submittedLink().click();
 
       // go to the 'policy' section via task list
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       // complete the first form - single contract policy
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
@@ -125,7 +125,7 @@ context('Insurance - Dashboard - populated application', () => {
       table.body.row(referenceNumber).submittedLink().click();
 
       // go to the 'policy' section via task list
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       // complete the first form - single contract policy
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services-final-destination-not-known.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services-final-destination-not-known.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Export contract - About goods or services page - Final dest
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceExportContractSection();
+      cy.startInsuranceExportContractSection({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
@@ -52,7 +52,7 @@ context('Insurance - Export contract - About goods or services page - Final dest
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceExportContractSection();
+      cy.startInsuranceExportContractSection({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/save-and-back.spec.js
@@ -36,7 +36,7 @@ context('Insurance - Export contract - About goods or services page - Save and g
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceExportContractSection();
+      cy.startInsuranceExportContractSection({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`;
       cy.assertUrl(url);
@@ -96,7 +96,7 @@ context('Insurance - Export contract - About goods or services page - Save and g
       saveAndBackButton().click();
 
       // go back to the page via the task list
-      cy.startInsuranceExportContractSection();
+      cy.startInsuranceExportContractSection({});
 
       aboutGoodsOrServicesPage[DESCRIPTION].textarea().should('have.value', application.EXPORT_CONTRACT[DESCRIPTION]);
     });
@@ -130,7 +130,7 @@ context('Insurance - Export contract - About goods or services page - Save and g
     });
 
     it('should have no value in `description` when going back to the page', () => {
-      cy.startInsuranceExportContractSection();
+      cy.startInsuranceExportContractSection({});
 
       field.textarea().should('have.value', '');
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/validation/about-goods-or-services-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/validation/about-goods-or-services-validation.spec.js
@@ -33,7 +33,7 @@ context('Insurance - Export contract - About goods or services page - form valid
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceExportContractSection();
+      cy.startInsuranceExportContractSection({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-about-goods-or-services-final-destination-known-to-unknown.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-about-goods-or-services-final-destination-known-to-unknown.spec.js
@@ -31,7 +31,7 @@ context('Insurance - Export contract - Change your answers - About goods or serv
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeExportContractSection();
+      cy.completeExportContractSection({});
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       cy.assertUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-about-goods-or-services.spec.js
@@ -32,7 +32,7 @@ context('Insurance - Export contract - Change your answers - About goods or serv
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeExportContractSection();
+      cy.completeExportContractSection({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       cy.assertUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
@@ -23,7 +23,7 @@ context('Insurance - Export contract - Check your answers - Summary list', () =>
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeExportContractSection();
+      cy.completeExportContractSection({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${EXPORT_CONTRACT.CHECK_YOUR_ANSWERS}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/check-your-answers/check-your-answers.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/check-your-answers/check-your-answers.spec.js
@@ -27,7 +27,7 @@ context('Insurance - Export contract - Check your answers - As an exporter, I wa
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeExportContractSection();
+      cy.completeExportContractSection({});
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
@@ -59,7 +59,7 @@ context('Insurance - Policy - Broker Page - As an Exporter I want to confirm if 
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
@@ -46,7 +46,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
@@ -97,7 +97,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
     it(`should retain the ${NAME} input on the page and the other fields should be empty`, () => {
       cy.navigateToUrl(allSectionsUrl);
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       // submit policy type form
       submitButton().click();
@@ -142,7 +142,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
       it('should retain all the fields on the page', () => {
         cy.navigateToUrl(allSectionsUrl);
 
-        cy.startInsurancePolicySection();
+        cy.startInsurancePolicySection({});
 
         // submit policy type form
         submitButton().click();
@@ -178,7 +178,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
       it('should retain all the relevant fields on the page', () => {
         cy.navigateToUrl(allSectionsUrl);
 
-        cy.startInsurancePolicySection();
+        cy.startInsurancePolicySection({});
 
         // submit policy type form
         submitButton().click();

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/are-you-using-a-broker-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/are-you-using-a-broker-answer-no.spec.js
@@ -31,7 +31,7 @@ context('Insurance - Policy - Broker Page - As an Exporter I want to confirm tha
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-all-required-fields.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-all-required-fields.spec.js
@@ -24,7 +24,7 @@ context('Insurance - Policy - Broker Page - As an Exporter I want to confirm tha
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-no-required-fields.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-no-required-fields.spec.js
@@ -38,7 +38,7 @@ context('Insurance - Policy - Broker Page - As an Exporter I want to confirm tha
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/broker-email-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/broker-email-validation.spec.js
@@ -42,7 +42,7 @@ context('Insurance - Policy - Broker Page - Validation - Email', () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/broker-postcode-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/broker-postcode-validation.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Policy - Broker Page - Validation - Postcode', () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-multiple-contract-policy.spec.js
@@ -23,7 +23,7 @@ context('Insurance - Policy - Complete the entire section as a multiple contract
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
       cy.completeAndSubmitMultipleContractPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-single-contract-policy.spec.js
@@ -23,7 +23,7 @@ context('Insurance - Policy - Complete the entire section as a single contract p
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/changing-from-same-name-to-different-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/changing-from-same-name-to-different-name.spec.js
@@ -36,7 +36,7 @@ context(`Insurance - Policy - Different name on Policy page - Changing ${SAME_NA
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitNameOnPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
@@ -49,7 +49,7 @@ context('Insurance - Policy - Different name on Policy page - I want to enter th
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: false });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/entering-details-of-policy-owner.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/entering-details-of-policy-owner.spec.js
@@ -41,7 +41,7 @@ context(`Insurance - Policy - Different name on Policy page - Entering name of p
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: false });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/save-and-back.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Policy - Different name on policy - Save and go back', () =
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: false });
@@ -142,7 +142,7 @@ context('Insurance - Policy - Different name on policy - Save and go back', () =
     });
 
     it('should have the originally submitted answers populated when going back to the page through policy and exports flow', () => {
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       submitButton().click();
       submitButton().click();

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/validation/different-name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/validation/different-name-on-policy-validation.spec.js
@@ -36,7 +36,7 @@ context('Insurance - Policy - Different name on Policy page - Validation', () =>
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: false });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -60,7 +60,7 @@ context('Insurance - Policy - Multiple contract policy page - As an exporter, I 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/save-and-back.spec.js
@@ -38,7 +38,7 @@ context('Insurance - Policy - Multiple contract policy page - Save and go back',
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
@@ -103,7 +103,7 @@ context('Insurance - Policy - Multiple contract policy page - Save and go back',
 
         saveAndBackButton().click();
 
-        cy.startInsurancePolicySection();
+        cy.startInsurancePolicySection({});
 
         submitButton().click();
       });
@@ -143,7 +143,7 @@ context('Insurance - Policy - Multiple contract policy page - Save and go back',
 
         saveAndBackButton().click();
 
-        cy.startInsurancePolicySection();
+        cy.startInsurancePolicySection({});
         submitButton().click();
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-maximum-buyer-will-owe.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-maximum-buyer-will-owe.spec.js
@@ -49,7 +49,7 @@ context('Insurance - Policy - Multiple contract policy page - form validation - 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-policy-currency-code.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-policy-currency-code.spec.js
@@ -32,7 +32,7 @@ context('Insurance - Policy - Multiple contract policy page - form validation - 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
 
       const expectedUrl = `${baseUrl}${INSURANCE.ROOT}/${referenceNumber}${INSURANCE.POLICY.MULTIPLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-requested-start-date.spec.js
@@ -19,7 +19,7 @@ context('Insurance - Policy - Multiple contract policy page - form validation - 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-total-months-of-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-total-months-of-cover.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Policy - Multiple contract policy page - form validation - 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
 
       const expectedUrl = `${baseUrl}${ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-total-sales-to-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-total-sales-to-buyer.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Policy - Multiple contract policy page - form validation - 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
@@ -40,7 +40,7 @@ context('Insurance - Policy - Multiple contract policy page - form validation', 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
 
       url = `${baseUrl}${INSURANCE.ROOT}/${referenceNumber}${INSURANCE.POLICY.MULTIPLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/name-on-policy-page.spec.js
@@ -50,7 +50,7 @@ context('Insurance - Policy - Name on Policy page - I want to enter the details 
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/save-and-back.spec.js
@@ -41,7 +41,7 @@ context('Insurance - Policy - Name on policy - Save and go back', () => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
@@ -42,7 +42,7 @@ context('Insurance - Policy - Name on policy - Validation', () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
@@ -39,7 +39,7 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
@@ -104,7 +104,7 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
     });
 
     it('should not have saved the submitted values  going back to the page', () => {
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       submitButton().click();
 
       field.dayInput().should('have.value', '');
@@ -137,7 +137,7 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
     });
 
     it('should have the submitted values when going back to the page', () => {
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       submitButton().click();
 
       field.dayInput().should('have.value', '1');

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
@@ -57,7 +57,7 @@ context('Insurance - Policy - Single contract policy page - As an exporter, I wa
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Policy - Single contract policy page - form validation - co
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-policy-currency-code.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-policy-currency-code.spec.js
@@ -32,7 +32,7 @@ context('Insurance - Policy - Single contract policy page - form validation - po
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
 
       const expectedUrl = `${baseUrl}${INSURANCE.ROOT}/${referenceNumber}${INSURANCE.POLICY.SINGLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
@@ -19,7 +19,7 @@ context('Insurance - Policy - Single contract policy page - form validation - re
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-total-contract-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-total-contract-value.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Policy - Single contract policy page - form validation - to
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation.spec.js
@@ -40,7 +40,7 @@ context('Insurance - Policy - Single contract policy page - form validation', ()
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
 
       url = `${baseUrl}${INSURANCE.ROOT}/${referenceNumber}${INSURANCE.POLICY.SINGLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/save-and-back.spec.js
@@ -20,7 +20,7 @@ context('Insurance - Policy - Type of policy page - Save and go back', () => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       url = `${baseUrl}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.POLICY.TYPE_OF_POLICY}`;
       cy.assertUrl(url);
@@ -61,7 +61,7 @@ context('Insurance - Policy - Type of policy page - Save and go back', () => {
 
       saveAndBackButton().click();
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       multiplePolicyField.input().click();
       saveAndBackButton().click();
@@ -81,7 +81,7 @@ context('Insurance - Policy - Type of policy page - Save and go back', () => {
 
     describe('when going back to the page', () => {
       it('should have the originally submitted answer selected', () => {
-        cy.startInsurancePolicySection();
+        cy.startInsurancePolicySection({});
 
         multiplePolicyField.input().should('be.checked');
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/type-of-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/type-of-policy.spec.js
@@ -52,7 +52,7 @@ context('Insurance - Policy - Type of policy page - As an exporter, I want to en
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/submit-name-fields-with-special-characters/different-name-on-policy-name-fields-with-special-characters.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/submit-name-fields-with-special-characters/different-name-on-policy-name-fields-with-special-characters.spec.js
@@ -31,7 +31,7 @@ context('Insurance - Name fields - `Policy contact` name fields should render sp
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.startInsurancePolicySection();
+      cy.startInsurancePolicySection({});
 
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-dashboard.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-dashboard.spec.js
@@ -21,7 +21,7 @@ context('Insurance - Name fields - Dashboard fields should render special charac
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       cy.completeAndSubmitCompanyOrOrganisationForm({
         buyerName: nameWithSpecialCharacters,

--- a/e2e-tests/insurance/cypress/e2e/journeys/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-header-and-page-fields.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-header-and-page-fields.spec.js
@@ -92,7 +92,7 @@ context('Insurance - Name fields - Header and page fields should render special 
       beforeEach(() => {
         cy.navigateToUrl(allSectionsUrl);
 
-        cy.startInsuranceYourBuyerSection();
+        cy.startInsuranceYourBuyerSection({});
 
         cy.completeAndSubmitCompanyOrOrganisationForm({
           buyerName: nameWithSpecialCharacters,

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/alternative-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/alternative-trading-address.spec.js
@@ -53,7 +53,7 @@ context('Insurance - Your business - Alternative trading address page - I want t
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({
         differentTradingAddress: true,

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/save-and-back.spec.js
@@ -39,7 +39,7 @@ context('Insurance - Your business - Alternative trading address - Save and go b
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
       cy.completeAndSubmitCompanyDetails({
         differentTradingAddress: true,
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
@@ -42,7 +42,7 @@ context('Insurance - Your business - Change your answers - Company details - As 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-credit-control.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-credit-control.spec.js
@@ -25,7 +25,7 @@ context('Insurance - Your business - Change your answers - Credit control - As a
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-nature-of-your-business.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-nature-of-your-business.spec.js
@@ -28,7 +28,7 @@ context('Insurance - Your business - Change your answers - Nature of your busine
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-trading-address.spec.js
@@ -46,7 +46,7 @@ context(`Insurance - Your business - Change your answers - ${TRADING_ADDRESS} an
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
@@ -25,7 +25,7 @@ context('Insurance - Your business - Change your answers - Turnover - As an expo
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-page.spec.js
@@ -32,7 +32,7 @@ context('Insurance - Your Business - Check your answers - As an exporter, I want
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
@@ -45,7 +45,7 @@ context('Insurance - Your business - Check your answers - Summary list - your bu
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.startYourBusinessSection();
+        cy.startYourBusinessSection({});
 
         cy.completeAndSubmitCompanyDetails({});
         cy.completeAndSubmitNatureOfYourBusiness();
@@ -116,7 +116,7 @@ context('Insurance - Your business - Check your answers - Summary list - your bu
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.startYourBusinessSection();
+        cy.startYourBusinessSection({});
 
         cy.completeAndSubmitCompanyDetails({ differentTradingAddress: true });
         cy.completeAndSubmitAlternativeTradingAddressForm();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
@@ -45,7 +45,7 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${COMPANY_DETAILS_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-save-and-back.spec.js
@@ -45,7 +45,7 @@ describe('Insurance - Your business - Company details page - Save and go back', 
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${COMPANY_DETAILS}`;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeCompanyDetailsForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-submit-different-trading-address-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-submit-different-trading-address-yes.spec.js
@@ -31,7 +31,7 @@ describe(`Insurance - Your business - Company details page - submit ${TRADING_AD
       url = `${baseUrl}${ROOT}/${referenceNumber}${COMPANY_DETAILS}`;
       alternativeTradingAddressUrl = `${baseUrl}${ROOT}/${referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_ROOT}`;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeCompanyDetailsForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-submit-different-trading-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-submit-different-trading-name.spec.js
@@ -33,7 +33,7 @@ describe(`Insurance - Your business - Company details page - submit ${DIFFERENT_
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${COMPANY_DETAILS}`;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeCompanyDetailsForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-submit.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-submit.spec.js
@@ -46,7 +46,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       url = `${baseUrl}${ROOT}/${referenceNumber}${COMPANY_DETAILS}`;
       natureOfBusinessUrl = `${baseUrl}${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS_ROOT}`;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeCompanyDetailsForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-company-website-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-company-website-validation.spec.js
@@ -34,7 +34,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       url = `${baseUrl}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`;
       natureOfBusinessUrl = `${baseUrl}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.NATURE_OF_BUSINESS_ROOT}`;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeCompanyDetailsForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-different-trading-name-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-different-trading-name-validation.spec.js
@@ -26,7 +26,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
 
       url = `${baseUrl}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${COMPANY_DETAILS}`;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeCompanyDetailsForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-invalid-phone-number-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-invalid-phone-number-validation.spec.js
@@ -42,7 +42,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeCompanyDetailsForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-address-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-address-validation.spec.js
@@ -23,7 +23,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
 
       url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeCompanyDetailsForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-name-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-name-validation.spec.js
@@ -23,7 +23,7 @@ describe("Insurance - Your business - Company details page- As an Exporter I wan
 
       url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeCompanyDetailsForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-valid-phone-number-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-valid-phone-number-validation.spec.js
@@ -41,7 +41,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
 
       natureOfBusinessUrl = `${baseUrl}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.NATURE_OF_BUSINESS_ROOT}`;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeCompanyDetailsForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control-answer-no.spec.js
@@ -17,7 +17,7 @@ context('Insurance - Your business - Credit control page - answer `no` - As an E
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Your business - Credit control page - answer `yes` - As an 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/save-and-back.spec.js
@@ -24,7 +24,7 @@ context('Insurance - Your business - Credit control - Save and go back', () => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
       cy.completeAndSubmitTurnoverForm();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/nature-of-business-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/nature-of-business-page.spec.js
@@ -38,7 +38,7 @@ context('Insurance - Your business - Nature of your business page - As an Export
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/save-and-back.spec.js
@@ -34,7 +34,7 @@ context('Insurance - Your business - Nature of your business page - Save and bac
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
 
@@ -90,7 +90,7 @@ context('Insurance - Your business - Nature of your business page - Save and bac
     });
 
     it(`should retain the ${GOODS_OR_SERVICES} input on the page and the other fields should be empty`, () => {
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       // submit companies house number form
       submitButton().click();
@@ -124,7 +124,7 @@ context('Insurance - Your business - Nature of your business page - Save and bac
     });
 
     it(`should retain the ${GOODS_OR_SERVICES} input on the page and the other fields should be empty`, () => {
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       // company details submit
       submitButton().click();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
@@ -29,7 +29,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
@@ -24,7 +24,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
@@ -24,7 +24,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/save-and-back.spec.js
@@ -35,7 +35,7 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
@@ -88,7 +88,7 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
     });
 
     it(`should retain the ${ESTIMATED_ANNUAL_TURNOVER} input on the page and the other fields should be empty`, () => {
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       // submit companies house number form
       submitButton().click();
@@ -121,7 +121,7 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
     });
 
     it('should retain all the fields on the page', () => {
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       // submit company details form
       submitButton().click();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-currency-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-currency-page.spec.js
@@ -19,7 +19,7 @@ context('Insurance - Your business - Turnover currency page - As an Exporter I w
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-financial-year-end.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-financial-year-end.spec.js
@@ -45,7 +45,7 @@ context(`Insurance - Your business - Turnover page - when ${fieldId} exists`, ()
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
@@ -81,7 +81,7 @@ context(`Insurance - Your business - Turnover page - when ${fieldId} does not ex
     }).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
@@ -46,7 +46,7 @@ context('Insurance - Your business - Turnover page - As an Exporter I want to en
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
@@ -30,7 +30,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
@@ -28,7 +28,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startYourBusinessSection();
+      cy.startYourBusinessSection({});
 
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-company-or-organisation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-company-or-organisation.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Your buyer - Change your answers - Company or organisation 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       cy.completeAndSubmitCompanyOrOrganisationForm({});
       cy.completeAndSubmitConnectionToTheBuyerForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer.spec.js
@@ -31,7 +31,7 @@ context('Insurance - Your buyer - Change your answers - Company or organisation 
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       cy.completeAndSubmitCompanyOrOrganisationForm({});
       cy.completeAndSubmitConnectionToTheBuyerForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/check-your-answers/check-your-answers-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/check-your-answers/check-your-answers-page.spec.js
@@ -25,7 +25,7 @@ context('Insurance - Your buyer - Check your answers - As an exporter, I want to
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       cy.completeAndSubmitCompanyOrOrganisationForm({});
       cy.completeAndSubmitConnectionToTheBuyerForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
@@ -39,7 +39,7 @@ context('Insurance - Your buyer - Check your answers - Summary list - your buyer
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       cy.completeAndSubmitCompanyOrOrganisationForm({});
       cy.completeAndSubmitConnectionToTheBuyerForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/company-or-organisation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/company-or-organisation.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Your Buyer - Company or organisation page - As an exporter,
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${COMPANY_OR_ORGANISATION}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/save-and-back.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Your buyer - Company or organisation - Save and back', () =
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${COMPANY_OR_ORGANISATION}`;
 
@@ -98,7 +98,7 @@ context('Insurance - Your buyer - Company or organisation - Save and back', () =
     });
 
     it(`should retain the ${NAME} and ${CAN_CONTACT_BUYER} input on the page and the other fields should be empty`, () => {
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       companyOrOrganisationPage[CAN_CONTACT_BUYER].yesRadioInput().should('be.checked');
       cy.checkValue(field(NAME), BUYER[NAME]);
@@ -139,7 +139,7 @@ context('Insurance - Your buyer - Company or organisation - Save and back', () =
     });
 
     it('should retain all inputs on the page', () => {
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       companyOrOrganisationPage[CAN_CONTACT_BUYER].yesRadioInput().should('be.checked');
       cy.checkValue(field(ADDRESS), BUYER[ADDRESS]);

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-address.spec.js
@@ -32,7 +32,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${COMPANY_OR_ORGANISATION}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-can-contact-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-can-contact-buyer.spec.js
@@ -30,7 +30,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-email.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-email.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${COMPANY_OR_ORGANISATION}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-first-last-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-first-last-name.spec.js
@@ -32,7 +32,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-position.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-position.spec.js
@@ -30,7 +30,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-website.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-website.spec.js
@@ -29,7 +29,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation.spec.js
@@ -32,7 +32,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/connection-to-the-buyer-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/connection-to-the-buyer-page.spec.js
@@ -33,7 +33,7 @@ context('Insurance - Your Buyer - Connection with the buyer - As an exporter, I 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       cy.completeAndSubmitCompanyOrOrganisationForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/validation/connection-to-the-buyer-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/validation/connection-to-the-buyer-validation.spec.js
@@ -36,7 +36,7 @@ context('Insurance - Your Buyer - Connection to the buyer page - form validation
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
       cy.completeAndSubmitCompanyOrOrganisationForm({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CONNECTION_TO_THE_BUYER}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/working-with-buyer/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/working-with-buyer/save-and-back.spec.js
@@ -33,7 +33,7 @@ context('Insurance - Your buyer - Working with buyer - Save and back', () => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       cy.completeAndSubmitCompanyOrOrganisationForm({});
       cy.completeAndSubmitConnectionToTheBuyerForm({});
@@ -88,7 +88,7 @@ context('Insurance - Your buyer - Working with buyer - Save and back', () => {
     });
 
     it(`should retain the ${CONNECTED_WITH_BUYER} radio button selection and the other fields should be empty`, () => {
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       // submit button to get to working with buyer page
       submitButton().click();
@@ -121,7 +121,7 @@ context('Insurance - Your buyer - Working with buyer - Save and back', () => {
     });
 
     it('should retain all inputs on the page', () => {
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       // submit button to get to working with buyer page
       submitButton().click();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/working-with-buyer/validation/working-with-buyer-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/working-with-buyer/validation/working-with-buyer-validation.spec.js
@@ -34,7 +34,7 @@ context('Insurance - Your Buyer - Working with buyer page - form validation', ()
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       cy.completeAndSubmitCompanyOrOrganisationForm({});
       cy.completeAndSubmitConnectionToTheBuyerForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/working-with-buyer/working-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/working-with-buyer/working-with-buyer.spec.js
@@ -28,7 +28,7 @@ context('Insurance - Your Buyer - Working with buyer page - As an exporter, I wa
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.startInsuranceYourBuyerSection();
+      cy.startInsuranceYourBuyerSection({});
 
       cy.completeAndSubmitCompanyOrOrganisationForm({});
       cy.completeAndSubmitConnectionToTheBuyerForm({});

--- a/e2e-tests/insurance/cypress/support/application/policy/index.js
+++ b/e2e-tests/insurance/cypress/support/application/policy/index.js
@@ -9,6 +9,8 @@ Cypress.Commands.add('completeAndSubmitNameOnPolicyForm', require('../../../../.
 Cypress.Commands.add('completeAndSubmitDifferentNameOnPolicyForm', require('../../../../../commands/insurance/complete-and-submit-different-name-on-policy-form'));
 Cypress.Commands.add('completeDifferentNameOnPolicyForm', require('../../../../../commands/insurance/complete-different-name-on-policy-form'));
 
+Cypress.Commands.add('completeBusinessSection', require('../../../../../commands/insurance/complete-business-section'));
+Cypress.Commands.add('completeBuyerSection', require('../../../../../commands/insurance/complete-buyer-section'));
 Cypress.Commands.add('completePolicySection', require('../../../../../commands/insurance/complete-policy-section'));
 Cypress.Commands.add('completeExportContractSection', require('../../../../../commands/insurance/complete-export-contract-section'));
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR improves various cypress commands mostly relating to the "prepare application" task list logic used in various E2E tests.

Previously, some task list assertion logic was not following the same order as the design, and some commands could be made simpler.

## Resolution :heavy_check_mark:
- Create new command to complete "your business" section, `completeBusinessSection`.
- Create new command to complete "export contract" section, `completeExportContractSection`.
- Update various "section" commands to accept `submitCheckYourAnswers` and `viaTaskList` flags.
- Simplify `completePrepareApplicationSinglePolicyType` command.
- Simplify `completePrepareApplicationMultiplePolicyType` command.

## Miscellaneous :heavy_plus_sign:
- Update some commands to have params in an object structure.
- Fix/update/simplify some documentation.
