### PR TITLE
fix(EMS-2566-2657): No PDF - Date validation - Return an error if days is over days in a month

### DIFF
--- a/e2e-tests/commands/insurance/date-field.js
+++ b/e2e-tests/commands/insurance/date-field.js
@@ -80,6 +80,32 @@ const checkValidation = ({
           errorMessage,
         });
       },
+      /**
+       * Submit a full date, but with the day over the current month's last day.
+       * Check validation errors.
+       */
+      isGreaterThanLastDayOfMonth: () => {
+        const date = new Date();
+        const month = date.getMonth() + 1;
+        const year = date.getFullYear();
+
+        const daysInMonth = new Date(year, month, 0).getDate();
+
+        const invalidMonthDay = daysInMonth + 1;
+
+        cy.keyboardInput(field.dayInput().clear(), invalidMonthDay);
+        cy.keyboardInput(field.monthInput().clear(), month);
+        cy.keyboardInput(field.yearInput().clear(), year);
+
+        cy.clickSubmitButton();
+
+        const errorMessage = errorMessages.INVALID_DAY;
+
+        cy.assertFieldErrors({
+          ...assertFieldErrorsParams,
+          errorMessage,
+        });
+      },
     },
     month: {
       /**

--- a/e2e-tests/commands/insurance/date-field.js
+++ b/e2e-tests/commands/insurance/date-field.js
@@ -262,7 +262,7 @@ const checkValidation = ({
 
       const futureDate = new Date(now.setDate(day + 1));
 
-      cy.keyboardInput(field.dayInput(), '50');
+      cy.keyboardInput(field.dayInput(), day);
       cy.keyboardInput(field.monthInput(), '24');
       cy.keyboardInput(field.yearInput(), futureDate.getFullYear());
       cy.clickSubmitButton();

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-requested-start-date.spec.js
@@ -108,6 +108,10 @@ context('Insurance - Policy - Multiple contract policy page - form validation - 
     year.notANumber();
   });
 
+  it('when the day is greater than the last day of month', () => {
+    day.isGreaterThanLastDayOfMonth();
+  });
+
   it('when the year does not have enough digits', () => {
     year.notEnoughDigits();
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
@@ -112,6 +112,10 @@ context('Insurance - Policy - Single contract policy page - form validation - co
     year.notANumber();
   });
 
+  it('when the day is greater than the last day of month', () => {
+    day.isGreaterThanLastDayOfMonth();
+  });
+
   it('when the year does not have enough digits', () => {
     year.notEnoughDigits();
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
@@ -76,6 +76,10 @@ context('Insurance - Policy - Single contract policy page - form validation - re
     day.notProvided();
   });
 
+  it('when the day is not provided', () => {
+    day.isOverDaysInMonth();
+  });
+
   it('when the month is not provided', () => {
     month.notProvided();
   });
@@ -106,6 +110,10 @@ context('Insurance - Policy - Single contract policy page - form validation - re
 
   it('when the year is not a number', () => {
     year.notANumber();
+  });
+
+  it('when the day is greater than the last day of month', () => {
+    day.isGreaterThanLastDayOfMonth();
   });
 
   it('when the year does not have enough digits', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
@@ -76,10 +76,6 @@ context('Insurance - Policy - Single contract policy page - form validation - re
     day.notProvided();
   });
 
-  it('when the day is not provided', () => {
-    day.isOverDaysInMonth();
-  });
-
   it('when the month is not provided', () => {
     month.notProvided();
   });

--- a/src/ui/server/helpers/date/get-date-fields-from-timestamp/index.test.ts
+++ b/src/ui/server/helpers/date/get-date-fields-from-timestamp/index.test.ts
@@ -20,22 +20,4 @@ describe('server/helpers/date/get-date-fields-from-timestamp', () => {
 
     expect(result).toEqual(expected);
   });
-
-  describe('when timestamp is not provided', () => {
-    it('should return an empty object', () => {
-      // @ts-ignore
-      const result = getDateFieldsFromTimestamp(undefined, mockFieldId);
-
-      expect(result).toEqual({});
-    });
-  });
-
-  describe('when fieldId is not provided', () => {
-    it('should return an empty object', () => {
-      // @ts-ignore
-      const result = getDateFieldsFromTimestamp(mockTimestamp);
-
-      expect(result).toEqual({});
-    });
-  });
 });

--- a/src/ui/server/helpers/date/get-days-in-a-month/index.test.ts
+++ b/src/ui/server/helpers/date/get-days-in-a-month/index.test.ts
@@ -1,0 +1,15 @@
+import getDaysInAMonth from '.';
+
+describe('server/helpers/date/get-days-in-a-month', () => {
+  const date = new Date();
+  const month = date.getMonth();
+  const year = date.getFullYear();
+
+  it('should return the days in the provided month', () => {
+    const result = getDaysInAMonth(month, year);
+
+    const expected = new Date(year, month, 0).getDate();
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/ui/server/helpers/date/get-days-in-a-month/index.ts
+++ b/src/ui/server/helpers/date/get-days-in-a-month/index.ts
@@ -1,0 +1,16 @@
+/**
+ * getDaysInAMonth
+ * Get the total days of a provided month.
+ * @param {Integer} month
+ * @param {Integer} year
+ * @returns {Integer} Days in the month
+ */
+const getDaysInAMonth = (month: number, year: number) => {
+  const day = 0;
+
+  const daysInMonth = new Date(year, month, day).getDate();
+
+  return daysInMonth;
+};
+
+export default getDaysInAMonth;

--- a/src/ui/server/shared-validation/date/index.test.ts
+++ b/src/ui/server/shared-validation/date/index.test.ts
@@ -1,6 +1,7 @@
 import dateRules from '.';
 import INSURANCE_FIELD_IDS from '../../constants/field-ids/insurance';
 import { ERROR_MESSAGES } from '../../content-strings';
+import validDateFormatRules from './valid-format';
 import generateValidationErrors from '../../helpers/validation';
 import getDaysInAMonth from '../../helpers/date/get-days-in-a-month';
 
@@ -44,141 +45,27 @@ describe('shared-validation/date', () => {
     [`${FIELD_ID}-year`]: futureDate.getFullYear(),
   };
 
-  describe('when no day/month/year fields are provided', () => {
-    it('should return validation error', () => {
+  describe('when a data has an invalid format', () => {
+    it('should return the result of validDateFormatRules', () => {
+      const mockEmptyString = '';
+
       const mockSubmittedData = {
-        [`${FIELD_ID}-day`]: '',
-        [`${FIELD_ID}-month`]: '',
-        [`${FIELD_ID}-year`]: '',
+        [`${FIELD_ID}-day`]: mockEmptyString,
+        [`${FIELD_ID}-month`]: mockEmptyString,
+        [`${FIELD_ID}-year`]: mockEmptyString,
       };
 
       const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INCORRECT_FORMAT, mockErrors);
+      const formatErrors = validDateFormatRules({
+        ...baseParams,
+        formBody: mockSubmittedData,
+        dayString: mockEmptyString,
+        monthString: mockEmptyString,
+        yearString: mockEmptyString,
+      });
 
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when any day/month/year field is NOT a number', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [`${FIELD_ID}-day`]: 'One',
-        [`${FIELD_ID}-month`]: 'Two',
-        [`${FIELD_ID}-year`]: 'Three',
-      };
-
-      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when a valid day is provided, but month and year are not', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        ...mockValidBody,
-        [`${FIELD_ID}-month`]: '',
-        [`${FIELD_ID}-year`]: '',
-      };
-
-      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.MISSING_MONTH_AND_YEAR, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when a valid month is provided, but day and year are not', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        ...mockValidBody,
-        [`${FIELD_ID}-day`]: '',
-        [`${FIELD_ID}-year`]: '',
-      };
-
-      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.MISSING_DAY_AND_YEAR, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when a valid year is provided, but day and month are not', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        ...mockValidBody,
-        [`${FIELD_ID}-day`]: '',
-        [`${FIELD_ID}-month`]: '',
-      };
-
-      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.MISSING_DAY_AND_MONTH, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when day is not provided', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        ...mockValidBody,
-        [`${FIELD_ID}-day`]: '',
-      };
-
-      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INVALID_DAY, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when month is not provided', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        ...mockValidBody,
-        [`${FIELD_ID}-month`]: '',
-      };
-
-      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INVALID_MONTH, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when year is not provided', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        ...mockValidBody,
-        [`${FIELD_ID}-year`]: '',
-      };
-
-      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INVALID_YEAR, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when year has less than 4 digits', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        ...mockValidBody,
-        [`${FIELD_ID}-year`]: '202',
-      };
-
-      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INVALID_YEAR_DIGITS, mockErrors);
+      const expected = formatErrors.errors;
 
       expect(result).toEqual(expected);
     });
