### PR TITLE
feat(EMS-2524): No PDF - Single contract policy - Total contract value - save and back

### DIFF
--- a/e2e-tests/constants/routes/insurance/policy.js
+++ b/e2e-tests/constants/routes/insurance/policy.js
@@ -12,6 +12,7 @@ export const POLICY = {
   SINGLE_CONTRACT_POLICY_CHANGE: `${ROOT}/single-contract-policy/change`,
   SINGLE_CONTRACT_POLICY_CHECK_AND_CHANGE: `${ROOT}/single-contract-policy/check-and-change`,
   SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE: `${ROOT}/single-contract-policy/total-contract-value`,
+  SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_SAVE_AND_BACK: `${ROOT}/single-contract-policy/total-contract-value/save-and-go-back`,
   SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_CHANGE: `${ROOT}/single-contract-policy/total-contract-value/change`,
   SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_CHECK_AND_CHANGE: `${ROOT}/single-contract-policy/total-contract-value/check-and-change`,
   MULTIPLE_CONTRACT_POLICY: `${ROOT}/multi-contract-policy`,

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/save-and-back.spec.js
@@ -143,22 +143,4 @@ context('Insurance - Policy - Single contract policy - total contract value page
       });
     });
   });
-
-  describe('when all fields are provided and submitting the form via `save and go back` button', () => {
-    beforeEach(() => {
-      cy.navigateToUrl(url);
-
-      saveAndBackButton().click();
-    });
-
-    describe('when going back to the page', () => {
-      beforeEach(() => {
-        cy.navigateToUrl(url);
-      });
-
-      it('should render the previously submitted value', () => {
-        fieldSelector(TOTAL_CONTRACT_VALUE).input().should('have.value', application.POLICY[TOTAL_CONTRACT_VALUE]);
-      });
-    });
-  });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/save-and-back.spec.js
@@ -1,0 +1,164 @@
+import { field as fieldSelector, submitButton, saveAndBackButton } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import { TASKS } from '../../../../../../../content-strings';
+import { FIELD_VALUES } from '../../../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
+import application from '../../../../../../../fixtures/application';
+
+const { taskList } = partials.insurancePartials;
+
+const {
+  ROOT,
+  ALL_SECTIONS,
+  POLICY: {
+    SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  POLICY: {
+    CONTRACT_POLICY: {
+      SINGLE: { TOTAL_CONTRACT_VALUE },
+    },
+  },
+} = INSURANCE_FIELD_IDS;
+
+const task = taskList.prepareApplication.tasks.policy;
+
+const policyType = FIELD_VALUES.POLICY_TYPE.SINGLE;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Policy - Single contract policy - total contract value page - Save and go back', () => {
+  let referenceNumber;
+  let url;
+  let allSectionsUrl;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.startInsurancePolicySection({});
+      cy.completeAndSubmitPolicyTypeForm(policyType);
+      cy.completeAndSubmitSingleContractPolicyForm();
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`;
+      allSectionsUrl = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when submitting an empty form via `save and go back` button', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      saveAndBackButton().click();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      cy.assertUrl(allSectionsUrl);
+    });
+
+    it('should retain the `type of policy` task status as `in progress`', () => {
+      cy.checkTaskStatus(task, TASKS.STATUS.IN_PROGRESS);
+    });
+  });
+
+  describe('when entering an invalid total contract value and submitting the form via `save and go back` button', () => {
+    const field = fieldSelector(TOTAL_CONTRACT_VALUE);
+    const invalidValue = 'Not a number';
+
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      cy.keyboardInput(field.input(), invalidValue);
+
+      saveAndBackButton().click();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      cy.assertUrl(allSectionsUrl);
+    });
+
+    it('should retain the `type of policy` task status as `in progress`', () => {
+      cy.checkTaskStatus(task, TASKS.STATUS.IN_PROGRESS);
+    });
+
+    describe('when going back to the page', () => {
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+
+        cy.keyboardInput(field.input(), invalidValue);
+
+        saveAndBackButton().click();
+
+        cy.startInsurancePolicySection({});
+
+        submitButton().click();
+        submitButton().click();
+      });
+
+      it('should not have saved the submitted value', () => {
+        field.input().should('have.value', '');
+      });
+    });
+  });
+
+  describe('when entering a valid total contract value and submitting the form via `save and go back` button', () => {
+    const field = fieldSelector(TOTAL_CONTRACT_VALUE);
+
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      cy.keyboardInput(field.input(), application.POLICY[TOTAL_CONTRACT_VALUE]);
+
+      saveAndBackButton().click();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      cy.assertUrl(allSectionsUrl);
+    });
+
+    it('should retain the `type of policy` task status as `in progress`', () => {
+      cy.checkTaskStatus(task, TASKS.STATUS.IN_PROGRESS);
+    });
+
+    describe('when going back to the page', () => {
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+      });
+
+      it('should have the submitted value', () => {
+        fieldSelector(TOTAL_CONTRACT_VALUE).input().should('have.value', application.POLICY[TOTAL_CONTRACT_VALUE]);
+      });
+    });
+  });
+
+  describe('when all fields are provided and submitting the form via `save and go back` button', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      saveAndBackButton().click();
+    });
+
+    describe('when going back to the page', () => {
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+      });
+
+      it('should render the previously submitted value', () => {
+        fieldSelector(TOTAL_CONTRACT_VALUE).input().should('have.value', application.POLICY[TOTAL_CONTRACT_VALUE]);
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value.spec.js
@@ -21,7 +21,7 @@ const { taskList } = partials.insurancePartials;
 const CONTENT_STRINGS = PAGES.INSURANCE.POLICY.SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE;
 
 const {
-  ROOT: INSURANCE_ROOT,
+  ROOT,
   ALL_SECTIONS,
   POLICY: {
     SINGLE_CONTRACT_POLICY,
@@ -56,7 +56,7 @@ context('Insurance - Policy - Single contract policy - total contract value page
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm();
 
-      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`;
 
       cy.assertUrl(url);
     });
