### PR TITLE
chore(EMS-2455): DRY "form buttons" nunjucks component

### DIFF
--- a/src/ui/templates/components/form-buttons.njk
+++ b/src/ui/templates/components/form-buttons.njk
@@ -1,0 +1,44 @@
+{% from 'govuk/components/button/macro.njk' import govukButton %}
+{% import '../components/submit-button.njk' as submitButton %}
+
+{% macro render(params) %}
+
+  {% set contentStrings = params.contentStrings %}
+  {% set submitText = params.submitButtonText %}
+  {% set saveAndBackUrl = params.saveAndBackUrl %}
+  {% set saveAndBackAsALink = params.saveAndBackAsALink %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters-from-desktop">
+      <div class="govuk-button-group">
+        {{ submitButton.render({
+          text: submitText or contentStrings.CONTINUE
+        }) }}
+
+        {# 
+          Only render a "save and back" button/link, if a saveAndBackUrl param is provided.
+          If a saveAndBackAsALink param is provided, the button will render as a link.
+          This is required because some forms do not need "save and back" to actually make a form POST and save data,
+          rather, they just need to redirect to somewhere.
+        #}
+
+        {% if saveAndBackUrl %}
+          {% if saveAndBackAsALink %}
+            <a class="govuk-button govuk-button--secondary" href="{{ saveAndBackUrl }}" data-cy="save-and-back-button">{{ contentStrings.SAVE_AND_BACK }}</a>
+
+            {% else %}
+              {{ govukButton({
+                text: contentStrings.SAVE_AND_BACK,
+                classes: "govuk-button--secondary",
+                attributes: {
+                  'data-cy': 'save-and-back-button',
+                  'formaction': saveAndBackUrl
+                }
+              }) }}
+          {% endif %}
+        {% endif %}
+      </div>
+    </div>
+  </div>
+
+{% endmacro %}

--- a/src/ui/templates/components/form-buttons.njk
+++ b/src/ui/templates/components/form-buttons.njk
@@ -4,7 +4,7 @@
 {% macro render(params) %}
 
   {% set contentStrings = params.contentStrings %}
-  {% set submitText = params.submitButtonText %}
+  {% set submitText = params.submitText %}
   {% set saveAndBackUrl = params.saveAndBackUrl %}
   {% set saveAndBackAsALink = params.saveAndBackAsALink %}
 

--- a/src/ui/templates/components/single-radio.njk
+++ b/src/ui/templates/components/single-radio.njk
@@ -1,7 +1,6 @@
-{% from 'govuk/components/button/macro.njk' import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% import './yes-no-radio-buttons.njk' as yesNoRadioButtons %}
-{% import '../components/submit-button.njk' as submitButton %}
+{% import '../components/form-buttons.njk' as formButtons %}
 
 {% macro render(params) %}
 
@@ -66,25 +65,9 @@
     {% include customContentHTML %}
   {% endif %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters-from-desktop">
-      <div class="govuk-button-group">
-        {{ submitButton.render({
-          text: continueButtonText
-        }) }}
-
-        {% if saveAndBackUrl %}
-          {{ govukButton({
-            text: saveAndBackButtonText,
-            classes: "govuk-button--secondary",
-            attributes: {
-              'data-cy': 'save-and-back-button',
-              'formaction': saveAndBackUrl
-            }
-          }) }}
-        {% endif %}
-      </div>
-    </div>
-  </div>
+  {{ formButtons.render({
+    contentStrings: CONTENT_STRINGS.BUTTONS,
+    saveAndBackUrl: saveAndBackUrl
+  }) }}
 
 {% endmacro %}

--- a/src/ui/templates/insurance/declarations/anti-bribery.njk
+++ b/src/ui/templates/insurance/declarations/anti-bribery.njk
@@ -2,10 +2,9 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
-{% from 'govuk/components/button/macro.njk' import govukButton %}
 {% import '../../components/keystone/document/index.njk' as keystoneDocument %}
 {% import '../../components/declarations/anti-bribery/expandable-content.njk' as expandableContent %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -83,20 +82,10 @@
       }
     }) }}
 
