### PR TITLE
feat(EMS-2558): No PDF - Policy - Pre-credit period - wipe a field if answer is changed

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
@@ -210,6 +210,25 @@ context(`Insurance - Policy - Pre-credit period page - ${story}`, () => {
           fieldSelector(CREDIT_PERIOD_WITH_BUYER).textarea().should('have.value', expectedValue);
         });
       });
+
+      // TODO: EMS-2621 - move this test into "check/change" answers.
+      describe(`when changing ${NEED_PRE_CREDIT_PERIOD} from 'yes' to 'no'`, () => {
+        beforeEach(() => {
+          cy.navigateToUrl(url);
+
+          cy.completeAndSubmitPreCreditPeriodForm({ needPreCreditPeriod: false });
+        });
+
+        describe('when going back to the page', () => {
+          it(`should have the submitted 'yes' value and an empty ${CREDIT_PERIOD_WITH_BUYER} value`, () => {
+            cy.navigateToUrl(url);
+
+            noRadioInput().should('be.checked');
+
+            fieldSelector(CREDIT_PERIOD_WITH_BUYER).textarea().should('have.value', '');
+          });
+        });
+      });
     });
   });
 });

--- a/src/ui/server/controllers/insurance/policy/map-submitted-data/policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/map-submitted-data/policy/index.test.ts
@@ -1,10 +1,8 @@
 import mapSubmittedData from '.';
-import { FIELD_IDS } from '../../../../../constants';
+import POLICY_FIELD_IDS from '../../../../../constants/field-ids/insurance/policy';
 import createTimestampFromNumbers from '../../../../../helpers/date/create-timestamp-from-numbers';
 
-const {
-  POLICY: { CONTRACT_POLICY },
-} = FIELD_IDS.INSURANCE;
+const { CONTRACT_POLICY, NEED_PRE_CREDIT_PERIOD, CREDIT_PERIOD_WITH_BUYER } = POLICY_FIELD_IDS;
 
 const {
   REQUESTED_START_DATE,
@@ -100,7 +98,7 @@ describe('controllers/insurance/policy/map-submitted-data/policy', () => {
     });
   });
 
