### PR TITLE
fix(EMS-2556-2570): No PDF - Multiple contract policy - Total months of cover - decimal places

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-total-months-of-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-total-months-of-cover.spec.js
@@ -89,6 +89,18 @@ context('Insurance - Policy - Multiple contract policy page - form validation - 
     });
   });
 
+  describe('when total months of cover contains a decimal', () => {
+    it('should render a validation error', () => {
+      cy.submitAndAssertFieldErrors(
+        field,
+        '7.5',
+        errorIndex,
+        expectedErrors,
+        CONTRACT_ERROR_MESSAGES[TOTAL_MONTHS_OF_COVER].INCORRECT_FORMAT,
+      );
+    });
+  });
+
   describe('when total months of cover is below the minimum', () => {
     it('should render a validation error', () => {
       cy.submitAndAssertFieldErrors(

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@commitlint/cli": "^18.4.4",
         "@commitlint/config-conventional": "^18.4.4",
         "@types/jest": "^29.5.11",
-        "@types/node": "^20.10.8",
+        "@types/node": "^20.11.0",
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "@typescript-eslint/parser": "^6.18.1",
         "commitlint": "^18.4.4",
@@ -6315,9 +6315,9 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "20.10.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.8.tgz",
-      "integrity": "sha512-f8nQs3cLxbAFc00vEU59yf9UyGUftkPaLGfvbVOIDdx2i1b8epBqj2aNGyP19fiyXWvlmZ7qC1XLjAzw/OKIeA==",
+      "version": "20.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
+      "integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@commitlint/cli": "^18.4.4",
     "@commitlint/config-conventional": "^18.4.4",
     "@types/jest": "^29.5.11",
-    "@types/node": "^20.10.8",
+    "@types/node": "^20.11.0",
     "@typescript-eslint/eslint-plugin": "^6.18.1",
     "@typescript-eslint/parser": "^6.18.1",
     "commitlint": "^18.4.4",

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@types/google-libphonenumber": "^7.4.30",
         "@types/is-url": "^1.2.32",
         "@types/morgan": "^1.9.9",
-        "@types/node": "^20.10.8",
+        "@types/node": "^20.11.0",
         "@types/nunjucks": "^3.2.6",
         "accessible-autocomplete": "^2.0.4",
         "apollo-cache-inmemory": "^1.6.6",
@@ -3040,9 +3040,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.10.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.8.tgz",
-      "integrity": "sha512-f8nQs3cLxbAFc00vEU59yf9UyGUftkPaLGfvbVOIDdx2i1b8epBqj2aNGyP19fiyXWvlmZ7qC1XLjAzw/OKIeA==",
+      "version": "20.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
+      "integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -34,7 +34,7 @@
     "@types/google-libphonenumber": "^7.4.30",
     "@types/is-url": "^1.2.32",
     "@types/morgan": "^1.9.9",
-    "@types/node": "^20.10.8",
+    "@types/node": "^20.11.0",
     "@types/nunjucks": "^3.2.6",
     "accessible-autocomplete": "^2.0.4",
     "apollo-cache-inmemory": "^1.6.6",

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/validation/rules/total-months-of-cover.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/validation/rules/total-months-of-cover.test.ts
@@ -1,18 +1,16 @@
 import totalMonthsOfCover, { MAXIMUM } from './total-months-of-cover';
-import { FIELD_IDS } from '../../../../../../constants';
+import INSURANCE_FIELD_IDS from '../../../../../../constants/field-ids/insurance';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import emptyFieldValidation from '../../../../../../shared-validation/empty-field';
 import generateValidationErrors from '../../../../../../helpers/validation';
 
 const {
-  INSURANCE: {
-    POLICY: {
-      CONTRACT_POLICY: {
-        MULTIPLE: { TOTAL_MONTHS_OF_COVER: FIELD_ID },
-      },
+  POLICY: {
+    CONTRACT_POLICY: {
+      MULTIPLE: { TOTAL_MONTHS_OF_COVER: FIELD_ID },
     },
   },
-} = FIELD_IDS;
+} = INSURANCE_FIELD_IDS;
 
 const {
   INSURANCE: {
@@ -56,6 +54,18 @@ describe('controllers/insurance/policy/multiple-contract-policy/validation/rules
     });
   });
 
+  describe('when a value contains a decimal', () => {
+    it('should return a validation error', () => {
+      mockBody[FIELD_ID] = '7.5';
+
+      const result = totalMonthsOfCover(mockBody, mockErrors);
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
   describe('when a value is below the minimum', () => {
     it('should return a validation error', () => {
       mockBody[FIELD_ID] = '0';
@@ -68,7 +78,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/validation/rules
     });
   });
 
-  describe('when a value is above the minimum', () => {
+  describe('when a value is above the maximum', () => {
     it('should return a validation error', () => {
       mockBody[FIELD_ID] = String(MAXIMUM + 1);
 

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/validation/rules/total-months-of-cover.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/validation/rules/total-months-of-cover.ts
@@ -1,20 +1,19 @@
-import { APPLICATION, FIELD_IDS } from '../../../../../../constants';
+import { APPLICATION } from '../../../../../../constants';
+import INSURANCE_FIELD_IDS from '../../../../../../constants/field-ids/insurance';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import { objectHasProperty } from '../../../../../../helpers/object';
 import emptyFieldValidation from '../../../../../../shared-validation/empty-field';
-import { isNumber } from '../../../../../../helpers/number';
+import { isNumber, numberHasDecimal } from '../../../../../../helpers/number';
 import generateValidationErrors from '../../../../../../helpers/validation';
 import { RequestBody } from '../../../../../../../types';
 
 const {
-  INSURANCE: {
-    POLICY: {
-      CONTRACT_POLICY: {
-        MULTIPLE: { TOTAL_MONTHS_OF_COVER: FIELD_ID },
-      },
+  POLICY: {
+    CONTRACT_POLICY: {
+      MULTIPLE: { TOTAL_MONTHS_OF_COVER: FIELD_ID },
     },
   },
-} = FIELD_IDS;
+} = INSURANCE_FIELD_IDS;
 
 const {
   INSURANCE: {
@@ -41,14 +40,20 @@ const totalMonthsOfCoverRules = (formBody: RequestBody, errors: object) => {
     return emptyFieldValidation(formBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
   }
 
-  if (!isNumber(formBody[FIELD_ID])) {
+  const submittedValue = formBody[FIELD_ID];
+
+  if (!isNumber(submittedValue)) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
-  const monthsOfCover = Number(formBody[FIELD_ID]);
+  const monthsOfCover = Number(submittedValue);
 
   if (monthsOfCover < MINIMUM) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, errors);
+  }
+
+  if (numberHasDecimal(Number(submittedValue))) {
+    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
   if (monthsOfCover > MAXIMUM) {


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where the "Total months of cover" field of a no PDF application, would allow decimal points and cause a "problem with service" issue.

## Resolution :heavy_check_mark:
- Add a validation rule so that "Total months of cover" cannot be submitted with decimal points.
- Add E2E test coverage.

## Miscellaneous :heavy_plus_sign:
- Bump depedencies.
- Minor destructuring improvements.