-    <div class="govuk-button-group">
-      {{ submitButton.render({
-        text: CONTENT_STRINGS.BUTTONS.CONTINUE
-      }) }}
-
-      {{ govukButton({
-        text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-        classes: "govuk-button--secondary",
-        attributes: {
-          formaction: SAVE_AND_BACK_URL,
-          'data-cy': 'save-and-back-button'
-        }
-      }) }}
-    </div>
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      saveAndBackUrl: SAVE_AND_BACK_URL
+    }) }}
 
   </form>
 

--- a/src/ui/templates/insurance/declarations/confidentiality.njk
+++ b/src/ui/templates/insurance/declarations/confidentiality.njk
@@ -3,7 +3,7 @@
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from 'govuk/components/button/macro.njk' import govukButton %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -117,20 +117,10 @@
       }
     }) }}
 
-    <div class="govuk-button-group">
-      {{ submitButton.render({
-        text: CONTENT_STRINGS.BUTTONS.CONTINUE
-      }) }}
-
-      {{ govukButton({
-        text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-        classes: "govuk-button--secondary",
-        attributes: {
-          formaction: SAVE_AND_BACK_URL,
-          'data-cy': 'save-and-back-button'
-        }
-      }) }}
-    </div>
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      saveAndBackUrl: SAVE_AND_BACK_URL
+    }) }}
 
   </form>
 

--- a/src/ui/templates/insurance/export-contract/about-goods-or-services.njk
+++ b/src/ui/templates/insurance/export-contract/about-goods-or-services.njk
@@ -5,9 +5,8 @@
 {% import '../../components/yes-no-radio-buttons.njk' as yesNoRadioButtons %}
 {% from "govuk/components/label/macro.njk" import govukLabel %}
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
-{% from 'govuk/components/button/macro.njk' import govukButton %}
 {% import '../../components/accessible-autocomplete-select.njk' as accessibleAutoCompleteSelect %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -138,20 +137,10 @@
       </div>
     </div>
 
-    <div class="govuk-button-group">
-      {{ submitButton.render({
-        text: CONTENT_STRINGS.BUTTONS.CONTINUE
-      }) }}
-
-      {{ govukButton({
-        text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-        classes: "govuk-button--secondary",
-        attributes: {
-          formaction: SAVE_AND_BACK_URL,
-          'data-cy': 'save-and-back-button'
-        }
-      }) }}
-    </div>
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      saveAndBackUrl: SAVE_AND_BACK_URL
+    }) }}
 
   </form>
 

--- a/src/ui/templates/insurance/export-contract/check-your-answers.njk
+++ b/src/ui/templates/insurance/export-contract/check-your-answers.njk
@@ -1,7 +1,7 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -33,13 +33,12 @@
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-    <div class="govuk-button-group">
-      {{ submitButton.render({
-        text: CONTENT_STRINGS.BUTTONS.CONTINUE_NEXT_SECTION
-      }) }}
-
-      <a class="govuk-button--secondary" href="{{ SAVE_AND_BACK_URL }}" data-cy="save-and-back-button">{{ CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK }}</a>
-    </div>
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      submitText: CONTENT_STRINGS.BUTTONS.CONTINUE_NEXT_SECTION,
+      saveAndBackUrl: SAVE_AND_BACK_URL,
+      saveAndBackAsALink: true
+    }) }}
 
   </form>
 

--- a/src/ui/templates/insurance/policy/broker.njk
+++ b/src/ui/templates/insurance/policy/broker.njk
@@ -1,11 +1,10 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% import '../../components/yes-no-radio-buttons.njk' as yesNoRadioButtons %}
 {% import '../../components/address-fields.njk' as addressInput %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% import '../../components/fieldset-legend.njk' as fieldsetLegend %}
@@ -138,22 +137,10 @@
         }) }}
       </div>
 
-      <div class="govuk-grid-column-three-quarters-from-desktop">
-        <div class="govuk-button-group">
-          {{ submitButton.render({
-            text: CONTENT_STRINGS.BUTTONS.CONTINUE
-          }) }}
-
-          {{ govukButton({
-            text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-            classes: "govuk-button--secondary",
-            attributes: {
-              'data-cy': 'save-and-back-button',
-              'formaction': SAVE_AND_BACK_URL
-            }
-          }) }}
-        </div>
-      </div>
+      {{ formButtons.render({
+        contentStrings: CONTENT_STRINGS.BUTTONS,
+        saveAndBackUrl: SAVE_AND_BACK_URL
+      }) }}
     </form>
   </div>
 

