### PR TITLE
style(EMS-2464): No PDF - Your business - Summary list updates

### DIFF
--- a/e2e-tests/commands/insurance/check-your-business-summary-list.js
+++ b/e2e-tests/commands/insurance/check-your-business-summary-list.js
@@ -1,34 +1,34 @@
 import { summaryList } from '../../pages/shared';
 import getSummaryListField from './get-summary-list-field';
-import { FIELD_IDS, FIELD_VALUES } from '../../constants';
+import { GBP_CURRENCY_CODE, FIELD_VALUES } from '../../constants';
+import { INSURANCE_FIELD_IDS } from '../../constants/field-ids/insurance';
 import { EXPORTER_BUSINESS_FIELDS as FIELDS } from '../../content-strings/fields/insurance/business';
+import formatCurrency from '../../helpers/format-currency';
 import application from '../../fixtures/application';
 
 const {
-  INSURANCE: {
-    EXPORTER_BUSINESS: {
-      YOUR_COMPANY: {
-        HAS_DIFFERENT_TRADING_NAME,
-        TRADING_ADDRESS,
-        WEBSITE,
-        PHONE_NUMBER,
-      },
-      ALTERNATIVE_TRADING_ADDRESS: {
-        FULL_ADDRESS,
-      },
-      NATURE_OF_YOUR_BUSINESS: {
-        YEARS_EXPORTING,
-        GOODS_OR_SERVICES,
-        EMPLOYEES_UK,
-      },
-      TURNOVER: {
-        ESTIMATED_ANNUAL_TURNOVER,
-        PERCENTAGE_TURNOVER,
-      },
-      HAS_CREDIT_CONTROL,
+  EXPORTER_BUSINESS: {
+    YOUR_COMPANY: {
+      HAS_DIFFERENT_TRADING_NAME,
+      TRADING_ADDRESS,
+      WEBSITE,
+      PHONE_NUMBER,
     },
+    ALTERNATIVE_TRADING_ADDRESS: {
+      FULL_ADDRESS,
+    },
+    NATURE_OF_YOUR_BUSINESS: {
+      YEARS_EXPORTING,
+      GOODS_OR_SERVICES,
+      EMPLOYEES_UK,
+    },
+    TURNOVER: {
+      ESTIMATED_ANNUAL_TURNOVER,
+      PERCENTAGE_TURNOVER,
+    },
+    HAS_CREDIT_CONTROL,
   },
-} = FIELD_IDS;
+} = INSURANCE_FIELD_IDS;
 
 const checkYourBusinessSummaryList = ({
   [HAS_DIFFERENT_TRADING_NAME]: () => {
@@ -105,7 +105,7 @@ const checkYourBusinessSummaryList = ({
     const fieldId = ESTIMATED_ANNUAL_TURNOVER;
 
     const { expectedKey, expectedChangeLinkText } = getSummaryListField(fieldId, FIELDS.TURNOVER);
-    const expectedValue = `£${application.EXPORTER_BUSINESS[fieldId]}`;
+    const expectedValue = formatCurrency(application.EXPORTER_BUSINESS[fieldId], GBP_CURRENCY_CODE);
 
     cy.assertSummaryListRow(summaryList, fieldId, expectedKey, expectedValue, expectedChangeLinkText);
   },

--- a/e2e-tests/content-strings/fields/insurance/business/index.js
+++ b/e2e-tests/content-strings/fields/insurance/business/index.js
@@ -79,7 +79,7 @@ export const EXPORTER_BUSINESS_FIELDS = {
     [FIELD_IDS.INSURANCE.EXPORTER_BUSINESS.NATURE_OF_YOUR_BUSINESS.EMPLOYEES_UK]: {
       LEGEND: 'How many employees do you have in the UK?',
       SUMMARY: {
-        TITLE: 'Number of employees',
+        TITLE: 'Number of UK employees',
         FORM_TITLE: NATURE_OF_BUSINESS,
       },
     },

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
@@ -1,7 +1,9 @@
 import partials from '../../../../../../../partials';
 import { field, summaryList } from '../../../../../../../pages/shared';
+import { GBP_CURRENCY_CODE } from '../../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import formatCurrency from '../../../../../../../helpers/format-currency';
 
 const {
   ROOT,
@@ -98,7 +100,8 @@ context('Insurance - Check your answers - Turnover - Your business - Summary lis
       });
 
       it('should render the new answer', () => {
-        fieldVariables.newValue = `£${fieldVariables.newValueInput}`;
+        fieldVariables.newValue = formatCurrency(fieldVariables.newValueInput, GBP_CURRENCY_CODE);
+
         cy.checkChangeAnswerRendered(fieldVariables);
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
@@ -1,6 +1,8 @@
 import { field, summaryList } from '../../../../../../pages/shared';
+import { GBP_CURRENCY_CODE } from '../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import formatCurrency from '../../../../../../helpers/format-currency';
 
 const {
   TURNOVER: {
@@ -75,7 +77,9 @@ context('Insurance - Your business - Change your answers - Turnover - As an expo
       });
 
       it('should render the new answer', () => {
-        cy.assertSummaryListRowValue(summaryList, fieldId, `£${newAnswer}`);
+        const expectedValue = formatCurrency(newAnswer, GBP_CURRENCY_CODE);
+
+        cy.assertSummaryListRowValue(summaryList, fieldId, expectedValue);
       });
     });
   });

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -4160,7 +4160,7 @@ var FIELDS = {
     },
     [EMPLOYEES_UK]: {
       SUMMARY: {
-        TITLE: "Number of employees"
+        TITLE: "Number of UK employees"
       }
     }
   },

--- a/src/api/content-strings/fields/insurance/your-business/index.ts
+++ b/src/api/content-strings/fields/insurance/your-business/index.ts
@@ -81,7 +81,7 @@ export const FIELDS = {
     },
     [EMPLOYEES_UK]: {
       SUMMARY: {
-        TITLE: 'Number of employees',
+        TITLE: 'Number of UK employees',
       },
     },
   },

--- a/src/ui/server/content-strings/fields/insurance/your-business/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/your-business/index.ts
@@ -77,7 +77,7 @@ export const FIELDS = {
     [EMPLOYEES_UK]: {
       LEGEND: 'How many employees do you have in the UK?',
       SUMMARY: {
-        TITLE: 'Number of employees',
+        TITLE: 'Number of UK employees',
         FORM_TITLE: NATURE_OF_BUSINESS,
       },
     },

--- a/src/ui/server/helpers/summary-lists/your-business/turnover-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-business/turnover-fields/index.test.ts
@@ -1,9 +1,11 @@
 import { FORM_TITLES } from '../../../../content-strings/form-titles';
 import { FIELDS } from '../../../../content-strings/fields/insurance';
+import { GBP_CURRENCY_CODE } from '../../../../constants';
 import INSURANCE_FIELD_IDS from '../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
 import fieldGroupItem from '../../generate-field-group-item';
 import getFieldById from '../../../get-field-by-id';
+import formatCurrency from '../../../format-currency';
 import generateTurnoverFields from '.';
 import mapPercentage from '../../../map-percentage';
 import generateChangeLink from '../../../generate-change-link';
@@ -36,7 +38,7 @@ describe('server/helpers/summary-lists/your-business/turnover-fields', () => {
         href: generateChangeLink(TURNOVER_CHANGE, TURNOVER_CHECK_AND_CHANGE, `#${ESTIMATED_ANNUAL_TURNOVER}-label`, referenceNumber, checkAndChange),
         renderChangeLink: true,
       },
-      `£${mockAnswers[ESTIMATED_ANNUAL_TURNOVER]}`,
+      formatCurrency(mockAnswers[ESTIMATED_ANNUAL_TURNOVER], GBP_CURRENCY_CODE),
     ),
     fieldGroupItem(
       {

--- a/src/ui/server/helpers/summary-lists/your-business/turnover-fields/index.ts
+++ b/src/ui/server/helpers/summary-lists/your-business/turnover-fields/index.ts
@@ -1,9 +1,11 @@
 import { FORM_TITLES } from '../../../../content-strings/form-titles';
 import { FIELDS } from '../../../../content-strings/fields/insurance';
+import { GBP_CURRENCY_CODE } from '../../../../constants';
 import INSURANCE_FIELD_IDS from '../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
 import fieldGroupItem from '../../generate-field-group-item';
 import getFieldById from '../../../get-field-by-id';
+import formatCurrency from '../../../format-currency';
 import mapPercentage from '../../../map-percentage';
 import { ApplicationBusiness, SummaryListItemData, SummaryListGroupData } from '../../../../../types';
 import generateChangeLink from '../../../generate-change-link';
@@ -39,7 +41,7 @@ const generateTurnoverFields = (answers: ApplicationBusiness, referenceNumber: n
         href: generateChangeLink(TURNOVER_CHANGE, TURNOVER_CHECK_AND_CHANGE, `#${ESTIMATED_ANNUAL_TURNOVER}-label`, referenceNumber, checkAndChange),
         renderChangeLink: true,
       },
-      `£${answers[ESTIMATED_ANNUAL_TURNOVER]}`,
+      formatCurrency(answers[ESTIMATED_ANNUAL_TURNOVER], GBP_CURRENCY_CODE),
     ),
     fieldGroupItem(
       {


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates some copy and formatting for the "Your business" summary list, in "Check your answers" pages of a no PDF application.

## Resolution :heavy_check_mark:
- Update content strings.
- Update the `ESTIMATED_ANNUAL_TURNOVER` field value to be formatted correctly. (Previously eg `£1500`, now `£1,500`).

## Miscellaneous :heavy_plus_sign:
- Minor destructuring improvements.
