### PR TITLE
fix(EMS-2538-2654-2658): No PDF - Get a quote currencies ordering, content updates

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -153,7 +153,7 @@ export const ERROR_MESSAGES = {
       },
       CONTRACT_POLICY: {
         [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.REQUESTED_START_DATE]: {
-          INCORRECT_FORMAT: 'Enter when you want your policy to start in the correct format, like 06 11 2023',
+          INCORRECT_FORMAT: 'Enter when you want your policy to start in the correct format - for example 06 11 2023',
           BEFORE_EARLIEST: 'You cannot enter a policy start date in the past - enter a future date',
           MISSING_DAY_AND_MONTH: 'Policy start date must include a day and month',
           MISSING_DAY_AND_YEAR: 'Policy start date must include a day and year',
@@ -169,7 +169,7 @@ export const ERROR_MESSAGES = {
         },
         SINGLE: {
           [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.SINGLE.CONTRACT_COMPLETION_DATE]: {
-            INCORRECT_FORMAT: 'Enter a contract completion date in the correct format, like 06 11 2023',
+            INCORRECT_FORMAT: 'Enter a contract completion date in the correct format - for example 06 11 2023',
             BEFORE_EARLIEST: 'You cannot enter a contract completion date in the past - enter a future date',
             MISSING_DAY_AND_MONTH: 'Policy completion date must include a day and month',
             MISSING_DAY_AND_YEAR: 'Policy completion date must include a day and year',

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -203,7 +203,7 @@ export const ERROR_MESSAGES = {
         MULTIPLE: {
           [FIELD_IDS.INSURANCE.POLICY.EXPORT_VALUE.MULTIPLE.TOTAL_SALES_TO_BUYER]: {
             INCORRECT_FORMAT: 'Enter your estimated total sales to your buyer during this time as a whole number - do not enter decimals',
-            BELOW_MINIMUM: 'Your estimated sales must be 1 or more',
+            BELOW_MINIMUM: 'Your total sales must be 1 or more',
           },
           [FIELD_IDS.INSURANCE.POLICY.EXPORT_VALUE.MULTIPLE.MAXIMUM_BUYER_WILL_OWE]: {
             INCORRECT_FORMAT: 'Enter the maximum the buyer will owe as a whole number - do not enter decimals',

--- a/e2e-tests/content-strings/fields/index.js
+++ b/e2e-tests/content-strings/fields/index.js
@@ -51,7 +51,7 @@ export const FIELDS = {
     },
   },
   [FIELD_IDS.ELIGIBILITY.CURRENCY]: {
-    LABEL: 'Select a currency (pounds sterling, euros or US dollars). You can send out your invoices in most currencies but UKEF only issues policies in these 3 currencies.',
+    LABEL: 'Select a currency (UK sterling, Euros, US dollars, or Japanese yen). You can send out your invoices in most currencies but UKEF only issues policies in these 3 currencies.',
   },
   [FIELD_IDS.ELIGIBILITY.CONTRACT_VALUE]: {
     LABEL: 'Contract value',

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
@@ -61,7 +61,7 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
     cy.saveSession();
   });
 
-  it('renders core page elements', () => {
+  it('should render core page elements', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.MULTIPLE_POLICY_PAGE_TITLE,
       currentHref: TELL_US_ABOUT_YOUR_POLICY,
@@ -82,7 +82,7 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
       cy.navigateToUrl(url);
     });
 
-    it('renders `currency and amount` legend', () => {
+    it('should render `currency and amount` legend', () => {
       const fieldId = AMOUNT_CURRENCY;
 
       const field = fieldSelector(fieldId);
@@ -91,7 +91,7 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
       cy.checkText(field.legend(), FIELDS[fieldId].MULTIPLE_POLICY.LEGEND);
     });
 
-    it('renders `currency` legend, label and input', () => {
+    it('should render `currency` legend, label and input', () => {
       const fieldId = CURRENCY;
 
       const field = fieldSelector(fieldId);
@@ -101,18 +101,18 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
       field.input().should('exist');
     });
 
-    it('renders only supported currencies in alphabetical order', () => {
+    it('should render only supported currencies in a specific order', () => {
       const fieldId = CURRENCY;
 
       const field = fieldSelector(fieldId);
 
-      field.input().select(1).should('have.value', EUR.isoCode);
-      field.input().select(2).should('have.value', JPY.isoCode);
-      field.input().select(3).should('have.value', GBP.isoCode);
-      field.input().select(4).should('have.value', USD.isoCode);
+      field.input().select(1).should('have.value', GBP.isoCode);
+      field.input().select(2).should('have.value', EUR.isoCode);
+      field.input().select(3).should('have.value', USD.isoCode);
+      field.input().select(4).should('have.value', JPY.isoCode);
     });
 
-    it('renders `max amount owed` label and input', () => {
+    it('should render `max amount owed` label and input', () => {
       const fieldId = MAX_AMOUNT_OWED;
 
       const field = fieldSelector(fieldId);
@@ -122,7 +122,7 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
       field.input().should('exist');
     });
 
-    it('renders `percentage of cover` label, hint and input', () => {
+    it('should render `percentage of cover` label, hint and input', () => {
       const fieldId = PERCENTAGE_OF_COVER;
 
       const field = fieldSelector(fieldId);
@@ -134,7 +134,7 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
       field.input().should('exist');
     });
 
-    it('renders `percentage of cover` label, hint and input with correct options', () => {
+    it('should render `percentage of cover` label, hint and input with correct options', () => {
       const fieldId = PERCENTAGE_OF_COVER;
 
       const field = fieldSelector(fieldId);
@@ -153,7 +153,7 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
       });
     });
 
-    it('renders `credit period` label, hint and input with correct options', () => {
+    it('should render `credit period` label, hint and input with correct options', () => {
       const fieldId = CREDIT_PERIOD;
 
       const field = tellUsAboutYourPolicyPage[fieldId];

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
@@ -103,15 +103,15 @@ context('Tell us about your single policy page - as an exporter, I want to provi
       field.input().should('exist');
     });
 
-    it('should render only supported currencies in alphabetical order', () => {
+    it('should render only supported currencies in a specific order', () => {
       const fieldId = CURRENCY;
 
       const field = fieldSelector(fieldId);
 
-      field.input().select(1).should('have.value', EUR.isoCode);
-      field.input().select(2).should('have.value', JPY.isoCode);
-      field.input().select(3).should('have.value', GBP.isoCode);
-      field.input().select(4).should('have.value', USD.isoCode);
+      field.input().select(1).should('have.value', GBP.isoCode);
+      field.input().select(2).should('have.value', EUR.isoCode);
+      field.input().select(3).should('have.value', USD.isoCode);
+      field.input().select(4).should('have.value', JPY.isoCode);
     });
 
     it('should render `contract value` label and input', () => {

--- a/src/api/constants/supported-currencies/index.ts
+++ b/src/api/constants/supported-currencies/index.ts
@@ -1,1 +1,6 @@
 export const SUPPORTED_CURRENCIES = ['EUR', 'GBP', 'JPY', 'USD'];
+
+export const EUR = 'EUR';
+export const GBP = 'GBP';
+export const JPY = 'JPY';
+export const USD = 'USD';

--- a/src/api/test-mocks/mock-currencies.ts
+++ b/src/api/test-mocks/mock-currencies.ts
@@ -1,26 +1,30 @@
 import { Currency } from '../types';
 
-const mockCurrencies = [
-  {
-    name: 'Euros',
-    isoCode: 'EUR',
-  },
-  {
-    name: 'Hong Kong Dollars',
-    isoCode: 'HKD',
-  },
-  {
-    name: 'Japanese Yen',
-    isoCode: 'JPY',
-  },
-  {
-    name: 'UK Sterling',
-    isoCode: 'GBP',
-  },
-  {
-    name: 'US Dollars',
-    isoCode: 'USD',
-  },
-] as Array<Currency>;
+export const EUR = {
+  name: 'Euros',
+  isoCode: 'EUR',
+};
+
+export const HKD = {
+  name: 'Hong Kong Dollars',
+  isoCode: 'HKD',
+};
+
+export const JPY = {
+  name: 'Japanese Yen',
+  isoCode: 'JPY',
+};
+
+export const GBP = {
+  name: 'UK Sterling',
+  isoCode: 'GBP',
+};
+
+export const USD = {
+  name: 'US Dollars',
+  isoCode: 'USD',
+};
+
+const mockCurrencies = [EUR, HKD, JPY, GBP, USD] as Array<Currency>;
 
 export default mockCurrencies;

--- a/src/ui/server/constants/supported-currencies.ts
+++ b/src/ui/server/constants/supported-currencies.ts
@@ -1,1 +1,6 @@
 export const SUPPORTED_CURRENCIES = ['EUR', 'GBP', 'JPY', 'USD'];
+
+export const EUR = 'EUR';
+export const GBP = 'GBP';
+export const JPY = 'JPY';
+export const USD = 'USD';

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -152,7 +152,7 @@ export const ERROR_MESSAGES = {
       },
       CONTRACT_POLICY: {
         [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.REQUESTED_START_DATE]: {
-          INCORRECT_FORMAT: 'Enter when you want your policy to start in the correct format, like 06 11 2023',
+          INCORRECT_FORMAT: 'Enter when you want your policy to start in the correct format - for example 06 11 2023',
           BEFORE_EARLIEST: 'You cannot enter a policy start date in the past - enter a future date',
           MISSING_DAY_AND_MONTH: 'Policy start date must include a day and month',
           MISSING_DAY_AND_YEAR: 'Policy start date must include a day and year',
@@ -168,7 +168,7 @@ export const ERROR_MESSAGES = {
         },
         SINGLE: {
           [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.SINGLE.CONTRACT_COMPLETION_DATE]: {
-            INCORRECT_FORMAT: 'Enter a contract completion date in the correct format, like 06 11 2023',
+            INCORRECT_FORMAT: 'Enter a contract completion date in the correct format - for example 06 11 2023',
             BEFORE_EARLIEST: 'You cannot enter a contract completion date in the past - enter a future date',
             MISSING_DAY_AND_MONTH: 'Policy completion date must include a day and month',
             MISSING_DAY_AND_YEAR: 'Policy completion date must include a day and year',
@@ -202,7 +202,7 @@ export const ERROR_MESSAGES = {
         MULTIPLE: {
           [FIELD_IDS.INSURANCE.POLICY.EXPORT_VALUE.MULTIPLE.TOTAL_SALES_TO_BUYER]: {
             INCORRECT_FORMAT: 'Enter your estimated total sales to your buyer during this time as a whole number - do not enter decimals',
-            BELOW_MINIMUM: 'Your estimated sales must be 1 or more',
+            BELOW_MINIMUM: 'Your total sales must be 1 or more',
           },
           [FIELD_IDS.INSURANCE.POLICY.EXPORT_VALUE.MULTIPLE.MAXIMUM_BUYER_WILL_OWE]: {
             INCORRECT_FORMAT: 'Enter the maximum the buyer will owe as a whole number - do not enter decimals',

--- a/src/ui/server/content-strings/fields/index.ts
+++ b/src/ui/server/content-strings/fields/index.ts
@@ -48,7 +48,8 @@ export const FIELDS = {
     },
   },
   [FIELD_IDS.ELIGIBILITY.CURRENCY]: {
-    LABEL: 'Select a currency (UK sterling, Euros, US dollars, or Japanese yen). You can send out your invoices in most currencies but UKEF only issues policies in these 3 currencies.',
+    LABEL:
+      'Select a currency (UK sterling, Euros, US dollars, or Japanese yen). You can send out your invoices in most currencies but UKEF only issues policies in these 3 currencies.',
   },
   [FIELD_IDS.ELIGIBILITY.CONTRACT_VALUE]: {
     LABEL: 'Contract value',

--- a/src/ui/server/content-strings/fields/index.ts
+++ b/src/ui/server/content-strings/fields/index.ts
@@ -48,8 +48,7 @@ export const FIELDS = {
     },
   },
   [FIELD_IDS.ELIGIBILITY.CURRENCY]: {
-    LABEL:
-      'Select a currency (pounds sterling, euros or US dollars). You can send out your invoices in most currencies but UKEF only issues policies in these 3 currencies.',
+    LABEL: 'Select a currency (UK sterling, Euros, US dollars, or Japanese yen). You can send out your invoices in most currencies but UKEF only issues policies in these 3 currencies.',
   },
   [FIELD_IDS.ELIGIBILITY.CONTRACT_VALUE]: {
     LABEL: 'Contract value',

--- a/src/ui/server/helpers/mappings/map-currencies/as-select-options/index.test.ts
+++ b/src/ui/server/helpers/mappings/map-currencies/as-select-options/index.test.ts
@@ -1,11 +1,9 @@
 import mapCurrenciesAsSelectOptions from '.';
-import mapSelectOption from '../../map-select-option';
+import mapAndSortCurrencies from './map-and-sort-currencies';
 import { mockCurrencies } from '../../../../test-mocks';
 
 describe('server/helpers/mappings/map-currencies/as-select-options', () => {
-  const renderValueInText = true;
-
-  it('should return an array of mapped objects from mapSelectOption and with a default option', () => {
+  it('should return an array of mapped objects from mapAndSortCurrencies function', () => {
     const result = mapCurrenciesAsSelectOptions(mockCurrencies);
 
     const expected = [
@@ -14,19 +12,19 @@ describe('server/helpers/mappings/map-currencies/as-select-options', () => {
         selected: true,
         value: '',
       },
-      ...mockCurrencies.map(({ name, isoCode }) => mapSelectOption(name, isoCode, renderValueInText)),
+      ...mapAndSortCurrencies(mockCurrencies),
     ];
 
     expect(result).toEqual(expected);
   });
 
   describe('when a selectedValue is passed', () => {
-    it('should return an array of mapped objects from mapSelectOption and no default option', () => {
-      const mockSelectedValue = mockCurrencies[1].isoCode;
+    const mockSelectedValue = mockCurrencies[1].isoCode;
 
+    it('should return an array of mapped objects from mapSelectOption and no default option', () => {
       const result = mapCurrenciesAsSelectOptions(mockCurrencies, mockSelectedValue);
 
-      const expected = mockCurrencies.map(({ name, isoCode }) => mapSelectOption(name, isoCode, renderValueInText, mockSelectedValue));
+      const expected = mapAndSortCurrencies(mockCurrencies, mockSelectedValue);
 
       expect(result).toEqual(expected);
     });

--- a/src/ui/server/helpers/mappings/map-currencies/as-select-options/index.ts
+++ b/src/ui/server/helpers/mappings/map-currencies/as-select-options/index.ts
@@ -1,17 +1,15 @@
-import mapSelectOption from '../../map-select-option';
+import mapAndSortCurrencies from './map-and-sort-currencies';
 import { Currency } from '../../../../../types';
 
 /**
  * mapCurrenciesAsSelectOptions
  * Map all currencies into the required structure for GOV select component.
- * @param {Array} Array of currency objects
- * @param {String} Selected currency
- * @returns {Array} Array of mapped currencies
+ * @param {Array} currencies: Array of currency objects
+ * @param {String} selectedValue: Selected currency
+ * @returns {Array} Array of mapped and sorted currencies
  */
 const mapCurrenciesAsSelectOptions = (currencies: Array<Currency>, selectedValue?: string) => {
-  const renderValueInText = true;
-
-  const mappedCurrencies = currencies.map(({ name, isoCode }) => mapSelectOption(name, isoCode, renderValueInText, selectedValue));
+  const mappedCurrencies = mapAndSortCurrencies(currencies, selectedValue);
 
   if (!selectedValue) {
     const defaultOption = {

--- a/src/ui/server/helpers/mappings/map-currencies/as-select-options/map-and-sort-currencies/index.test.ts
+++ b/src/ui/server/helpers/mappings/map-currencies/as-select-options/map-and-sort-currencies/index.test.ts
@@ -1,0 +1,18 @@
+import mapAndSortCurrencies from '.';
+import mapSelectOption from '../../../map-select-option';
+import { mockCurrencies, EUR, JPY, GBP, USD } from '../../../../../test-mocks';
+
+const renderValueInText = true;
+const mockSelectedValue = mockCurrencies[1].isoCode;
+
+describe('server/helpers/mappings/map-currencies/as-select-options/map-and-sort-currencies', () => {
+  it('should return an array of mapped objects from mapSelectOption', () => {
+    const result = mapAndSortCurrencies(mockCurrencies, mockSelectedValue);
+
+    const initCurrencies = [GBP, EUR, USD, JPY];
+
+    const expected = initCurrencies.map((currency) => mapSelectOption(currency.name, currency.isoCode, renderValueInText, mockSelectedValue));
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/ui/server/helpers/mappings/map-currencies/as-select-options/map-and-sort-currencies/index.ts
+++ b/src/ui/server/helpers/mappings/map-currencies/as-select-options/map-and-sort-currencies/index.ts
@@ -1,0 +1,39 @@
+import { EUR, GBP, JPY, USD } from '../../../../../constants';
+import mapSelectOption from '../../../map-select-option';
+import { Currency } from '../../../../../../types';
+
+/**
+ * mapAndSortCurrencies
+ * Map all currencies into the required structure for GOV select component.
+ * We also need to manually sort the currencies to meet design.
+ * The currencies need to be specifically ordered - not alphabetically.
+ * @param {Array} currencies: Array of currency objects
+ * @param {String} selectedValue: Selected currency
+ * @returns {Array} Mapped and sorted currencies
+ */
+const mapAndSortCurrencies = (currencies: Array<Currency>, selectedValue?: string) => {
+  const renderValueInText = true;
+
+  /**
+   * 1) Create an initial currencies object
+   * 2) Loop over each currency
+   * 3) Push a mapped currency to the object with an isoCode key
+   */
+  const currenciesObject = {};
+
+  currencies.forEach((currency: Currency) => {
+    const { name, isoCode } = currency;
+
+    currenciesObject[currency.isoCode] = mapSelectOption(name, isoCode, renderValueInText, selectedValue);
+  });
+
+  /**
+   * Define an array of sorted currencies.
+   * This is required to meet design requirements.
+   */
+  const sortedCurrencies = [currenciesObject[GBP], currenciesObject[EUR], currenciesObject[USD], currenciesObject[JPY]];
+
+  return sortedCurrencies;
+};
+
+export default mapAndSortCurrencies;

--- a/src/ui/server/test-mocks/index.ts
+++ b/src/ui/server/test-mocks/index.ts
@@ -4,7 +4,7 @@ import mockAnswers from './mock-answers';
 import mockSession from './mock-session';
 import mockQuote from './mock-quote';
 import mockCountries from './mock-countries';
-import mockCurrencies from './mock-currencies';
+import mockCurrencies, { EUR, HKD, JPY, GBP, USD } from './mock-currencies';
 import mockCompaniesHouseResponse from './mock-companies-house-response';
 import mockCompany from './mock-company';
 import mockApplication, { mockApplicationMultiplePolicy, mockBusiness, mockCompanyDifferentTradingAddress } from './mock-application';
@@ -91,6 +91,11 @@ const mockRes = () => {
 const mockNext = jest.fn();
 
 export {
+  EUR,
+  HKD,
+  JPY,
+  GBP,
+  USD,
   mockAccount,
   mockAnswers,
   mockApplication,

--- a/src/ui/server/test-mocks/mock-currencies.ts
+++ b/src/ui/server/test-mocks/mock-currencies.ts
@@ -1,26 +1,30 @@
 import { Currency } from '../../types';
 
-const mockCurrencies = [
-  {
-    name: 'Euros',
-    isoCode: 'EUR',
-  },
-  {
-    name: 'Hong Kong Dollars',
-    isoCode: 'HKD',
-  },
-  {
-    name: 'Japanese Yen',
-    isoCode: 'JPY',
-  },
-  {
-    name: 'UK Sterling',
-    isoCode: 'GBP',
-  },
-  {
-    name: 'US Dollars',
-    isoCode: 'USD',
-  },
-] as Array<Currency>;
+export const EUR = {
+  name: 'Euros',
+  isoCode: 'EUR',
+};
+
+export const HKD = {
+  name: 'Hong Kong Dollars',
+  isoCode: 'HKD',
+};
+
+export const JPY = {
+  name: 'Japanese Yen',
+  isoCode: 'JPY',
+};
+
+export const GBP = {
+  name: 'UK Sterling',
+  isoCode: 'GBP',
+};
+
+export const USD = {
+  name: 'US Dollars',
+  isoCode: 'USD',
+};
+
+const mockCurrencies = [EUR, HKD, JPY, GBP, USD] as Array<Currency>;
 
 export default mockCurrencies;


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the "currency as select options" mapping so that they are specifically ordered as per design, instead of being alphabetical.

Have also fixed/updated various copy to align with the No PDF design.

## Resolution :heavy_check_mark:
- Update content strings.
- Update mock and supported currencies fixtures and constants to export currency codes e.g `GBP`, `EUR` etc.
- Create a new UI helper function to map and specifically sort currencies for a select drop down, `mapAndSortCurrencies`.
- Update `mapCurrenciesAsSelectOptions` to consume new `mapAndSortCurrencies`.

## Miscellaneous :heavy_plus_sign:
- Rename some E2E test descriptions.
- Documentation improvements.