--- a/src/ui/templates/insurance/policy/check-your-answers.njk
+++ b/src/ui/templates/insurance/policy/check-your-answers.njk
@@ -1,7 +1,7 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% import '../../components/group-of-summary-lists.njk' as groupOfSummaryLists %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -32,13 +32,12 @@
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-    <div class="govuk-button-group">
-      {{ submitButton.render({
-        text: CONTENT_STRINGS.BUTTONS.CONTINUE_NEXT_SECTION
-      }) }}
-
-      <a class="govuk-button--secondary" href="{{ SAVE_AND_BACK_URL }}" data-cy="save-and-back-button">{{ CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK }}</a>
-    </div>
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      submitText: CONTENT_STRINGS.BUTTONS.CONTINUE_NEXT_SECTION,
+      saveAndBackUrl: SAVE_AND_BACK_URL,
+      saveAndBackAsALink: true
+    }) }}
 
   </form>
 

--- a/src/ui/templates/insurance/policy/different-name-on-policy.njk
+++ b/src/ui/templates/insurance/policy/different-name-on-policy.njk
@@ -1,12 +1,11 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/hint/macro.njk" import govukHint %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% import '../../components/personal-details-input.njk' as personalDetailsInput %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -92,22 +91,10 @@
         {% endcall %}
       </div>
 
-      <div class="govuk-grid-column-three-quarters-from-desktop govuk-!-margin-top-5">
-        <div class="govuk-button-group">
-          {{ submitButton.render({
-            text: CONTENT_STRINGS.BUTTONS.CONTINUE
-          }) }}
-
-          {{ govukButton({
-            text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-            classes: "govuk-button--secondary",
-            attributes: {
-              'data-cy': 'save-and-back-button',
-              'formaction': SAVE_AND_BACK_URL
-            }
-          }) }}
-        </div>
-      </div>
+      {{ formButtons.render({
+        contentStrings: CONTENT_STRINGS.BUTTONS,
+        saveAndBackUrl: SAVE_AND_BACK_URL
+      }) }}
     </form>
   </div>
 

--- a/src/ui/templates/insurance/policy/multiple-contract-policy-export-value.njk
+++ b/src/ui/templates/insurance/policy/multiple-contract-policy-export-value.njk
@@ -2,8 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from 'govuk/components/button/macro.njk' import govukButton %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -126,20 +125,10 @@
       </div>
     </div>
 
-    <div class="govuk-button-group">
-      {{ submitButton.render({
-        text: CONTENT_STRINGS.BUTTONS.CONTINUE
-      }) }}
-
-      {{ govukButton({
-        text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-        classes: "govuk-button--secondary",
-        attributes: {
-          formaction: SAVE_AND_BACK_URL,
-          'data-cy': 'save-and-back-button'
-        }
-      }) }}
-    </div>
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      saveAndBackUrl: SAVE_AND_BACK_URL
+    }) }}
 
   </form>
 

--- a/src/ui/templates/insurance/policy/multiple-contract-policy.njk
+++ b/src/ui/templates/insurance/policy/multiple-contract-policy.njk
@@ -2,10 +2,9 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from 'govuk/components/button/macro.njk' import govukButton %}
 {% import '../../components/date-input.njk' as dateInput %}
 {% import '../../components/currency-radio-inputs.njk' as radiosInputs %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -97,20 +96,10 @@
       </div>
     </div>
 
-    <div class="govuk-button-group">
-      {{ submitButton.render({
-        text: CONTENT_STRINGS.BUTTONS.CONTINUE
-      }) }}
-
-      {{ govukButton({
-        text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-        classes: "govuk-button--secondary",
-        attributes: {
-          formaction: SAVE_AND_BACK_URL,
-          'data-cy': 'save-and-back-button'
-        }
-      }) }}
-    </div>
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      saveAndBackUrl: SAVE_AND_BACK_URL
+    }) }}
 
   </form>
 

