### PR TITLE
style(EMS-2444): No pdf - Single/multiple policy - Add currency hint

### DIFF
--- a/e2e-tests/commands/insurance/check-policy-currency-code-input.js
+++ b/e2e-tests/commands/insurance/check-policy-currency-code-input.js
@@ -27,6 +27,11 @@ const checkPolicyCurrencyCodeInput = () => {
     CONTENT_STRINGS.LEGEND,
   );
 
+  cy.checkText(
+    field.hint(),
+    CONTENT_STRINGS.HINT,
+  );
+
   const { option: option1 } = radios(fieldId, EUR.isoCode);
   const { option: option2 } = radios(fieldId, GBP.isoCode);
   const { option: option3 } = radios(fieldId, USD.isoCode);

--- a/e2e-tests/content-strings/fields/insurance/policy/index.js
+++ b/e2e-tests/content-strings/fields/insurance/policy/index.js
@@ -66,6 +66,7 @@ export const POLICY_FIELDS = {
     },
     [CONTRACT_POLICY.POLICY_CURRENCY_CODE]: {
       LEGEND: "Select currency you'd like your policy to be issued in",
+      HINT: 'This is the currency your policy will be issued in',
       SUMMARY: {
         TITLE: 'Policy currency',
         FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -112,7 +112,7 @@ context('Insurance - Policy - Multiple contract policy page - As an exporter, I 
       field.input().should('exist');
     });
 
-    it('renders `currency` label and radio inputs', () => {
+    it('renders `currency` label, hint and radio inputs', () => {
       checkPolicyCurrencyCodeInput();
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
@@ -135,7 +135,7 @@ context('Insurance - Policy - Single contract policy page - As an exporter, I wa
       field.input().should('exist');
     });
 
-    it('renders `currency` label and radio inputs', () => {
+    it('renders `currency` label, hint and radio inputs', () => {
       checkPolicyCurrencyCodeInput();
     });
 

--- a/src/ui/server/content-strings/fields/insurance/policy/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy/index.ts
@@ -59,6 +59,7 @@ export const POLICY_FIELDS = {
     },
     [CONTRACT_POLICY.POLICY_CURRENCY_CODE]: {
       LEGEND: "Select currency you'd like your policy to be issued in",
+      HINT: 'This is the currency your policy will be issued in',
       SUMMARY: {
         TITLE: 'Policy currency',
       },

--- a/src/ui/templates/components/currency-radio-inputs.njk
+++ b/src/ui/templates/components/currency-radio-inputs.njk
@@ -5,6 +5,7 @@
 
   {% set id = params.id %}
   {% set legend = params.legend %}
+  {% set hint = params.hint %}
   {% set supportedCurrencies = params.supportedCurrencies %}
   {% set error = params.error %}
   {% set submittedValue = params.submittedValue %}
@@ -13,7 +14,13 @@
     name: id,
     fieldset: {
       legend: {
-        html: fieldsetLegend.render({ id: id , legendText: legend })
+        html: fieldsetLegend.render({ id: id, legendText: legend })
+      }
+    },
+    hint: {
+      text: hint,
+      attributes: {
+        "data-cy": id + '-hint'
       }
     },
     items: [

--- a/src/ui/templates/insurance/policy/single-contract-policy.njk
+++ b/src/ui/templates/insurance/policy/single-contract-policy.njk
@@ -106,6 +106,7 @@
         {{ radiosInputs.render({
           id: FIELDS.POLICY_CURRENCY_CODE.ID,
           legend: FIELDS.POLICY_CURRENCY_CODE.LEGEND,
+          hint: FIELDS.POLICY_CURRENCY_CODE.HINT,
           supportedCurrencies: currencies,
           error: validationErrors.errorList[FIELDS.POLICY_CURRENCY_CODE.ID],
           submittedValue: submittedValues[FIELDS.POLICY_CURRENCY_CODE.ID] or application.policy[FIELDS.POLICY_CURRENCY_CODE.ID]


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds a new hint to the "currency" field in both single and multiple contract policy forms.

## Resolution :heavy_check_mark:
- Add `HINT` to content strings.
- Update `currency-radio-inputs` nunjucks component to consume and pass a hint.
- Add E2E test coverage.
