### PR TITLE
fix(EMS-2399-2418): No PDF - About goods or services - yes/no radio ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ These are the key aspects of the UK Export Finance EXIP service codebase and dev
 ---
 
 ## Sub-resource integrity [(SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)
-JavaScript files are protected by SRI security feature which allows the browser to verify the authenticity of the JavaScript files in use.
+Client side JavaScript files are protected by SRI security feature which allows the browser to verify the authenticity of the JavaScript files in use.
 We use `SHA512` hashing algrothim for all our JavaScript files.
 
 To calculate file hash use the following Bash command with reference to the file in question (Webpack compiled JS file).
@@ -380,3 +380,4 @@ To calculate file hash use the following Bash command with reference to the file
 cat FILENAME.js | openssl dgst -sha512 -binary | openssl base64 -A
 ```
 
+:warning: If a client side JavaScript file is changed and recompiled, a new file hash will need to be generated. Otherwise, the script will not be executed.

--- a/e2e-tests/commands/shared-commands/assertions/assert-first-and-last-radios.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-first-and-last-radios.js
@@ -12,23 +12,28 @@ import { radioInputs } from '../../../pages/shared';
  */
 const assertYesNoRadiosOrder = ({ noRadioFirst = false }) => {
   cy.get(radioInputs).each((element, index) => {
-    if (noRadioFirst) {
-      if (index === 0) {
+    switch (noRadioFirst) {
+      case true && index === 0:
         cy.wrap(element).should('have.attr', 'data-cy', 'no-input');
-      }
+        break;
 
-      if (index === 1) {
+      case true && index === 1:
         cy.wrap(element).should('have.attr', 'data-cy', 'yes-input');
-      }
-    } else {
-      if (index === 0) {
-        cy.wrap(element).should('have.attr', 'data-cy', 'yes-input');
-      }
+        break;
 
-      if (index === 1) {
+      case index === 0:
+        cy.wrap(element).should('have.attr', 'data-cy', 'yes-input');
+        break;
+
+      case index === 1:
         cy.wrap(element).should('have.attr', 'data-cy', 'no-input');
-      }
+        break;
+
+      default:
+        return null;
     }
+
+    return null;
   });
 };
 

--- a/e2e-tests/commands/shared-commands/assertions/assert-first-and-last-radios.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-first-and-last-radios.js
@@ -3,6 +3,11 @@ import { radioInputs } from '../../../pages/shared';
 /**
  * assertYesNoRadiosOrder
  * Check that "yes" and "no" radio inputs are in the correct order.
+ * Note: other cypress approaches for this test assertion have been explored.
+ * All explored options involve adding 2/3 more commands, purely for this command.
+ * Such commands would make this assertion harder to read.
+ * Mostly due to being unable to assign cy.wrap to a variable.
+ * It is simpler and easier to follow to have as below.
  * @param {Boolean} noRadioFirst: No radio should be the first radio. Defaults to false.
  */
 const assertYesNoRadiosOrder = ({ noRadioFirst = false }) => {

--- a/e2e-tests/commands/shared-commands/assertions/assert-first-and-last-radios.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-first-and-last-radios.js
@@ -1,0 +1,30 @@
+import { radioInputs } from '../../../pages/shared';
+
+/**
+ * assertYesNoRadiosOrder
+ * Check that "yes" and "no" radio inputs are in the correct order.
+ * @param {Boolean} noRadioFirst: No radio should be the first radio. Defaults to false.
+ */
+const assertYesNoRadiosOrder = ({ noRadioFirst = false }) => {
+  cy.get(radioInputs).each((element, index) => {
+    if (noRadioFirst) {
+      if (index === 0) {
+        cy.wrap(element).should('have.attr', 'data-cy', 'no-input');
+      }
+
+      if (index === 1) {
+        cy.wrap(element).should('have.attr', 'data-cy', 'yes-input');
+      }
+    } else {
+      if (index === 0) {
+        cy.wrap(element).should('have.attr', 'data-cy', 'yes-input');
+      }
+
+      if (index === 1) {
+        cy.wrap(element).should('have.attr', 'data-cy', 'no-input');
+      }
+    }
+  });
+};
+
+export default assertYesNoRadiosOrder;

--- a/e2e-tests/commands/shared-commands/assertions/index.js
+++ b/e2e-tests/commands/shared-commands/assertions/index.js
@@ -16,6 +16,7 @@ import {
 } from './actions';
 
 Cypress.Commands.add('assertUrl', require('./assert-url'));
+Cypress.Commands.add('assertYesNoRadiosOrder', require('./assert-first-and-last-radios'));
 
 Cypress.Commands.add('checkAnalyticsCookiesConsentAndAccept', analytics.checkAnalyticsCookiesConsentAndAccept);
 Cypress.Commands.add('checkAnalyticsCookieDoesNotExist', analytics.checkAnalyticsCookieDoesNotExist);

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
@@ -107,18 +107,18 @@ context('Insurance - Export contract - About goods or services page - Final dest
     describe(`${FINAL_DESTINATION_KNOWN} label and input`, () => {
       const fieldId = FINAL_DESTINATION_KNOWN;
 
+      it('renders `no` radio button', () => {
+        cy.checkText(noRadio().label(), FIELD_VALUES.NO);
+
+        cy.checkRadioInputNoAriaLabel(FIELDS.ABOUT_GOODS_OR_SERVICES[fieldId].LABEL);
+      });
+
       it('renders `yes` radio button', () => {
         yesRadio().input().should('exist');
 
         cy.checkText(yesRadio().label(), FIELD_VALUES.YES);
 
         cy.checkRadioInputYesAriaLabel(FIELDS.ABOUT_GOODS_OR_SERVICES[fieldId].LABEL);
-      });
-
-      it('renders `no` radio button', () => {
-        cy.checkText(noRadio().label(), FIELD_VALUES.NO);
-
-        cy.checkRadioInputNoAriaLabel(FIELDS.ABOUT_GOODS_OR_SERVICES[fieldId].LABEL);
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
@@ -107,6 +107,10 @@ context('Insurance - Export contract - About goods or services page - Final dest
     describe(`${FINAL_DESTINATION_KNOWN} label and input`, () => {
       const fieldId = FINAL_DESTINATION_KNOWN;
 
+      it('renders `yes` and `no` radio buttons in the correct order', () => {
+        cy.assertYesNoRadiosOrder({ noRadioFirst: true });
+      });
+
       it('renders `no` radio button', () => {
         cy.checkText(noRadio().label(), FIELD_VALUES.NO);
 

--- a/e2e-tests/pages/shared/index.js
+++ b/e2e-tests/pages/shared/index.js
@@ -34,6 +34,7 @@ const noRadio = (fieldId) => ({
 });
 const noRadioInput = () => cy.get('[data-cy="no-input"]');
 const outro = () => cy.get('[data-cy="outro"]');
+const radioInputs = () => cy.get('.govuk-radios__item > input');
 const submitButton = () => cy.get('[data-cy="submit-button"]');
 const saveAndBackButton = () => cy.get('[data-cy="save-and-back-button"]');
 const startNowLink = () => cy.get('[data-cy="start-now-link"]');
@@ -64,6 +65,7 @@ export {
   noRadio,
   noRadioInput,
   outro,
+  radioInputs,
   submitButton,
   saveAndBackButton,
   startNowLink,

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/validation/rules/contract-completion-date.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/validation/rules/contract-completion-date.test.ts
@@ -179,7 +179,7 @@ describe('controllers/insurance/policy/single-contract-policy/validation/rules/c
       it('should return validation error', () => {
         const mockSubmittedData = {
           [`${REQUESTED_START_DATE}-day`]: nextYear1week.getDate(),
-          [`${REQUESTED_START_DATE}-month`]: nextYear1week.getMonth(),
+          [`${REQUESTED_START_DATE}-month`]: nextYear1week.getMonth() + 1,
           [`${REQUESTED_START_DATE}-year`]: nextYear1week.getFullYear(),
           [`${CONTRACT_COMPLETION_DATE}-day`]: nextYear.getDate(),
           [`${CONTRACT_COMPLETION_DATE}-month`]: nextYear.getMonth(),

--- a/src/ui/templates/components/yes-no-radio-buttons.njk
+++ b/src/ui/templates/components/yes-no-radio-buttons.njk
@@ -11,6 +11,8 @@
   {% set conditionalYesHtml = params.conditionalYesHtml %}
   {% set conditionalNoHtml = params.conditionalNoHtml %}
 
+  {% set noRadioAsFirstOption = params.noRadioAsFirstOption %}
+
   {% if params.headingLevel %}
     {% set headingLevel = params.headingLevel %}
   {% else %}
@@ -45,6 +47,60 @@
     {% set radioClass = 'govuk-radios--inline' %}
   {% endif %}
 
+  {#
+    Define the "yes" radio input option
+  #}
+  {% set yesRadio = {
+    value: true,
+    text: "Yes",
+    label: {
+      attributes: {
+        "data-cy": "yes"
+      }
+    },
+    conditional: {
+      html: conditionalYesHtml
+    },
+    attributes: {
+      "data-cy": "yes-input",
+      'aria-label': legendText + ' Yes'
+    },
+    checked: submittedAnswer === true
+  } %}
+
+  {#
+    Define the "no" radio input option
+  #}
+  {% set noRadio = {
+    value: false,
+    text: "No",
+    label: {
+      attributes: {
+        "data-cy": "no"
+      }
+    },
+    conditional: {
+      html: conditionalNoHtml
+    },
+    attributes: {
+      "data-cy": "no-input",
+      'aria-label': legendText + ' No'
+    },
+    checked: submittedAnswer === false
+  } %}
+
+  {#
+    Define the radio items/options array.
+    If noRadioAsFirstOption is provided, order is "no, yes".
+    Otherwise, default the order to "yes, no".
+  #}
+  {% if noRadioAsFirstOption %}
+    {% set radioItems = [noRadio, yesRadio] %}
+
+    {% else %}
+    {% set radioItems = [yesRadio, noRadio] %}
+  {% endif %}
+
   {{ govukRadios({
     classes: radioClass,
     idPrefix: fieldId,
@@ -61,42 +117,7 @@
         'data-cy': dataCyHint
       }
     },
-    items: [
-      {
-        value: true,
-        text: "Yes",
-        label: {
-          attributes: {
-            "data-cy": "yes"
-          }
-        },
-        conditional: {
-          html: conditionalYesHtml
-        },
-        attributes: {
-          "data-cy": "yes-input",
-          'aria-label': legendText + ' Yes'
-        },
-        checked: submittedAnswer === true
-      },
-      {
-        value: false,
-        text: "No",
-        label: {
-          attributes: {
-            "data-cy": "no"
-          }
-        },
-        conditional: {
-          html: conditionalNoHtml
-        },
-        attributes: {
-          "data-cy": "no-input",
-          'aria-label': legendText + ' No'
-        },
-        checked: submittedAnswer === false
-      }
-    ],
+    items: radioItems,
     errorMessage: errorMessage and {
       text: errorMessage.text,
       attributes: {

--- a/src/ui/templates/insurance/export-contract/about-goods-or-services.njk
+++ b/src/ui/templates/insurance/export-contract/about-goods-or-services.njk
@@ -132,7 +132,8 @@
           submittedAnswer: submittedValues[FIELDS.FINAL_DESTINATION_KNOWN.ID] or application.exportContract[FIELDS.FINAL_DESTINATION_KNOWN.ID],
           errorMessage: validationErrors.errorList[FIELDS.FINAL_DESTINATION_KNOWN.ID],
           conditionalYesHtml: conditionalYesHtml,
-          horizontalRadios: true
+          horizontalRadios: true,
+          noRadioAsFirstOption: true
         }) }}
       </div>
     </div>


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the "About goods or services" form to order the yes/no radio buttons in the opposite order ("no" radio button as the first option).

Here, we are setting up patterns/approaches to be used in other future forms that will have the same requirement.

## Resolution :heavy_check_mark:
- Create new cypress command to assert multiple radio button input `data-cy` values via index, `assertYesNoRadiosOrder`.
- Update "About goods or services" E2E test to check the ordering of the radio buttons.
- Update `yesNoRadioButtons` nunjucks component to optionally render the "no" radio option as the first option.
- Update "About goods or services" nunjucks template to pass a `noRadioAsFirstOption` flag to the `yesNoRadioButtons` nunjucks component.

## Miscellaneous :heavy_plus_sign:
- Update SRI documentation.
- Fixed a date issue in a validation unit test.
