### PR TITLE
feat(EMS-2349-2536): No PDF - Policy type - Completion date validation enhancements

### DIFF
--- a/e2e-tests/commands/insurance/complete-and-submit-export-value-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-export-value-form.js
@@ -1,5 +1,4 @@
 import { FIELD_VALUES } from '../../constants';
-import completeExportValueForm from './complete-export-value-form';
 import { submitButton } from '../../pages/shared';
 
 /**
@@ -10,7 +9,7 @@ import { submitButton } from '../../pages/shared';
  * - policyMaximumValue: should submit an application with the maximum value of 500000
  */
 const completeAndSubmitExportValueForm = ({ policyType = FIELD_VALUES.POLICY_TYPE.SINGLE }) => {
-  completeExportValueForm({ policyType });
+  cy.completeExportValueForm({ policyType });
   submitButton().click();
 };
 

--- a/e2e-tests/commands/insurance/complete-export-value-form.js
+++ b/e2e-tests/commands/insurance/complete-export-value-form.js
@@ -5,7 +5,7 @@ import { field } from '../../pages/shared';
 import application from '../../fixtures/application';
 
 const {
-  POLICY_TYPE: { SINGLE, MULTIPLE},
+  POLICY_TYPE: { SINGLE, MULTIPLE },
 } = FIELD_VALUES;
 
 const {

--- a/e2e-tests/commands/insurance/complete-export-value-form.js
+++ b/e2e-tests/commands/insurance/complete-export-value-form.js
@@ -5,6 +5,10 @@ import { field } from '../../pages/shared';
 import application from '../../fixtures/application';
 
 const {
+  POLICY_TYPE: { SINGLE, MULTIPLE},
+} = FIELD_VALUES;
+
+const {
   POLICY: {
     EXPORT_VALUE: {
       MULTIPLE: {
@@ -22,8 +26,8 @@ const {
  * - policyType: type of policy
  * - policyMaximumValue: should submit an application with the maximum value of 500000
  */
-const completeExportValueForm = ({ policyType = FIELD_VALUES.POLICY_TYPE.SINGLE }) => {
-  if (policyType === FIELD_VALUES.POLICY_TYPE.MULTIPLE) {
+const completeExportValueForm = ({ policyType = SINGLE }) => {
+  if (policyType === MULTIPLE) {
     cy.keyboardInput(field(TOTAL_SALES_TO_BUYER).input(), application.POLICY[TOTAL_SALES_TO_BUYER]);
 
     cy.keyboardInput(multipleContractPolicyExportValuePage[MAXIMUM_BUYER_WILL_OWE].input(), application.POLICY[MAXIMUM_BUYER_WILL_OWE]);

--- a/e2e-tests/commands/insurance/date-field.js
+++ b/e2e-tests/commands/insurance/date-field.js
@@ -1,25 +1,5 @@
 import partials from '../../partials';
-import { field as fieldSelector, submitButton } from '../../pages/shared';
-import { ERROR_MESSAGES } from '../../content-strings';
-import { INSURANCE_FIELD_IDS } from '../../constants/field-ids/insurance';
-
-const {
-  POLICY: {
-    CONTRACT_POLICY: {
-      REQUESTED_START_DATE,
-    },
-  },
-} = INSURANCE_FIELD_IDS;
-
-const {
-  INSURANCE: {
-    POLICY: {
-      CONTRACT_POLICY: CONTRACT_ERROR_MESSAGES,
-    },
-  },
-} = ERROR_MESSAGES;
-
-const field = fieldSelector(REQUESTED_START_DATE);
+import { submitButton } from '../../pages/shared';
 
 /**
  * checkValidation
@@ -30,12 +10,23 @@ const field = fieldSelector(REQUESTED_START_DATE);
  * 4) notInTheFuture
  * 5) invalidFormat
  * 6) isToday
+ * 7) withTwoDateFields.cannotBeTheSame
+ * 8) withTwoDateFields.cannotBeBefore
+ * 9) withTwoDateFields.cannotBeAfter
  * @param {Number} errorSummaryLength: The number of expected errors in the summary list
+ * @param {Number} errorIndex: Index of summary list error
+ * @param {String} fieldId: Field ID
+ * @param {Object} errorMessages: Error messages
  */
-const checkValidation = ({ errorSummaryLength }) => {
+const checkValidation = ({
+  errorSummaryLength,
+  errorIndex = 0,
+  field,
+  errorMessages,
+}) => {
   const assertFieldErrorsParams = {
     field,
-    errorIndex: 0,
+    errorIndex,
     errorSummaryLength,
     fieldShouldGainFocus: false,
   };
@@ -51,7 +42,7 @@ const checkValidation = ({ errorSummaryLength }) => {
         cy.keyboardInput(field.yearInput(), '2023');
         submitButton().click();
 
-        const errorMessage = CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INVALID_DAY;
+        const errorMessage = errorMessages.INVALID_DAY;
 
         cy.assertFieldErrors({
           ...assertFieldErrorsParams,
@@ -68,7 +59,7 @@ const checkValidation = ({ errorSummaryLength }) => {
         field.yearInput().clear();
         submitButton().click();
 
-        const errorMessage = CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].MISSING_MONTH_AND_YEAR;
+        const errorMessage = errorMessages.MISSING_MONTH_AND_YEAR;
 
         cy.assertFieldErrors({
           ...assertFieldErrorsParams,
@@ -83,7 +74,7 @@ const checkValidation = ({ errorSummaryLength }) => {
         cy.keyboardInput(field.dayInput().clear(), 'Test');
         submitButton().click();
 
-        const errorMessage = CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INCORRECT_FORMAT;
+        const errorMessage = errorMessages.INCORRECT_FORMAT;
 
         cy.assertFieldErrors({
           ...assertFieldErrorsParams,
@@ -102,7 +93,7 @@ const checkValidation = ({ errorSummaryLength }) => {
         cy.keyboardInput(field.yearInput(), '2023');
         submitButton().click();
 
-        const errorMessage = CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INVALID_MONTH;
+        const errorMessage = errorMessages.INVALID_MONTH;
 
         cy.assertFieldErrors({
           ...assertFieldErrorsParams,
@@ -119,7 +110,7 @@ const checkValidation = ({ errorSummaryLength }) => {
         field.yearInput().clear();
         submitButton().click();
 
-        const errorMessage = CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].MISSING_DAY_AND_YEAR;
+        const errorMessage = errorMessages.MISSING_DAY_AND_YEAR;
 
         cy.assertFieldErrors({
           ...assertFieldErrorsParams,
@@ -135,7 +126,7 @@ const checkValidation = ({ errorSummaryLength }) => {
         cy.keyboardInput(field.monthInput(), 'One');
         submitButton().click();
 
-        const errorMessage = CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INCORRECT_FORMAT;
+        const errorMessage = errorMessages.INCORRECT_FORMAT;
 
         cy.assertFieldErrors({
           ...assertFieldErrorsParams,
@@ -154,7 +145,7 @@ const checkValidation = ({ errorSummaryLength }) => {
         field.yearInput().clear();
         submitButton().click();
 
-        const errorMessage = CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INVALID_YEAR;
+        const errorMessage = errorMessages.INVALID_YEAR;
 
         cy.assertFieldErrors({
           ...assertFieldErrorsParams,
@@ -171,7 +162,7 @@ const checkValidation = ({ errorSummaryLength }) => {
         cy.keyboardInput(field.yearInput(), '2023');
         submitButton().click();
 
-        const errorMessage = CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].MISSING_DAY_AND_MONTH;
+        const errorMessage = errorMessages.MISSING_DAY_AND_MONTH;
 
         cy.assertFieldErrors({
           ...assertFieldErrorsParams,
@@ -188,7 +179,7 @@ const checkValidation = ({ errorSummaryLength }) => {
         cy.keyboardInput(field.yearInput(), '202');
         submitButton().click();
 
-        const errorMessage = CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INVALID_YEAR_DIGITS;
+        const errorMessage = errorMessages.INVALID_YEAR_DIGITS;
 
         cy.assertFieldErrors({
           ...assertFieldErrorsParams,
@@ -205,7 +196,7 @@ const checkValidation = ({ errorSummaryLength }) => {
         cy.keyboardInput(field.yearInput(), 'One');
         submitButton().click();
 
-        const errorMessage = CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INCORRECT_FORMAT;
+        const errorMessage = errorMessages.INCORRECT_FORMAT;
 
         cy.assertFieldErrors({
           ...assertFieldErrorsParams,
@@ -229,7 +220,7 @@ const checkValidation = ({ errorSummaryLength }) => {
       cy.keyboardInput(field.yearInput(), yesterday.getFullYear());
       submitButton().click();
 
-      const errorMessage = CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].BEFORE_EARLIEST;
+      const errorMessage = errorMessages.BEFORE_EARLIEST;
 
       cy.assertFieldErrors({
         ...assertFieldErrorsParams,
@@ -251,7 +242,7 @@ const checkValidation = ({ errorSummaryLength }) => {
       cy.keyboardInput(field.yearInput(), futureDate.getFullYear());
       submitButton().click();
 
-      const errorMessage = CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].INVALID_DATE;
+      const errorMessage = errorMessages.INVALID_DATE;
 
       cy.assertFieldErrors({
         ...assertFieldErrorsParams,
@@ -272,11 +263,95 @@ const checkValidation = ({ errorSummaryLength }) => {
       submitButton().click();
 
       partials.errorSummaryListItems().eq(0).invoke('text').then((text) => {
-        expect(text.trim()).not.equal(CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE].BEFORE_EARLIEST);
+        expect(text.trim()).not.equal(errorMessages.BEFORE_EARLIEST);
       });
 
       field.errorMessage().should('not.exist');
     },
+    /**
+     * Validations for when there are 2 date fields.
+     * E.g, start and end date fields.
+     */
+    withTwoDateFields: ({
+      fieldA, fieldB, expectedErrorSummaryLength, fieldBErrorIndex,
+    }) => ({
+      /**
+       * Enter the same date into both date fields.
+       * Check validation errors.
+       */
+      cannotBeTheSame: (dateValue) => {
+        const day = dateValue.getDate();
+        const month = dateValue.getMonth() + 1;
+        const year = dateValue.getFullYear();
+
+        cy.keyboardInput(fieldA.dayInput(), day);
+        cy.keyboardInput(fieldA.monthInput(), month);
+        cy.keyboardInput(fieldA.yearInput(), year);
+
+        cy.keyboardInput(fieldB.dayInput(), day);
+        cy.keyboardInput(fieldB.monthInput(), month);
+        cy.keyboardInput(fieldB.yearInput(), year);
+
+        submitButton().click();
+
+        const errorMessage = errorMessages.CANNOT_BE_THE_SAME;
+
+        cy.assertFieldErrors({
+          ...assertFieldErrorsParams,
+          errorMessage,
+          errorIndex: fieldBErrorIndex,
+          errorSummaryLength: expectedErrorSummaryLength,
+        });
+      },
+      /**
+       * Enter a date that is before the first date field.
+       * Check validation errors.
+       */
+      cannotBeBefore: (dateValue) => {
+        const day = dateValue.getDate();
+        const month = dateValue.getMonth() + 1;
+        const year = dateValue.getFullYear();
+
+        cy.keyboardInput(fieldB.dayInput(), day);
+        cy.keyboardInput(fieldB.monthInput(), month);
+        cy.keyboardInput(fieldB.yearInput(), year);
+
+        submitButton().click();
+
+        const errorMessage = errorMessages.CANNOT_BE_BEFORE;
+
+        cy.assertFieldErrors({
+          ...assertFieldErrorsParams,
+          errorMessage,
+          errorIndex: fieldBErrorIndex,
+          errorSummaryLength: expectedErrorSummaryLength,
+        });
+      },
+      /**
+       * Enter a date that is after the first date field.
+       * Check validation errors.
+       */
+      cannotBeAfter: (dateValue) => {
+        const day = dateValue.getDate();
+        const month = dateValue.getMonth() + 1;
+        const year = dateValue.getFullYear();
+
+        cy.keyboardInput(fieldB.dayInput(), day);
+        cy.keyboardInput(fieldB.monthInput(), month);
+        cy.keyboardInput(fieldB.yearInput(), year);
+
+        submitButton().click();
+
+        const errorMessage = errorMessages.AFTER_LATEST;
+
+        cy.assertFieldErrors({
+          ...assertFieldErrorsParams,
+          errorMessage,
+          errorIndex: fieldBErrorIndex,
+          errorSummaryLength: expectedErrorSummaryLength,
+        });
+      },
+    }),
   };
 };
 

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -165,7 +165,7 @@ export const ERROR_MESSAGES = {
           INVALID_DATE: 'Policy start date must be a real date',
         },
         [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.POLICY_CURRENCY_CODE]: {
-          IS_EMPTY: "Select the currency you would like your policy to be issued in",
+          IS_EMPTY: 'Select the currency you would like your policy to be issued in',
         },
         SINGLE: {
           [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.SINGLE.CONTRACT_COMPLETION_DATE]: {

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -170,12 +170,19 @@ export const ERROR_MESSAGES = {
         SINGLE: {
           [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.SINGLE.CONTRACT_COMPLETION_DATE]: {
             INCORRECT_FORMAT: 'Enter a contract completion date in the correct format, like 06 11 2023',
-            NOT_A_NUMBER: 'Enter a contract completion date in the correct format, like 06 11 2023',
             BEFORE_EARLIEST: 'You cannot enter a contract completion date in the past - enter a future date',
+            MISSING_DAY_AND_MONTH: 'Policy completion date must include a day and month',
+            MISSING_DAY_AND_YEAR: 'Policy completion date must include a day and year',
+            MISSING_MONTH_AND_YEAR: 'Policy completion date must include a month and year',
             AFTER_LATEST:
               "Your contract completion date is more than 2 years after your policy start date. You'll need to speak with an export finance manager, if you still want to apply",
             CANNOT_BE_THE_SAME: 'Your contract completion date cannot be the same as your policy start date',
-            CANNOT_BE_BEFORE: 'Your contract completion date must be after your policy start date',
+            CANNOT_BE_BEFORE: 'The date you expect to complete your export contract must be after the policy start date',
+            INVALID_DAY: 'Enter a valid day',
+            INVALID_MONTH: 'Enter a valid month',
+            INVALID_YEAR: 'Enter a valid year',
+            INVALID_YEAR_DIGITS: 'Year must include 4 numbers',
+            INVALID_DATE: 'Policy completion date must be a real date',
           },
         },
         MULTIPLE: {

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -165,7 +165,7 @@ export const ERROR_MESSAGES = {
           INVALID_DATE: 'Policy start date must be a real date',
         },
         [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.POLICY_CURRENCY_CODE]: {
-          IS_EMPTY: "Select currency you'd like your policy to be issued in",
+          IS_EMPTY: "Select the currency you would like your policy to be issued in",
         },
         SINGLE: {
           [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.SINGLE.CONTRACT_COMPLETION_DATE]: {

--- a/e2e-tests/content-strings/fields/insurance/policy/index.js
+++ b/e2e-tests/content-strings/fields/insurance/policy/index.js
@@ -68,7 +68,7 @@ export const POLICY_FIELDS = {
     SINGLE: {
       [CONTRACT_POLICY.SINGLE.CONTRACT_COMPLETION_DATE]: {
         LABEL: 'When do you expect to complete the export contract?',
-        HINT: 'For example, 6 11 2024',
+        HINT: 'For example, 06 11 2024',
         SUMMARY: {
           TITLE: 'Date you expect contract to complete',
         },

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-requested-start-date.spec.js
@@ -1,19 +1,38 @@
+import { field as fieldSelector } from '../../../../../../../pages/shared';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
-import requestedCoverStartDate from '../../../../../../../commands/insurance/requested-start-date-field';
+import dateField from '../../../../../../../commands/insurance/date-field';
 
 const {
   ROOT,
   POLICY: { MULTIPLE_CONTRACT_POLICY },
 } = INSURANCE_ROUTES;
 
-const { checkValidation } = requestedCoverStartDate;
+const {
+  POLICY: {
+    CONTRACT_POLICY: {
+      REQUESTED_START_DATE,
+    },
+  },
+} = INSURANCE_FIELD_IDS;
+
+const {
+  INSURANCE: {
+    POLICY: {
+      CONTRACT_POLICY: CONTRACT_ERROR_MESSAGES,
+    },
+  },
+} = ERROR_MESSAGES;
 
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Policy - Multiple contract policy page - form validation - requested start date', () => {
   let referenceNumber;
   let url;
+
+  const field = fieldSelector(REQUESTED_START_DATE);
 
   const {
     day,
@@ -22,7 +41,13 @@ context('Insurance - Policy - Multiple contract policy page - form validation - 
     notInTheFuture,
     invalidFormat,
     isToday,
-  } = checkValidation({ errorSummaryLength: 3 });
+  } = dateField.checkValidation({
+    errorSummaryLength: 3,
+    errorIndex: 0,
+    field,
+    fieldId: REQUESTED_START_DATE,
+    errorMessages: CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE],
+  });
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
@@ -1,9 +1,9 @@
-import { field as fieldSelector, submitButton } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
+import { field as fieldSelector } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { FIELD_VALUES, ELIGIBILITY } from '../../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import dateField from '../../../../../../../commands/insurance/date-field';
 
 const {
   POLICY: {
@@ -22,7 +22,9 @@ const {
 const {
   INSURANCE: {
     POLICY: {
-      CONTRACT_POLICY: CONTRACT_ERROR_MESSAGES,
+      CONTRACT_POLICY: {
+        SINGLE: CONTRACT_ERROR_MESSAGES,
+      },
     },
   },
 } = ERROR_MESSAGES;
@@ -33,9 +35,23 @@ context('Insurance - Policy - Single contract policy page - form validation - co
   let referenceNumber;
   let url;
 
-  let date = new Date();
-  let day = date.getDate();
-  let year = new Date(date).getFullYear();
+  const field = fieldSelector(CONTRACT_COMPLETION_DATE);
+
+  const {
+    day,
+    month,
+    year,
+    notInTheFuture,
+    invalidFormat,
+    isToday,
+    withTwoDateFields,
+  } = dateField.checkValidation({
+    errorSummaryLength: 4,
+    errorIndex: 1,
+    field,
+    fieldId: CONTRACT_COMPLETION_DATE,
+    errorMessages: CONTRACT_ERROR_MESSAGES[CONTRACT_COMPLETION_DATE],
+  });
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
@@ -60,215 +76,107 @@ context('Insurance - Policy - Single contract policy page - form validation - co
     cy.deleteApplication(referenceNumber);
   });
 
-  const field = fieldSelector(CONTRACT_COMPLETION_DATE);
-
-  it('should render a validation error when day is not provided', () => {
-    cy.keyboardInput(field.monthInput(), '1');
-    cy.keyboardInput(field.yearInput(), year);
-    submitButton().click();
-
-    cy.checkText(
-      partials.errorSummaryListItems().eq(1),
-      CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT,
-    );
-
-    cy.checkText(
-      field.errorMessage(),
-      `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT}`,
-    );
+  it('when the day is not provided', () => {
+    day.notProvided();
   });
 
-  it('should render a validation error when month is not provided', () => {
-    cy.keyboardInput(field.dayInput().clear(), '1');
-    field.monthInput().clear();
-    cy.keyboardInput(field.yearInput(), year);
-    submitButton().click();
-
-    cy.checkText(
-      partials.errorSummaryListItems().eq(1),
-      CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT,
-    );
-
-    cy.checkText(
-      field.errorMessage(),
-      `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT}`,
-    );
+  it('when the month is not provided', () => {
+    month.notProvided();
   });
 
-  it('should render a validation error when year is not provided', () => {
-    cy.keyboardInput(field.dayInput(), '1');
-    field.monthInput().clear('2');
-    field.yearInput().clear();
-    submitButton().click();
-
-    cy.checkText(
-      partials.errorSummaryListItems().eq(1),
-      CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT,
-    );
-
-    cy.checkText(
-      field.errorMessage(),
-      `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT}`,
-    );
+  it('when the year is not provided', () => {
+    year.notProvided();
   });
 
-  it('should render a validation error when day is not a number', () => {
-    cy.keyboardInput(field.dayInput(), 'Test');
-    submitButton().click();
-
-    cy.checkText(
-      partials.errorSummaryListItems().eq(1),
-      CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].NOT_A_NUMBER,
-    );
-
-    cy.checkText(
-      field.errorMessage(),
-      `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].NOT_A_NUMBER}`,
-    );
+  it('when the day is provided, but month and year are not', () => {
+    day.providedWithoutOtherFields();
   });
 
-  it('should render a validation error when month is not a number', () => {
-    field.dayInput().clear();
-    cy.keyboardInput(field.monthInput(), 'Test');
-    submitButton().click();
-
-    cy.checkText(
-      partials.errorSummaryListItems().eq(1),
-      CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].NOT_A_NUMBER,
-    );
-
-    cy.checkText(
-      field.errorMessage(),
-      `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].NOT_A_NUMBER}`,
-    );
+  it('when the month is provided, but day and year are not', () => {
+    month.providedWithoutOtherFields();
   });
 
-  it('should render a validation error when year is not a number', () => {
-    field.dayInput().clear();
-    field.monthInput().clear();
-    cy.keyboardInput(field.yearInput(), 'Test');
-    submitButton().click();
-
-    cy.checkText(
-      partials.errorSummaryListItems().eq(1),
-      CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].NOT_A_NUMBER,
-    );
-
-    cy.checkText(
-      field.errorMessage(),
-      `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].NOT_A_NUMBER}`,
-    );
+  it('when the year is provided, but day and month are not', () => {
+    year.providedWithoutOtherFields();
   });
 
-  it('should render a validation error when the date is not in the future', () => {
-    const yesterday = new Date(date.setDate(day - 1));
-    const month = yesterday.getMonth() + 1;
-
-    cy.keyboardInput(field.dayInput(), yesterday.getDate());
-    cy.keyboardInput(field.monthInput(), month);
-    cy.keyboardInput(field.yearInput(), year);
-
-    submitButton().click();
-
-    cy.checkText(
-      partials.errorSummaryListItems().eq(1),
-      CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].BEFORE_EARLIEST,
-    );
-
-    cy.checkText(
-      field.errorMessage(),
-      `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].BEFORE_EARLIEST}`,
-    );
+  it('when the day is not a number', () => {
+    day.notANumber();
   });
 
-  it('should render a validation error when the date has an invalid format', () => {
-    date = new Date();
+  it('when the month is not a number', () => {
+    month.notANumber();
+  });
 
-    cy.keyboardInput(field.dayInput(), new Date(date).getDate());
-    cy.keyboardInput(field.monthInput(), '24');
-    cy.keyboardInput(field.yearInput(), new Date(date).getFullYear());
-    submitButton().click();
+  it('when the year is not a number', () => {
+    year.notANumber();
+  });
 
-    cy.checkText(
-      partials.errorSummaryListItems().eq(1),
-      CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT,
-    );
+  it('when the year does not have enough digits', () => {
+    year.notEnoughDigits();
+  });
 
-    cy.checkText(
-      field.errorMessage(),
-      `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].INCORRECT_FORMAT}`,
-    );
+  it('when the the date is not in the future', () => {
+    notInTheFuture();
+  });
+
+  it('when the the date has an invalid format', () => {
+    invalidFormat();
+  });
+
+  it('should NOT render a validation error when the date is today', () => {
+    isToday();
   });
 
   describe(`when ${REQUESTED_START_DATE} is also provided`, () => {
-    date = new Date();
-    day = date.getDate();
-    year = date.getFullYear();
+    const date = new Date();
+    const initYear = date.getFullYear();
+    const startDate = new Date(date.setFullYear(initYear + 1));
 
-    const startDate = new Date(date.setFullYear(year + 1));
-    const month = startDate.getMonth() + 1;
+    const startDateObj = {
+      day: startDate.getDate(),
+      month: startDate.getMonth() + 1,
+      year: startDate.getFullYear(),
+    };
+
+    const fieldA = fieldSelector(REQUESTED_START_DATE);
+    const fieldB = fieldSelector(CONTRACT_COMPLETION_DATE);
+
+    const { cannotBeTheSame, cannotBeBefore, cannotBeAfter } = withTwoDateFields({
+      fieldA,
+      fieldB,
+      fieldBErrorIndex: 0,
+      errorSummaryLength: 3,
+    });
 
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.keyboardInput(fieldSelector(REQUESTED_START_DATE).dayInput(), day);
-      cy.keyboardInput(fieldSelector(REQUESTED_START_DATE).monthInput(), month);
-      cy.keyboardInput(fieldSelector(REQUESTED_START_DATE).yearInput(), startDate.getFullYear());
+      cy.keyboardInput(fieldSelector(REQUESTED_START_DATE).dayInput(), startDateObj.day);
+      cy.keyboardInput(fieldSelector(REQUESTED_START_DATE).monthInput(), startDateObj.month);
+      cy.keyboardInput(fieldSelector(REQUESTED_START_DATE).yearInput(), startDateObj.year);
     });
 
     it(`should render a validation error when the date is the same as ${REQUESTED_START_DATE}`, () => {
-      cy.keyboardInput(field.dayInput(), day);
-      cy.keyboardInput(field.monthInput(), month);
-      cy.keyboardInput(field.yearInput(), startDate.getFullYear());
-      submitButton().click();
-
-      cy.checkText(
-        partials.errorSummaryListItems().eq(0),
-        CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].CANNOT_BE_THE_SAME,
-      );
-
-      cy.checkText(
-        field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].CANNOT_BE_THE_SAME}`,
-      );
+      cannotBeTheSame(startDate);
     });
 
     it(`should render a validation error when the date is before the ${REQUESTED_START_DATE}`, () => {
-      cy.keyboardInput(field.dayInput(), day - 1);
-      cy.keyboardInput(field.monthInput(), month);
-      cy.keyboardInput(field.yearInput(), startDate.getFullYear());
-      submitButton().click();
+      const yesterday = new Date(date.setDate(startDateObj.day - 1));
 
-      cy.checkText(
-        partials.errorSummaryListItems().eq(0),
-        CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].CANNOT_BE_BEFORE,
-      );
-
-      cy.checkText(
-        field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].CANNOT_BE_BEFORE}`,
-      );
+      cannotBeBefore(yesterday);
     });
 
     it(`should render a validation error when the date is over the maximum years allowed after ${REQUESTED_START_DATE}`, () => {
-      const endDateUnformatted = date.setFullYear(startDate.getFullYear() + ELIGIBILITY.MAX_COVER_PERIOD_YEARS);
-      const endDate = new Date(endDateUnformatted);
-      const endDateMonth = endDate.getMonth() + 1;
+      const additionalYears = startDateObj.year + ELIGIBILITY.MAX_COVER_PERIOD_YEARS;
 
-      cy.keyboardInput(field.dayInput(), endDate.getDate() + 1);
-      cy.keyboardInput(field.monthInput(), endDateMonth);
-      cy.keyboardInput(field.yearInput(), endDate.getFullYear());
-      submitButton().click();
+      const futureDate = new Date(startDate.setFullYear(additionalYears));
 
-      cy.checkText(
-        partials.errorSummaryListItems().eq(0),
-        CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].AFTER_LATEST,
-      );
+      const additionalDays = new Date(futureDate).getDate() + 1;
 
-      cy.checkText(
-        field.errorMessage(),
-        `Error: ${CONTRACT_ERROR_MESSAGES.SINGLE[CONTRACT_COMPLETION_DATE].AFTER_LATEST}`,
-      );
+      const overMaxDate = new Date(futureDate.setDate(additionalDays));
+
+      cannotBeAfter(overMaxDate);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
@@ -146,7 +146,7 @@ context('Insurance - Policy - Single contract policy page - form validation - co
       fieldA,
       fieldB,
       fieldBErrorIndex: 0,
-      errorSummaryLength: 3,
+      expectedErrorSummaryLength: 3,
     });
 
     beforeEach(() => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
@@ -1,19 +1,38 @@
+import { field as fieldSelector } from '../../../../../../../pages/shared';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
-import requestedCoverStartDate from '../../../../../../../commands/insurance/requested-start-date-field';
+import dateField from '../../../../../../../commands/insurance/date-field';
 
 const {
   ROOT,
   POLICY: { SINGLE_CONTRACT_POLICY },
 } = INSURANCE_ROUTES;
 
-const { checkValidation } = requestedCoverStartDate;
+const {
+  POLICY: {
+    CONTRACT_POLICY: {
+      REQUESTED_START_DATE,
+    },
+  },
+} = INSURANCE_FIELD_IDS;
+
+const {
+  INSURANCE: {
+    POLICY: {
+      CONTRACT_POLICY: CONTRACT_ERROR_MESSAGES,
+    },
+  },
+} = ERROR_MESSAGES;
 
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Policy - Single contract policy page - form validation - requested start date', () => {
   let referenceNumber;
   let url;
+
+  const field = fieldSelector(REQUESTED_START_DATE);
 
   const {
     day,
@@ -22,7 +41,13 @@ context('Insurance - Policy - Single contract policy page - form validation - re
     notInTheFuture,
     invalidFormat,
     isToday,
-  } = checkValidation({ errorSummaryLength: 4 });
+  } = dateField.checkValidation({
+    errorSummaryLength: 4,
+    errorIndex: 0,
+    field,
+    fieldId: REQUESTED_START_DATE,
+    errorMessages: CONTRACT_ERROR_MESSAGES[REQUESTED_START_DATE],
+  });
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -164,7 +164,7 @@ export const ERROR_MESSAGES = {
           INVALID_DATE: 'Policy start date must be a real date',
         },
         [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.POLICY_CURRENCY_CODE]: {
-          IS_EMPTY: "Select currency you'd like your policy to be issued in",
+          IS_EMPTY: "Select the currency you would like your policy to be issued in",
         },
         SINGLE: {
           [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.SINGLE.CONTRACT_COMPLETION_DATE]: {

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -164,7 +164,7 @@ export const ERROR_MESSAGES = {
           INVALID_DATE: 'Policy start date must be a real date',
         },
         [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.POLICY_CURRENCY_CODE]: {
-          IS_EMPTY: "Select the currency you would like your policy to be issued in",
+          IS_EMPTY: 'Select the currency you would like your policy to be issued in',
         },
         SINGLE: {
           [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.SINGLE.CONTRACT_COMPLETION_DATE]: {

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -169,12 +169,19 @@ export const ERROR_MESSAGES = {
         SINGLE: {
           [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.SINGLE.CONTRACT_COMPLETION_DATE]: {
             INCORRECT_FORMAT: 'Enter a contract completion date in the correct format, like 06 11 2023',
-            NOT_A_NUMBER: 'Enter a contract completion date in the correct format, like 06 11 2023',
             BEFORE_EARLIEST: 'You cannot enter a contract completion date in the past - enter a future date',
+            MISSING_DAY_AND_MONTH: 'Policy completion date must include a day and month',
+            MISSING_DAY_AND_YEAR: 'Policy completion date must include a day and year',
+            MISSING_MONTH_AND_YEAR: 'Policy completion date must include a month and year',
             AFTER_LATEST:
               "Your contract completion date is more than 2 years after your policy start date. You'll need to speak with an export finance manager, if you still want to apply",
             CANNOT_BE_THE_SAME: 'Your contract completion date cannot be the same as your policy start date',
-            CANNOT_BE_BEFORE: 'Your contract completion date must be after your policy start date',
+            CANNOT_BE_BEFORE: 'The date you expect to complete your export contract must be after the policy start date',
+            INVALID_DAY: 'Enter a valid day',
+            INVALID_MONTH: 'Enter a valid month',
+            INVALID_YEAR: 'Enter a valid year',
+            INVALID_YEAR_DIGITS: 'Year must include 4 numbers',
+            INVALID_DATE: 'Policy completion date must be a real date',
           },
         },
         MULTIPLE: {

--- a/src/ui/server/content-strings/fields/insurance/policy/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy/index.ts
@@ -71,7 +71,7 @@ export const POLICY_FIELDS = {
     SINGLE: {
       [CONTRACT_POLICY.SINGLE.CONTRACT_COMPLETION_DATE]: {
         LABEL: 'When do you expect to complete the export contract?',
-        HINT: 'For example, 6 11 2024',
+        HINT: 'For example, 06 11 2024',
         SUMMARY: {
           TITLE: 'Date you expect contract to complete',
         },

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/validation/rules/contract-completion-date.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/validation/rules/contract-completion-date.test.ts
@@ -1,6 +1,7 @@
 import contractCompletionDateRules from './contract-completion-date';
 import { FIELD_IDS, ELIGIBILITY } from '../../../../../../constants';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
+import dateRules from '../../../../../../shared-validation/date';
 import generateValidationErrors from '../../../../../../helpers/validation';
 
 const {
@@ -18,7 +19,7 @@ const {
   INSURANCE: {
     POLICY: {
       CONTRACT_POLICY: {
-        SINGLE: { [CONTRACT_COMPLETION_DATE]: ERROR_MESSAGE },
+        SINGLE: { [CONTRACT_COMPLETION_DATE]: ERROR_MESSAGES_OBJECT },
       },
     },
   },
@@ -30,101 +31,20 @@ describe('controllers/insurance/policy/single-contract-policy/validation/rules/c
     errorList: {},
   };
 
-  describe('when day field is not provided', () => {
-    it('should return validation error', () => {
+  describe('when fields are invalid', () => {
+    it('should return validation the result of dateRules', () => {
       const mockSubmittedData = {
-        [`${CONTRACT_COMPLETION_DATE}-month`]: '1',
-        [`${CONTRACT_COMPLETION_DATE}-year`]: '2022',
+        [`${CONTRACT_COMPLETION_DATE}-day`]: '1',
       };
 
       const result = contractCompletionDateRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when month field is not provided', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [`${CONTRACT_COMPLETION_DATE}-day`]: '10',
-        [`${CONTRACT_COMPLETION_DATE}-year`]: '2022',
-      };
-
-      const result = contractCompletionDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when year field is not provided', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [`${CONTRACT_COMPLETION_DATE}-day`]: '10',
-        [`${CONTRACT_COMPLETION_DATE}-month`]: '1',
-      };
-
-      const result = contractCompletionDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when any day/month/year field is NOT a number', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [`${CONTRACT_COMPLETION_DATE}-day`]: 'One',
-        [`${CONTRACT_COMPLETION_DATE}-month`]: '!@',
-        [`${CONTRACT_COMPLETION_DATE}-year`]: ' ',
-      };
-
-      const result = contractCompletionDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.NOT_A_NUMBER, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when the date is invalid', () => {
-    it('should return validation error', () => {
-      const date = new Date();
-      const day = date.getDate();
-      const month = date.getMonth();
-
-      const mockSubmittedData = {
-        [`${CONTRACT_COMPLETION_DATE}-day`]: day,
-        [`${CONTRACT_COMPLETION_DATE}-month`]: '24',
-        [`${CONTRACT_COMPLETION_DATE}-year`]: month,
-      };
-
-      const result = contractCompletionDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when the date is in the past', () => {
-    it('should return validation error', () => {
-      const today = new Date();
-      const yesterday = new Date(today.setDate(today.getDate() - 1));
-
-      const mockSubmittedData = {
-        [`${CONTRACT_COMPLETION_DATE}-day`]: yesterday.getDate(),
-        [`${CONTRACT_COMPLETION_DATE}-month`]: yesterday.getMonth() + 1,
-        [`${CONTRACT_COMPLETION_DATE}-year`]: yesterday.getFullYear(),
-      };
-
-      const result = contractCompletionDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.BEFORE_EARLIEST, mockErrors);
+      const expected = dateRules({
+        formBody: mockSubmittedData,
+        errors: mockErrors,
+        fieldId: CONTRACT_COMPLETION_DATE,
+        errorMessages: ERROR_MESSAGES_OBJECT,
+      });
 
       expect(result).toEqual(expected);
     });
@@ -165,7 +85,7 @@ describe('controllers/insurance/policy/single-contract-policy/validation/rules/c
 
         const result = contractCompletionDateRules(mockSubmittedData, mockErrors);
 
-        const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.CANNOT_BE_THE_SAME, mockErrors);
+        const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGES_OBJECT.CANNOT_BE_THE_SAME, mockErrors);
 
         expect(result).toEqual(expected);
       });
@@ -191,7 +111,7 @@ describe('controllers/insurance/policy/single-contract-policy/validation/rules/c
 
         const result = contractCompletionDateRules(mockSubmittedData, mockErrors);
 
-        const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.CANNOT_BE_BEFORE, mockErrors);
+        const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGES_OBJECT.CANNOT_BE_BEFORE, mockErrors);
 
         expect(result).toEqual(expected);
       });
@@ -218,7 +138,7 @@ describe('controllers/insurance/policy/single-contract-policy/validation/rules/c
 
         const result = contractCompletionDateRules(mockSubmittedData, mockErrors);
 
-        const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGE.AFTER_LATEST, mockErrors);
+        const expected = generateValidationErrors(CONTRACT_COMPLETION_DATE, ERROR_MESSAGES_OBJECT.AFTER_LATEST, mockErrors);
 
         expect(result).toEqual(expected);
       });

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/validation/rules/contract-completion-date.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/validation/rules/contract-completion-date.ts
@@ -1,10 +1,9 @@
-import { add, isAfter, isBefore, isPast, isSameDay, isValid } from 'date-fns';
+import { add, isAfter, isBefore, isSameDay } from 'date-fns';
 import { FIELD_IDS, ELIGIBILITY } from '../../../../../../constants';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../helpers/validation';
-import { objectHasProperty } from '../../../../../../helpers/object';
+import dateRules from '../../../../../../shared-validation/date';
 import createTimestampFromNumbers from '../../../../../../helpers/date/create-timestamp-from-numbers';
-import { isNumber } from '../../../../../../helpers/number';
+import generateValidationErrors from '../../../../../../helpers/validation';
 import { RequestBody } from '../../../../../../../types';
 
 const {
@@ -22,26 +21,13 @@ const {
   INSURANCE: {
     POLICY: {
       CONTRACT_POLICY: {
-        SINGLE: { [FIELD_ID]: ERROR_MESSAGE },
+        SINGLE: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
       },
     },
   },
 } = ERROR_MESSAGES;
 
 export const MAXIMUM_FUTURE_YEARS = 2;
-
-const DATE_INPUT_IDS = {
-  start: {
-    day: `${REQUESTED_START_DATE}-day`,
-    month: `${REQUESTED_START_DATE}-month`,
-    year: `${REQUESTED_START_DATE}-year`,
-  },
-  end: {
-    day: `${FIELD_ID}-day`,
-    month: `${FIELD_ID}-month`,
-    year: `${FIELD_ID}-year`,
-  },
-};
 
 const getDateInputValues = (formBody: RequestBody) => ({
   start: {
@@ -65,52 +51,39 @@ const getDateInputValues = (formBody: RequestBody) => ({
  * @returns {Object} Validation errors
  */
 const contractCompletionDateRules = (formBody: RequestBody, errors: object) => {
+  const genericDataErrors = dateRules({
+    formBody,
+    errors,
+    fieldId: FIELD_ID,
+    errorMessages: ERROR_MESSAGES_OBJECT,
+  });
+
+  if (genericDataErrors.count) {
+    return genericDataErrors;
+  }
+
   const inputValues = getDateInputValues(formBody);
 
-  // check that no fields are empty.
-  const hasDay = objectHasProperty(formBody, DATE_INPUT_IDS.end.day);
-  const hasMonth = objectHasProperty(formBody, DATE_INPUT_IDS.end.month);
-  const hasYear = objectHasProperty(formBody, DATE_INPUT_IDS.end.year);
-
-  if (!hasDay || !hasMonth || !hasYear) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
-  }
-
-  // check that all fields are numbers.
-  if (!isNumber(inputValues.end.day) || !isNumber(inputValues.end.month) || !isNumber(inputValues.end.year)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.NOT_A_NUMBER, errors);
-  }
+  const requestedStartDate = createTimestampFromNumbers(inputValues.start.day, inputValues.start.month, inputValues.start.year);
 
   const submittedDate = createTimestampFromNumbers(inputValues.end.day, inputValues.end.month, inputValues.end.year);
-
-  // check that the date is valid e.g not a month value of 24.
-  if (submittedDate && !isValid(submittedDate)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
-  }
-
-  // check that the date is in the future.
-  if (submittedDate && isPast(submittedDate)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BEFORE_EARLIEST, errors);
-  }
-
-  const requestedStartDate = createTimestampFromNumbers(inputValues.start.day, inputValues.start.month, inputValues.start.year);
 
   if (submittedDate && requestedStartDate) {
     // check that the date is not the same as the requested start date.
     if (isSameDay(submittedDate, requestedStartDate)) {
-      return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.CANNOT_BE_THE_SAME, errors);
+      return generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.CANNOT_BE_THE_SAME, errors);
     }
 
     // check that the date is not before the requested start date.
     if (isBefore(submittedDate, requestedStartDate)) {
-      return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.CANNOT_BE_BEFORE, errors);
+      return generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.CANNOT_BE_BEFORE, errors);
     }
 
     // check that the end date is not past the maximum years of cover.
     const maximum = add(requestedStartDate, { years: ELIGIBILITY.MAX_COVER_PERIOD_YEARS });
 
     if (isAfter(submittedDate, maximum)) {
-      return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.AFTER_LATEST, errors);
+      return generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.AFTER_LATEST, errors);
     }
   }
 

--- a/src/ui/server/shared-validation/date/index.test.ts
+++ b/src/ui/server/shared-validation/date/index.test.ts
@@ -1,0 +1,243 @@
+import dateRules from '.';
+import INSURANCE_FIELD_IDS from '../../constants/field-ids/insurance';
+import { ERROR_MESSAGES } from '../../content-strings';
+import generateValidationErrors from '../../helpers/validation';
+
+const {
+  POLICY: {
+    CONTRACT_POLICY: { REQUESTED_START_DATE: FIELD_ID },
+  },
+} = INSURANCE_FIELD_IDS;
+
+const {
+  INSURANCE: {
+    POLICY: {
+      CONTRACT_POLICY: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
+    },
+  },
+} = ERROR_MESSAGES;
+
+describe('shared-validation/date', () => {
+  const date = new Date();
+
+  const day = date.getDate();
+  const month = date.getMonth();
+  const year = date.getFullYear();
+
+  const futureDate = new Date(date.setMonth(month + 6));
+
+  const mockErrors = {
+    summary: [],
+    errorList: {},
+  };
+
+  const baseParams = {
+    errors: mockErrors,
+    fieldId: FIELD_ID,
+    errorMessages: ERROR_MESSAGES_OBJECT,
+  };
+
+  const mockValidBody = {
+    [`${FIELD_ID}-day`]: futureDate.getDate(),
+    [`${FIELD_ID}-month`]: futureDate.getMonth(),
+    [`${FIELD_ID}-year`]: futureDate.getFullYear(),
+  };
+
+  describe('when no day/month/year fields are provided', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        [`${FIELD_ID}-day`]: '',
+        [`${FIELD_ID}-month`]: '',
+        [`${FIELD_ID}-year`]: '',
+      };
+
+      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INCORRECT_FORMAT, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when any day/month/year field is NOT a number', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        [`${FIELD_ID}-day`]: 'One',
+        [`${FIELD_ID}-month`]: 'Two',
+        [`${FIELD_ID}-year`]: 'Three',
+      };
+
+      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INCORRECT_FORMAT, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a valid day is provided, but month and year are not', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        ...mockValidBody,
+        [`${FIELD_ID}-month`]: '',
+        [`${FIELD_ID}-year`]: '',
+      };
+
+      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.MISSING_MONTH_AND_YEAR, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a valid month is provided, but day and year are not', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        ...mockValidBody,
+        [`${FIELD_ID}-day`]: '',
+        [`${FIELD_ID}-year`]: '',
+      };
+
+      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.MISSING_DAY_AND_YEAR, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a valid year is provided, but day and month are not', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        ...mockValidBody,
+        [`${FIELD_ID}-day`]: '',
+        [`${FIELD_ID}-month`]: '',
+      };
+
+      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.MISSING_DAY_AND_MONTH, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when day is not provided', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        ...mockValidBody,
+        [`${FIELD_ID}-day`]: '',
+      };
+
+      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INVALID_DAY, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when month is not provided', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        ...mockValidBody,
+        [`${FIELD_ID}-month`]: '',
+      };
+
+      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INVALID_MONTH, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when year is not provided', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        ...mockValidBody,
+        [`${FIELD_ID}-year`]: '',
+      };
+
+      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INVALID_YEAR, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when year has less than 4 digits', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        ...mockValidBody,
+        [`${FIELD_ID}-year`]: '202',
+      };
+
+      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INVALID_YEAR_DIGITS, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when the date is invalid', () => {
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        [`${FIELD_ID}-day`]: '50',
+        [`${FIELD_ID}-month`]: '24',
+        [`${FIELD_ID}-year`]: year,
+      };
+
+      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INVALID_DATE, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when the date is in the past', () => {
+    it('should return validation error', () => {
+      const yesterday = new Date(date.setDate(day - 1));
+
+      const mockSubmittedData = {
+        [`${FIELD_ID}-day`]: yesterday.getDate(),
+        [`${FIELD_ID}-month`]: month + 1,
+        [`${FIELD_ID}-year`]: year,
+      };
+
+      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.BEFORE_EARLIEST, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when the date is today', () => {
+    it('should NOT return a validation error', () => {
+      const today = new Date();
+
+      const mockSubmittedData = {
+        [`${FIELD_ID}-day`]: today.getDate(),
+        [`${FIELD_ID}-month`]: today.getMonth() + 1,
+        [`${FIELD_ID}-year`]: today.getFullYear(),
+      };
+
+      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
+
+      expect(result).toEqual(mockErrors);
+    });
+  });
+
+  describe('when there are no validation errors', () => {
+    it('should return the provided errors object', () => {
+      const result = dateRules({ ...baseParams, formBody: mockValidBody });
+
+      expect(result).toEqual(mockErrors);
+    });
+  });
+});

--- a/src/ui/server/shared-validation/date/index.ts
+++ b/src/ui/server/shared-validation/date/index.ts
@@ -1,0 +1,126 @@
+import { endOfDay, isFuture, isValid } from 'date-fns';
+import generateValidationErrors from '../../helpers/validation';
+import createTimestampFromNumbers from '../../helpers/date/create-timestamp-from-numbers';
+import { isNumber } from '../../helpers/number';
+import { RequestBody, DateErrorMessage, ValidationErrors } from '../../../types';
+
+interface DateRulesTempType {
+  formBody: RequestBody;
+  errors: object;
+  fieldId: string;
+  errorMessages: DateErrorMessage;
+}
+
+/**
+ * dateRules
+ * Check submitted form data for errors with a date field
+ * Returns generateValidationErrors if there are any errors.
+ * @param {Express.Response.body} Express response body
+ * @param {Object} Errors object from previous validation errors
+ * @returns {Object} Validation errors
+ */
+const dateRules = ({ formBody, errors, fieldId, errorMessages }: DateRulesTempType): ValidationErrors => {
+  const dayId = `${fieldId}-day`;
+  const monthId = `${fieldId}-month`;
+  const yearId = `${fieldId}-year`;
+
+  const dayString = formBody[dayId];
+  const monthString = formBody[monthId];
+  const yearString = formBody[yearId];
+
+  if (!dayString && !monthString && !yearString) {
+    return generateValidationErrors(fieldId, errorMessages.INCORRECT_FORMAT, errors);
+  }
+
+  const day = isNumber(dayString);
+  const month = isNumber(monthString);
+  const year = isNumber(yearString);
+
+  /**
+   * All fields must be numbers.
+   */
+  if (!day && !month && !year) {
+    return generateValidationErrors(fieldId, errorMessages.INCORRECT_FORMAT, errors);
+  }
+
+  /**
+   * has a day,
+   * no month or year.
+   */
+  if (day && !month && !year) {
+    return generateValidationErrors(fieldId, errorMessages.MISSING_MONTH_AND_YEAR, errors);
+  }
+
+  /**
+   * has a month,
+   * no day or year.
+   */
+  if (!day && month && !year) {
+    return generateValidationErrors(fieldId, errorMessages.MISSING_DAY_AND_YEAR, errors);
+  }
+
+  /**
+   * has a year,
+   * no day or month.
+   */
+  if (!day && !month && year) {
+    return generateValidationErrors(fieldId, errorMessages.MISSING_DAY_AND_MONTH, errors);
+  }
+
+  /**
+   * Individual date field validation rules.
+   * I.e, all but 1 date fields are provided.
+   */
+  if (!day) {
+    return generateValidationErrors(fieldId, errorMessages.INVALID_DAY, errors);
+  }
+
+  if (!month) {
+    return generateValidationErrors(fieldId, errorMessages.INVALID_MONTH, errors);
+  }
+
+  if (!year) {
+    return generateValidationErrors(fieldId, errorMessages.INVALID_YEAR, errors);
+  }
+
+  /**
+   * Check that a year has 4 digits.
+   * E.g a year cannot be 200.
+   */
+  if (yearString.length < 4) {
+    return generateValidationErrors(fieldId, errorMessages.INVALID_YEAR_DIGITS, errors);
+  }
+
+  const dayNumber = Number(dayString);
+  const monthNumber = Number(monthString);
+  const yearNumber = Number(yearString);
+
+  const submittedDate = createTimestampFromNumbers(dayNumber, monthNumber, yearNumber);
+
+  if (submittedDate) {
+    /**
+     * Check that the date is valid. E.g:
+     * A month cannot have a value of 13.
+     * A day cannot have a value of 50 or over the maximum days in a month.
+     */
+    if (!isValid(submittedDate)) {
+      return generateValidationErrors(fieldId, errorMessages.INVALID_DATE, errors);
+    }
+
+    /**
+     * Check that the date is in the future.
+     * A date cannot be in the past.
+     */
+    if (!isFuture(endOfDay(submittedDate))) {
+      return generateValidationErrors(fieldId, errorMessages.BEFORE_EARLIEST, errors);
+    }
+  }
+
+  /**
+   * No date validation errors.
+   * Return the provided errors object.
+   */
+  return errors;
+};
+
+export default dateRules;

--- a/src/ui/server/shared-validation/date/index.ts
+++ b/src/ui/server/shared-validation/date/index.ts
@@ -15,9 +15,10 @@ interface DateRulesTempType {
  * dateRules
  * Check submitted form data for errors with a date field
  * Returns generateValidationErrors if there are any errors.
- * @param {Express.Response.body} Express response body
- * @param {Object} Errors object from previous validation errors
- * @returns {Object} Validation errors
+ * @param {Express.Response.body} formBody: Express response body
+ * @param {Object} errors: Errors object from previous validation errors
+ * @param {String} fieldId: Date field ID
+ * @returns {Object} errorMessages: All possible error messages for the date field.
  */
 const dateRules = ({ formBody, errors, fieldId, errorMessages }: DateRulesTempType): ValidationErrors => {
   const dayId = `${fieldId}-day`;

--- a/src/ui/server/shared-validation/requested-start-date/index.test.ts
+++ b/src/ui/server/shared-validation/requested-start-date/index.test.ts
@@ -1,7 +1,7 @@
-import requestedStartDateRules from '.';
 import INSURANCE_FIELD_IDS from '../../constants/field-ids/insurance';
 import { ERROR_MESSAGES } from '../../content-strings';
-import generateValidationErrors from '../../helpers/validation';
+import dateRules from '../date';
+import requestedStartDateRules from '.';
 
 const {
   POLICY: {
@@ -12,226 +12,28 @@ const {
 const {
   INSURANCE: {
     POLICY: {
-      CONTRACT_POLICY: { [FIELD_ID]: ERROR_MESSAGE },
+      CONTRACT_POLICY: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
     },
   },
 } = ERROR_MESSAGES;
 
 describe('shared-validation/requested-start-date', () => {
-  const date = new Date();
-
-  const day = date.getDate();
-  const month = date.getMonth();
-  const year = date.getFullYear();
-
-  const futureDate = new Date(date.setMonth(month + 6));
-
+  const mockFormBody = {};
   const mockErrors = {
     summary: [],
     errorList: {},
   };
 
-  const mockValidBody = {
-    [`${FIELD_ID}-day`]: futureDate.getDate(),
-    [`${FIELD_ID}-month`]: futureDate.getMonth(),
-    [`${FIELD_ID}-year`]: futureDate.getFullYear(),
-  };
+  it('should return the result of dateRules', () => {
+    const result = requestedStartDateRules(mockFormBody, mockErrors);
 
-  describe('when no day/month/year fields are provided', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [`${FIELD_ID}-day`]: '',
-        [`${FIELD_ID}-month`]: '',
-        [`${FIELD_ID}-year`]: '',
-      };
-
-      const result = requestedStartDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
+    const expected = dateRules({
+      formBody: mockFormBody,
+      errors: mockErrors,
+      fieldId: FIELD_ID,
+      errorMessages: ERROR_MESSAGES_OBJECT,
     });
-  });
 
-  describe('when any day/month/year field is NOT a number', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [`${FIELD_ID}-day`]: 'One',
-        [`${FIELD_ID}-month`]: 'Two',
-        [`${FIELD_ID}-year`]: 'Three',
-      };
-
-      const result = requestedStartDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when a valid day is provided, but month and year are not', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        ...mockValidBody,
-        [`${FIELD_ID}-month`]: '',
-        [`${FIELD_ID}-year`]: '',
-      };
-
-      const result = requestedStartDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.MISSING_MONTH_AND_YEAR, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when a valid month is provided, but day and year are not', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        ...mockValidBody,
-        [`${FIELD_ID}-day`]: '',
-        [`${FIELD_ID}-year`]: '',
-      };
-
-      const result = requestedStartDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.MISSING_DAY_AND_YEAR, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when a valid year is provided, but day and month are not', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        ...mockValidBody,
-        [`${FIELD_ID}-day`]: '',
-        [`${FIELD_ID}-month`]: '',
-      };
-
-      const result = requestedStartDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.MISSING_DAY_AND_MONTH, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when day is not provided', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        ...mockValidBody,
-        [`${FIELD_ID}-day`]: '',
-      };
-
-      const result = requestedStartDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INVALID_DAY, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when month is not provided', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        ...mockValidBody,
-        [`${FIELD_ID}-month`]: '',
-      };
-
-      const result = requestedStartDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INVALID_MONTH, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when year is not provided', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        ...mockValidBody,
-        [`${FIELD_ID}-year`]: '',
-      };
-
-      const result = requestedStartDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INVALID_YEAR, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when year has less than 4 digits', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        ...mockValidBody,
-        [`${FIELD_ID}-year`]: '202',
-      };
-
-      const result = requestedStartDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INVALID_YEAR_DIGITS, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when the date is invalid', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [`${FIELD_ID}-day`]: '50',
-        [`${FIELD_ID}-month`]: '24',
-        [`${FIELD_ID}-year`]: year,
-      };
-
-      const result = requestedStartDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INVALID_DATE, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when the date is in the past', () => {
-    it('should return validation error', () => {
-      const yesterday = new Date(date.setDate(day - 1));
-
-      const mockSubmittedData = {
-        [`${FIELD_ID}-day`]: yesterday.getDate(),
-        [`${FIELD_ID}-month`]: month + 1,
-        [`${FIELD_ID}-year`]: year,
-      };
-
-      const result = requestedStartDateRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BEFORE_EARLIEST, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when the date is today', () => {
-    it('should NOT return a validation error', () => {
-      const today = new Date();
-
-      const mockSubmittedData = {
-        [`${FIELD_ID}-day`]: today.getDate(),
-        [`${FIELD_ID}-month`]: today.getMonth() + 1,
-        [`${FIELD_ID}-year`]: today.getFullYear(),
-      };
-
-      const result = requestedStartDateRules(mockSubmittedData, mockErrors);
-
-      expect(result).toEqual(mockErrors);
-    });
-  });
-
-  describe('when there are no validation errors', () => {
-    it('should return the provided errors object', () => {
-      const result = requestedStartDateRules(mockValidBody, mockErrors);
-
-      expect(result).toEqual(mockErrors);
-    });
+    expect(result).toEqual(expected);
   });
 });

--- a/src/ui/server/shared-validation/requested-start-date/index.ts
+++ b/src/ui/server/shared-validation/requested-start-date/index.ts
@@ -1,9 +1,6 @@
-import { endOfDay, isFuture, isValid } from 'date-fns';
 import INSURANCE_FIELD_IDS from '../../constants/field-ids/insurance';
 import { ERROR_MESSAGES } from '../../content-strings';
-import generateValidationErrors from '../../helpers/validation';
-import createTimestampFromNumbers from '../../helpers/date/create-timestamp-from-numbers';
-import { isNumber } from '../../helpers/number';
+import dateRules from '../date';
 import { RequestBody } from '../../../types';
 
 const {
@@ -15,121 +12,27 @@ const {
 const {
   INSURANCE: {
     POLICY: {
-      CONTRACT_POLICY: { [FIELD_ID]: ERROR_MESSAGE },
+      CONTRACT_POLICY: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
     },
   },
 } = ERROR_MESSAGES;
 
 /**
  * requestedStartDateRules
- * Check submitted form data for errors with the requested start date field
- * Returns generateValidationErrors if there are any errors.
- * @param {Express.Response.body} Express response body
- * @param {Object} Errors object from previous validation errors
- * @returns {Object} Validation errors
+ * Requested start date validation rules
+ * @param {RequestBody} formBody
+ * @param {Object} errors
+ * @returns {Object} Result of dateRules
  */
 const requestedStartDateRules = (formBody: RequestBody, errors: object) => {
-  const dayId = `${FIELD_ID}-day`;
-  const monthId = `${FIELD_ID}-month`;
-  const yearId = `${FIELD_ID}-year`;
+  const rules = dateRules({
+    formBody,
+    errors,
+    fieldId: FIELD_ID,
+    errorMessages: ERROR_MESSAGES_OBJECT,
+  });
 
-  const dayString = formBody[dayId];
-  const monthString = formBody[monthId];
-  const yearString = formBody[yearId];
-
-  if (!dayString && !monthString && !yearString) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
-  }
-
-  const day = isNumber(dayString);
-  const month = isNumber(monthString);
-  const year = isNumber(yearString);
-
-  /**
-   * All fields must be numbers.
-   */
-  if (!day && !month && !year) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
-  }
-
-  /**
-   * has a day,
-   * no month or year.
-   */
-  if (day && !month && !year) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.MISSING_MONTH_AND_YEAR, errors);
-  }
-
-  /**
-   * has a month,
-   * no day or year.
-   */
-  if (!day && month && !year) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.MISSING_DAY_AND_YEAR, errors);
-  }
-
-  /**
-   * has a year,
-   * no day or month.
-   */
-  if (!day && !month && year) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.MISSING_DAY_AND_MONTH, errors);
-  }
-
-  /**
-   * Individual date field validation rules.
-   * I.e, all but 1 date fields are provided.
-   */
-  if (!day) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INVALID_DAY, errors);
-  }
-
-  if (!month) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INVALID_MONTH, errors);
-  }
-
-  if (!year) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INVALID_YEAR, errors);
-  }
-
-  /**
-   * Check that a year has 4 digits.
-   * E.g a year cannot be 200.
-   */
-  if (yearString.length < 4) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INVALID_YEAR_DIGITS, errors);
-  }
-
-  const dayNumber = Number(dayString);
-  const monthNumber = Number(monthString);
-  const yearNumber = Number(yearString);
-
-  const submittedDate = createTimestampFromNumbers(dayNumber, monthNumber, yearNumber);
-
-  if (submittedDate) {
-    /**
-     * Check that the date is valid. E.g:
-     * A month cannot have a value of 13.
-     * A day cannot have a value of 50 or over the maximum days in a month.
-     */
-    if (!isValid(submittedDate)) {
-      return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INVALID_DATE, errors);
-    }
-
-    /**
-     * Check that the date is in the future.
-     * A start date cannot be in the past.
-     */
-    if (!isFuture(endOfDay(submittedDate))) {
-      return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BEFORE_EARLIEST, errors);
-    }
-  }
-
-  /**
-   * No date validation errors.
-   * Return the provided errors object.
-   */
-  return errors;
+  return rules;
 };
 
 export default requestedStartDateRules;

--- a/src/ui/types/errors.ts
+++ b/src/ui/types/errors.ts
@@ -1,3 +1,19 @@
+interface DateErrorMessage {
+  INCORRECT_FORMAT: string;
+  BEFORE_EARLIEST: string;
+  MISSING_DAY_AND_MONTH: string;
+  MISSING_DAY_AND_YEAR: string;
+  MISSING_MONTH_AND_YEAR: string;
+  CANNOT_BE_THE_SAME: string;
+  CANNOT_BE_BEFORE: string;
+  INVALID_DAY: string;
+  INVALID_MONTH: string;
+  INVALID_YEAR: string;
+  INVALID_YEAR_DIGITS: string;
+  INVALID_DATE: string;
+  AFTER_LATEST: string;
+}
+
 interface NumberErrorMessage {
   IS_EMPTY: string;
   INCORRECT_FORMAT: string;
@@ -5,4 +21,4 @@ interface NumberErrorMessage {
   ABOVE_MAXIMUM: string;
 }
 
-export { NumberErrorMessage };
+export { DateErrorMessage, NumberErrorMessage };

--- a/src/ui/types/index.d.ts
+++ b/src/ui/types/index.d.ts
@@ -22,7 +22,7 @@ import { CompaniesHouseResponse } from './company-house-response';
 import { Connect } from './connect';
 import { Country } from './country';
 import { Currency, CurrencyRadios } from './currency';
-import { NumberErrorMessage } from './errors';
+import { DateErrorMessage, NumberErrorMessage } from './errors';
 import { Business } from './business';
 import { Next, Request, RequestBody, RequestSession, RequestSessionUser, Response } from './express';
 import { RequiredDataStateInsuranceEligibility, RequiredDataStateQuoteEligibility } from './required-data-state';
@@ -92,6 +92,7 @@ export {
   Country,
   Currency,
   CurrencyRadios,
+  DateErrorMessage,
   NumberErrorMessage,
   Business,
   InsuranceEligibility,


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the validation rules for the "contract completion date" field, for the Policy type's "single contract policy" form.

## Resolution :heavy_check_mark:
- Update content strings (error messages, field hint).
- Extract recently enhanced "requested start date" validation rules into a new "generic date validation" helper function.
- Update `contractCompletionDateRules` to call "generic date validation" helper function.
- Update cypress "check date validation" function to check for errors when there are 2 date fields:
  - Dates cannot be the same date.
  - Second date cannot be before the first date.
  - Second date cannot be after a certain time period.
- Update an error message used for the currency field.

## Miscellaneous :heavy_plus_sign:
- Update cypress "check date validation" function to have object structured params.
- Minor destructuring and cypress command improvements.