--- a/src/ui/templates/insurance/policy/name-on-policy.njk
+++ b/src/ui/templates/insurance/policy/name-on-policy.njk
@@ -1,11 +1,10 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% import '../../components/submit-button.njk' as submitButton %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from 'govuk/components/radios/macro.njk' import govukRadios %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from 'govuk/components/button/macro.njk' import govukButton %}
 {% from "govuk/components/hint/macro.njk" import govukHint %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -118,20 +117,10 @@
       }
     }) }}
 
-    <div class="govuk-button-group">
-      {{ submitButton.render({
-        text: CONTENT_STRINGS.BUTTONS.CONTINUE
-      }) }}
-
-      {{ govukButton({
-        text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-        classes: "govuk-button--secondary",
-        attributes: {
-          formaction: SAVE_AND_BACK_URL,
-          'data-cy': 'save-and-back-button'
-        }
-      }) }}
-    </div>
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      saveAndBackUrl: SAVE_AND_BACK_URL
+    }) }}
 
   </form>
 

--- a/src/ui/templates/insurance/policy/single-contract-policy-total-contract-value.njk
+++ b/src/ui/templates/insurance/policy/single-contract-policy-total-contract-value.njk
@@ -4,9 +4,8 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/hint/macro.njk" import govukHint %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from 'govuk/components/button/macro.njk' import govukButton %}
 {% import '../../components/fieldset-legend.njk' as fieldsetLegend %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -89,20 +88,10 @@
       </div>
     </div>
 
-    <div class="govuk-button-group">
-      {{ submitButton.render({
-        text: CONTENT_STRINGS.BUTTONS.CONTINUE
-      }) }}
-
-      {{ govukButton({
-        text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-        classes: "govuk-button--secondary",
-        attributes: {
-          formaction: SAVE_AND_BACK_URL,
-          'data-cy': 'save-and-back-button'
-        }
-      }) }}
-    </div>
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      saveAndBackUrl: SAVE_AND_BACK_URL
+    }) }}
 
   </form>
 

--- a/src/ui/templates/insurance/policy/single-contract-policy.njk
+++ b/src/ui/templates/insurance/policy/single-contract-policy.njk
@@ -1,10 +1,9 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
-{% from 'govuk/components/button/macro.njk' import govukButton %}
 {% import '../../components/date-input.njk' as dateInput %}
 {% import '../../components/currency-radio-inputs.njk' as radiosInputs %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -75,20 +74,10 @@
       </div>
     </div>
 
-    <div class="govuk-button-group">
-      {{ submitButton.render({
-        text: CONTENT_STRINGS.BUTTONS.CONTINUE
-      }) }}
-
-      {{ govukButton({
-        text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-        classes: "govuk-button--secondary",
-        attributes: {
-          formaction: SAVE_AND_BACK_URL,
-          'data-cy': 'save-and-back-button'
-        }
-      }) }}
-    </div>
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      saveAndBackUrl: SAVE_AND_BACK_URL
+    }) }}
 
   </form>
 

--- a/src/ui/templates/insurance/policy/type-of-policy.njk
+++ b/src/ui/templates/insurance/policy/type-of-policy.njk
@@ -2,8 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from 'govuk/components/button/macro.njk' import govukButton %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -114,20 +113,10 @@
       </div>
     </div>
 
-    <div class="govuk-button-group">
-      {{ submitButton.render({
-        text: CONTENT_STRINGS.BUTTONS.CONTINUE
-      }) }}
-
-      {{ govukButton({
-        text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-        classes: "govuk-button--secondary",
-        attributes: {
-          formaction: SAVE_AND_BACK_URL,
-          'data-cy': 'save-and-back-button'
-        }
-      }) }}
-    </div>
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      saveAndBackUrl: SAVE_AND_BACK_URL
+    }) }}
 
   </form>
 

--- a/src/ui/templates/insurance/your-business/alternative-trading-address.njk
+++ b/src/ui/templates/insurance/your-business/alternative-trading-address.njk
@@ -1,10 +1,9 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "govuk/components/hint/macro.njk" import govukHint %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -88,25 +87,13 @@
           }) }}
         <div>
 