@@ -73,8 +73,8 @@ context('Insurance - Policy - Single contract policy - total contract value page
   it('renders core page elements', () => {
     cy.corePageChecks({
       pageTitle: expectedPageTitle,
-      currentHref: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`,
-      backLink: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`,
+      currentHref: `${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`,
+      backLink: `${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`,
     });
   });
 
@@ -114,12 +114,12 @@ context('Insurance - Policy - Single contract policy - total contract value page
     });
 
     it(`should redirect to ${NAME_ON_POLICY}`, () => {
-      const expectedUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${NAME_ON_POLICY}`;
+      const expectedUrl = `${baseUrl}${ROOT}/${referenceNumber}${NAME_ON_POLICY}`;
       cy.assertUrl(expectedUrl);
     });
 
     it('should retain the `type of policy` task status as `in progress` after submitting the form', () => {
-      cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`);
+      cy.navigateToUrl(`${ROOT}/${referenceNumber}${ALL_SECTIONS}`);
 
       const expected = TASKS.STATUS.IN_PROGRESS;
       cy.checkText(task.status(), expected);

--- a/src/ui/server/constants/routes/insurance/policy.ts
+++ b/src/ui/server/constants/routes/insurance/policy.ts
@@ -12,6 +12,7 @@ export const POLICY = {
   SINGLE_CONTRACT_POLICY_CHANGE: `${ROOT}/single-contract-policy/change`,
   SINGLE_CONTRACT_POLICY_CHECK_AND_CHANGE: `${ROOT}/single-contract-policy/check-and-change`,
   SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE: `${ROOT}/single-contract-policy/total-contract-value`,
+  SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_SAVE_AND_BACK: `${ROOT}/single-contract-policy/total-contract-value/save-and-go-back`,
   SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_CHANGE: `${ROOT}/single-contract-policy/total-contract-value/change`,
   SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_CHECK_AND_CHANGE: `${ROOT}/single-contract-policy/total-contract-value/check-and-change`,
   MULTIPLE_CONTRACT_POLICY: `${ROOT}/multi-contract-policy`,

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
@@ -18,7 +18,13 @@ import { mockApplicationMultiplePolicy as mockApplication } from '../../../../..
 
 const {
   INSURANCE_ROOT,
-  POLICY: { NAME_ON_POLICY, CHECK_YOUR_ANSWERS, SINGLE_CONTRACT_POLICY_CHANGE, SINGLE_CONTRACT_POLICY_CHECK_AND_CHANGE },
+  POLICY: {
+    NAME_ON_POLICY,
+    CHECK_YOUR_ANSWERS,
+    SINGLE_CONTRACT_POLICY_CHANGE,
+    SINGLE_CONTRACT_POLICY_CHECK_AND_CHANGE,
+    SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_SAVE_AND_BACK,
+  },
   CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY: CHECK_AND_CHANGE_ROUTE },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
@@ -32,6 +38,7 @@ const {
 const { PAGE_TITLE } = PAGE_CONTENT_STRINGS;
 
 const {
+  referenceNumber,
   policy: { policyCurrencyCode },
 } = mockApplication;
 
@@ -67,7 +74,7 @@ describe('controllers/insurance/policy/single-contract-policy//total-contract-va
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockCurrencies, String(policyCurrencyCode));
+      const result = pageVariables(referenceNumber, mockCurrencies, String(policyCurrencyCode));
 
       const expected = {
         FIELD: {
@@ -75,6 +82,7 @@ describe('controllers/insurance/policy/single-contract-policy//total-contract-va
           ...FIELDS.CONTRACT_POLICY.SINGLE[FIELD_ID],
         },
         DYNAMIC_PAGE_TITLE: `${PAGE_TITLE} ${getCurrencyByCode(mockCurrencies, String(policyCurrencyCode)).name}?`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -103,7 +111,7 @@ describe('controllers/insurance/policy/single-contract-policy//total-contract-va
     it('should render template', async () => {
       await get(req, res);
 
-      const generatedPageVariables = pageVariables(mockCurrencies, String(policyCurrencyCode));
+      const generatedPageVariables = pageVariables(referenceNumber, mockCurrencies, String(policyCurrencyCode));
 
       const { DYNAMIC_PAGE_TITLE } = generatedPageVariables;
 
@@ -234,7 +242,7 @@ describe('controllers/insurance/policy/single-contract-policy//total-contract-va
 
         const payload = constructPayload(req.body, [FIELD_ID]);
 
-        const generatedPageVariables = pageVariables(mockCurrencies, String(policyCurrencyCode));
+        const generatedPageVariables = pageVariables(referenceNumber, mockCurrencies, String(policyCurrencyCode));
 
         const { DYNAMIC_PAGE_TITLE } = generatedPageVariables;
 

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.ts
@@ -18,7 +18,7 @@ import { Currency, Request, Response } from '../../../../../../types';
 
 const {
   INSURANCE_ROOT,
-  POLICY: { NAME_ON_POLICY, CHECK_YOUR_ANSWERS },
+  POLICY: { NAME_ON_POLICY, CHECK_YOUR_ANSWERS, SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_SAVE_AND_BACK },
   CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY: CHECK_AND_CHANGE_ROUTE },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
@@ -38,16 +38,18 @@ const { PAGE_TITLE } = PAGE_CONTENT_STRINGS;
 /**
  * pageVariables
  * Page fields and "save and go back" URL
+ * @param {Number} Application reference number
  * @param {Array} currencies: Currencies
  * @param {String} policyCurrencyCode: Policy currency code
  * @returns {Object} Page variables
  */
-export const pageVariables = (currencies: Array<Currency>, policyCurrencyCode: string) => ({
+export const pageVariables = (referenceNumber: number, currencies: Array<Currency>, policyCurrencyCode: string) => ({
   FIELD: {
     ID: FIELD_ID,
     ...FIELDS.CONTRACT_POLICY.SINGLE[FIELD_ID],
   },
   DYNAMIC_PAGE_TITLE: `${PAGE_TITLE} ${getCurrencyByCode(currencies, policyCurrencyCode).name}?`,
+  SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_SAVE_AND_BACK}`,
 });
 
 export const TEMPLATE = TEMPLATES.INSURANCE.POLICY.SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE;
@@ -67,6 +69,7 @@ export const get = async (req: Request, res: Response) => {
   }
 
   const {
+    referenceNumber,
     policy: { policyCurrencyCode },
   } = application;
 
@@ -77,7 +80,7 @@ export const get = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    const generatedPageVariables = pageVariables(currencies, String(policyCurrencyCode));
+    const generatedPageVariables = pageVariables(referenceNumber, currencies, String(policyCurrencyCode));
 
     const { DYNAMIC_PAGE_TITLE } = generatedPageVariables;
 
@@ -115,10 +118,9 @@ export const post = async (req: Request, res: Response) => {
   }
 
   const {
+    referenceNumber,
     policy: { policyCurrencyCode },
   } = application;
-
-  const { referenceNumber } = req.params;
 
   const payload = constructPayload(req.body, [TOTAL_CONTRACT_VALUE]);
 
@@ -132,7 +134,7 @@ export const post = async (req: Request, res: Response) => {
         return res.redirect(PROBLEM_WITH_SERVICE);
       }
 
-      const generatedPageVariables = pageVariables(currencies, String(policyCurrencyCode));
+      const generatedPageVariables = pageVariables(referenceNumber, currencies, String(policyCurrencyCode));
 
       const { DYNAMIC_PAGE_TITLE } = generatedPageVariables;
 

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/save-and-back/index.test.ts
@@ -1,0 +1,109 @@
+import { post } from '.';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { FIELD_ID } from '..';
+import constructPayload from '../../../../../../helpers/construct-payload';
+import mapAndSave from '../../../map-and-save/policy';
+import generateValidationErrors from '../validation';
+import { Request, Response } from '../../../../../../../types';
+import { mockApplication, mockReq, mockRes } from '../../../../../../test-mocks';
+
+const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
+
+describe('controllers/insurance/policy/single-contract-policy/total-contract-value/save-and-back', () => {
+  let req: Request;
+  let res: Response;
+
+  jest.mock('../../../map-and-save/policy');
+
+  let mockMapAndSave = jest.fn(() => Promise.resolve(true));
+  mapAndSave.policy = mockMapAndSave;
+
+  const refNumber = Number(mockApplication.referenceNumber);
+
+  const mockFormBody = {
+    _csrf: '1234',
+    mock: true,
+  };
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+
+    req.params.referenceNumber = String(mockApplication.referenceNumber);
+
+    req.body = mockFormBody;
+  });
+
+  describe('when the form has data', () => {
+    it('should call mapAndSave.policy with data from constructPayload function, application and validationErrors', async () => {
+      await post(req, res);
+
+      const payload = constructPayload(req.body, [FIELD_ID]);
+
+      const validationErrors = generateValidationErrors(payload);
+
+      expect(mapAndSave.policy).toHaveBeenCalledTimes(1);
+      expect(mapAndSave.policy).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
+      await post(req, res);
+
+      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+
+      expect(res.redirect).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('when the form does not have any data', () => {
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
+      req.body = { _csrf: '1234' };
+
+      await post(req, res);
+
+      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+
+      expect(res.redirect).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('when there is no application', () => {
+    beforeEach(() => {
+      delete res.locals.application;
+    });
+
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+      await post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+    });
+  });
+
+  describe('api error handling', () => {
+    describe('when the mapAndSave call does not return anything', () => {
+      beforeEach(() => {
+        mockMapAndSave = jest.fn(() => Promise.resolve(false));
+        mapAndSave.policy = mockMapAndSave;
+      });
+
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+      });
+    });
+
+    describe('when the mapAndSave call fails', () => {
+      beforeEach(() => {
+        mockMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        mapAndSave.policy = mockMapAndSave;
+      });
+
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/save-and-back/index.ts
@@ -1,0 +1,44 @@
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import hasFormData from '../../../../../../helpers/has-form-data';
+import { FIELD_ID } from '..';
+import constructPayload from '../../../../../../helpers/construct-payload';
+import generateValidationErrors from '../validation';
+import callMapAndSave from '../../../call-map-and-save';
+import { Request, Response } from '../../../../../../../types';
+
+const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
+
+/**
+ * post
+ * Save any valid Total contract value fields and if successful, redirect to the all sections page
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.redirect} All sections page or error page
+ */
+export const post = async (req: Request, res: Response) => {
+  try {
+    const { application } = res.locals;
+
+    if (!application) {
+      return res.redirect(PROBLEM_WITH_SERVICE);
+    }
+
+    const { referenceNumber } = req.params;
+
+    if (hasFormData(req.body)) {
+      const payload = constructPayload(req.body, [FIELD_ID]);
+
+      const saveResponse = await callMapAndSave(payload, application, generateValidationErrors(payload));
+
+      if (!saveResponse) {
+        return res.redirect(PROBLEM_WITH_SERVICE);
+      }
+    }
+
+    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`);
+  } catch (err) {
+    console.error('Error updating application - policy - single contract policy - total contract value (save and back) %O', err);
+
+    return res.redirect(PROBLEM_WITH_SERVICE);
+  }
+};

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -22,7 +22,7 @@ describe('routes/insurance', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(135);
-    expect(post).toHaveBeenCalledTimes(121);
+    expect(post).toHaveBeenCalledTimes(122);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);

--- a/src/ui/server/routes/insurance/policy/index.test.ts
+++ b/src/ui/server/routes/insurance/policy/index.test.ts
@@ -9,6 +9,7 @@ import {
   get as singleContractPolicyContractValueGet,
   post as singleContractPolicyContractValuePost,
 } from '../../../controllers/insurance/policy/single-contract-policy/total-contract-value';
+import { post as contractValueSaveAndBackPost } from '../../../controllers/insurance/policy/single-contract-policy/total-contract-value/save-and-back';
 import { get as multipleContractPolicyGet, post as multipleContractPolicyPost } from '../../../controllers/insurance/policy/multiple-contract-policy';
 import { post as multipleContractPolicySaveAndBackPost } from '../../../controllers/insurance/policy/multiple-contract-policy/save-and-back';
 import {
@@ -36,7 +37,7 @@ describe('routes/insurance/policy', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(25);
-    expect(post).toHaveBeenCalledTimes(30);
+    expect(post).toHaveBeenCalledTimes(31);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.ROOT}`, policyRootGet);
 
@@ -62,6 +63,11 @@ describe('routes/insurance/policy', () => {
     expect(post).toHaveBeenCalledWith(
       `/:referenceNumber${INSURANCE_ROUTES.POLICY.SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`,
       singleContractPolicyContractValuePost,
+    );
+
+    expect(post).toHaveBeenCalledWith(
+      `/:referenceNumber${INSURANCE_ROUTES.POLICY.SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_SAVE_AND_BACK}`,
+      contractValueSaveAndBackPost,
     );
 
     expect(get).toHaveBeenCalledWith(

--- a/src/ui/server/routes/insurance/policy/index.ts
+++ b/src/ui/server/routes/insurance/policy/index.ts
@@ -9,6 +9,7 @@ import {
   get as singleContractPolicyContractValueGet,
   post as singleContractPolicyContractValuePost,
 } from '../../../controllers/insurance/policy/single-contract-policy/total-contract-value';
+import { post as contractValueSaveAndBackPost } from '../../../controllers/insurance/policy/single-contract-policy/total-contract-value/save-and-back';
 import { get as multipleContractPolicyGet, post as multipleContractPolicyPost } from '../../../controllers/insurance/policy/multiple-contract-policy';
 import {
   get as multipleContractPolicyExportValueGet,
@@ -48,6 +49,12 @@ insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.SINGLE_CO
 
 insurancePolicyRouter.get(`/:referenceNumber${INSURANCE_ROUTES.POLICY.SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`, singleContractPolicyContractValueGet);
 insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`, singleContractPolicyContractValuePost);
+
+insurancePolicyRouter.post(
+  `/:referenceNumber${INSURANCE_ROUTES.POLICY.SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_SAVE_AND_BACK}`,
+  contractValueSaveAndBackPost,
+);
+
 insurancePolicyRouter.get(
   `/:referenceNumber${INSURANCE_ROUTES.POLICY.SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_CHANGE}`,
   singleContractPolicyContractValueGet,


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds "save and back" functionality to the "Total contract value" form in the Single contract policy section of a no PDF application

## Resolution :heavy_check_mark:
- Add new "save and back" route and POST endpoint.
- Add `SAVE_AND_BACK_URL` page variable to the "Total contract value" GET controller.
- Add E2E test coverage.

## Miscellaneous :heavy_plus_sign:
- Minor destructuring improvements.
