### PR TITLE
feat(EMS-2572): No PDF - Policy - Pre-credit period - Form submission, redirection flow

### DIFF
--- a/e2e-tests/commands/insurance/complete-and-submit-pre-credit-period-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-pre-credit-period-form.js
@@ -1,0 +1,11 @@
+import { submitButton } from '../../pages/shared';
+
+/**
+ * completeAndSubmitPreCreditPeriodForm
+ * Complete and submit the "pre-credit period" form
+ */
+const completeAndSubmitPreCreditPeriodForm = () => {
+  submitButton().click();
+};
+
+export default completeAndSubmitPreCreditPeriodForm;

--- a/e2e-tests/commands/insurance/complete-policy-section.js
+++ b/e2e-tests/commands/insurance/complete-policy-section.js
@@ -41,6 +41,8 @@ const completePolicySection = ({
     cy.completeAndSubmitDifferentNameOnPolicyForm({});
   }
 
+  cy.completeAndSubmitPreCreditPeriodForm();
+
   cy.completeAndSubmitBrokerForm({ usingBroker });
 
   if (submitCheckYourAnswers) {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
@@ -32,7 +32,7 @@ const {
   POLICY: {
     BROKER_ROOT,
     CHECK_YOUR_ANSWERS,
-    NAME_ON_POLICY,
+    PRE_CREDIT_PERIOD,
   },
 } = INSURANCE_ROUTES;
 
@@ -65,6 +65,7 @@ context('Insurance - Policy - Broker Page - As an Exporter I want to confirm if 
       cy.completeAndSubmitSingleContractPolicyForm();
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitPreCreditPeriodForm();
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
       checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
@@ -85,7 +86,7 @@ context('Insurance - Policy - Broker Page - As an Exporter I want to confirm if 
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${BROKER_ROOT}`,
-      backLink: `${ROOT}/${referenceNumber}${NAME_ON_POLICY}`,
+      backLink: `${ROOT}/${referenceNumber}${PRE_CREDIT_PERIOD}`,
       assertSubmitButton: true,
       lightHouseThresholds: {
         // accessibility threshold is reduced here because

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
@@ -52,6 +52,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
       cy.completeAndSubmitSingleContractPolicyForm();
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({});
+      cy.completeAndSubmitPreCreditPeriodForm();
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
       allSectionsUrl = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
@@ -108,6 +109,8 @@ context('Insurance - Policy - Broker page - Save and back', () => {
       submitButton().click();
       // submit name on policy form
       submitButton().click();
+      // submit pre-credit period form
+      submitButton().click();
 
       brokerPage[USING_BROKER].yesRadioInput().should('be.checked');
       cy.checkValue(field(NAME), application.EXPORTER_BROKER[NAME]);
@@ -155,6 +158,8 @@ context('Insurance - Policy - Broker page - Save and back', () => {
         submitButton().click();
         // submit name on policy form
         submitButton().click();
+        // submit pre-credit period form
+        submitButton().click();
 
         brokerPage[USING_BROKER].yesRadioInput().should('be.checked');
         cy.checkValue(field(NAME), application.EXPORTER_BROKER[NAME]);
@@ -192,6 +197,8 @@ context('Insurance - Policy - Broker page - Save and back', () => {
         // submit total contract value form
         submitButton().click();
         // submit name on policy form
+        submitButton().click();
+        // submit pre-credit period form
         submitButton().click();
 
         brokerPage[USING_BROKER].noRadioInput().should('be.checked');

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/are-you-using-a-broker-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/are-you-using-a-broker-answer-no.spec.js
@@ -37,6 +37,7 @@ context('Insurance - Policy - Broker Page - As an Exporter I want to confirm tha
       cy.completeAndSubmitSingleContractPolicyForm();
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitPreCreditPeriodForm();
 
       const url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
       checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-all-required-fields.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-all-required-fields.spec.js
@@ -30,6 +30,7 @@ context('Insurance - Policy - Broker Page - As an Exporter I want to confirm tha
       cy.completeAndSubmitSingleContractPolicyForm();
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({});
+      cy.completeAndSubmitPreCreditPeriodForm();
 
       const url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
       checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-no-required-fields.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/are-you-using-a-broker-answer-yes/are-you-using-a-broker-answer-yes-no-required-fields.spec.js
@@ -44,6 +44,7 @@ context('Insurance - Policy - Broker Page - As an Exporter I want to confirm tha
       cy.completeAndSubmitSingleContractPolicyForm();
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({});
+      cy.completeAndSubmitPreCreditPeriodForm();
 
       const url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/broker-email-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/broker-email-validation.spec.js
@@ -48,6 +48,7 @@ context('Insurance - Policy - Broker Page - Validation - Email', () => {
       cy.completeAndSubmitSingleContractPolicyForm();
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitPreCreditPeriodForm();
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/broker-postcode-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/validation/broker-postcode-validation.spec.js
@@ -49,6 +49,7 @@ context('Insurance - Policy - Broker Page - Validation - Postcode', () => {
       cy.completeAndSubmitSingleContractPolicyForm();
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitPreCreditPeriodForm();
 
       url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-multiple-contract-policy.spec.js
@@ -31,6 +31,7 @@ context('Insurance - Policy - Complete the entire section as a multiple contract
       cy.completeAndSubmitMultipleContractPolicyForm();
       cy.completeAndSubmitExportValueForm({ policyType });
       cy.completeAndSubmitNameOnPolicyForm({});
+      cy.completeAndSubmitPreCreditPeriodForm();
       cy.completeAndSubmitBrokerForm({});
 
       // go back to the all sections page

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-single-contract-policy.spec.js
@@ -29,6 +29,7 @@ context('Insurance - Policy - Complete the entire section as a single contract p
       cy.completeAndSubmitSingleContractPolicyForm();
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({});
+      cy.completeAndSubmitPreCreditPeriodForm();
       cy.completeAndSubmitBrokerForm({});
 
       // go back to the all sections page

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/changing-from-same-name-to-different-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/changing-from-same-name-to-different-name.spec.js
@@ -41,6 +41,7 @@ context(`Insurance - Policy - Different name on Policy page - Changing ${SAME_NA
       cy.completeAndSubmitSingleContractPolicyForm();
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({});
+      cy.completeAndSubmitPreCreditPeriodForm();
       cy.completeAndSubmitBrokerForm({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
@@ -21,7 +21,7 @@ const CONTENT_STRINGS = PAGES.INSURANCE.POLICY.DIFFERENT_NAME_ON_POLICY;
 const {
   ROOT: INSURANCE_ROOT,
   POLICY: {
-    BROKER_ROOT,
+    PRE_CREDIT_PERIOD,
     NAME_ON_POLICY,
     DIFFERENT_NAME_ON_POLICY,
   },
@@ -132,12 +132,12 @@ context('Insurance - Policy - Different name on Policy page - I want to enter th
   });
 
   describe('form submission', () => {
-    it(`should redirect to ${BROKER_ROOT}`, () => {
+    it(`should redirect to ${PRE_CREDIT_PERIOD}`, () => {
       cy.navigateToUrl(url);
 
       cy.completeAndSubmitDifferentNameOnPolicyForm({});
 
-      const expectedUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${BROKER_ROOT}`;
+      const expectedUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${PRE_CREDIT_PERIOD}`;
       cy.assertUrl(expectedUrl);
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/entering-details-of-policy-owner.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/entering-details-of-policy-owner.spec.js
@@ -67,6 +67,7 @@ context(`Insurance - Policy - Different name on Policy page - Entering name of p
 
       cy.completeAndSubmitDifferentNameOnPolicyForm({ firstName: account[FIRST_NAME], lastName: account[LAST_NAME], email: account[EMAIL] });
 
+      cy.completeAndSubmitPreCreditPeriodForm();
       cy.completeAndSubmitBrokerForm({});
 
       summaryList.field(NAME).changeLink().click();

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/name-on-policy-page.spec.js
@@ -19,7 +19,7 @@ const CONTENT_STRINGS = PAGES.INSURANCE.POLICY.NAME_ON_POLICY;
 const {
   ROOT: INSURANCE_ROOT,
   POLICY: {
-    BROKER_ROOT,
+    PRE_CREDIT_PERIOD,
     DIFFERENT_NAME_ON_POLICY,
     NAME_ON_POLICY,
     SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE,
@@ -121,12 +121,12 @@ context('Insurance - Policy - Name on Policy page - I want to enter the details 
 
   describe('form submission', () => {
     describe(SAME_NAME, () => {
-      it(`should redirect to ${BROKER_ROOT} when ${SAME_NAME} is selected`, () => {
+      it(`should redirect to ${PRE_CREDIT_PERIOD} when ${SAME_NAME} is selected`, () => {
         cy.navigateToUrl(url);
 
         cy.completeAndSubmitNameOnPolicyForm({});
 
-        const expectedUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${BROKER_ROOT}`;
+        const expectedUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${PRE_CREDIT_PERIOD}`;
         cy.assertUrl(expectedUrl);
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
@@ -10,7 +10,7 @@ import account from '../../../../../../../fixtures/account';
 const {
   ROOT: INSURANCE_ROOT,
   POLICY: {
-    BROKER_ROOT,
+    PRE_CREDIT_PERIOD,
     DIFFERENT_NAME_ON_POLICY,
     NAME_ON_POLICY,
   },
@@ -120,7 +120,7 @@ context('Insurance - Policy - Name on policy - Validation', () => {
 
       partials.errorSummaryListItems().should('not.exist');
 
-      const expectedUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${BROKER_ROOT}`;
+      const expectedUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${PRE_CREDIT_PERIOD}`;
       cy.assertUrl(expectedUrl);
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
@@ -22,8 +22,8 @@ const { preCreditPeriodDescription } = partials;
 const CONTENT_STRINGS = PAGES.INSURANCE.POLICY.PRE_CREDIT_PERIOD;
 
 const {
-  ROOT: INSURANCE_ROOT,
-  POLICY: { PRE_CREDIT_PERIOD },
+  ROOT,
+  POLICY: { PRE_CREDIT_PERIOD, BROKER_ROOT },
 } = INSURANCE_ROUTES;
 
 const {
@@ -42,7 +42,7 @@ context(`Insurance - Policy - Pre-credit period page - ${story}`, () => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${PRE_CREDIT_PERIOD}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${PRE_CREDIT_PERIOD}`;
 
       cy.navigateToUrl(url);
       cy.assertUrl(url);
@@ -60,7 +60,7 @@ context(`Insurance - Policy - Pre-credit period page - ${story}`, () => {
   it('renders core page elements', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
-      currentHref: `${INSURANCE_ROOT}/${referenceNumber}${PRE_CREDIT_PERIOD}`,
+      currentHref: `${ROOT}/${referenceNumber}${PRE_CREDIT_PERIOD}`,
       backLink: `${url}#`,
     });
   });
@@ -142,6 +142,18 @@ context(`Insurance - Policy - Pre-credit period page - ${story}`, () => {
           cy.checkText(preCreditPeriodDescription.happensBefore(), HAPPENS_BEFORE);
         });
       });
+    });
+  });
+
+  context('form submission', () => {
+    it(`should redirect to ${BROKER_ROOT}`, () => {
+      cy.navigateToUrl(url);
+
+      cy.completeAndSubmitPreCreditPeriodForm();
+
+      const expected = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
+
+      cy.assertUrl(expected);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/support/application/business/index.js
+++ b/e2e-tests/insurance/cypress/support/application/business/index.js
@@ -4,4 +4,3 @@ Cypress.Commands.add('completeAndSubmitAlternativeTradingAddressForm', require('
 Cypress.Commands.add('completeAndSubmitNatureOfYourBusiness', require('../../../../../commands/insurance/complete-and-submit-nature-of-your-business'));
 Cypress.Commands.add('completeAndSubmitTurnoverForm', require('../../../../../commands/insurance/complete-and-submit-turnover-form'));
 Cypress.Commands.add('completeAndSubmitCreditControlForm', require('../../../../../commands/insurance/complete-and-submit-credit-control-form'));
-Cypress.Commands.add('completeAndSubmitBrokerForm', require('../../../../../commands/insurance/complete-and-submit-broker-form'));

--- a/e2e-tests/insurance/cypress/support/application/policy/index.js
+++ b/e2e-tests/insurance/cypress/support/application/policy/index.js
@@ -15,6 +15,8 @@ Cypress.Commands.add('completeNameOnPolicyForm', require('../../../../../command
 Cypress.Commands.add('completeAndSubmitNameOnPolicyForm', require('../../../../../commands/insurance/complete-and-submit-name-on-policy-form'));
 Cypress.Commands.add('completeAndSubmitDifferentNameOnPolicyForm', require('../../../../../commands/insurance/complete-and-submit-different-name-on-policy-form'));
 Cypress.Commands.add('completeDifferentNameOnPolicyForm', require('../../../../../commands/insurance/complete-different-name-on-policy-form'));
+Cypress.Commands.add('completeAndSubmitPreCreditPeriodForm', require('../../../../../commands/insurance/complete-and-submit-pre-credit-period-form'));
+Cypress.Commands.add('completeAndSubmitBrokerForm', require('../../../../../commands/insurance/complete-and-submit-broker-form'));
 
 Cypress.Commands.add('completeBusinessSection', require('../../../../../commands/insurance/complete-business-section'));
 Cypress.Commands.add('completeBuyerSection', require('../../../../../commands/insurance/complete-buyer-section'));

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/index.test.ts
@@ -17,7 +17,7 @@ import { mockReq, mockRes, mockApplication, mockContact } from '../../../../test
 const {
   INSURANCE_ROOT,
   POLICY: {
-    BROKER_ROOT,
+    PRE_CREDIT_PERIOD,
     CHECK_YOUR_ANSWERS,
     DIFFERENT_NAME_ON_POLICY_CHECK_AND_CHANGE,
     DIFFERENT_NAME_ON_POLICY_CHANGE,
@@ -144,10 +144,10 @@ describe('controllers/insurance/policy/different-name-on-policy', () => {
         req.body = validBody;
       });
 
-      it(`should redirect to ${BROKER_ROOT}`, async () => {
+      it(`should redirect to ${PRE_CREDIT_PERIOD}`, async () => {
         await post(req, res);
 
-        const expected = `${INSURANCE_ROOT}/${req.params.referenceNumber}${BROKER_ROOT}`;
+        const expected = `${INSURANCE_ROOT}/${req.params.referenceNumber}${PRE_CREDIT_PERIOD}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/index.ts
@@ -16,7 +16,7 @@ import { Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
-  POLICY: { BROKER_ROOT, DIFFERENT_NAME_ON_POLICY_SAVE_AND_BACK, CHECK_YOUR_ANSWERS },
+  POLICY: { DIFFERENT_NAME_ON_POLICY_SAVE_AND_BACK, CHECK_YOUR_ANSWERS, PRE_CREDIT_PERIOD },
   CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY: CHECK_AND_CHANGE_ROUTE },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
@@ -143,7 +143,7 @@ export const post = async (req: Request, res: Response) => {
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`);
     }
 
-    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${BROKER_ROOT}`);
+    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${PRE_CREDIT_PERIOD}`);
   } catch (err) {
     console.error('Error updating application - policy - Different name on policy %O', err);
 

--- a/src/ui/server/controllers/insurance/policy/name-on-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/name-on-policy/index.test.ts
@@ -16,7 +16,6 @@ const {
   INSURANCE: {
     INSURANCE_ROOT,
     POLICY: {
-      BROKER_ROOT,
       CHECK_YOUR_ANSWERS,
       NAME_ON_POLICY_SAVE_AND_BACK,
       DIFFERENT_NAME_ON_POLICY,
@@ -24,6 +23,7 @@ const {
       DIFFERENT_NAME_ON_POLICY_CHECK_AND_CHANGE,
       NAME_ON_POLICY_CHANGE,
       NAME_ON_POLICY_CHECK_AND_CHANGE,
+      PRE_CREDIT_PERIOD,
     },
     CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY: CHECK_AND_CHANGE_ROUTE },
     PROBLEM_WITH_SERVICE,
@@ -138,10 +138,10 @@ describe('controllers/insurance/policy/name-on-policy', () => {
           req.body = validBody;
         });
 
-        it(`should redirect to ${BROKER_ROOT}`, async () => {
+        it(`should redirect to ${PRE_CREDIT_PERIOD}`, async () => {
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${req.params.referenceNumber}${BROKER_ROOT}`;
+          const expected = `${INSURANCE_ROOT}/${req.params.referenceNumber}${PRE_CREDIT_PERIOD}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/policy/name-on-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy/name-on-policy/index.ts
@@ -1,4 +1,5 @@
-import { ROUTES, TEMPLATES } from '../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
+import { TEMPLATES } from '../../../../constants';
 import POLICY_FIELD_IDS from '../../../../constants/field-ids/insurance/policy';
 import { PAGES } from '../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance';
@@ -13,13 +14,11 @@ import isCheckAndChangeRoute from '../../../../helpers/is-check-and-change-route
 import { Request, Response } from '../../../../../types';
 
 const {
-  INSURANCE: {
-    INSURANCE_ROOT,
-    POLICY: { BROKER_ROOT, DIFFERENT_NAME_ON_POLICY, DIFFERENT_NAME_ON_POLICY_CHANGE, NAME_ON_POLICY_SAVE_AND_BACK, CHECK_YOUR_ANSWERS },
-    CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY: CHECK_AND_CHANGE_ROUTE },
-    PROBLEM_WITH_SERVICE,
-  },
-} = ROUTES;
+  INSURANCE_ROOT,
+  POLICY: { DIFFERENT_NAME_ON_POLICY, DIFFERENT_NAME_ON_POLICY_CHANGE, NAME_ON_POLICY_SAVE_AND_BACK, CHECK_YOUR_ANSWERS, PRE_CREDIT_PERIOD },
+  CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY: CHECK_AND_CHANGE_ROUTE },
+  PROBLEM_WITH_SERVICE,
+} = INSURANCE_ROUTES;
 
 const {
   NAME_ON_POLICY: { NAME, POSITION, OTHER_NAME, SAME_NAME },
@@ -129,7 +128,7 @@ export const post = async (req: Request, res: Response) => {
   }
 
   try {
-    let redirectRoute = `${INSURANCE_ROOT}/${referenceNumber}${BROKER_ROOT}`;
+    let redirectRoute = `${INSURANCE_ROOT}/${referenceNumber}${PRE_CREDIT_PERIOD}`;
 
     const differentNameOnPolicyRoute = `${INSURANCE_ROOT}/${referenceNumber}${DIFFERENT_NAME_ON_POLICY}`;
 

--- a/src/ui/server/controllers/insurance/policy/pre-credit-period/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/pre-credit-period/index.test.ts
@@ -1,4 +1,4 @@
-import { pageVariables, HTML_FLAGS, TEMPLATE, PAGE_CONTENT_STRINGS, get } from '.';
+import { pageVariables, HTML_FLAGS, TEMPLATE, PAGE_CONTENT_STRINGS, get, post } from '.';
 import { TEMPLATES } from '../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
 import POLICY_FIELD_IDS from '../../../../constants/field-ids/insurance/policy';
@@ -12,7 +12,7 @@ import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
-  POLICY: { PRE_CREDIT_PERIOD_SAVE_AND_BACK },
+  POLICY: { PRE_CREDIT_PERIOD_SAVE_AND_BACK, BROKER_ROOT },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -124,6 +124,28 @@ describe('controllers/insurance/policy/pre-credit-period', () => {
 
       it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
         get(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+      });
+    });
+  });
+
+  describe('post', () => {
+    it(`should redirect to ${BROKER_ROOT}`, () => {
+      post(req, res);
+
+      const expected = `${INSURANCE_ROOT}/${req.params.referenceNumber}${BROKER_ROOT}`;
+
+      expect(res.redirect).toHaveBeenCalledWith(expected);
+    });
+
+    describe('when there is no application', () => {
+      beforeEach(() => {
+        delete res.locals.application;
+      });
+
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
 
         expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
       });

--- a/src/ui/server/controllers/insurance/policy/pre-credit-period/index.ts
+++ b/src/ui/server/controllers/insurance/policy/pre-credit-period/index.ts
@@ -9,7 +9,7 @@ import { Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
-  POLICY: { PRE_CREDIT_PERIOD_SAVE_AND_BACK },
+  POLICY: { PRE_CREDIT_PERIOD_SAVE_AND_BACK, BROKER_ROOT },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -90,4 +90,23 @@ export const get = (req: Request, res: Response) => {
     userName: getUserNameFromSession(req.session.user),
     application,
   });
+};
+
+/**
+ * post
+ * Check Pre-credit period validation errors and if successful, redirect to the next part of the flow.
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.redirect} Next part of the flow or error page
+ */
+export const post = async (req: Request, res: Response) => {
+  const { application } = res.locals;
+
+  if (!application) {
+    return res.redirect(PROBLEM_WITH_SERVICE);
+  }
+
+  const { referenceNumber } = req.params;
+
+  res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${BROKER_ROOT}`);
 };

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -22,7 +22,7 @@ describe('routes/insurance', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(135);
-    expect(post).toHaveBeenCalledTimes(121);
+    expect(post).toHaveBeenCalledTimes(122);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);

--- a/src/ui/server/routes/insurance/policy/index.test.ts
+++ b/src/ui/server/routes/insurance/policy/index.test.ts
@@ -19,7 +19,7 @@ import { post as multipleContractPolicyExportValueSaveAndBackPost } from '../../
 import { get as nameOnPolicyGet, post as nameOnPolicyPost } from '../../../controllers/insurance/policy/name-on-policy';
 import { post as nameOnPolicySaveAndBackPost } from '../../../controllers/insurance/policy/name-on-policy/save-and-back';
 import { get as differentNameOnPolicyGet, post as differentNameOnPolicyPost } from '../../../controllers/insurance/policy/different-name-on-policy';
-import { get as preCreditPeriodGet } from '../../../controllers/insurance/policy/pre-credit-period';
+import { get as preCreditPeriodGet, post as preCreditPeriodPost } from '../../../controllers/insurance/policy/pre-credit-period';
 import { post as differentNameOnPolicySaveAndBackPost } from '../../../controllers/insurance/policy/different-name-on-policy/save-and-back';
 import { get as getBroker, post as postBroker } from '../../../controllers/insurance/policy/broker';
 import { post as postBrokerSaveAndBack } from '../../../controllers/insurance/policy/broker/save-and-back';
@@ -36,7 +36,7 @@ describe('routes/insurance/policy', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(25);
-    expect(post).toHaveBeenCalledTimes(30);
+    expect(post).toHaveBeenCalledTimes(31);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.ROOT}`, policyRootGet);
 
@@ -123,6 +123,7 @@ describe('routes/insurance/policy', () => {
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.DIFFERENT_NAME_ON_POLICY_CHECK_AND_CHANGE}`, differentNameOnPolicyPost);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD}`, preCreditPeriodGet);
+    expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD}`, preCreditPeriodPost);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_ROOT}`, getBroker);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_ROOT}`, postBroker);

--- a/src/ui/server/routes/insurance/policy/index.ts
+++ b/src/ui/server/routes/insurance/policy/index.ts
@@ -19,7 +19,7 @@ import { post as multipleContractPolicySaveAndBackPost } from '../../../controll
 import { get as nameOnPolicyGet, post as nameOnPolicyPost } from '../../../controllers/insurance/policy/name-on-policy';
 import { post as nameOnPolicySaveAndBackPost } from '../../../controllers/insurance/policy/name-on-policy/save-and-back';
 import { get as differentNameOnPolicyGet, post as differentNameOnPolicyPost } from '../../../controllers/insurance/policy/different-name-on-policy';
-import { get as preCreditPeriodGet } from '../../../controllers/insurance/policy/pre-credit-period';
+import { get as preCreditPeriodGet, post as preCreditPeriodPost } from '../../../controllers/insurance/policy/pre-credit-period';
 import { post as differentNameOnPolicySaveAndBackPost } from '../../../controllers/insurance/policy/different-name-on-policy/save-and-back';
 import { get as getBroker, post as postBroker } from '../../../controllers/insurance/policy/broker';
 import { post as postBrokerSaveAndBack } from '../../../controllers/insurance/policy/broker/save-and-back';
@@ -100,6 +100,7 @@ insurancePolicyRouter.get(`/:referenceNumber${INSURANCE_ROUTES.POLICY.DIFFERENT_
 insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.DIFFERENT_NAME_ON_POLICY_CHECK_AND_CHANGE}`, differentNameOnPolicyPost);
 
 insurancePolicyRouter.get(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD}`, preCreditPeriodGet);
+insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD}`, preCreditPeriodPost);
 
 insurancePolicyRouter.get(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_ROOT}`, getBroker);
 insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_ROOT}`, postBroker);


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the Policy form submission redirects to that the "Pre-credit period" form is part of the flow.

Note - there is no form validation yet, this is purely updating the flow.

## Resolution :heavy_check_mark:
- Update the `NAME_ON_POLICY` and `DIFFERENT_NAME_ON_POLICY` forms to redirect to the `PRE_CREDIT_PERIOD` page, instead  of `BROKER`.
- Add a`PRE_CREDIT_PERIOD` POST endpoint redirect to the `BROKER` page.
- Create new cypress command `completeAndSubmitPreCreditPeriodForm`. This will eventually be updated to actually complete the form.
- Update all relevant E2E tests and commands to submit the "Pre-credit period" form before submitting the "broker" form.

## Miscellaneous :heavy_plus_sign:
- Moved the `completeAndSubmitBrokerForm` cypress command into the policy directory.
