### PR TITLE
fix(EMS-2557): No PDF - Your business - check/change business trading address

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-trading-address.spec.js
@@ -76,6 +76,26 @@ context(`Insurance - Change your answers - ${TRADING_ADDRESS} and ${FULL_ADDRESS
     cy.deleteApplication(referenceNumber);
   });
 
+  describe(`do NOT change any answers (${TRADING_ADDRESS} remains as ${FIELD_VALUES.NO})`, () => {
+    const fieldId = TRADING_ADDRESS;
+
+    describe('form submission with a new answer', () => {
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.clickSubmitButton();
+      });
+
+      it(`should redirect to ${YOUR_BUSINESS} and retain a 'completed' status tag`, () => {
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: YOUR_BUSINESS, fieldId });
+
+        cy.checkTaskStatusCompleted(status());
+      });
+    });
+  });
+
   describe(`change ${TRADING_ADDRESS} from ${FIELD_VALUES.NO} to ${FIELD_VALUES.YES}`, () => {
     const fieldId = TRADING_ADDRESS;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
@@ -11,6 +11,8 @@ import {
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
+// TODO - missing TRADING_ADDRESS
+
 const {
   EXPORTER_BUSINESS: {
     YOUR_COMPANY: {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
@@ -7,19 +7,21 @@ import {
   field,
   summaryList,
   noRadioInput,
+  yesRadioInput,
 } from '../../../../../../pages/shared';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
-
-// TODO - missing TRADING_ADDRESS
+import application from '../../../../../../fixtures/application';
 
 const {
   EXPORTER_BUSINESS: {
     YOUR_COMPANY: {
+      TRADING_ADDRESS,
       HAS_DIFFERENT_TRADING_NAME,
       WEBSITE,
       PHONE_NUMBER,
     },
+    ALTERNATIVE_TRADING_ADDRESS: { FULL_ADDRESS },
   },
 } = INSURANCE_FIELD_IDS;
 
@@ -27,6 +29,7 @@ const {
   ROOT,
   EXPORTER_BUSINESS: {
     COMPANY_DETAILS_CHANGE,
+    ALTERNATIVE_TRADING_ADDRESS_CHANGE,
     CHECK_YOUR_ANSWERS,
   },
 } = INSURANCE_ROUTES;
@@ -94,6 +97,50 @@ context('Insurance - Your business - Change your answers - Company details - As 
         const expected = FIELD_VALUES.NO;
 
         cy.assertSummaryListRowValue(summaryList, fieldId, expected);
+      });
+    });
+  });
+
+  describe(TRADING_ADDRESS, () => {
+    const fieldId = TRADING_ADDRESS;
+
+    describe('when clicking the `change` link', () => {
+      it(`should redirect to ${COMPANY_DETAILS_CHANGE}`, () => {
+        cy.navigateToUrl(url);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: COMPANY_DETAILS_CHANGE, fieldId });
+      });
+    });
+
+    describe(`form submission with a new answer (change ${TRADING_ADDRESS} from ${FIELD_VALUES.NO} to ${FIELD_VALUES.YES})`, () => {
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        yesRadioInput().last().click();
+
+        cy.clickSubmitButton();
+      });
+
+      it(`should redirect to ${ALTERNATIVE_TRADING_ADDRESS_CHANGE}`, () => {
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: ALTERNATIVE_TRADING_ADDRESS_CHANGE, fieldId });
+      });
+
+      it(`should redirect to ${CHECK_YOUR_ANSWERS} after submitting new ${TRADING_ADDRESS} and ${FULL_ADDRESS} answers`, () => {
+        cy.completeAndSubmitAlternativeTradingAddressForm();
+
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId });
+
+        // TRADING_ADDRESS
+        cy.assertSummaryListRowValue(summaryList, TRADING_ADDRESS, FIELD_VALUES.YES);
+
+        // DIFFERENT_TRADING_ADDRESS.FULL_ADDRESS
+        const expectedFullAddress = application.DIFFERENT_TRADING_ADDRESS[FULL_ADDRESS];
+
+        cy.assertSummaryListRowValue(summaryList, FULL_ADDRESS, expectedFullAddress);
       });
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-trading-address.spec.js
@@ -61,6 +61,22 @@ context(`Insurance - Your business - Change your answers - ${TRADING_ADDRESS} an
     cy.deleteApplication(referenceNumber);
   });
 
