### PR TITLE
fix(EMS-2543-2571-2607-2608-2611): No PDF - copy fixes, country pre-population issue

### DIFF
--- a/e2e-tests/commands/insurance/complete-and-submit-about-goods-or-services-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-about-goods-or-services-form.js
@@ -20,14 +20,16 @@ const {
 /**
  * completeAndSubmitAboutGoodsOrServicesForm
  * Complete and submit the "About goods or services" form
+ * @param {Boolean} description: description value
  * @param {Boolean} finalDestinationKnown: flag for if the final destination is known
  * @param {Boolean} includeFinalDestination: flag for if the final destination should be included.
  */
 const completeAndSubmitAboutGoodsOrServicesForm = ({
+  description = application.EXPORT_CONTRACT[DESCRIPTION],
   finalDestinationKnown = true,
   includeFinalDestination = true,
 }) => {
-  cy.keyboardInput(aboutGoodsOrServicesPage[DESCRIPTION].textarea(), application.EXPORT_CONTRACT[DESCRIPTION]);
+  cy.keyboardInput(aboutGoodsOrServicesPage[DESCRIPTION].textarea(), description);
 
   if (finalDestinationKnown) {
     yesRadio().input().click();

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -202,7 +202,7 @@ export const ERROR_MESSAGES = {
       EXPORT_VALUE: {
         MULTIPLE: {
           [FIELD_IDS.INSURANCE.POLICY.EXPORT_VALUE.MULTIPLE.TOTAL_SALES_TO_BUYER]: {
-            INCORRECT_FORMAT: 'Enter your estimated sales as a whole number - do not enter decimals',
+            INCORRECT_FORMAT: 'Enter your estimated total sales to your buyer during this time as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your estimated sales must be 1 or more',
           },
           [FIELD_IDS.INSURANCE.POLICY.EXPORT_VALUE.MULTIPLE.MAXIMUM_BUYER_WILL_OWE]: {

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -19,7 +19,7 @@ export const ERROR_MESSAGES = {
     [FIELD_IDS.ELIGIBILITY.VALID_BUYER_BODY]: 'Select if your buyer is a government or public sector body',
     [FIELD_IDS.ELIGIBILITY.VALID_EXPORTER_LOCATION]: "Select whether you're exporting from a business base in the UK, Channel Islands, Isle of Man or not",
     [FIELD_IDS.ELIGIBILITY.HAS_MINIMUM_UK_GOODS_OR_SERVICES]: {
-      IS_EMPTY: 'Select if 20% of your export contract value is made up from UK goods/services or not',
+      IS_EMPTY: 'Select whether at least 20% of your export contract value is made up from UK goods or services or not',
     },
     [FIELD_IDS.ELIGIBILITY.CURRENCY]: {
       IS_EMPTY: 'Select currency',
@@ -135,7 +135,7 @@ export const ERROR_MESSAGES = {
       ABOUT_GOODS_OR_SERVICES: {
         [FIELD_IDS.INSURANCE.EXPORT_CONTRACT.ABOUT_GOODS_OR_SERVICES.DESCRIPTION]: {
           IS_EMPTY: 'Enter the goods or services you will supply to the buyer',
-          ABOVE_MAXIMUM: 'The goods or services you will supply to the buyer cannot be more than 1000 characters',
+          ABOVE_MAXIMUM: 'The description of the goods or services you want to insure cannot be more than 1000 characters',
         },
         [FIELD_IDS.INSURANCE.EXPORT_CONTRACT.ABOUT_GOODS_OR_SERVICES.FINAL_DESTINATION_KNOWN]: {
           IS_EMPTY: 'Select if you know the final destination of the goods or services',
@@ -195,7 +195,7 @@ export const ERROR_MESSAGES = {
             INCORRECT_FORMAT: 'You must enter how many months you want to be insured for as a whole number. Do not use symbols or letters',
             IS_EMPTY: 'Enter how many months you want to be insured for',
             BELOW_MINIMUM: 'Your length of insurance must be 1 month or more',
-            ABOVE_MAXIMUM: `The maximum duration of coverage cannot be more than ${TOTAL_MONTHS_OF_COVER} months.`,
+            ABOVE_MAXIMUM: `The maximum length of your insurance cannot be more than ${TOTAL_MONTHS_OF_COVER} months.`,
           },
         },
       },

--- a/e2e-tests/content-strings/uk-goods-and-services-calculate-description.js
+++ b/e2e-tests/content-strings/uk-goods-and-services-calculate-description.js
@@ -2,7 +2,7 @@ export const UK_GOODS_AND_SERVICES_CALCULATE_DESCRIPTION = {
   INTRO: 'How do I calculate my percentage?',
   LIST: [
     {
-      TEXT: 'Find out your export contract’s total value.',
+      TEXT: "Find out your export contract's total value",
     },
     {
       TEXT: 'Deduct the cost of any:',
@@ -16,10 +16,10 @@ export const UK_GOODS_AND_SERVICES_CALCULATE_DESCRIPTION = {
       ],
     },
     {
-      TEXT: "You're left with your amount of UK goods and services (this may include your profit margin).",
+      TEXT: "You're left with your amount of UK goods and services (this may include your profit margin)",
     },
     {
-      TEXT: 'Convert this to a percentage of the total export contract value.',
+      TEXT: 'Convert this to a percentage of the total export contract value',
     },
   ],
 };

--- a/e2e-tests/content-strings/uk-goods-and-services-description.js
+++ b/e2e-tests/content-strings/uk-goods-and-services-description.js
@@ -24,7 +24,7 @@ export const UK_GOODS_AND_SERVICES_DESCRIPTION = {
   },
   DOES_NOT_COUNT: {
     HEADING: 'What does not count as UK goods and services',
-    TEXT: "Goods or services from outside the UK that are sent directly to the buyer without processing or modifying them. Instead, these are classed as foreign goods and services.",
+    TEXT: 'Goods or services from outside the UK that are sent directly to the buyer without processing or modifying them. Instead, these are classed as foreign goods and services.',
   },
   STAFFING_COSTS: {
     HEADING: 'Staffing costs for this export contract',

--- a/e2e-tests/content-strings/uk-goods-and-services-description.js
+++ b/e2e-tests/content-strings/uk-goods-and-services-description.js
@@ -24,7 +24,7 @@ export const UK_GOODS_AND_SERVICES_DESCRIPTION = {
   },
   DOES_NOT_COUNT: {
     HEADING: 'What does not count as UK goods and services',
-    TEXT: "Goods or services from outside the UK that you'll send directly to the buyer unprocessed or unaltered in the UK do not count. Instead, they're classed as foreign goods and services.",
+    TEXT: "Goods or services from outside the UK that are sent directly to the buyer without processing or modifying them. Instead, these are classed as foreign goods and services.",
   },
   STAFFING_COSTS: {
     HEADING: 'Staffing costs for this export contract',
@@ -37,13 +37,13 @@ export const UK_GOODS_AND_SERVICES_DESCRIPTION = {
         TEXT: 'contractors supplied to work for you by a UK sub-contractor',
       },
       {
-        TEXT: "staff seconded from abroad to work for you in the UK, on the export contract, and for whom you're financially responsible",
+        TEXT: "staff seconded from abroad to work for you in the UK on the export contract that you're financially responsible for",
       },
     ],
   },
   NON_PHYSICAL_ASSETS: {
     HEADING: 'Non-physical assets',
-    TEXT: "Some assets cannot have a certificate of origin as they're not physical goods, for example, a licence to manufacture goods in another country. But they still count as UK goods or services if they originate from the UK.",
+    TEXT: "Some assets cannot have a certificate of origin as they're not physical goods. For example, a licence to manufacture goods in another country. But they still count as UK goods or services if they originate from the UK.",
   },
   NOT_SURE: {
     HEADING: "If you're not sure",

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -18,7 +18,7 @@ export const ERROR_MESSAGES = {
     [FIELD_IDS.ELIGIBILITY.VALID_BUYER_BODY]: 'Select if your buyer is a government or public sector body',
     [FIELD_IDS.ELIGIBILITY.VALID_EXPORTER_LOCATION]: "Select whether you're exporting from a business base in the UK, Channel Islands, Isle of Man or not",
     [FIELD_IDS.ELIGIBILITY.HAS_MINIMUM_UK_GOODS_OR_SERVICES]: {
-      IS_EMPTY: 'Select if 20% of your export contract value is made up from UK goods/services or not',
+      IS_EMPTY: 'Select whether at least 20% of your export contract value is made up from UK goods or services or not',
     },
     [FIELD_IDS.ELIGIBILITY.CURRENCY]: {
       IS_EMPTY: 'Select currency',
@@ -134,7 +134,7 @@ export const ERROR_MESSAGES = {
       ABOUT_GOODS_OR_SERVICES: {
         [FIELD_IDS.INSURANCE.EXPORT_CONTRACT.ABOUT_GOODS_OR_SERVICES.DESCRIPTION]: {
           IS_EMPTY: 'Enter the goods or services you will supply to the buyer',
-          ABOVE_MAXIMUM: 'The goods or services you will supply to the buyer cannot be more than 1000 characters',
+          ABOVE_MAXIMUM: 'The description of the goods or services you want to insure cannot be more than 1000 characters',
         },
         [FIELD_IDS.INSURANCE.EXPORT_CONTRACT.ABOUT_GOODS_OR_SERVICES.FINAL_DESTINATION_KNOWN]: {
           IS_EMPTY: 'Select if you know the final destination of the goods or services',
@@ -194,7 +194,7 @@ export const ERROR_MESSAGES = {
             INCORRECT_FORMAT: 'You must enter how many months you want to be insured for as a whole number. Do not use symbols or letters',
             IS_EMPTY: 'Enter how many months you want to be insured for',
             BELOW_MINIMUM: 'Your length of insurance must be 1 month or more',
-            ABOVE_MAXIMUM: `The maximum duration of coverage cannot be more than ${TOTAL_MONTHS_OF_COVER} months.`,
+            ABOVE_MAXIMUM: `The maximum length of your insurance cannot be more than ${TOTAL_MONTHS_OF_COVER} months.`,
           },
         },
       },

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -201,7 +201,7 @@ export const ERROR_MESSAGES = {
       EXPORT_VALUE: {
         MULTIPLE: {
           [FIELD_IDS.INSURANCE.POLICY.EXPORT_VALUE.MULTIPLE.TOTAL_SALES_TO_BUYER]: {
-            INCORRECT_FORMAT: 'Enter your estimated sales as a whole number - do not enter decimals',
+            INCORRECT_FORMAT: 'Enter your estimated total sales to your buyer during this time as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your estimated sales must be 1 or more',
           },
           [FIELD_IDS.INSURANCE.POLICY.EXPORT_VALUE.MULTIPLE.MAXIMUM_BUYER_WILL_OWE]: {

--- a/src/ui/server/content-strings/uk-goods-and-services-calculate-description.ts
+++ b/src/ui/server/content-strings/uk-goods-and-services-calculate-description.ts
@@ -2,7 +2,7 @@ export const UK_GOODS_AND_SERVICES_CALCULATE_DESCRIPTION = {
   INTRO: 'How do I calculate my percentage?',
   LIST: [
     {
-      TEXT: 'Find out your export contract’s total value.',
+      TEXT: "Find out your export contract's total value",
     },
     {
       TEXT: 'Deduct the cost of any:',
@@ -16,10 +16,10 @@ export const UK_GOODS_AND_SERVICES_CALCULATE_DESCRIPTION = {
       ],
     },
     {
-      TEXT: "You're left with your amount of UK goods and services (this may include your profit margin).",
+      TEXT: "You're left with your amount of UK goods and services (this may include your profit margin)",
     },
     {
-      TEXT: 'Convert this to a percentage of the total export contract value.',
+      TEXT: 'Convert this to a percentage of the total export contract value',
     },
   ],
 };

--- a/src/ui/server/content-strings/uk-goods-and-services-description.ts
+++ b/src/ui/server/content-strings/uk-goods-and-services-description.ts
@@ -24,7 +24,7 @@ export const UK_GOODS_AND_SERVICES_DESCRIPTION = {
   },
   DOES_NOT_COUNT: {
     HEADING: 'What does not count as UK goods and services',
-    TEXT: "Goods or services from outside the UK that are sent directly to the buyer without processing or modifying them. Instead, these are classed as foreign goods and services.",
+    TEXT: 'Goods or services from outside the UK that are sent directly to the buyer without processing or modifying them. Instead, these are classed as foreign goods and services.',
   },
   STAFFING_COSTS: {
     HEADING: 'Staffing costs for this export contract',

--- a/src/ui/server/content-strings/uk-goods-and-services-description.ts
+++ b/src/ui/server/content-strings/uk-goods-and-services-description.ts
@@ -24,7 +24,7 @@ export const UK_GOODS_AND_SERVICES_DESCRIPTION = {
   },
   DOES_NOT_COUNT: {
     HEADING: 'What does not count as UK goods and services',
-    TEXT: "Goods or services from outside the UK that you'll send directly to the buyer unprocessed or unaltered in the UK do not count. Instead, they're classed as foreign goods and services.",
+    TEXT: "Goods or services from outside the UK that are sent directly to the buyer without processing or modifying them. Instead, these are classed as foreign goods and services.",
   },
   STAFFING_COSTS: {
     HEADING: 'Staffing costs for this export contract',
@@ -37,13 +37,13 @@ export const UK_GOODS_AND_SERVICES_DESCRIPTION = {
         TEXT: 'contractors supplied to work for you by a UK sub-contractor',
       },
       {
-        TEXT: "staff seconded from abroad to work for you in the UK, on the export contract, and for whom you're financially responsible",
+        TEXT: "staff seconded from abroad to work for you in the UK on the export contract that you're financially responsible for",
       },
     ],
   },
   NON_PHYSICAL_ASSETS: {
     HEADING: 'Non-physical assets',
-    TEXT: "Some assets cannot have a certificate of origin as they're not physical goods, for example, a licence to manufacture goods in another country. But they still count as UK goods or services if they originate from the UK.",
+    TEXT: "Some assets cannot have a certificate of origin as they're not physical goods. For example, a licence to manufacture goods in another country. But they still count as UK goods or services if they originate from the UK.",
   },
   NOT_SURE: {
     HEADING: "If you're not sure",

--- a/src/ui/server/controllers/insurance/export-contract/about-goods-or-services/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/about-goods-or-services/index.test.ts
@@ -305,6 +305,8 @@ describe('controllers/insurance/export-contract/about-goods-or-services', () => 
 
           const payload = constructPayload(req.body, FIELD_IDS);
 
+          const submittedCountryName = payload[FINAL_DESTINATION];
+
           const expectedVariables = {
             ...insuranceCorePageVariables({
               PAGE_CONTENT_STRINGS,
@@ -314,7 +316,7 @@ describe('controllers/insurance/export-contract/about-goods-or-services', () => 
             userName: getUserNameFromSession(req.session.user),
             application: mockApplicationWithoutCountryCode,
             submittedValues: payload,
-            countries: mapCountries(mockCountries, countryIsoCode),
+            countries: mapCountries(mockCountries, submittedCountryName.isoCode),
             validationErrors: generateValidationErrors(payload),
           };
 

--- a/src/ui/server/controllers/insurance/export-contract/about-goods-or-services/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/about-goods-or-services/index.ts
@@ -10,6 +10,7 @@ import getUserNameFromSession from '../../../../helpers/get-user-name-from-sessi
 import constructPayload from '../../../../helpers/construct-payload';
 import { objectHasProperty } from '../../../../helpers/object';
 import generateValidationErrors from './validation';
+import getCountryByName from '../../../../helpers/get-country-by-name';
 import mapCountries from '../../../../helpers/mappings/map-countries';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import mapAndSave from '../map-and-save';
@@ -139,7 +140,11 @@ export const post = async (req: Request, res: Response) => {
       let mappedCountries;
 
       if (objectHasProperty(payload, FINAL_DESTINATION)) {
-        mappedCountries = mapCountries(countries, payload[FINAL_DESTINATION]);
+        const submittedCountryName = payload[FINAL_DESTINATION];
+
+        const country = getCountryByName(countries, submittedCountryName);
+
+        mappedCountries = mapCountries(countries, country?.isoCode);
       } else {
         mappedCountries = mapCountries(countries);
       }


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes some issues where:
- "About goods or services" had some copy that did not match the No PDF design.
- Some error messages did not match the No PDF design.
- In the "About goods or services" form, if the "description" field is submitted with a value over the maximum amount and a "final destination" country is provided, the submitted country would not be pre-populated with the submitted country.a

## Resolution :heavy_check_mark:
- Update various content strings.
- Update `completeAndSubmitAboutGoodsOrServicesForm` cypress command to accept a custom "description" value.
- Update "about goods or services" validation E2E test to include:
  - A test for maximum "description" characters.
  - A test that all fields have pre-populated values when the "description" field is submitted with a value over the maximum amount.
- Update the "About goods or services" POST controller to correctly map a submitted country.