-        </div>
+        {{ formButtons.render({
+          contentStrings: CONTENT_STRINGS.BUTTONS,
+          saveAndBackUrl: SAVE_AND_BACK_URL
+        }) }}
+
       </div>
 
-      <div class="govuk-grid-column-three-quarters-from-desktop">
-        <div class="govuk-button-group">
-          {{ submitButton.render({
-            text: CONTENT_STRINGS.BUTTONS.CONTINUE
-          }) }}
-
-          {{ govukButton({
-            text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-            classes: "govuk-button--secondary",
-            attributes: {
-              'data-cy': 'save-and-back-button',
-              formaction : SAVE_AND_BACK_URL
-            }
-          }) }}
-        </div>
-      </div>
     </form>
   </div>
 

--- a/src/ui/templates/insurance/your-business/check-your-answers.njk
+++ b/src/ui/templates/insurance/your-business/check-your-answers.njk
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% import '../../components/group-of-summary-lists.njk' as groupOfSummaryLists %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -33,15 +33,13 @@
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-    <div class="govuk-button-group">
-      {{ submitButton.render({
-        text: CONTENT_STRINGS.BUTTONS.CONTINUE_NEXT_SECTION
-      }) }}
-
-      <a class="govuk-button--secondary" href="{{ SAVE_AND_BACK_URL }}" data-cy="save-and-back-button">{{ CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK }}</a>
-    </div>
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      submitText: CONTENT_STRINGS.BUTTONS.CONTINUE_NEXT_SECTION,
+      saveAndBackUrl: SAVE_AND_BACK_URL,
+      saveAndBackAsALink: true
+    }) }}
 
   </form>
-
 
 {% endblock %}

--- a/src/ui/templates/insurance/your-business/companies_house_number.njk
+++ b/src/ui/templates/insurance/your-business/companies_house_number.njk
@@ -1,9 +1,8 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -66,24 +65,14 @@
         </div>
 
         <p class="govuk-!-margin-bottom-6"><a class="govuk-link" href="{{EXIT_PAGE_URL}}" data-cy="do-not-have-number">{{CONTENT_STRINGS.NO_COMPANIES_HOUSE_NUMBER}}</a></p>
+
+        {{ formButtons.render({
+          contentStrings: CONTENT_STRINGS.BUTTONS,
+          saveAndBackUrl: SAVE_AND_BACK_URL
+        }) }}
+
       </div>
 
-      <div class="govuk-grid-column-three-quarters-from-desktop">
-        <div class="govuk-button-group">
-          {{ submitButton.render({
-            text: CONTENT_STRINGS.BUTTONS.CONTINUE
-          }) }}
-
-          {{ govukButton({
-            text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-            classes: "govuk-button--secondary",
-            attributes: {
-              'data-cy': 'save-and-back-button',
-              'formaction': SAVE_AND_BACK_URL
-            }
-          }) }}
-        </div>
-      </div>
     </form>
   </div>
 

--- a/src/ui/templates/insurance/your-business/company-details.njk
+++ b/src/ui/templates/insurance/your-business/company-details.njk
@@ -1,12 +1,11 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% import '../../components/yes-no-radio-buttons.njk' as yesNoRadioButtons %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -167,24 +166,14 @@
             }
           }
         }) }}
+
+        {{ formButtons.render({
+          contentStrings: CONTENT_STRINGS.BUTTONS,
+          saveAndBackUrl: SAVE_AND_BACK_URL
+        }) }}
+
       </div>
 
-      <div class="govuk-grid-column-three-quarters-from-desktop">
-        <div class="govuk-button-group">
-          {{ submitButton.render({
-            text: CONTENT_STRINGS.BUTTONS.CONTINUE
-          }) }}
-
-          {{ govukButton({
-            text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-            classes: "govuk-button--secondary",
-            attributes: {
-              'data-cy': 'save-and-back-button',
-              formaction : SAVE_AND_BACK_URL
-            }
-          }) }}
-        </div>
-      </div>
     </form>
   </div>
 