-  describe('when form body does not have any day/month/year fields', () => {
+  describe(`when form body does not have any day/month/year ${NEED_PRE_CREDIT_PERIOD} fields`, () => {
     it('should return the form body', () => {
       const mockBody = {
         anotherField: true,
@@ -109,6 +107,24 @@ describe('controllers/insurance/policy/map-submitted-data/policy', () => {
       const result = mapSubmittedData(mockBody);
 
       expect(result).toEqual(mockBody);
+    });
+  });
+
+  describe(`when a ${NEED_PRE_CREDIT_PERIOD} field with a value of 'false' is provided`, () => {
+    it(`should return an object with empty ${CREDIT_PERIOD_WITH_BUYER} field`, () => {
+      const mockBody = {
+        [NEED_PRE_CREDIT_PERIOD]: 'false',
+        [CREDIT_PERIOD_WITH_BUYER]: 'mock',
+      };
+
+      const result = mapSubmittedData(mockBody);
+
+      const expected = {
+        ...mockBody,
+        [CREDIT_PERIOD_WITH_BUYER]: '',
+      };
+
+      expect(result).toEqual(expected);
     });
   });
 });

--- a/src/ui/server/controllers/insurance/policy/map-submitted-data/policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy/map-submitted-data/policy/index.ts
@@ -1,15 +1,15 @@
 import { RequestBody } from '../../../../../../types';
-import { FIELD_IDS } from '../../../../../constants';
+import POLICY_FIELD_IDS from '../../../../../constants/field-ids/insurance/policy';
 import createTimestampFromNumbers from '../../../../../helpers/date/create-timestamp-from-numbers';
 
 const {
-  POLICY: {
-    CONTRACT_POLICY: {
-      REQUESTED_START_DATE,
-      SINGLE: { CONTRACT_COMPLETION_DATE },
-    },
+  CONTRACT_POLICY: {
+    REQUESTED_START_DATE,
+    SINGLE: { CONTRACT_COMPLETION_DATE },
   },
-} = FIELD_IDS.INSURANCE;
+  NEED_PRE_CREDIT_PERIOD,
+  CREDIT_PERIOD_WITH_BUYER,
+} = POLICY_FIELD_IDS;
 
 /**
  * mapSubmittedData
@@ -35,6 +35,10 @@ const mapSubmittedData = (formBody: RequestBody): object => {
 
   const { start, end } = dateFieldIds;
 
+  /**
+   * If REQUESTED_START_DATE and/or CONTRACT_COMPLETION_DATE fields are provided,
+   * transform the day/month/year fields into a timestamp.
+   */
   if (formBody[start.day] && formBody[start.month] && formBody[start.year]) {
     const day = Number(formBody[start.day]);
     const month = Number(formBody[start.month]);
@@ -49,6 +53,14 @@ const mapSubmittedData = (formBody: RequestBody): object => {
     const year = Number(formBody[end.year]);
 
     populatedData[CONTRACT_COMPLETION_DATE] = createTimestampFromNumbers(day, month, year);
+  }
+
+  /**
+   * If NEED_PRE_CREDIT_PERIOD is answered as "no",
+   * wipe the CREDIT_PERIOD_WITH_BUYER field.
+   */
+  if (formBody[NEED_PRE_CREDIT_PERIOD] === 'false') {
+    populatedData[CREDIT_PERIOD_WITH_BUYER] = '';
   }
 
   return populatedData;

--- a/src/ui/server/controllers/insurance/policy/save-data/policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/policy/index.test.ts
@@ -1,6 +1,5 @@
 import save from '.';
 import api from '../../../../../api';
-import stripEmptyFormFields from '../../../../../helpers/strip-empty-form-fields';
 import getDataToSave from '../../../../../helpers/get-data-to-save';
 import generateValidationErrors from '../../type-of-policy/validation';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
@@ -33,7 +32,7 @@ describe('controllers/insurance/policy/save-data/policy', () => {
 
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
-      const dataToSave = stripEmptyFormFields(getDataToSave(mockFormBody.invalid, mockErrorList));
+      const dataToSave = getDataToSave(mockFormBody.invalid, mockErrorList);
       const expectedSanitisedData = sanitiseData(dataToSave);
 
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.policy.id, expectedSanitisedData);
@@ -52,7 +51,7 @@ describe('controllers/insurance/policy/save-data/policy', () => {
 
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
-      const dataToSave = stripEmptyFormFields(getDataToSave(mockFormBody.valid));
+      const dataToSave = getDataToSave(mockFormBody.valid);
       const expectedSanitisedData = sanitiseData(dataToSave);
 
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.policy.id, expectedSanitisedData);

--- a/src/ui/server/controllers/insurance/policy/save-data/policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/policy/index.ts
@@ -1,5 +1,4 @@
 import api from '../../../../../api';
-import stripEmptyFormFields from '../../../../../helpers/strip-empty-form-fields';
 import getDataToSave from '../../../../../helpers/get-data-to-save';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import { Application, RequestBody } from '../../../../../../types';
@@ -14,7 +13,7 @@ import { Application, RequestBody } from '../../../../../../types';
  * @returns {Object} Saved data
  */
 const policy = async (application: Application, formBody: RequestBody, errorList?: object) => {
-  const dataToSave = stripEmptyFormFields(getDataToSave(formBody, errorList));
+  const dataToSave = getDataToSave(formBody, errorList);
 
   // sanitise the form data.
   const sanitisedData = sanitiseData(dataToSave);


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the "save data" functionality for the "policy" section of a No PDF application, so that if the "Pre-credit period" yes/no field is changed from yes to no, the previously provided description (`CREDIT_PERIOD_WITH_BUYER`) is wiped.

## Resolution :heavy_check_mark:
- Remove `stripEmptyFormFields` from `save.policy` function.
- Update policy `mapSubmittedData` function to wipe `CREDIT_PERIOD_WITH_BUYER` if `NEED_PRE_CREDIT_PERIOD` is "no"/"false".
- Add E2E test.

## Miscellaneous :heavy_plus_sign:
- Documentation improvements.