+  describe(`do NOT change any answers (${TRADING_ADDRESS} remains as ${FIELD_VALUES.NO})`, () => {
+    const fieldId = TRADING_ADDRESS;
+
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(fieldId).changeLink().click();
+
+      cy.clickSubmitButton();
+    });
+
+    it(`should should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId });
+    });
+  });
+
   describe(`change ${TRADING_ADDRESS} from ${FIELD_VALUES.NO} to ${FIELD_VALUES.YES}`, () => {
     const fieldId = TRADING_ADDRESS;
 

--- a/src/ui/server/controllers/insurance/business/company-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.test.ts
@@ -40,6 +40,14 @@ const {
 
 const IS_APPLICATION_SUMMARY_LIST = true;
 
+const applicationWithoutDifferentTradingAddress = {
+  ...mockApplication,
+  company: {
+    ...mockApplication.company,
+    differentTradingAddress: { id: '' },
+  },
+};
+
 describe('controllers/insurance/business/companies-details', () => {
   let req: Request;
   let res: Response;
@@ -189,49 +197,57 @@ describe('controllers/insurance/business/companies-details', () => {
         expect(mapAndSave.companyDetails).toHaveBeenCalledWith(payload, mockApplication);
       });
 
-      describe(`when req.body has ${TRADING_ADDRESS} with a value of 'true' but is not a check or check-and-change route`, () => {
-        it(`should redirect to ${ALTERNATIVE_TRADING_ADDRESS_ROOT}`, async () => {
-          req.body = {
-            ...validBody,
-            [TRADING_ADDRESS]: 'true',
-          };
-
-          await post(req, res);
-
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_ROOT}`;
-          expect(res.redirect).toHaveBeenCalledWith(expected);
+      describe('when an application does NOT have application.company.differentTradingAddress.fullAddress', () => {
+        beforeEach(() => {
+          res.locals.application = applicationWithoutDifferentTradingAddress;
         });
-      });
 
-      describe(`when req.body has ${TRADING_ADDRESS} with a value of 'true' and is a check route`, () => {
-        it(`should redirect to ${ALTERNATIVE_TRADING_ADDRESS_CHANGE}`, async () => {
-          req.body = {
-            ...validBody,
-            [TRADING_ADDRESS]: 'true',
-          };
+        describe(`when req.body has ${TRADING_ADDRESS} with a value of 'true'`, () => {
+          describe('when the route is NOT a check or check-and-change route', () => {
+            it(`should redirect to ${ALTERNATIVE_TRADING_ADDRESS_ROOT}`, async () => {
+              req.body = {
+                ...validBody,
+                [TRADING_ADDRESS]: 'true',
+              };
 
-          req.originalUrl = COMPANY_DETAILS_CHANGE;
+              await post(req, res);
 
-          await post(req, res);
+              const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_ROOT}`;
+              expect(res.redirect).toHaveBeenCalledWith(expected);
+            });
+          });
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_CHANGE}`;
-          expect(res.redirect).toHaveBeenCalledWith(expected);
-        });
-      });
+          describe('when the route is a is a check route', () => {
+            it(`should redirect to ${ALTERNATIVE_TRADING_ADDRESS_CHANGE}`, async () => {
+              req.body = {
+                ...validBody,
+                [TRADING_ADDRESS]: 'true',
+              };
 
-      describe(`when req.body has ${TRADING_ADDRESS} with a value of 'true' and is a check-and-change route`, () => {
-        it(`should redirect to ${ALTERNATIVE_TRADING_ADDRESS_CHECK_AND_CHANGE}`, async () => {
-          req.body = {
-            ...validBody,
-            [TRADING_ADDRESS]: 'true',
-          };
+              req.originalUrl = COMPANY_DETAILS_CHANGE;
 
-          req.originalUrl = COMPANY_DETAILS_CHECK_AND_CHANGE;
+              await post(req, res);
 
-          await post(req, res);
+              const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_CHANGE}`;
+              expect(res.redirect).toHaveBeenCalledWith(expected);
+            });
+          });
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_CHECK_AND_CHANGE}`;
-          expect(res.redirect).toHaveBeenCalledWith(expected);
+          describe('when the route is a check-and-change route', () => {
+            it(`should redirect to ${ALTERNATIVE_TRADING_ADDRESS_CHECK_AND_CHANGE}`, async () => {
+              req.body = {
+                ...validBody,
+                [TRADING_ADDRESS]: 'true',
+              };
+
+              req.originalUrl = COMPANY_DETAILS_CHECK_AND_CHANGE;
+
+              await post(req, res);
+
+              const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_CHECK_AND_CHANGE}`;
+              expect(res.redirect).toHaveBeenCalledWith(expected);
+            });
+          });
         });
       });
 

--- a/src/ui/server/controllers/insurance/business/company-details/index.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.ts
@@ -110,11 +110,13 @@ const post = async (req: Request, res: Response) => {
 
     const payload = constructPayload(req.body, FIELD_IDS);
 
+    const sanitisedHasTradingAddress = sanitiseValue({ key: TRADING_ADDRESS, value: payload[TRADING_ADDRESS] });
+
     // populate submittedValues
     const submittedValues = {
       // if trading name is string true, then convert to boolean true
       [HAS_DIFFERENT_TRADING_NAME]: sanitiseValue({ key: HAS_DIFFERENT_TRADING_NAME, value: payload[HAS_DIFFERENT_TRADING_NAME] }),
-      [TRADING_ADDRESS]: sanitiseValue({ key: TRADING_ADDRESS, value: payload[TRADING_ADDRESS] }),
+      [TRADING_ADDRESS]: sanitisedHasTradingAddress,
       [WEBSITE]: payload[WEBSITE],
       [PHONE_NUMBER]: payload[PHONE_NUMBER],
       [DIFFERENT_TRADING_NAME]: payload[DIFFERENT_TRADING_NAME],
@@ -158,7 +160,7 @@ const post = async (req: Request, res: Response) => {
      * - Change answers form POST.
      * - Check/change answers form POST.
      */
-    const tradingAddressIsRequired = payload[TRADING_ADDRESS] && !application.company.differentTradingAddress.fullAddress;
+    const tradingAddressIsRequired = sanitisedHasTradingAddress && !application.company.differentTradingAddress.fullAddress;
 
     /**
      * If "different trading address" has been submitted as "yes"/true,

--- a/src/ui/server/controllers/insurance/business/company-details/index.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.ts
@@ -155,7 +155,7 @@ const post = async (req: Request, res: Response) => {
      * - Regular form POST.
      * - Change answers form POST.
      * - Check/change answers form POST.
-     * 2) When TRADING_ADDRESS is "no"/false
+     * 2) When TRADING_ADDRESS is "no"/false:
      * - Regular form POST.
      * - Change answers form POST.
      * - Check/change answers form POST.

--- a/src/ui/server/controllers/insurance/business/company-details/index.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.ts
@@ -146,30 +146,55 @@ const post = async (req: Request, res: Response) => {
     }
 
     /**
+     * Flag to determine if "alternative trading address" field is required.
+     * This field is required if TRADING_ADDRESS is "yes"/true and an address has not been provided.
+     * This enables us to handle many scenarios that require different redirects:
+     * 1) When TRADING_ADDRESS is "yes"/true:
+     * - Regular form POST.
+     * - Change answers form POST.
+     * - Check/change answers form POST.
+     * 2) When TRADING_ADDRESS is "no"/false
+     * - Regular form POST.
+     * - Change answers form POST.
+     * - Check/change answers form POST.
+     */
+    const tradingAddressIsRequired = payload[TRADING_ADDRESS] && !application.company.differentTradingAddress.fullAddress;
+
+    /**
      * If "different trading address" has been submitted as "yes"/true,
-     * Redirect to the "alternative trading address" route if not a check/check or change route.
+     * the trading address does not exist
+     * and the route is NOT a check-and-change route,
+     * redirect to ALTERNATIVE_TRADING_ADDRESS_ROOT.
      */
     if (submittedValues[TRADING_ADDRESS] && !(isChangeRoute(req.originalUrl) || isCheckAndChangeRoute(req.originalUrl))) {
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_ROOT}`);
     }
 
-    // check and check-and-change routes
+    /**
+     * Default routes for:
+     * 1) Check your answers.
+     * 2) Check and change your answers.
+     */
     let changeRoute = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
     let checkAndChangeRoute = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
     /**
-     * If is a change route and TRADING_ADDRESS is true,
+     * If "different trading address" has been submitted as "yes"/true,
+     * the trading address does not exist
+     * and the route is a change route,
      * redirect to ALTERNATIVE_TRADING_ADDRESS_CHANGE
      */
-    if (submittedValues[TRADING_ADDRESS] && isChangeRoute(req.originalUrl)) {
+    if (tradingAddressIsRequired && isChangeRoute(req.originalUrl)) {
       changeRoute = `${INSURANCE_ROOT}/${referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_CHANGE}`;
     }
 
     /**
-     * If is a check-and-change route and TRADING_ADDRESS is true,
+     * If "different trading address" has been submitted as "yes"/true,
+     * the trading address does not exist
+     * and the route is a check-and-change route,
      * redirect to ALTERNATIVE_TRADING_ADDRESS_CHECK_AND_CHANGE
      */
-    if (submittedValues[TRADING_ADDRESS] && isCheckAndChangeRoute(req.originalUrl)) {
+    if (tradingAddressIsRequired && isCheckAndChangeRoute(req.originalUrl)) {
       checkAndChangeRoute = `${INSURANCE_ROOT}/${referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_CHECK_AND_CHANGE}`;
     }
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes some issues where, if a user is in one of the following summary lists:

- "Insurance - Check your answers - Your business".
- "Your business - Check your answers".

..and then, when clicking the "change" link to get back to the "Company details" form - the form would always redirect to the "alternative trading address" if the "alternative trading address" answer is "yes".

This should only happen when the "alternative trading address" answer is "yes" _and a full address is not provided._

## Resolution :heavy_check_mark:
- Update the "company details" POST controller to determine if a "trading address" field is required.
- Update the logic for "redirect to check/change" routes to include the "trading address" field check.
- Improve E2E test coverage

## Miscellaneous :heavy_plus_sign:
- Improve the POST redirection documentation.