--- a/src/ui/templates/insurance/your-business/contact.njk
+++ b/src/ui/templates/insurance/your-business/contact.njk
@@ -1,12 +1,11 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/hint/macro.njk" import govukHint %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% import '../../components/personal-details-input.njk' as personalDetailsInput %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 {% import '../../components/fieldset-legend.njk' as fieldsetLegend %}
 
 {% block pageTitle %}
@@ -109,22 +108,10 @@
         {% endcall %}
       </div>
 
-      <div class="govuk-grid-column-three-quarters-from-desktop govuk-!-margin-top-5">
-        <div class="govuk-button-group">
-          {{ submitButton.render({
-            text: CONTENT_STRINGS.BUTTONS.CONTINUE
-          }) }}
-
-          {{ govukButton({
-            text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-            classes: "govuk-button--secondary",
-            attributes: {
-              'data-cy': 'save-and-back-button',
-              'formaction': SAVE_AND_BACK_URL
-            }
-          }) }}
-        </div>
-      </div>
+      {{ formButtons.render({
+        contentStrings: CONTENT_STRINGS.BUTTONS,
+        saveAndBackUrl: SAVE_AND_BACK_URL
+      }) }}
     </form>
   </div>
 

--- a/src/ui/templates/insurance/your-business/nature-of-your-business.njk
+++ b/src/ui/templates/insurance/your-business/nature-of-your-business.njk
@@ -1,10 +1,9 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -137,24 +136,13 @@
           }
         }) }}
 
+        {{ formButtons.render({
+          contentStrings: CONTENT_STRINGS.BUTTONS,
+          saveAndBackUrl: POST_ROUTES.SAVE_AND_BACK_URL
+        }) }}
+
       </div>
 
-      <div class="govuk-grid-column-three-quarters-from-desktop">
-        <div class="govuk-button-group">
-          {{ submitButton.render({
-            text: CONTENT_STRINGS.BUTTONS.CONTINUE
-          }) }}
-
-          {{ govukButton({
-            text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-            classes: "govuk-button--secondary",
-            attributes: {
-              'data-cy': 'save-and-back-button',
-              'formaction': POST_ROUTES.SAVE_AND_BACK_URL
-            }
-          }) }}
-        </div>
-      </div>
     </form>
   </div>
 

--- a/src/ui/templates/insurance/your-business/turnover.njk
+++ b/src/ui/templates/insurance/your-business/turnover.njk
@@ -1,11 +1,10 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/hint/macro.njk" import govukHint %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 {% import '../../components/fieldset-legend.njk' as fieldsetLegend %}
 
 {% block pageTitle %}
@@ -129,25 +128,13 @@
             }
           }) }}
         {% endcall %}
+
+        {{ formButtons.render({
+          contentStrings: CONTENT_STRINGS.BUTTONS,
+          saveAndBackUrl: SAVE_AND_BACK_URL
+        }) }}
       </div>
 
-
-      <div class="govuk-grid-column-three-quarters-from-desktop">
-        <div class="govuk-button-group">
-          {{ submitButton.render({
-            text: CONTENT_STRINGS.BUTTONS.CONTINUE
-          }) }}
-
-          {{ govukButton({
-            text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-            classes: "govuk-button--secondary",
-            attributes: {
-              'data-cy': 'save-and-back-button',
-              'formaction': SAVE_AND_BACK_URL
-            }
-          }) }}
-        </div>
-      </div>
     </form>
   </div>
 

--- a/src/ui/templates/insurance/your-buyer/check-your-answers.njk
+++ b/src/ui/templates/insurance/your-buyer/check-your-answers.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from 'govuk/components/button/macro.njk' import govukButton %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -34,13 +34,12 @@
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-    <div class="govuk-button-group">
-      {{ submitButton.render({
-        text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK
-      }) }}
-
-      <a class="govuk-button--secondary" href="{{ SAVE_AND_BACK_URL }}" data-cy="save-and-back-button">{{ CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK }}</a>
-    </div>
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      submitText: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
+      saveAndBackUrl: SAVE_AND_BACK_URL,
+      saveAndBackAsALink: true
+    }) }}
 
   </form>
 

--- a/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
+++ b/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
@@ -3,7 +3,6 @@
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from 'govuk/components/label/macro.njk' import govukLabel %}
 {% from "govuk/components/hint/macro.njk" import govukHint %}
