### PR TITLE
fix(release-please): specify target branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,5 +24,4 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           release-type: node
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
+          target-branch: main


### PR DESCRIPTION
## Introduction :pencil2:
Ensure default branch is not the GitHub base branch.

## Resolution :heavy_check_mark:
* Specified `target-branch` to be `main`
