### PR TITLE
fix(tests): Mock months generated as 0

### DIFF
--- a/e2e-tests/commands/insurance/requested-start-date-field.js
+++ b/e2e-tests/commands/insurance/requested-start-date-field.js
@@ -125,11 +125,12 @@ const checkValidation = {
   notInTheFuture: () => {
     const now = new Date();
     const day = now.getDate();
+    const month = now.getMonth() + 1;
 
     const yesterday = new Date(now.setDate(day - 1));
 
     cy.keyboardInput(field.dayInput(), yesterday.getDate());
-    cy.keyboardInput(field.monthInput(), yesterday.getMonth());
+    cy.keyboardInput(field.monthInput(), month);
     cy.keyboardInput(field.yearInput(), yesterday.getFullYear());
     submitButton().click();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
@@ -84,12 +84,13 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
 
       // enter an invalid date
       const now = new Date();
-      const day = new Date(now).getDate();
+      const day = now.getDate();
+      const month = now.getMonth() + 1;
 
       const yesterday = new Date(now.setDate(day - 1));
 
       cy.keyboardInput(field.dayInput(), yesterday.getDate());
-      cy.keyboardInput(field.monthInput(), yesterday.getMonth());
+      cy.keyboardInput(field.monthInput(), month);
       cy.keyboardInput(field.yearInput(), yesterday.getFullYear());
 
       saveAndBackButton().click();
@@ -117,12 +118,13 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
 
   describe('when entering a valid requested cover start date and submitting the form via `save and go back` button', () => {
     const field = fieldSelector(REQUESTED_START_DATE);
+    const month = new Date(futureDate).getMonth() + 1;
 
     beforeEach(() => {
       cy.navigateToUrl(url);
 
       cy.keyboardInput(field.dayInput(), '1');
-      cy.keyboardInput(field.monthInput(), new Date(futureDate).getMonth());
+      cy.keyboardInput(field.monthInput(), month);
       cy.keyboardInput(field.yearInput(), new Date(futureDate).getFullYear());
 
       saveAndBackButton().click();
@@ -143,7 +145,7 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
       submitButton().click();
 
       field.dayInput().should('have.value', '1');
-      field.monthInput().should('have.value', new Date(futureDate).getMonth());
+      field.monthInput().should('have.value', month);
       field.yearInput().should('have.value', new Date(futureDate).getFullYear());
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
@@ -35,6 +35,10 @@ context('Insurance - Policy - Single contract policy page - form validation - co
   let referenceNumber;
   let url;
 
+  let date = new Date();
+  let day = date.getDate();
+  let year = new Date(date).getFullYear();
+
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
@@ -63,7 +67,7 @@ context('Insurance - Policy - Single contract policy page - form validation - co
 
   it('should render a validation error when day is not provided', () => {
     cy.keyboardInput(field.monthInput(), '1');
-    cy.keyboardInput(field.yearInput(), '2023');
+    cy.keyboardInput(field.yearInput(), year);
     submitButton().click();
 
     cy.checkText(
@@ -80,7 +84,7 @@ context('Insurance - Policy - Single contract policy page - form validation - co
   it('should render a validation error when month is not provided', () => {
     cy.keyboardInput(field.dayInput().clear(), '1');
     field.monthInput().clear();
-    cy.keyboardInput(field.yearInput(), '2023');
+    cy.keyboardInput(field.yearInput(), year);
     submitButton().click();
 
     cy.checkText(
@@ -160,13 +164,11 @@ context('Insurance - Policy - Single contract policy page - form validation - co
   });
 
   it('should render a validation error when the date is not in the future', () => {
-    const date = new Date();
-    const day = date.getDate();
-
     const yesterday = new Date(date.setDate(day - 1));
+    const month = yesterday.getMonth() + 1;
 
     cy.keyboardInput(field.dayInput(), yesterday.getDate());
-    cy.keyboardInput(field.monthInput(), yesterday.getMonth());
+    cy.keyboardInput(field.monthInput(), month);
     cy.keyboardInput(field.yearInput(), yesterday.getFullYear());
     submitButton().click();
 
@@ -182,7 +184,7 @@ context('Insurance - Policy - Single contract policy page - form validation - co
   });
 
   it('should render a validation error when the date has an invalid format', () => {
-    const date = new Date();
+    date = new Date();
 
     cy.keyboardInput(field.dayInput(), new Date(date).getDate());
     cy.keyboardInput(field.monthInput(), '24');
@@ -201,23 +203,24 @@ context('Insurance - Policy - Single contract policy page - form validation - co
   });
 
   describe(`when ${REQUESTED_START_DATE} is also provided`, () => {
-    const date = new Date();
-    const day = date.getDate();
-    const year = date.getFullYear();
+    date = new Date();
+    day = date.getDate();
+    year = date.getFullYear();
 
     const startDate = new Date(date.setFullYear(year + 1));
+    const month = startDate.getMonth() + 1;
 
     beforeEach(() => {
       cy.navigateToUrl(url);
 
       cy.keyboardInput(fieldSelector(REQUESTED_START_DATE).dayInput(), day);
-      cy.keyboardInput(fieldSelector(REQUESTED_START_DATE).monthInput(), startDate.getMonth());
+      cy.keyboardInput(fieldSelector(REQUESTED_START_DATE).monthInput(), month);
       cy.keyboardInput(fieldSelector(REQUESTED_START_DATE).yearInput(), startDate.getFullYear());
     });
 
     it(`should render a validation error when the date is the same as ${REQUESTED_START_DATE}`, () => {
       cy.keyboardInput(field.dayInput(), day);
-      cy.keyboardInput(field.monthInput(), startDate.getMonth());
+      cy.keyboardInput(field.monthInput(), month);
       cy.keyboardInput(field.yearInput(), startDate.getFullYear());
       submitButton().click();
 
@@ -234,7 +237,7 @@ context('Insurance - Policy - Single contract policy page - form validation - co
 
     it(`should render a validation error when the date is before the ${REQUESTED_START_DATE}`, () => {
       cy.keyboardInput(field.dayInput(), day - 1);
-      cy.keyboardInput(field.monthInput(), startDate.getMonth());
+      cy.keyboardInput(field.monthInput(), month);
       cy.keyboardInput(field.yearInput(), startDate.getFullYear());
       submitButton().click();
 
@@ -252,9 +255,10 @@ context('Insurance - Policy - Single contract policy page - form validation - co
     it(`should render a validation error when the date is over the maximum years allowed after ${REQUESTED_START_DATE}`, () => {
       const endDateUnformatted = date.setFullYear(startDate.getFullYear() + ELIGIBILITY.MAX_COVER_PERIOD_YEARS);
       const endDate = new Date(endDateUnformatted);
+      const endDateMonth = endDate.getMonth() + 1;
 
       cy.keyboardInput(field.dayInput(), endDate.getDate() + 1);
-      cy.keyboardInput(field.monthInput(), endDate.getMonth());
+      cy.keyboardInput(field.monthInput(), endDateMonth);
       cy.keyboardInput(field.yearInput(), endDate.getFullYear());
       submitButton().click();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
@@ -169,7 +169,8 @@ context('Insurance - Policy - Single contract policy page - form validation - co
 
     cy.keyboardInput(field.dayInput(), yesterday.getDate());
     cy.keyboardInput(field.monthInput(), month);
-    cy.keyboardInput(field.yearInput(), yesterday.getFullYear());
+    cy.keyboardInput(field.yearInput(), year);
+
     submitButton().click();
 
     cy.checkText(

--- a/src/ui/server/controllers/insurance/policy/map-submitted-data/policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/map-submitted-data/policy/index.test.ts
@@ -21,7 +21,7 @@ describe('controllers/insurance/policy/map-submitted-data/policy', () => {
     date = new Date();
 
     day = date.getDate();
-    month = date.getMonth();
+    month = date.getMonth() + 1;
     year = date.getFullYear();
   });
 

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/index.test.ts
@@ -238,7 +238,7 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
     const futureDate = new Date(date.setDate(date.getDate() + 1));
 
     const day = futureDate.getDate();
-    const month = futureDate.getMonth();
+    const month = futureDate.getMonth() + 1;
     const year = futureDate.getFullYear();
 
     const oneYearFromNow = new Date(futureDate.setFullYear(year + 1)).getFullYear();

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/validation/rules/contract-completion-date.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/validation/rules/contract-completion-date.test.ts
@@ -118,7 +118,7 @@ describe('controllers/insurance/policy/single-contract-policy/validation/rules/c
 
       const mockSubmittedData = {
         [`${CONTRACT_COMPLETION_DATE}-day`]: yesterday.getDate(),
-        [`${CONTRACT_COMPLETION_DATE}-month`]: yesterday.getMonth(),
+        [`${CONTRACT_COMPLETION_DATE}-month`]: yesterday.getMonth() + 1,
         [`${CONTRACT_COMPLETION_DATE}-year`]: yesterday.getFullYear(),
       };
 
@@ -132,6 +132,7 @@ describe('controllers/insurance/policy/single-contract-policy/validation/rules/c
 
   describe(`when ${REQUESTED_START_DATE} is also provided`, () => {
     let date = new Date();
+    const month = date.getMonth() + 1;
     let year = date.getFullYear();
 
     // Add 1 day
@@ -141,12 +142,14 @@ describe('controllers/insurance/policy/single-contract-policy/validation/rules/c
     const futureDateYear = initFutureDate.getFullYear();
     const futureDate = new Date(initFutureDate.setFullYear(futureDateYear + 1));
 
+    const futureDateMonth = initFutureDate.getMonth() + 1;
+
     let requestedStartDateFields = {};
 
     beforeEach(() => {
       requestedStartDateFields = {
         [`${REQUESTED_START_DATE}-day`]: futureDate.getDate(),
-        [`${REQUESTED_START_DATE}-month`]: futureDate.getMonth(),
+        [`${REQUESTED_START_DATE}-month`]: futureDateMonth,
         [`${REQUESTED_START_DATE}-year`]: futureDate.getFullYear(),
       };
     });
@@ -156,7 +159,7 @@ describe('controllers/insurance/policy/single-contract-policy/validation/rules/c
         const mockSubmittedData = {
           ...requestedStartDateFields,
           [`${CONTRACT_COMPLETION_DATE}-day`]: futureDate.getDate(),
-          [`${CONTRACT_COMPLETION_DATE}-month`]: futureDate.getMonth(),
+          [`${CONTRACT_COMPLETION_DATE}-month`]: futureDateMonth,
           [`${CONTRACT_COMPLETION_DATE}-year`]: futureDate.getFullYear(),
         };
 
@@ -182,7 +185,7 @@ describe('controllers/insurance/policy/single-contract-policy/validation/rules/c
           [`${REQUESTED_START_DATE}-month`]: nextYear1week.getMonth() + 1,
           [`${REQUESTED_START_DATE}-year`]: nextYear1week.getFullYear(),
           [`${CONTRACT_COMPLETION_DATE}-day`]: nextYear.getDate(),
-          [`${CONTRACT_COMPLETION_DATE}-month`]: nextYear.getMonth(),
+          [`${CONTRACT_COMPLETION_DATE}-month`]: nextYear.getMonth() + 1,
           [`${CONTRACT_COMPLETION_DATE}-year`]: nextYear.getFullYear(),
         };
 
@@ -198,7 +201,6 @@ describe('controllers/insurance/policy/single-contract-policy/validation/rules/c
       date = new Date();
 
       const day = date.getDate();
-      const month = date.getMonth();
       year = date.getFullYear();
 
       const futureYear = new Date(futureDate.setFullYear(futureDateYear + ELIGIBILITY.MAX_COVER_PERIOD_YEARS));
@@ -210,7 +212,7 @@ describe('controllers/insurance/policy/single-contract-policy/validation/rules/c
           [`${REQUESTED_START_DATE}-month`]: month,
           [`${REQUESTED_START_DATE}-year`]: year,
           [`${CONTRACT_COMPLETION_DATE}-day`]: completionDate.getDate(),
-          [`${CONTRACT_COMPLETION_DATE}-month`]: completionDate.getMonth(),
+          [`${CONTRACT_COMPLETION_DATE}-month`]: completionDate.getMonth() + 1,
           [`${CONTRACT_COMPLETION_DATE}-year`]: completionDate.getFullYear(),
         };
 

--- a/src/ui/server/shared-validation/requested-start-date/index.test.ts
+++ b/src/ui/server/shared-validation/requested-start-date/index.test.ts
@@ -112,7 +112,7 @@ describe('shared-validation/requested-start-date', () => {
 
       const mockSubmittedData = {
         [`${FIELD_ID}-day`]: yesterday.getDate(),
-        [`${FIELD_ID}-month`]: month,
+        [`${FIELD_ID}-month`]: month + 1,
         [`${FIELD_ID}-year`]: year,
       };
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes some issues with the UI and E2E tests where the generated months would be `0`, due to date constructions being index based and the current time of year.

## Resolution :heavy_check_mark:
- Fix/update months; Always add 1 so the month's will never be 0.

## Miscellaneous :heavy_plus_sign:
- Remove some hard coded year values.
