### PR TITLE
feat(EMS-2558): No PDF - Policy - Pre-credit period - Save and back

### DIFF
--- a/e2e-tests/commands/insurance/complete-and-submit-pre-credit-period-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-pre-credit-period-form.js
@@ -1,25 +1,14 @@
-import { noRadioInput, yesRadioInput, field } from '../../pages/shared';
-import { POLICY as POLICY_FIELD_IDS } from '../../constants/field-ids/insurance/policy';
-import mockApplication from '../../fixtures/application';
-
-const { CREDIT_PERIOD_WITH_BUYER } = POLICY_FIELD_IDS;
 /**
  * completeAndSubmitPreCreditPeriodForm
  * Complete and submit the "pre-credit period" form
- * @param {Boolean} needPreCreditPeriod - if a pre-credit period is required - default false
+ * @param {Boolean} needPreCreditPeriod: If a pre-credit period is required - default false
+ * @param {String} description: Custom "credit period with buyer" description value
  */
-const completeAndSubmitPreCreditPeriodForm = ({ needPreCreditPeriod = false }) => {
-  if (needPreCreditPeriod) {
-    yesRadioInput().click();
-
-    const descriptionField = field(CREDIT_PERIOD_WITH_BUYER);
-
-    const value = mockApplication.POLICY[CREDIT_PERIOD_WITH_BUYER];
-
-    cy.keyboardInput(descriptionField.textarea(), value);
-  } else {
-    noRadioInput().click();
-  }
+const completeAndSubmitPreCreditPeriodForm = ({ needPreCreditPeriod, description }) => {
+  cy.completePreCreditPeriodForm({
+    needPreCreditPeriod,
+    description,
+  });
 
   cy.clickSubmitButton();
 };

--- a/e2e-tests/commands/insurance/complete-pre-credit-period-form.js
+++ b/e2e-tests/commands/insurance/complete-pre-credit-period-form.js
@@ -1,0 +1,27 @@
+import { noRadioInput, yesRadioInput, field } from '../../pages/shared';
+import { POLICY as POLICY_FIELD_IDS } from '../../constants/field-ids/insurance/policy';
+import mockApplication from '../../fixtures/application';
+
+const { CREDIT_PERIOD_WITH_BUYER } = POLICY_FIELD_IDS;
+/**
+ * completePreCreditPeriodForm
+ * Complete the "pre-credit period" form
+ * @param {Boolean} needPreCreditPeriod: If a pre-credit period is required - default false
+ * @param {String} description: Custom "credit period with buyer" description value
+ */
+const completePreCreditPeriodForm = ({
+  needPreCreditPeriod = false,
+  description = mockApplication.POLICY[CREDIT_PERIOD_WITH_BUYER],
+}) => {
+  if (needPreCreditPeriod) {
+    yesRadioInput().click();
+
+    const descriptionField = field(CREDIT_PERIOD_WITH_BUYER);
+
+    cy.keyboardInput(descriptionField.textarea(), description);
+  } else {
+    noRadioInput().click();
+  }
+};
+
+export default completePreCreditPeriodForm;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
@@ -101,11 +101,8 @@ context('Insurance - Policy - Broker page - Save and back', () => {
 
       cy.startInsurancePolicySection({});
 
-      // go through 4 policy forms.
-      cy.clickSubmitButtonMultipleTimes({ count: 4 });
-
-      // TODO: EMS-2558 - this will not be required once pre-credit period has data saving.
-      cy.completeAndSubmitPreCreditPeriodForm({});
+      // go through 5 policy forms.
+      cy.clickSubmitButtonMultipleTimes({ count: 5 });
 
       brokerPage[USING_BROKER].yesRadioInput().should('be.checked');
       cy.checkValue(field(NAME), application.EXPORTER_BROKER[NAME]);
@@ -145,11 +142,8 @@ context('Insurance - Policy - Broker page - Save and back', () => {
 
         cy.startInsurancePolicySection({});
 
-        // go through 4 policy forms.
-        cy.clickSubmitButtonMultipleTimes({ count: 4 });
-
-        // TODO: EMS-2558 - this will not be required once pre-credit period has data saving.
-        cy.completeAndSubmitPreCreditPeriodForm({});
+        // go through 5 policy forms.
+        cy.clickSubmitButtonMultipleTimes({ count: 5 });
 
         brokerPage[USING_BROKER].yesRadioInput().should('be.checked');
         cy.checkValue(field(NAME), application.EXPORTER_BROKER[NAME]);
@@ -180,11 +174,8 @@ context('Insurance - Policy - Broker page - Save and back', () => {
 
         cy.startInsurancePolicySection({});
 
-        // go through 4 policy forms.
-        cy.clickSubmitButtonMultipleTimes({ count: 4 });
-
-        // TODO: EMS-2558 - this will not be required once pre-credit period has data saving.
-        cy.completeAndSubmitPreCreditPeriodForm({});
+        // go through 5 policy forms.
+        cy.clickSubmitButtonMultipleTimes({ count: 5 });
 
         brokerPage[USING_BROKER].noRadioInput().should('be.checked');
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/save-and-back.spec.js
@@ -1,0 +1,168 @@
+import {
+  field as fieldSelector,
+  yesRadioInput,
+  noRadioInput,
+  saveAndBackButton,
+} from '../../../../../../pages/shared';
+import partials from '../../../../../../partials';
+import { TASKS } from '../../../../../../content-strings';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
+import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
+import { FIELD_VALUES } from '../../../../../../constants';
+import mockApplication from '../../../../../../fixtures/application';
+
+const { taskList } = partials.insurancePartials;
+
+const {
+  ROOT,
+  ALL_SECTIONS,
+  POLICY: {
+    PRE_CREDIT_PERIOD,
+  },
+} = INSURANCE_ROUTES;
+
+const { CREDIT_PERIOD_WITH_BUYER } = POLICY_FIELD_IDS;
+
+const {
+  [CREDIT_PERIOD_WITH_BUYER]: { MAXIMUM },
+} = FIELDS;
+
+const descriptionField = fieldSelector(CREDIT_PERIOD_WITH_BUYER);
+
+const task = taskList.prepareApplication.tasks.policy;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Policy - Pre-credit period page - Save and go back', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.startInsurancePolicySection({});
+      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitSingleContractPolicyForm();
+      cy.completeAndSubmitTotalContractValueForm({});
+      cy.completeAndSubmitNameOnPolicyForm({});
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${PRE_CREDIT_PERIOD}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when submitting an empty form via `save and go back` button', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      saveAndBackButton().click();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      const expected = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      cy.assertUrl(expected);
+    });
+
+    it('should retain the `type of policy` task status as `in progress`', () => {
+      cy.checkTaskStatus(task, TASKS.STATUS.IN_PROGRESS);
+    });
+  });
+
+  describe('when submitting only the `no` radio and submitting the form via `save and go back` button', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      cy.completePreCreditPeriodForm({ needPreCreditPeriod: false });
+
+      saveAndBackButton().click();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      const expected = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      cy.assertUrl(expected);
+    });
+
+    it('should retain the `type of policy` task status as `in progress`', () => {
+      cy.checkTaskStatus(task, TASKS.STATUS.IN_PROGRESS);
+    });
+
+    it('should have saved the submitted value when going back to the page', () => {
+      cy.startInsurancePolicySection({});
+      cy.clickSubmitButtonMultipleTimes({ count: 4 });
+
+      noRadioInput().should('be.checked');
+    });
+  });
+
+  describe(`when entering an invalid ${CREDIT_PERIOD_WITH_BUYER} and submitting the form via 'save and go back' button`, () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      cy.completePreCreditPeriodForm({
+        needPreCreditPeriod: true,
+        description: 'a'.repeat(MAXIMUM + 1),
+      });
+
+      saveAndBackButton().click();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      const expected = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      cy.assertUrl(expected);
+    });
+
+    it('should retain the `type of policy` task status as `in progress`', () => {
+      cy.checkTaskStatus(task, TASKS.STATUS.IN_PROGRESS);
+    });
+
+    it('should not have saved the invalid submitted value when going back to the page', () => {
+      cy.startInsurancePolicySection({});
+      cy.clickSubmitButtonMultipleTimes({ count: 4 });
+
+      yesRadioInput().should('be.checked');
+      descriptionField.textarea().should('have.value', '');
+    });
+  });
+
+  describe(`when entering a valid ${CREDIT_PERIOD_WITH_BUYER} and submitting the form via 'save and go back' button`, () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      cy.completePreCreditPeriodForm({ needPreCreditPeriod: true });
+
+      saveAndBackButton().click();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      const expected = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      cy.assertUrl(expected);
+    });
+
+    it('should retain the `type of policy` task status as `in progress`', () => {
+      cy.checkTaskStatus(task, TASKS.STATUS.IN_PROGRESS);
+    });
+
+    it('should have saved all submitted value when going back to the page', () => {
+      cy.startInsurancePolicySection({});
+      cy.clickSubmitButtonMultipleTimes({ count: 4 });
+
+      yesRadioInput().should('be.checked');
+      descriptionField.textarea().should('have.value', mockApplication.POLICY[CREDIT_PERIOD_WITH_BUYER]);
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
@@ -104,7 +104,7 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
       cy.checkTaskStatus(task, TASKS.STATUS.IN_PROGRESS);
     });
 
