### PR TITLE
fix(test): Invalid month causing unit test to fail

### DIFF
--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/validation/rules/contract-completion-date.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/validation/rules/contract-completion-date.test.ts
@@ -179,7 +179,7 @@ describe('controllers/insurance/policy/single-contract-policy/validation/rules/c
       it('should return validation error', () => {
         const mockSubmittedData = {
           [`${REQUESTED_START_DATE}-day`]: nextYear1week.getDate(),
-          [`${REQUESTED_START_DATE}-month`]: nextYear1week.getMonth(),
+          [`${REQUESTED_START_DATE}-month`]: nextYear1week.getMonth() + 1,
           [`${REQUESTED_START_DATE}-year`]: nextYear1week.getFullYear(),
           [`${CONTRACT_COMPLETION_DATE}-day`]: nextYear.getDate(),
           [`${CONTRACT_COMPLETION_DATE}-month`]: nextYear.getMonth(),


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where a unit test's date assertion was failing due to the month being set to `0`, an invalid month.

## Resolution :heavy_check_mark:
- Update mock month in "contract completion date" unit test.