-{% from 'govuk/components/button/macro.njk' import govukButton %}
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
@@ -11,7 +10,7 @@
 {% from "govuk/components/hint/macro.njk" import govukHint %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% import '../../components/yes-no-radio-buttons.njk' as yesNoRadioButtons %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 {% import '../../components/fieldset-legend.njk' as fieldsetLegend %}
 
 {% block pageTitle %}
@@ -274,22 +273,10 @@
         }) }}
       </div>
 
-      <div class="govuk-grid-column-three-quarters-from-desktop">
-        <div class="govuk-button-group">
-          {{ submitButton.render({
-            text: CONTENT_STRINGS.BUTTONS.CONTINUE
-          }) }}
-
-          {{ govukButton({
-            text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-            classes: "govuk-button--secondary",
-            attributes: {
-              'data-cy': 'save-and-back-button',
-              'formaction': SAVE_AND_BACK_URL
-            }
-          }) }}
-        </div>
-      </div>
+      {{ formButtons.render({
+        contentStrings: CONTENT_STRINGS.BUTTONS,
+        saveAndBackUrl: SAVE_AND_BACK_URL
+      }) }}
     </div>
   </form>
 

--- a/src/ui/templates/insurance/your-buyer/trading-history.njk
+++ b/src/ui/templates/insurance/your-buyer/trading-history.njk
@@ -1,13 +1,12 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/hint/macro.njk" import govukHint %}
 {% import '../../components/yes-no-radio-buttons.njk' as yesNoRadioButtons %}
-{% import '../../components/submit-button.njk' as submitButton %}
+{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -76,22 +75,11 @@
           }) }}
         </div>
 
-        <div class="govuk-grid-column-three-quarters-from-desktop">
-          <div class="govuk-button-group">
-            {{ submitButton.render({
-              text: CONTENT_STRINGS.BUTTONS.CONTINUE
-            }) }}
+        {{ formButtons.render({
+          contentStrings: CONTENT_STRINGS.BUTTONS,
+          saveAndBackUrl: SAVE_AND_BACK_URL
+        }) }}
 
-            {{ govukButton({
-              text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-              classes: "govuk-button--secondary",
-              attributes: {
-                'data-cy': 'save-and-back-button',
-                formaction : SAVE_AND_BACK_URL
-              }
-            }) }}
-          </div>
-      </div>
     </form>
   </div>
 

--- a/src/ui/templates/shared-pages/declaration.njk
+++ b/src/ui/templates/shared-pages/declaration.njk
@@ -2,9 +2,8 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
-{% from 'govuk/components/button/macro.njk' import govukButton %}
 {% import '../components/keystone/document/index.njk' as keystoneDocument %}
-{% import '../components/submit-button.njk' as submitButton %}
+{% import '../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -78,20 +77,11 @@
       }
     }) }}
 
-    <div class="govuk-button-group">
-      {{ submitButton.render({
-        text: SUBMIT_BUTTON_COPY or CONTENT_STRINGS.BUTTONS.CONTINUE
-      }) }}
-
-      {{ govukButton({
-        text: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK,
-        classes: "govuk-button--secondary",
-        attributes: {
-          formaction: SAVE_AND_BACK_URL,
-          'data-cy': 'save-and-back-button'
-        }
-      }) }}
-    </div>
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      submitText: SUBMIT_BUTTON_COPY or CONTENT_STRINGS.BUTTONS.CONTINUE,
+      saveAndBackUrl: SAVE_AND_BACK_URL
+    }) }}
 
   </form>
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds a new "form buttons" component to be used in any form that has a "continue" and an optional "save and back" button.

This ensures that every instance of such buttons is DRY and consistent. This will also save us some time as we setup new forms.

## Resolution :heavy_check_mark:
- Create new component.
  - Conditionally render custom submit button text.
  - Conditionally render the "save and back" button as a link, if a `saveAndBackAsALink` param is passed.
- Update all nunjucks templates and partials/components that have submit and "save and back" buttons.

## Miscellaneous :heavy_plus_sign:
List any additional fixes or improvements.