@@ -189,7 +76,7 @@ describe('shared-validation/date', () => {
 
     const invalidDay = daysInMonth + 1;
 
-    it('should return validation error', () => {
+    it('should a return validation error', () => {
       const mockSubmittedData = {
         ...mockValidBody,
         [`${FIELD_ID}-day`]: invalidDay,
@@ -204,7 +91,7 @@ describe('shared-validation/date', () => {
   });
 
   describe('when the date is invalid', () => {
-    it('should return validation error', () => {
+    it('should a return validation error', () => {
       const mockSubmittedData = {
         ...mockValidBody,
         [`${FIELD_ID}-month`]: '24',
@@ -219,7 +106,7 @@ describe('shared-validation/date', () => {
   });
 
   describe('when the date is in the past', () => {
-    it('should return validation error', () => {
+    it('should a return validation error', () => {
       const yesterday = new Date(date.setDate(day - 1));
 
       const mockSubmittedData = {

--- a/src/ui/server/shared-validation/date/index.test.ts
+++ b/src/ui/server/shared-validation/date/index.test.ts
@@ -2,6 +2,7 @@ import dateRules from '.';
 import INSURANCE_FIELD_IDS from '../../constants/field-ids/insurance';
 import { ERROR_MESSAGES } from '../../content-strings';
 import generateValidationErrors from '../../helpers/validation';
+import getDaysInAMonth from '../../helpers/date/get-days-in-a-month';
 
 const {
   POLICY: {
@@ -183,12 +184,30 @@ describe('shared-validation/date', () => {
     });
   });
 
+  describe('when the day is greater than the current month', () => {
+    const daysInMonth = getDaysInAMonth(month, year);
+
+    const invalidDay = daysInMonth + 1;
+
+    it('should return validation error', () => {
+      const mockSubmittedData = {
+        ...mockValidBody,
+        [`${FIELD_ID}-day`]: invalidDay,
+      };
+
+      const result = dateRules({ ...baseParams, formBody: mockSubmittedData });
+
+      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INVALID_DAY, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
   describe('when the date is invalid', () => {
     it('should return validation error', () => {
       const mockSubmittedData = {
-        [`${FIELD_ID}-day`]: '50',
+        ...mockValidBody,
         [`${FIELD_ID}-month`]: '24',
-        [`${FIELD_ID}-year`]: year,
       };
 
       const result = dateRules({ ...baseParams, formBody: mockSubmittedData });

--- a/src/ui/server/shared-validation/date/index.ts
+++ b/src/ui/server/shared-validation/date/index.ts
@@ -2,6 +2,7 @@ import { endOfDay, isFuture, isValid } from 'date-fns';
 import generateValidationErrors from '../../helpers/validation';
 import createTimestampFromNumbers from '../../helpers/date/create-timestamp-from-numbers';
 import { isNumber } from '../../helpers/number';
+import getDaysInAMonth from '../../helpers/date/get-days-in-a-month';
 import { RequestBody, DateErrorMessage, ValidationErrors } from '../../../types';
 
 interface DateRulesTempType {
@@ -101,9 +102,15 @@ const dateRules = ({ formBody, errors, fieldId, errorMessages }: DateRulesTempTy
   if (submittedDate) {
     /**
      * Check that the date is valid. E.g:
+     * A day cannot be greater than the last day in a month.
      * A month cannot have a value of 13.
-     * A day cannot have a value of 50 or over the maximum days in a month.
      */
+    const daysInMonth = getDaysInAMonth(monthNumber, yearNumber);
+
+    if (dayNumber > daysInMonth) {
+      return generateValidationErrors(fieldId, errorMessages.INVALID_DAY, errors);
+    }
+
     if (!isValid(submittedDate)) {
       return generateValidationErrors(fieldId, errorMessages.INVALID_DATE, errors);
     }

--- a/src/ui/server/shared-validation/date/valid-format/index.test.ts
+++ b/src/ui/server/shared-validation/date/valid-format/index.test.ts
@@ -1,0 +1,171 @@
+import validDateFormatRules from '.';
+import INSURANCE_FIELD_IDS from '../../../constants/field-ids/insurance';
+import { ERROR_MESSAGES } from '../../../content-strings';
+import generateValidationErrors from '../../../helpers/validation';
+
+const {
+  POLICY: {
+    CONTRACT_POLICY: { REQUESTED_START_DATE: FIELD_ID },
+  },
+} = INSURANCE_FIELD_IDS;
+
+const {
+  INSURANCE: {
+    POLICY: {
+      CONTRACT_POLICY: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
+    },
+  },
+} = ERROR_MESSAGES;
+
+describe('shared-validation/date/valid-format', () => {
+  const date = new Date();
+
+  const dayString = String(date.getDate());
+  const monthString = String(date.getMonth());
+  const yearString = String(date.getFullYear());
+
+  const mockErrors = {
+    summary: [],
+    errorList: {},
+  };
+
+  const baseParams = {
+    formBody: {},
+    dayString,
+    monthString,
+    yearString,
+    errors: mockErrors,
+    fieldId: FIELD_ID,
+    errorMessages: ERROR_MESSAGES_OBJECT,
+  };
+
+  describe('when no day/month/year fields are provided', () => {
+    it('should return a validation error', () => {
+      const result = validDateFormatRules({ ...baseParams, dayString: '', monthString: '', yearString: '' });
+
+      const expected = {
+        hasErrors: true,
+        errors: generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INCORRECT_FORMAT, mockErrors),
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when any day/month/year field is NOT a number', () => {
+    it('should return a validation error', () => {
+      const result = validDateFormatRules({ ...baseParams, dayString: 'One', monthString: 'Two', yearString: 'Three' });
+
+      const expected = {
+        hasErrors: true,
+        errors: generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INCORRECT_FORMAT, mockErrors),
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a valid day is provided, but month and year are not', () => {
+    it('should return a validation error', () => {
+      const result = validDateFormatRules({ ...baseParams, monthString: '', yearString: '' });
+
+      const expected = {
+        hasErrors: true,
+        errors: generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.MISSING_MONTH_AND_YEAR, mockErrors),
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a valid month is provided, but day and year are not', () => {
+    it('should return a validation error', () => {
+      const result = validDateFormatRules({ ...baseParams, dayString: '', yearString: '' });
+
+      const expected = {
+        hasErrors: true,
+        errors: generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.MISSING_DAY_AND_YEAR, mockErrors),
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a valid year is provided, but day and month are not', () => {
+    it('should return a validation error', () => {
+      const result = validDateFormatRules({ ...baseParams, dayString: '', monthString: '' });
+
+      const expected = {
+        hasErrors: true,
+        errors: generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.MISSING_DAY_AND_MONTH, mockErrors),
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when day is not provided', () => {
+    it('should return a validation error', () => {
+      const result = validDateFormatRules({ ...baseParams, dayString: '' });
+
+      const expected = {
+        hasErrors: true,
+        errors: generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INVALID_DAY, mockErrors),
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when month is not provided', () => {
+    it('should return a validation error', () => {
+      const result = validDateFormatRules({ ...baseParams, monthString: '' });
+
+      const expected = {
+        hasErrors: true,
+        errors: generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INVALID_MONTH, mockErrors),
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when year is not provided', () => {
+    it('should return a validation error', () => {
+      const result = validDateFormatRules({ ...baseParams, yearString: '' });
+
+      const expected = {
+        hasErrors: true,
+        errors: generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INVALID_YEAR, mockErrors),
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when year has less than 4 digits', () => {
+    it('should return a validation error', () => {
+      const result = validDateFormatRules({ ...baseParams, yearString: '202' });
+
+      const expected = {
+        hasErrors: true,
+        errors: generateValidationErrors(FIELD_ID, ERROR_MESSAGES_OBJECT.INVALID_YEAR_DIGITS, mockErrors),
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when there are no validation errors', () => {
+    it('should return the provided errors object', () => {
+      const result = validDateFormatRules({ ...baseParams });
+
+      const expected = {
+        hasErrors: false,
+        errors: mockErrors,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/src/ui/server/shared-validation/date/valid-format/index.ts
+++ b/src/ui/server/shared-validation/date/valid-format/index.ts
@@ -1,0 +1,120 @@
+import generateValidationErrors from '../../../helpers/validation';
+import { isNumber } from '../../../helpers/number';
+import { DateValidationFormatRulesParams, DateValidationFormatRules } from '../../../../types';
+
+/**
+ * validDateFormatRules
+ * Check the format of day/month/year strings.
+ * @param {String} dayString: Day string
+ * @param {String} monthString: Month string
+ * @param {String} yearString: Year string
+ * @param {Object} errors: Errors object from previous validation errors
+ * @param {Object} errorMessages: All possible error messages for the date field.
+ * @param {String} fieldId: Date field ID
+ * @returns {ValidationErrors}
+ */
+const validDateFormatRules = ({
+  dayString,
+  monthString,
+  yearString,
+  errors,
+  errorMessages,
+  fieldId,
+}: DateValidationFormatRulesParams): DateValidationFormatRules => {
+  if (!dayString && !monthString && !yearString) {
+    return {
+      hasErrors: true,
+      errors: generateValidationErrors(fieldId, errorMessages.INCORRECT_FORMAT, errors),
+    };
+  }
+
+  const day = isNumber(dayString);
+  const month = isNumber(monthString);
+  const year = isNumber(yearString);
+
+  /**
+   * All fields must be numbers.
+   */
+  if (!day && !month && !year) {
+    return {
+      hasErrors: true,
+      errors: generateValidationErrors(fieldId, errorMessages.INCORRECT_FORMAT, errors),
+    };
+  }
+
+  /**
+   * has a day,
+   * no month or year.
+   */
+  if (day && !month && !year) {
+    return {
+      hasErrors: true,
+      errors: generateValidationErrors(fieldId, errorMessages.MISSING_MONTH_AND_YEAR, errors),
+    };
+  }
+
+  /**
+   * has a month,
+   * no day or year.
+   */
+  if (!day && month && !year) {
+    return {
+      hasErrors: true,
+      errors: generateValidationErrors(fieldId, errorMessages.MISSING_DAY_AND_YEAR, errors),
+    };
+  }
+
+  /**
+   * has a year,
+   * no day or month.
+   */
+  if (!day && !month && year) {
+    return {
+      hasErrors: true,
+      errors: generateValidationErrors(fieldId, errorMessages.MISSING_DAY_AND_MONTH, errors),
+    };
+  }
+
+  /**
+   * Individual date field validation rules.
+   * I.e, all but 1 date fields are provided.
+   */
+  if (!day) {
+    return {
+      hasErrors: true,
+      errors: generateValidationErrors(fieldId, errorMessages.INVALID_DAY, errors),
+    };
+  }
+
+  if (!month) {
+    return {
+      hasErrors: true,
+      errors: generateValidationErrors(fieldId, errorMessages.INVALID_MONTH, errors),
+    };
+  }
+
+  if (!year) {
+    return {
+      hasErrors: true,
+      errors: generateValidationErrors(fieldId, errorMessages.INVALID_YEAR, errors),
+    };
+  }
+
+  /**
+   * Check that a year has 4 digits.
+   * E.g a year cannot be 200.
+   */
+  if (yearString.length < 4) {
+    return {
+      hasErrors: true,
+      errors: generateValidationErrors(fieldId, errorMessages.INVALID_YEAR_DIGITS, errors),
+    };
+  }
+
+  return {
+    hasErrors: false,
+    errors,
+  };
+};
+
+export default validDateFormatRules;

--- a/src/ui/types/index.d.ts
+++ b/src/ui/types/index.d.ts
@@ -48,7 +48,7 @@ import {
   SummaryListGroupData,
 } from './summary-list';
 import { TaskList, TaskListData, TaskListDataTask, TaskListDataGroup, TaskListGroup, TaskListTask } from './task-list';
-import { ValidationErrors } from './validation-errors';
+import { DateValidationRulesParams, DateValidationFormatRulesParams, DateValidationFormatRules, ValidationErrors } from './validation-errors';
 import {
   CorePageVariablesInitialInput,
   CorePageVariablesInput,
@@ -93,6 +93,9 @@ export {
   Currency,
   CurrencyRadios,
   DateErrorMessage,
+  DateValidationRulesParams,
+  DateValidationFormatRulesParams,
+  DateValidationFormatRules,
   NumberErrorMessage,
   Business,
   InsuranceEligibility,

--- a/src/ui/types/validation-errors.d.ts
+++ b/src/ui/types/validation-errors.d.ts
@@ -1,3 +1,19 @@
+import { RequestBody } from './express';
+import { DateErrorMessage } from './errors';
+
+interface DateValidationRulesParams {
+  formBody: RequestBody;
+  errors: object;
+  fieldId: string;
+  errorMessages: DateErrorMessage;
+}
+
+interface DateValidationFormatRulesParams extends DateValidationRulesParams {
+  dayString: string;
+  monthString: string;
+  yearString: string;
+}
+
 type ValidationErrorsSummaryItem = {
   text: string;
   href: string;
@@ -9,4 +25,9 @@ interface ValidationErrors {
   summary?: Array<ValidationErrorsSummaryItem>;
 }
 
-export { ValidationErrors };
+interface DateValidationFormatRules {
+  hasErrors: boolean;
+  errors: ValidationErrors;
+}
+
+export { DateValidationRulesParams, DateValidationFormatRulesParams, DateValidationFormatRules, ValidationErrors };


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where date validation (currently only used in single/contract policy forms), would transform an invalid day into a valid date. E.g, "**31/02/2024**" would be transformed to "**02/03/2024**".

Now, a validation error is shown if a day is greater than the the total amount of days in the provided month.

## Resolution :heavy_check_mark:
- Add new helper function `getDaysInAMonth`.
- Extract some shared date rules into its own function, `validDateFormatRules`.
- Add a validation rule so that if the provided day is greater than the total amount of days in the month, an error will be returned.
- Add E2E  test coverage.

## Miscellaneous :heavy_plus_sign:
- Remove some unnecessary UI unit tests.
- Extract a type into the `/types` directory.