-    it('should not have saved the submitted values  going back to the page', () => {
+    it('should not have saved the submitted values when going back to the page', () => {
       cy.startInsurancePolicySection({});
       cy.clickSubmitButton();
 

--- a/e2e-tests/insurance/cypress/support/application/policy/index.js
+++ b/e2e-tests/insurance/cypress/support/application/policy/index.js
@@ -15,6 +15,7 @@ Cypress.Commands.add('completeNameOnPolicyForm', require('../../../../../command
 Cypress.Commands.add('completeAndSubmitNameOnPolicyForm', require('../../../../../commands/insurance/complete-and-submit-name-on-policy-form'));
 Cypress.Commands.add('completeAndSubmitDifferentNameOnPolicyForm', require('../../../../../commands/insurance/complete-and-submit-different-name-on-policy-form'));
 Cypress.Commands.add('completeDifferentNameOnPolicyForm', require('../../../../../commands/insurance/complete-different-name-on-policy-form'));
+Cypress.Commands.add('completePreCreditPeriodForm', require('../../../../../commands/insurance/complete-pre-credit-period-form'));
 Cypress.Commands.add('completeAndSubmitPreCreditPeriodForm', require('../../../../../commands/insurance/complete-and-submit-pre-credit-period-form'));
 Cypress.Commands.add('completeAndSubmitBrokerForm', require('../../../../../commands/insurance/complete-and-submit-broker-form'));
 

--- a/src/ui/server/controllers/insurance/policy/pre-credit-period/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/pre-credit-period/save-and-back/index.test.ts
@@ -1,0 +1,109 @@
+import { post } from '.';
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+import { FIELD_IDS } from '..';
+import constructPayload from '../../../../../helpers/construct-payload';
+import mapAndSave from '../../map-and-save/policy';
+import generateValidationErrors from '../validation';
+import { Request, Response } from '../../../../../../types';
+import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
+
+const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
+
+describe('controllers/insurance/policy/pre-credit-period/save-and-back', () => {
+  let req: Request;
+  let res: Response;
+
+  jest.mock('../../map-and-save/policy');
+
+  let mockMapAndSave = jest.fn(() => Promise.resolve(true));
+  mapAndSave.policy = mockMapAndSave;
+
+  const refNumber = Number(mockApplication.referenceNumber);
+
+  const mockFormBody = {
+    _csrf: '1234',
+    mock: true,
+  };
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+
+    req.params.referenceNumber = String(mockApplication.referenceNumber);
+
+    req.body = mockFormBody;
+  });
+
+  describe('when the form has data', () => {
+    it('should call mapAndSave.policy with data from constructPayload function, application and validationErrors', async () => {
+      await post(req, res);
+
+      const payload = constructPayload(req.body, FIELD_IDS);
+
+      const validationErrors = generateValidationErrors(payload);
+
+      expect(mapAndSave.policy).toHaveBeenCalledTimes(1);
+      expect(mapAndSave.policy).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
+      await post(req, res);
+
+      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+
+      expect(res.redirect).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('when the form does not have any data', () => {
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
+      req.body = { _csrf: '1234' };
+
+      await post(req, res);
+
+      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+
+      expect(res.redirect).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('when there is no application', () => {
+    beforeEach(() => {
+      delete res.locals.application;
+    });
+
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+      await post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+    });
+  });
+
+  describe('api error handling', () => {
+    describe('when the mapAndSave call does not return anything', () => {
+      beforeEach(() => {
+        mockMapAndSave = jest.fn(() => Promise.resolve(false));
+        mapAndSave.policy = mockMapAndSave;
+      });
+
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+      });
+    });
+
+    describe('when the mapAndSave call fails', () => {
+      beforeEach(() => {
+        mockMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        mapAndSave.policy = mockMapAndSave;
+      });
+
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/policy/pre-credit-period/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/policy/pre-credit-period/save-and-back/index.ts
@@ -1,0 +1,44 @@
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+import hasFormData from '../../../../../helpers/has-form-data';
+import { FIELD_IDS } from '..';
+import constructPayload from '../../../../../helpers/construct-payload';
+import generateValidationErrors from '../validation';
+import callMapAndSave from '../../call-map-and-save';
+import { Request, Response } from '../../../../../../types';
+
+const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
+
+/**
+ * post
+ * Save any valid Pre-credit period fields and if successful, redirect to the all sections page
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.redirect} All sections page or error page
+ */
+export const post = async (req: Request, res: Response) => {
+  try {
+    const { application } = res.locals;
+
+    if (!application) {
+      return res.redirect(PROBLEM_WITH_SERVICE);
+    }
+
+    const { referenceNumber } = req.params;
+
+    if (hasFormData(req.body)) {
+      const payload = constructPayload(req.body, FIELD_IDS);
+
+      const saveResponse = await callMapAndSave(payload, application, generateValidationErrors(payload));
+
+      if (!saveResponse) {
+        return res.redirect(PROBLEM_WITH_SERVICE);
+      }
+    }
+
+    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`);
+  } catch (err) {
+    console.error('Error updating application - policy - pre-credit period (save and back) %O', err);
+
+    return res.redirect(PROBLEM_WITH_SERVICE);
+  }
+};

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -22,7 +22,7 @@ describe('routes/insurance', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(136);
-    expect(post).toHaveBeenCalledTimes(124);
+    expect(post).toHaveBeenCalledTimes(125);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);

--- a/src/ui/server/routes/insurance/policy/index.test.ts
+++ b/src/ui/server/routes/insurance/policy/index.test.ts
@@ -21,6 +21,7 @@ import { get as nameOnPolicyGet, post as nameOnPolicyPost } from '../../../contr
 import { post as nameOnPolicySaveAndBackPost } from '../../../controllers/insurance/policy/name-on-policy/save-and-back';
 import { get as differentNameOnPolicyGet, post as differentNameOnPolicyPost } from '../../../controllers/insurance/policy/different-name-on-policy';
 import { get as preCreditPeriodGet, post as preCreditPeriodPost } from '../../../controllers/insurance/policy/pre-credit-period';
+import { post as preCreditPeriodSaveAndBackPost } from '../../../controllers/insurance/policy/pre-credit-period/save-and-back';
 import { post as differentNameOnPolicySaveAndBackPost } from '../../../controllers/insurance/policy/different-name-on-policy/save-and-back';
 import { get as getBroker, post as postBroker } from '../../../controllers/insurance/policy/broker';
 import { post as postBrokerSaveAndBack } from '../../../controllers/insurance/policy/broker/save-and-back';
@@ -37,7 +38,7 @@ describe('routes/insurance/policy', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(25);
-    expect(post).toHaveBeenCalledTimes(32);
+    expect(post).toHaveBeenCalledTimes(33);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.ROOT}`, policyRootGet);
 
@@ -130,6 +131,7 @@ describe('routes/insurance/policy', () => {
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD}`, preCreditPeriodGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD}`, preCreditPeriodPost);
+    expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD_SAVE_AND_BACK}`, preCreditPeriodSaveAndBackPost);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_ROOT}`, getBroker);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_ROOT}`, postBroker);

--- a/src/ui/server/routes/insurance/policy/index.ts
+++ b/src/ui/server/routes/insurance/policy/index.ts
@@ -21,6 +21,7 @@ import { get as nameOnPolicyGet, post as nameOnPolicyPost } from '../../../contr
 import { post as nameOnPolicySaveAndBackPost } from '../../../controllers/insurance/policy/name-on-policy/save-and-back';
 import { get as differentNameOnPolicyGet, post as differentNameOnPolicyPost } from '../../../controllers/insurance/policy/different-name-on-policy';
 import { get as preCreditPeriodGet, post as preCreditPeriodPost } from '../../../controllers/insurance/policy/pre-credit-period';
+import { post as preCreditPeriodSaveAndBackPost } from '../../../controllers/insurance/policy/pre-credit-period/save-and-back';
 import { post as differentNameOnPolicySaveAndBackPost } from '../../../controllers/insurance/policy/different-name-on-policy/save-and-back';
 import { get as getBroker, post as postBroker } from '../../../controllers/insurance/policy/broker';
 import { post as postBrokerSaveAndBack } from '../../../controllers/insurance/policy/broker/save-and-back';
@@ -108,6 +109,7 @@ insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.DIFFERENT
 
 insurancePolicyRouter.get(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD}`, preCreditPeriodGet);
 insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD}`, preCreditPeriodPost);
+insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD_SAVE_AND_BACK}`, preCreditPeriodSaveAndBackPost);
 
 insurancePolicyRouter.get(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_ROOT}`, getBroker);
 insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_ROOT}`, postBroker);


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds "save and go back" functionality to the "Pre-credit period" form.

## Resolution :heavy_check_mark:
- Create a new cypress command to complete the "Pre-credit period" form, `completePreCreditPeriodForm`.
- Simplify `completeAndSubmitPreCreditPeriodForm`.
- Add E2E test coverage.
- Add new "save and go back" route and controller.

## Miscellaneous :heavy_plus_sign:
- Address TODO comment in a "broker" E2E test, not that we have "save and back" functionality.
- Fixed some typos.