### PR TITLE
feat(EMS-2583): No PDF - Policy - Another company - Page setup

### DIFF
--- a/e2e-tests/constants/field-ids/insurance/policy/index.js
+++ b/e2e-tests/constants/field-ids/insurance/policy/index.js
@@ -38,9 +38,11 @@ export const POLICY = {
   },
   NAME_ON_POLICY: {
     NAME: 'nameOnPolicy',
+    IS_SAME_AS_OWNER: 'isSameAsOwner',
     SAME_NAME: 'sameName',
     OTHER_NAME: 'otherName',
     POSITION: 'position',
+    POLICY_CONTACT_EMAIL: 'policyContact.email',
   },
   DIFFERENT_NAME_ON_POLICY: {
     POLICY_CONTACT_DETAIL: 'policyContactDetail',
@@ -48,6 +50,7 @@ export const POLICY = {
   },
   NEED_PRE_CREDIT_PERIOD: 'needPreCreditPeriodCover',
   CREDIT_PERIOD_WITH_BUYER: 'creditPeriodWithBuyer',
+  NEED_ANOTHER_COMPANY_TO_BE_INSURED: 'needAnotherCompanyToBeInsured',
   BROKER: {
     LEGEND: 'broker',
     USING_BROKER: 'isUsingBroker',

--- a/e2e-tests/constants/routes/insurance/policy.js
+++ b/e2e-tests/constants/routes/insurance/policy.js
@@ -33,6 +33,8 @@ export const POLICY = {
   PRE_CREDIT_PERIOD_SAVE_AND_BACK: `${ROOT}/pre-credit-period/save-and-go-back`,
   PRE_CREDIT_PERIOD_CHANGE: `${ROOT}/pre-credit-period/change`,
   PRE_CREDIT_PERIOD_CHECK_AND_CHANGE: `${ROOT}/pre-credit-period/check-and-change`,
+  ANOTHER_COMPANY: `${ROOT}/another-company`,
+  ANOTHER_COMPANY_SAVE_AND_BACK: `${ROOT}/another-company/save-and-go-back`,
   BROKER_ROOT,
   BROKER_SAVE_AND_BACK: `${BROKER_ROOT}/save-and-back`,
   BROKER_CHANGE: `${BROKER_ROOT}/change`,

--- a/e2e-tests/content-strings/fields/insurance/policy/index.js
+++ b/e2e-tests/content-strings/fields/insurance/policy/index.js
@@ -71,7 +71,7 @@ export const POLICY_FIELDS = {
   CONTRACT_POLICY: {
     [CONTRACT_POLICY.REQUESTED_START_DATE]: {
       LABEL: 'When do you want your policy to start?',
-      HINT: 'For example, 06 11 2023 ',
+      HINT: 'For example, 06 11 2023',
       SUMMARY: {
         TITLE: 'Policy start date',
         FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,

--- a/e2e-tests/content-strings/fields/insurance/policy/index.js
+++ b/e2e-tests/content-strings/fields/insurance/policy/index.js
@@ -1,21 +1,34 @@
-import {
-  APPLICATION,
-  ELIGIBILITY,
-  FIELD_IDS,
-  FIELD_VALUES,
-} from '../../../../constants';
+import { APPLICATION, ELIGIBILITY, FIELD_VALUES } from '../../../../constants';
+import { INSURANCE_FIELD_IDS } from '../../../../constants/field-ids/insurance';
 import { FORM_TITLES } from '../../../form-titles';
 
-const { POLICY, ACCOUNT } = FIELD_IDS.INSURANCE;
-
 const {
-  BROKER, CONTRACT_POLICY, EXPORT_VALUE, NAME_ON_POLICY, DIFFERENT_NAME_ON_POLICY, NEED_PRE_CREDIT_PERIOD, CREDIT_PERIOD_WITH_BUYER,
-} = POLICY;
-
-const { EMAIL } = ACCOUNT;
+  ACCOUNT: { EMAIL },
+  POLICY: {
+    POLICY_TYPE,
+    SINGLE_POLICY_TYPE,
+    MULTIPLE_POLICY_TYPE,
+    CONTRACT_POLICY,
+    EXPORT_VALUE,
+    NAME_ON_POLICY,
+    DIFFERENT_NAME_ON_POLICY,
+    NEED_PRE_CREDIT_PERIOD,
+    CREDIT_PERIOD_WITH_BUYER,
+    NEED_ANOTHER_COMPANY_TO_BE_INSURED,
+    BROKER: {
+      LEGEND,
+      USING_BROKER,
+      NAME,
+      ADDRESS_LINE_1,
+      ADDRESS_LINE_2,
+      COUNTY,
+      POSTCODE,
+      TOWN,
+    },
+  },
+} = INSURANCE_FIELD_IDS;
 
 const { MAX_COVER_PERIOD_MONTHS } = ELIGIBILITY;
-
 const {
   POLICY: { TOTAL_MONTHS_OF_COVER },
 } = APPLICATION;
@@ -25,11 +38,11 @@ const {
 } = FORM_TITLES;
 
 export const POLICY_FIELDS = {
-  [POLICY.POLICY_TYPE]: {
-    ID: FIELD_IDS.POLICY_TYPE,
+  [POLICY_TYPE]: {
+    ID: POLICY_TYPE,
     OPTIONS: {
       SINGLE: {
-        ID: POLICY.SINGLE_POLICY_TYPE,
+        ID: SINGLE_POLICY_TYPE,
         VALUE: FIELD_VALUES.POLICY_TYPE.SINGLE,
         TEXT: 'Single contract policy',
         HINT_LIST: [
@@ -40,11 +53,11 @@ export const POLICY_FIELDS = {
         ],
       },
       MULTIPLE: {
-        ID: POLICY.MULTIPLE_POLICY_TYPE,
+        ID: MULTIPLE_POLICY_TYPE,
         VALUE: FIELD_VALUES.POLICY_TYPE.MULTIPLE,
         TEXT: 'Multiple contract policy',
         HINT_LIST: [
-          'Covers multiple contracts with the same buyer, usually for 12 months',
+          `Covers multiple contracts with the same buyer, usually for ${TOTAL_MONTHS_OF_COVER} months`,
           "Best if you'll have an ongoing relationship with the buyer but you're not sure yet how many contracts or sales you'll have",
           'You only pay for your insurance each time you declare a new contract or sale - no need to pay before the policy starts',
         ],
@@ -58,7 +71,7 @@ export const POLICY_FIELDS = {
   CONTRACT_POLICY: {
     [CONTRACT_POLICY.REQUESTED_START_DATE]: {
       LABEL: 'When do you want your policy to start?',
-      HINT: 'For example, 06 11 2023',
+      HINT: 'For example, 06 11 2023 ',
       SUMMARY: {
         TITLE: 'Policy start date',
         FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,
@@ -173,63 +186,57 @@ export const POLICY_FIELDS = {
     },
   },
   [CREDIT_PERIOD_WITH_BUYER]: {
-    LABEL: 'What period of pre-credit cover do you require?',
     MAXIMUM: 1000,
     SUMMARY: {
       TITLE: 'Period of pre-credit cover',
       FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,
     },
   },
+  [NEED_ANOTHER_COMPANY_TO_BE_INSURED]: {
+    HINT: 'This could be a parent company, subsidiary or a subcontractor.',
+  },
   BROKER: {
-    [BROKER.LEGEND]: {
+    [LEGEND]: {
       LEGEND: 'Enter contact details for your broker',
     },
-    [BROKER.USING_BROKER]: {
+    [USING_BROKER]: {
       SUMMARY: {
         TITLE: 'Using a broker',
         FORM_TITLE: POLICY_FORM_TITLES.BROKER,
       },
     },
-    [BROKER.NAME]: {
+    [NAME]: {
       LABEL: 'Name of broker or company',
       SUMMARY: {
         TITLE: "Broker's name or company",
         FORM_TITLE: POLICY_FORM_TITLES.BROKER,
       },
     },
-    [BROKER.ADDRESS_LINE_1]: {
+    [ADDRESS_LINE_1]: {
       LABEL: 'Address line 1',
       SUMMARY: {
         TITLE: "Broker's address",
         FORM_TITLE: POLICY_FORM_TITLES.BROKER,
       },
     },
-    [BROKER.ADDRESS_LINE_2]: {
+    [ADDRESS_LINE_2]: {
       LABEL: 'Address line 2 (optional)',
     },
-    [BROKER.TOWN]: {
+    [TOWN]: {
       LABEL: 'Town or city',
     },
-    [BROKER.COUNTY]: {
+    [COUNTY]: {
       LABEL: 'County (optional)',
     },
-    [BROKER.POSTCODE]: {
+    [POSTCODE]: {
       LABEL: 'Postcode',
     },
-    [BROKER.EMAIL]: {
+    [EMAIL]: {
       LABEL: 'Email address',
       SUMMARY: {
         TITLE: "Broker's email",
         FORM_TITLE: POLICY_FORM_TITLES.BROKER,
       },
-    },
-    [BROKER.DETAILS]: {
-      SUMMARY: 'Why appoint a broker?',
-      LINE_1: 'A broker can advise you during the application process and lifetime of any UKEF insurance policy.',
-      LINE_2: "You can find your nearest one on UKEF's list of approved brokers.",
-      LINK_TEXT: "UKEF's list of approved brokers.",
-      LINE_3: 'Alternatively, you can use any broker you prefer. They do not have to be approved by UKEF.',
-      LINE_4: 'Appointing a broker does not change the cost to you of any UKEF credit insurance policy.',
     },
   },
 };

--- a/e2e-tests/content-strings/pages/insurance/policy/index.js
+++ b/e2e-tests/content-strings/pages/insurance/policy/index.js
@@ -59,6 +59,11 @@ const PRE_CREDIT_PERIOD = {
   PAGE_TITLE: 'Do you need cover for a period before you supply the goods or services to the buyer?',
 };
 
+const ANOTHER_COMPANY = {
+  ...SHARED,
+  PAGE_TITLE: 'Is there another company that needs to be insured in your policy?',
+};
+
 const BROKER = {
   ...SHARED,
   PAGE_TITLE: 'Are you using a broker to get this insurance?',
@@ -85,6 +90,7 @@ module.exports = {
   NAME_ON_POLICY,
   DIFFERENT_NAME_ON_POLICY,
   PRE_CREDIT_PERIOD,
+  ANOTHER_COMPANY,
   BROKER,
   CHECK_YOUR_ANSWERS,
 };

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/another-company.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/another-company.spec.js
@@ -1,0 +1,101 @@
+import {
+  headingCaption,
+  yesRadio,
+  yesNoRadioHint,
+  noRadio,
+  saveAndBackButton,
+} from '../../../../../../pages/shared';
+import {
+  BUTTONS,
+  PAGES,
+} from '../../../../../../content-strings';
+import { FIELD_VALUES } from '../../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
+import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
+
+const CONTENT_STRINGS = PAGES.INSURANCE.POLICY.ANOTHER_COMPANY;
+
+const {
+  ROOT,
+  POLICY: { ANOTHER_COMPANY },
+} = INSURANCE_ROUTES;
+
+const { NEED_ANOTHER_COMPANY_TO_BE_INSURED } = POLICY_FIELD_IDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+const story = 'As an exporter, I want to inform UKEF of any other company I would like to include on my policy, So that cover is available for all appropriate parties';
+
+context(`Insurance - Policy - Another company page - ${story}`, () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      // go to the page we want to test.
+      cy.startInsurancePolicySection({});
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${ANOTHER_COMPANY}`;
+
+      cy.navigateToUrl(url);
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders core page elements', () => {
+    cy.corePageChecks({
+      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+      currentHref: `${ROOT}/${referenceNumber}${ANOTHER_COMPANY}`,
+      backLink: `${url}#`,
+    });
+  });
+
+  describe('page tests', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    it('renders a heading caption', () => {
+      cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
+    });
+
+    it('renders a `save and back` button', () => {
+      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+    });
+
+    describe(`renders ${NEED_ANOTHER_COMPANY_TO_BE_INSURED} label and inputs`, () => {
+      it('renders a hint', () => {
+        cy.checkText(yesNoRadioHint(), FIELDS[NEED_ANOTHER_COMPANY_TO_BE_INSURED].HINT);
+      });
+
+      it('renders `yes` and `no` radio buttons in the correct order', () => {
+        cy.assertYesNoRadiosOrder({ noRadioFirst: true });
+      });
+
+      it('renders `no` radio button', () => {
+        cy.checkText(noRadio().label(), FIELD_VALUES.NO);
+
+        cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
+      });
+
+      it('renders `yes` radio button', () => {
+        yesRadio().input().should('exist');
+
+        cy.checkText(yesRadio().label(), FIELD_VALUES.YES);
+
+        cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
@@ -167,7 +167,7 @@ context('Insurance - Policy - Broker Page - As an Exporter I want to confirm if 
     });
 
     it('should display summary text with collapsed conditional `details` content', () => {
-      cy.checkText(brokerPage[DETAILS].summary(), FIELDS.BROKER[DETAILS].SUMMARY);
+      cy.checkText(brokerPage[DETAILS].summary(), CONTENT_STRINGS.SUMMARY);
 
       brokerPage[DETAILS].details().should('not.have.attr', 'open');
     });
@@ -178,12 +178,12 @@ context('Insurance - Policy - Broker Page - As an Exporter I want to confirm if 
 
         brokerPage[DETAILS].details().should('have.attr', 'open');
 
-        cy.checkText(brokerPage[DETAILS].line_1(), FIELDS.BROKER[DETAILS].LINE_1);
-        cy.checkText(brokerPage[DETAILS].line_2(), FIELDS.BROKER[DETAILS].LINE_2);
-        cy.checkText(brokerPage[DETAILS].line_3(), FIELDS.BROKER[DETAILS].LINE_3);
-        cy.checkText(brokerPage[DETAILS].line_4(), FIELDS.BROKER[DETAILS].LINE_4);
+        cy.checkText(brokerPage[DETAILS].line1(), CONTENT_STRINGS.LINE_1);
+        cy.checkText(brokerPage[DETAILS].line2(), `${CONTENT_STRINGS.LINE_2} ${CONTENT_STRINGS.LINK_TEXT}`);
+        cy.checkText(brokerPage[DETAILS].line3(), CONTENT_STRINGS.LINE_3);
+        cy.checkText(brokerPage[DETAILS].line4(), CONTENT_STRINGS.LINE_4);
 
-        cy.checkLink(brokerPage[DETAILS].link(), APPROVED_BROKER_LIST, FIELDS.BROKER[DETAILS].LINK_TEXT);
+        cy.checkLink(brokerPage[DETAILS].link(), APPROVED_BROKER_LIST, CONTENT_STRINGS.LINK_TEXT);
       });
     });
 

--- a/e2e-tests/pages/insurance/policy/broker.js
+++ b/e2e-tests/pages/insurance/policy/broker.js
@@ -17,10 +17,10 @@ const brokerPage = {
   [DETAILS]: {
     details: () => cy.get(`[data-cy="${DETAILS}`),
     summary: () => cy.get(`[data-cy="${DETAILS}"] summary`),
-    line_1: () => cy.get(`[data-cy="${DETAILS}-line-1"]`),
-    line_2: () => cy.get(`[data-cy="${DETAILS}-line-2`),
-    line_3: () => cy.get(`[data-cy="${DETAILS}-line-3`),
-    line_4: () => cy.get(`[data-cy="${DETAILS}-line-4`),
+    line1: () => cy.get(`[data-cy="${DETAILS}-line-1"]`),
+    line2: () => cy.get(`[data-cy="${DETAILS}-line-2`),
+    line3: () => cy.get(`[data-cy="${DETAILS}-line-3`),
+    line4: () => cy.get(`[data-cy="${DETAILS}-line-4`),
     link: () => cy.get(`[data-cy="${DETAILS}-link`),
   },
 };

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -162,9 +162,15 @@ var ACCOUNT = {
 var account_default = ACCOUNT;
 
 // constants/field-ids/insurance/policy/index.ts
+var REQUESTED_START_DATE = "requestedStartDate";
+var CONTRACT_COMPLETION_DATE = "contractCompletionDate";
 var SHARED_CONTRACT_POLICY = {
-  REQUESTED_START_DATE: "requestedStartDate",
-  POLICY_CURRENCY_CODE: "policyCurrencyCode"
+  REQUESTED_START_DATE,
+  REQUESTED_START_DATE_DAY: `${REQUESTED_START_DATE}-day`,
+  REQUESTED_START_DATE_MONTH: `${REQUESTED_START_DATE}-month`,
+  REQUESTED_START_DATE_YEAR: `${REQUESTED_START_DATE}-year`,
+  POLICY_CURRENCY_CODE: "policyCurrencyCode",
+  ALTERNATIVE_POLICY_CURRENCY_CODE: "alternativePolicyCurrencyCode"
 };
 var POLICY = {
   ...shared_default,
@@ -174,7 +180,10 @@ var POLICY = {
   CONTRACT_POLICY: {
     ...SHARED_CONTRACT_POLICY,
     SINGLE: {
-      CONTRACT_COMPLETION_DATE: "contractCompletionDate",
+      CONTRACT_COMPLETION_DATE,
+      CONTRACT_COMPLETION_DATE_DAY: `${CONTRACT_COMPLETION_DATE}-day`,
+      CONTRACT_COMPLETION_DATE_MONTH: `${CONTRACT_COMPLETION_DATE}-month`,
+      CONTRACT_COMPLETION_DATE_YEAR: `${CONTRACT_COMPLETION_DATE}-year`,
       TOTAL_CONTRACT_VALUE: "totalValueOfContract"
     },
     MULTIPLE: {
@@ -187,8 +196,23 @@ var POLICY = {
       MAXIMUM_BUYER_WILL_OWE: "maximumBuyerWillOwe"
     }
   },
+  NAME_ON_POLICY: {
+    NAME: "nameOnPolicy",
+    IS_SAME_AS_OWNER: "isSameAsOwner",
+    SAME_NAME: "sameName",
+    OTHER_NAME: "otherName",
+    POSITION: "position",
+    POLICY_CONTACT_EMAIL: "policyContact.email"
+  },
+  DIFFERENT_NAME_ON_POLICY: {
+    POLICY_CONTACT_DETAIL: "policyContactDetail",
+    POSITION: "position"
+  },
+  NEED_PRE_CREDIT_PERIOD: "needPreCreditPeriodCover",
+  CREDIT_PERIOD_WITH_BUYER: "creditPeriodWithBuyer",
+  NEED_ANOTHER_COMPANY_TO_BE_INSURED: "needAnotherCompanyToBeInsured",
   BROKER: {
-    HEADING: "broker",
+    LEGEND: "broker",
     USING_BROKER: "isUsingBroker",
     NAME: "name",
     ADDRESS_LINE_1: "addressLine1",
@@ -380,8 +404,7 @@ var CUSTOM_RESOLVERS = [
   // feedback
   "createFeedbackAndSendEmail",
   "getApimCisCountries",
-  "getApimCurrencies",
-  "getAllApimCurrencies"
+  "getApimCurrencies"
 ];
 if (isDevEnvironment) {
   CUSTOM_RESOLVERS.push(
@@ -1806,24 +1829,9 @@ var typeDefs = `
     name: String!
   }
 
-  type MappedCurrency {
-    isoCode: String!
-    name: String!
-  }
-
-  type MappedCurrency {
-    isoCode: String!
-    name: String!
-  }
-
-  type MappedCurrency {
-    isoCode: String!
-    name: String!
-  }
-
-  type MappedCurrency {
-    isoCode: String!
-    name: String!
+  type GetApimCurrencyResponse {
+    supportedCurrencies: [MappedCurrency]
+    allCurrencies: [MappedCurrency]
   }
 
   type Mutation {
@@ -1963,10 +1971,7 @@ var typeDefs = `
     getApimCisCountries: [MappedCisCountry]
 
     """ get currencies from APIM """
-    getApimCurrencies: [MappedCurrency]
-
-    """ get all currencies from APIM """
-    getAllApimCurrencies: [MappedCurrency]
+    getApimCurrencies: GetApimCurrencyResponse
   }
 `;
 var type_defs_default = typeDefs;
@@ -4274,7 +4279,7 @@ var DEFAULT = {
 var { FIRST_NAME, LAST_NAME } = account_default;
 var {
   CONTRACT_POLICY: {
-    SINGLE: { CONTRACT_COMPLETION_DATE }
+    SINGLE: { CONTRACT_COMPLETION_DATE: CONTRACT_COMPLETION_DATE2 }
   },
   BROKER: { USING_BROKER: USING_BROKER3, NAME: BROKER_NAME, ADDRESS_LINE_1: BROKER_ADDRESS, EMAIL: BROKER_EMAIL }
 } = policy_default;
@@ -4305,7 +4310,7 @@ var XLSX = {
       [LAST_NAME]: "Exporter last name",
       EXPORTER_CONTACT_EMAIL: "Exporter email address"
     },
-    [CONTRACT_COMPLETION_DATE]: "Date expected for contract to complete",
+    [CONTRACT_COMPLETION_DATE2]: "Date expected for contract to complete",
     [EXPORTER_COMPANY_NAME]: "Exporter company name",
     [EXPORTER_COMPANY_ADDRESS]: "Exporter registered office address",
     [EXPORTER_COMPANY_SIC]: "Exporter standard industry classification (SIC) codes and nature of business",
@@ -4423,8 +4428,8 @@ var {
   POLICY: {
     TYPE_OF_POLICY: { POLICY_TYPE: POLICY_TYPE5 },
     CONTRACT_POLICY: {
-      REQUESTED_START_DATE,
-      SINGLE: { CONTRACT_COMPLETION_DATE: CONTRACT_COMPLETION_DATE2 },
+      REQUESTED_START_DATE: REQUESTED_START_DATE2,
+      SINGLE: { CONTRACT_COMPLETION_DATE: CONTRACT_COMPLETION_DATE3 },
       MULTIPLE: { TOTAL_MONTHS_OF_COVER },
       POLICY_CURRENCY_CODE,
       SINGLE: { TOTAL_CONTRACT_VALUE: TOTAL_CONTRACT_VALUE2 }
@@ -4442,14 +4447,14 @@ var mapPolicyIntro = (application2) => {
   const mapped = [
     xlsx_row_default(XLSX.SECTION_TITLES.POLICY, ""),
     xlsx_row_default(String(CONTENT_STRINGS2[POLICY_TYPE5].SUMMARY?.TITLE), policy[POLICY_TYPE5]),
-    xlsx_row_default(String(CONTENT_STRINGS2[REQUESTED_START_DATE].SUMMARY?.TITLE), format_date_default(policy[REQUESTED_START_DATE], "dd-MMM-yy"))
+    xlsx_row_default(String(CONTENT_STRINGS2[REQUESTED_START_DATE2].SUMMARY?.TITLE), format_date_default(policy[REQUESTED_START_DATE2], "dd-MMM-yy"))
   ];
   return mapped;
 };
 var mapSinglePolicyFields = (application2) => {
   const { policy } = application2;
   return [
-    xlsx_row_default(String(CONTENT_STRINGS2[CONTRACT_COMPLETION_DATE2].SUMMARY?.TITLE), format_date_default(policy[CONTRACT_COMPLETION_DATE2], "dd-MMM-yy")),
+    xlsx_row_default(String(CONTENT_STRINGS2[CONTRACT_COMPLETION_DATE3].SUMMARY?.TITLE), format_date_default(policy[CONTRACT_COMPLETION_DATE3], "dd-MMM-yy")),
     xlsx_row_default(String(CONTENT_STRINGS2[TOTAL_CONTRACT_VALUE2].SUMMARY?.TITLE), format_currency_default2(policy[TOTAL_CONTRACT_VALUE2], GBP_CURRENCY_CODE))
   ];
 };
@@ -5163,13 +5168,12 @@ var getSupportedCurrencies = (currencies) => {
   const supported = currencies.filter((currency) => SUPPORTED_CURRENCIES.find((currencyCode) => currency.isoCode === currencyCode));
   return supported;
 };
-var mapCurrencies = (currencies) => {
-  const supportedCurrencies = getSupportedCurrencies(currencies);
-  const sorted = sort_array_alphabetically_default(supportedCurrencies, FIELD_IDS.NAME);
-  return sorted;
-};
-var mapAndSortAllCurrencies = (currencies) => {
-  const sorted = sort_array_alphabetically_default(currencies, FIELD_IDS.NAME);
+var mapCurrencies = (currencies, allCurrencies) => {
+  let currenciesArray = currencies;
+  if (!allCurrencies) {
+    currenciesArray = getSupportedCurrencies(currencies);
+  }
+  const sorted = sort_array_alphabetically_default(currenciesArray, FIELD_IDS.NAME);
   return sorted;
 };
 var map_currencies_default = mapCurrencies;
@@ -5180,8 +5184,10 @@ var getApimCurrencies = async () => {
     console.info("Getting and mapping currencies from APIM");
     const response = await APIM_default.getCurrencies();
     if (response.data) {
-      const mapped = map_currencies_default(response.data);
-      return mapped;
+      return {
+        supportedCurrencies: map_currencies_default(response.data, false),
+        allCurrencies: map_currencies_default(response.data, true)
+      };
     }
     return { success: false };
   } catch (err) {
@@ -5190,23 +5196,6 @@ var getApimCurrencies = async () => {
   }
 };
 var get_APIM_currencies_default = getApimCurrencies;
-
-// custom-resolvers/queries/get-all-APIM-currencies/index.ts
-var getAllApimCurrencies = async () => {
-  try {
-    console.info("Getting all currencies from APIM");
-    const response = await APIM_default.getCurrencies();
-    if (response.data) {
-      const mapped = mapAndSortAllCurrencies(response.data);
-      return mapped;
-    }
-    return { success: false };
-  } catch (err) {
-    console.error("Error getting and mapping all currencies from APIM %O", err);
-    throw new Error(`Getting and mapping all currencies from APIM ${err}`);
-  }
-};
-var get_all_APIM_currencies_default = getAllApimCurrencies;
 
 // helpers/remove-white-space/index.ts
 var removeWhiteSpace = (string) => string.replace(" ", "");
@@ -5551,7 +5540,6 @@ var customResolvers = {
     getAccountPasswordResetToken: get_account_password_reset_token_default,
     getApimCisCountries: get_APIM_CIS_countries_default,
     getApimCurrencies: get_APIM_currencies_default,
-    getAllApimCurrencies: get_all_APIM_currencies_default,
     getCompaniesHouseInformation: get_companies_house_information_default,
     getOrdnanceSurveyAddress: get_ordnance_survey_address_default,
     verifyAccountPasswordResetToken: verify_account_password_reset_token_default

--- a/src/api/constants/field-ids/insurance/policy/index.ts
+++ b/src/api/constants/field-ids/insurance/policy/index.ts
@@ -1,11 +1,18 @@
 import SHARED from '../../shared';
 
+const REQUESTED_START_DATE = 'requestedStartDate';
+const CONTRACT_COMPLETION_DATE = 'contractCompletionDate';
+
 export const SHARED_CONTRACT_POLICY = {
-  REQUESTED_START_DATE: 'requestedStartDate',
+  REQUESTED_START_DATE,
+  REQUESTED_START_DATE_DAY: `${REQUESTED_START_DATE}-day`,
+  REQUESTED_START_DATE_MONTH: `${REQUESTED_START_DATE}-month`,
+  REQUESTED_START_DATE_YEAR: `${REQUESTED_START_DATE}-year`,
   POLICY_CURRENCY_CODE: 'policyCurrencyCode',
+  ALTERNATIVE_POLICY_CURRENCY_CODE: 'alternativePolicyCurrencyCode',
 };
 
-const POLICY = {
+export const POLICY = {
   ...SHARED,
   TYPE_OF_POLICY: {
     POLICY_TYPE: SHARED.POLICY_TYPE,
@@ -13,7 +20,10 @@ const POLICY = {
   CONTRACT_POLICY: {
     ...SHARED_CONTRACT_POLICY,
     SINGLE: {
-      CONTRACT_COMPLETION_DATE: 'contractCompletionDate',
+      CONTRACT_COMPLETION_DATE,
+      CONTRACT_COMPLETION_DATE_DAY: `${CONTRACT_COMPLETION_DATE}-day`,
+      CONTRACT_COMPLETION_DATE_MONTH: `${CONTRACT_COMPLETION_DATE}-month`,
+      CONTRACT_COMPLETION_DATE_YEAR: `${CONTRACT_COMPLETION_DATE}-year`,
       TOTAL_CONTRACT_VALUE: 'totalValueOfContract',
     },
     MULTIPLE: {
@@ -26,8 +36,23 @@ const POLICY = {
       MAXIMUM_BUYER_WILL_OWE: 'maximumBuyerWillOwe',
     },
   },
+  NAME_ON_POLICY: {
+    NAME: 'nameOnPolicy',
+    IS_SAME_AS_OWNER: 'isSameAsOwner',
+    SAME_NAME: 'sameName',
+    OTHER_NAME: 'otherName',
+    POSITION: 'position',
+    POLICY_CONTACT_EMAIL: 'policyContact.email',
+  },
+  DIFFERENT_NAME_ON_POLICY: {
+    POLICY_CONTACT_DETAIL: 'policyContactDetail',
+    POSITION: 'position',
+  },
+  NEED_PRE_CREDIT_PERIOD: 'needPreCreditPeriodCover',
+  CREDIT_PERIOD_WITH_BUYER: 'creditPeriodWithBuyer',
+  NEED_ANOTHER_COMPANY_TO_BE_INSURED: 'needAnotherCompanyToBeInsured',
   BROKER: {
-    HEADING: 'broker',
+    LEGEND: 'broker',
     USING_BROKER: 'isUsingBroker',
     NAME: 'name',
     ADDRESS_LINE_1: 'addressLine1',

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -2393,7 +2393,7 @@ type Query {
   getOrdnanceSurveyAddress(postcode: String!, houseNameOrNumber: String!): OrdnanceSurveyResponse
 
   """ get currencies from APIM """
-  getApimCurrencies: [MappedCurrency]
+  getApimCurrencies: GetApimCurrencyResponse
 }
 
 union AuthenticatedItem = User
@@ -2700,4 +2700,9 @@ type MappedCisCountry {
 type MappedCurrency {
   isoCode: String!
   name: String!
+}
+
+type GetApimCurrencyResponse {
+  supportedCurrencies: [MappedCurrency]
+  allCurrencies: [MappedCurrency]
 }

--- a/src/ui/server/constants/field-ids/insurance/policy/index.ts
+++ b/src/ui/server/constants/field-ids/insurance/policy/index.ts
@@ -12,7 +12,7 @@ export const SHARED_CONTRACT_POLICY = {
   ALTERNATIVE_POLICY_CURRENCY_CODE: 'alternativePolicyCurrencyCode',
 };
 
-const POLICY = {
+export const POLICY = {
   ...SHARED,
   TYPE_OF_POLICY: {
     POLICY_TYPE: SHARED.POLICY_TYPE,
@@ -50,6 +50,7 @@ const POLICY = {
   },
   NEED_PRE_CREDIT_PERIOD: 'needPreCreditPeriodCover',
   CREDIT_PERIOD_WITH_BUYER: 'creditPeriodWithBuyer',
+  NEED_ANOTHER_COMPANY_TO_BE_INSURED: 'needAnotherCompanyToBeInsured',
   BROKER: {
     LEGEND: 'broker',
     USING_BROKER: 'isUsingBroker',

--- a/src/ui/server/constants/routes/insurance/policy.ts
+++ b/src/ui/server/constants/routes/insurance/policy.ts
@@ -33,6 +33,8 @@ export const POLICY = {
   PRE_CREDIT_PERIOD_SAVE_AND_BACK: `${ROOT}/pre-credit-period/save-and-go-back`,
   PRE_CREDIT_PERIOD_CHANGE: `${ROOT}/pre-credit-period/change`,
   PRE_CREDIT_PERIOD_CHECK_AND_CHANGE: `${ROOT}/pre-credit-period/check-and-change`,
+  ANOTHER_COMPANY: `${ROOT}/another-company`,
+  ANOTHER_COMPANY_SAVE_AND_BACK: `${ROOT}/another-company/save-and-go-back`,
   BROKER_ROOT,
   BROKER_SAVE_AND_BACK: `${BROKER_ROOT}/save-and-back`,
   BROKER_CHANGE: `${BROKER_ROOT}/change`,

--- a/src/ui/server/content-strings/fields/insurance/policy/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy/index.ts
@@ -60,7 +60,7 @@ export const POLICY_FIELDS = {
   CONTRACT_POLICY: {
     [CONTRACT_POLICY.REQUESTED_START_DATE]: {
       LABEL: 'When do you want your policy to start?',
-      HINT: 'For example, 06 11 2023 ',
+      HINT: 'For example, 06 11 2023',
       SUMMARY: {
         TITLE: 'Policy start date',
         FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,

--- a/src/ui/server/content-strings/fields/insurance/policy/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy/index.ts
@@ -1,4 +1,6 @@
-import { APPLICATION, ELIGIBILITY, FIELD_IDS, FIELD_VALUES } from '../../../../constants';
+import { APPLICATION, ELIGIBILITY, FIELD_VALUES } from '../../../../constants';
+import INSURANCE_FIELD_IDS from '../../../../constants/field-ids/insurance';
+import { FORM_TITLES } from '../../../form-titles';
 
 const {
   ACCOUNT: { EMAIL },
@@ -12,18 +14,21 @@ const {
     DIFFERENT_NAME_ON_POLICY,
     NEED_PRE_CREDIT_PERIOD,
     CREDIT_PERIOD_WITH_BUYER,
+    NEED_ANOTHER_COMPANY_TO_BE_INSURED,
     BROKER: { LEGEND, USING_BROKER, NAME, ADDRESS_LINE_1, ADDRESS_LINE_2, COUNTY, POSTCODE, TOWN },
   },
-} = FIELD_IDS.INSURANCE;
+} = INSURANCE_FIELD_IDS;
 
 const { MAX_COVER_PERIOD_MONTHS } = ELIGIBILITY;
 const {
   POLICY: { TOTAL_MONTHS_OF_COVER },
 } = APPLICATION;
 
+const { POLICY: POLICY_FORM_TITLES } = FORM_TITLES;
+
 export const POLICY_FIELDS = {
   [POLICY_TYPE]: {
-    ID: FIELD_IDS.POLICY_TYPE,
+    ID: POLICY_TYPE,
     OPTIONS: {
       SINGLE: {
         ID: SINGLE_POLICY_TYPE,
@@ -49,6 +54,7 @@ export const POLICY_FIELDS = {
     },
     SUMMARY: {
       TITLE: 'Policy type',
+      FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,
     },
   },
   CONTRACT_POLICY: {
@@ -57,6 +63,7 @@ export const POLICY_FIELDS = {
       HINT: 'For example, 06 11 2023 ',
       SUMMARY: {
         TITLE: 'Policy start date',
+        FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,
       },
     },
     [CONTRACT_POLICY.POLICY_CURRENCY_CODE]: {
@@ -64,6 +71,7 @@ export const POLICY_FIELDS = {
       HINT: 'This is the currency your policy will be issued in',
       SUMMARY: {
         TITLE: 'Policy currency',
+        FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,
       },
       [CONTRACT_POLICY.ALTERNATIVE_POLICY_CURRENCY_CODE]: {
         ID: CONTRACT_POLICY.ALTERNATIVE_POLICY_CURRENCY_CODE,
@@ -76,12 +84,14 @@ export const POLICY_FIELDS = {
         HINT: 'For example, 06 11 2024',
         SUMMARY: {
           TITLE: 'Date you expect it to complete',
+          FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,
         },
       },
       [CONTRACT_POLICY.SINGLE.TOTAL_CONTRACT_VALUE]: {
         HINT: 'Enter a whole number - do not enter decimals.',
         SUMMARY: {
           TITLE: 'Contract value',
+          FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,
         },
       },
     },
@@ -92,6 +102,7 @@ export const POLICY_FIELDS = {
         OPTIONS: FIELD_VALUES.TOTAL_MONTHS_OF_COVER,
         SUMMARY: {
           TITLE: 'How many months you want to be insured for',
+          FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,
         },
       },
     },
@@ -103,6 +114,7 @@ export const POLICY_FIELDS = {
         HINT: 'Enter a whole number - do not enter decimals.',
         SUMMARY: {
           TITLE: 'Estimated total sales to the buyer',
+          FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,
         },
       },
       [EXPORT_VALUE.MULTIPLE.MAXIMUM_BUYER_WILL_OWE]: {
@@ -113,6 +125,7 @@ export const POLICY_FIELDS = {
         },
         SUMMARY: {
           TITLE: 'Estimated maximum amount owed by the buyer',
+          FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,
         },
       },
     },
@@ -133,11 +146,13 @@ export const POLICY_FIELDS = {
       LABEL: "What's your position at the company?",
       SUMMARY: {
         TITLE: 'Position at company',
+        FORM_TITLE: POLICY_FORM_TITLES.NAME_ON_POLICY,
       },
     },
     [NAME_ON_POLICY.NAME]: {
       SUMMARY: {
         TITLE: 'Contact name',
+        FORM_TITLE: POLICY_FORM_TITLES.NAME_ON_POLICY,
       },
     },
   },
@@ -148,6 +163,7 @@ export const POLICY_FIELDS = {
     [EMAIL]: {
       SUMMARY: {
         TITLE: 'Contact email',
+        FORM_TITLE: POLICY_FORM_TITLES.NAME_ON_POLICY,
       },
     },
   },
@@ -155,14 +171,18 @@ export const POLICY_FIELDS = {
     HINT: 'This is known as the pre-credit period',
     SUMMARY: {
       TITLE: 'Pre-credit period',
+      FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,
     },
   },
   [CREDIT_PERIOD_WITH_BUYER]: {
-    LABEL: 'What period of pre-credit cover do you require?',
     MAXIMUM: 1000,
     SUMMARY: {
       TITLE: 'Period of pre-credit cover',
+      FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,
     },
+  },
+  [NEED_ANOTHER_COMPANY_TO_BE_INSURED]: {
+    HINT: 'This could be a parent company, subsidiary or a subcontractor.',
   },
   BROKER: {
     [LEGEND]: {
@@ -171,18 +191,21 @@ export const POLICY_FIELDS = {
     [USING_BROKER]: {
       SUMMARY: {
         TITLE: 'Using a broker',
+        FORM_TITLE: POLICY_FORM_TITLES.BROKER,
       },
     },
     [NAME]: {
       LABEL: 'Name of broker or company',
       SUMMARY: {
         TITLE: "Broker's name or company",
+        FORM_TITLE: POLICY_FORM_TITLES.BROKER,
       },
     },
     [ADDRESS_LINE_1]: {
       LABEL: 'Address line 1',
       SUMMARY: {
         TITLE: "Broker's address",
+        FORM_TITLE: POLICY_FORM_TITLES.BROKER,
       },
     },
     [ADDRESS_LINE_2]: {
@@ -201,6 +224,7 @@ export const POLICY_FIELDS = {
       LABEL: 'Email address',
       SUMMARY: {
         TITLE: "Broker's email",
+        FORM_TITLE: POLICY_FORM_TITLES.BROKER,
       },
     },
   },

--- a/src/ui/server/content-strings/pages/insurance/policy/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/policy/index.ts
@@ -59,6 +59,11 @@ const PRE_CREDIT_PERIOD = {
   PAGE_TITLE: 'Do you need cover for a period before you supply the goods or services to the buyer?',
 };
 
+const ANOTHER_COMPANY = {
+  ...SHARED,
+  PAGE_TITLE: 'Is there another company that needs to be insured in your policy?',
+};
+
 const BROKER = {
   ...SHARED,
   PAGE_TITLE: 'Are you using a broker to get this insurance?',
@@ -86,5 +91,6 @@ export default {
   BROKER,
   DIFFERENT_NAME_ON_POLICY,
   PRE_CREDIT_PERIOD,
+  ANOTHER_COMPANY,
   CHECK_YOUR_ANSWERS,
 };

--- a/src/ui/server/controllers/insurance/policy/another-company/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/another-company/index.test.ts
@@ -1,0 +1,125 @@
+import { FIELD_ID, PAGE_CONTENT_STRINGS, pageVariables, HTML_FLAGS, TEMPLATE, get } from '.';
+import { TEMPLATES } from '../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
+import POLICY_FIELD_IDS from '../../../../constants/field-ids/insurance/policy';
+import { PAGES } from '../../../../content-strings';
+import { POLICY_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance';
+import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
+import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapAndSave from '../map-and-save/policy';
+import { Request, Response } from '../../../../../types';
+import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+
+const {
+  INSURANCE_ROOT,
+  POLICY: { ANOTHER_COMPANY_SAVE_AND_BACK },
+  PROBLEM_WITH_SERVICE,
+} = INSURANCE_ROUTES;
+
+const { NEED_ANOTHER_COMPANY_TO_BE_INSURED } = POLICY_FIELD_IDS;
+
+const { SHARED_PAGES } = TEMPLATES;
+
+describe('controllers/insurance/policy/another-company', () => {
+  let req: Request;
+  let res: Response;
+  let refNumber: number;
+
+  jest.mock('../map-and-save/policy');
+
+  mapAndSave.policy = jest.fn(() => Promise.resolve(true));
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+
+    res.locals.application = mockApplication;
+
+    req.params.referenceNumber = String(mockApplication.referenceNumber);
+    refNumber = Number(mockApplication.referenceNumber);
+  });
+
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('FIELD_ID', () => {
+    it('should have the correct ID', () => {
+      const expected = NEED_ANOTHER_COMPANY_TO_BE_INSURED;
+
+      expect(FIELD_ID).toEqual(expected);
+    });
+  });
+
+  describe('PAGE_CONTENT_STRINGS', () => {
+    it('should have the correct properties', () => {
+      const expected = {
+        ...PAGES.INSURANCE.POLICY.ANOTHER_COMPANY,
+        HINT: FIELDS[NEED_ANOTHER_COMPANY_TO_BE_INSURED].HINT,
+      };
+
+      expect(PAGE_CONTENT_STRINGS).toEqual(expected);
+    });
+  });
+
+  describe('pageVariables', () => {
+    it('should have correct properties', () => {
+      const result = pageVariables(refNumber);
+
+      const expected = {
+        FIELD_ID: NEED_ANOTHER_COMPANY_TO_BE_INSURED,
+        FIELD_HINT: PAGE_CONTENT_STRINGS.HINT,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${req.params.referenceNumber}${ANOTHER_COMPANY_SAVE_AND_BACK}`,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('HTML_FLAGS', () => {
+    it('should have the correct properties', () => {
+      const expected = {
+        HORIZONTAL_RADIOS: true,
+        NO_RADIO_AS_FIRST_OPTION: true,
+      };
+
+      expect(HTML_FLAGS).toEqual(expected);
+    });
+  });
+
+  describe('TEMPLATE', () => {
+    it('should have the correct template defined', () => {
+      expect(TEMPLATE).toEqual(SHARED_PAGES.SINGLE_RADIO);
+    });
+  });
+
+  describe('get', () => {
+    it('should render template', () => {
+      get(req, res);
+
+      const expectedVariables = {
+        ...insuranceCorePageVariables({
+          PAGE_CONTENT_STRINGS,
+          BACK_LINK: req.headers.referer,
+          HTML_FLAGS,
+        }),
+        ...pageVariables(refNumber),
+        userName: getUserNameFromSession(req.session.user),
+      };
+
+      expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
+    });
+
+    describe('when there is no application', () => {
+      beforeEach(() => {
+        delete res.locals.application;
+      });
+
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
+        get(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/policy/another-company/index.ts
+++ b/src/ui/server/controllers/insurance/policy/another-company/index.ts
@@ -1,0 +1,76 @@
+import { TEMPLATES } from '../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
+import POLICY_FIELD_IDS from '../../../../constants/field-ids/insurance/policy';
+import { PAGES } from '../../../../content-strings';
+import { POLICY_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance';
+import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
+import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import { Request, Response } from '../../../../../types';
+
+const {
+  INSURANCE_ROOT,
+  POLICY: { ANOTHER_COMPANY_SAVE_AND_BACK },
+  PROBLEM_WITH_SERVICE,
+} = INSURANCE_ROUTES;
+
+const { NEED_ANOTHER_COMPANY_TO_BE_INSURED } = POLICY_FIELD_IDS;
+
+const { SHARED_PAGES } = TEMPLATES;
+
+export const FIELD_ID = NEED_ANOTHER_COMPANY_TO_BE_INSURED;
+
+export const PAGE_CONTENT_STRINGS = {
+  ...PAGES.INSURANCE.POLICY.ANOTHER_COMPANY,
+  HINT: FIELDS[NEED_ANOTHER_COMPANY_TO_BE_INSURED].HINT,
+};
+
+/**
+ * pageVariables
+ * Page fields and "save and go back" URL
+ * @param {Number} Application reference number
+ * @returns {Object} Page variables
+ */
+export const pageVariables = (referenceNumber: number) => ({
+  FIELD_ID: NEED_ANOTHER_COMPANY_TO_BE_INSURED,
+  FIELD_HINT: PAGE_CONTENT_STRINGS.HINT,
+  SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${ANOTHER_COMPANY_SAVE_AND_BACK}`,
+});
+
+/**
+ * HTML_FLAGS
+ * Conditional flags for the nunjucks template to match design
+ */
+export const HTML_FLAGS = {
+  HORIZONTAL_RADIOS: true,
+  NO_RADIO_AS_FIRST_OPTION: true,
+};
+
+export const TEMPLATE = SHARED_PAGES.SINGLE_RADIO;
+
+/**
+ * get
+ * Get the application and render the Policy - another company page
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.render} Policy - another company page
+ */
+export const get = (req: Request, res: Response) => {
+  const { application } = res.locals;
+
+  if (!application) {
+    return res.redirect(PROBLEM_WITH_SERVICE);
+  }
+
+  const { referenceNumber } = req.params;
+  const refNumber = Number(referenceNumber);
+
+  return res.render(TEMPLATE, {
+    ...insuranceCorePageVariables({
+      PAGE_CONTENT_STRINGS,
+      BACK_LINK: req.headers.referer,
+      HTML_FLAGS,
+    }),
+    ...pageVariables(refNumber),
+    userName: getUserNameFromSession(req.session.user),
+  });
+};

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -21,7 +21,7 @@ describe('routes/insurance', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(140);
+    expect(get).toHaveBeenCalledTimes(141);
     expect(post).toHaveBeenCalledTimes(128);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);

--- a/src/ui/server/routes/insurance/policy/index.test.ts
+++ b/src/ui/server/routes/insurance/policy/index.test.ts
@@ -22,6 +22,7 @@ import { post as nameOnPolicySaveAndBackPost } from '../../../controllers/insura
 import { get as differentNameOnPolicyGet, post as differentNameOnPolicyPost } from '../../../controllers/insurance/policy/different-name-on-policy';
 import { get as preCreditPeriodGet, post as preCreditPeriodPost } from '../../../controllers/insurance/policy/pre-credit-period';
 import { post as preCreditPeriodSaveAndBackPost } from '../../../controllers/insurance/policy/pre-credit-period/save-and-back';
+import { get as anotherCompanyGet } from '../../../controllers/insurance/policy/another-company';
 import { post as differentNameOnPolicySaveAndBackPost } from '../../../controllers/insurance/policy/different-name-on-policy/save-and-back';
 import { get as getBroker, post as postBroker } from '../../../controllers/insurance/policy/broker';
 import { post as postBrokerSaveAndBack } from '../../../controllers/insurance/policy/broker/save-and-back';
@@ -37,7 +38,7 @@ describe('routes/insurance/policy', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(27);
+    expect(get).toHaveBeenCalledTimes(28);
     expect(post).toHaveBeenCalledTimes(35);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.ROOT}`, policyRootGet);
@@ -137,6 +138,8 @@ describe('routes/insurance/policy', () => {
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD_CHANGE}`, preCreditPeriodPost);
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD_CHECK_AND_CHANGE}`, preCreditPeriodGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD_CHECK_AND_CHANGE}`, preCreditPeriodPost);
+
+    expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.ANOTHER_COMPANY}`, anotherCompanyGet);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_ROOT}`, getBroker);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_ROOT}`, postBroker);

--- a/src/ui/server/routes/insurance/policy/index.ts
+++ b/src/ui/server/routes/insurance/policy/index.ts
@@ -21,6 +21,7 @@ import { get as nameOnPolicyGet, post as nameOnPolicyPost } from '../../../contr
 import { post as nameOnPolicySaveAndBackPost } from '../../../controllers/insurance/policy/name-on-policy/save-and-back';
 import { get as differentNameOnPolicyGet, post as differentNameOnPolicyPost } from '../../../controllers/insurance/policy/different-name-on-policy';
 import { get as preCreditPeriodGet, post as preCreditPeriodPost } from '../../../controllers/insurance/policy/pre-credit-period';
+import { get as anotherCompanyGet } from '../../../controllers/insurance/policy/another-company';
 import { post as preCreditPeriodSaveAndBackPost } from '../../../controllers/insurance/policy/pre-credit-period/save-and-back';
 import { post as differentNameOnPolicySaveAndBackPost } from '../../../controllers/insurance/policy/different-name-on-policy/save-and-back';
 import { get as getBroker, post as postBroker } from '../../../controllers/insurance/policy/broker';
@@ -115,6 +116,8 @@ insurancePolicyRouter.get(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT
 insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD_CHANGE}`, preCreditPeriodPost);
 insurancePolicyRouter.get(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD_CHECK_AND_CHANGE}`, preCreditPeriodGet);
 insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.PRE_CREDIT_PERIOD_CHECK_AND_CHANGE}`, preCreditPeriodPost);
+
+insurancePolicyRouter.get(`/:referenceNumber${INSURANCE_ROUTES.POLICY.ANOTHER_COMPANY}`, anotherCompanyGet);
 
 insurancePolicyRouter.get(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_ROOT}`, getBroker);
 insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_ROOT}`, postBroker);


### PR DESCRIPTION
## Introduction :pencil2:
This PR sets up a new page/route for an "Another company" form as part of a No PDF's policy section.

Note, this is not setup with the flow, this is simply setting up the page.

## Resolution :heavy_check_mark:
- Setup new route, controller, content strings.
- Add E2E test.

## Miscellaneous :heavy_plus_sign:
- Align policy field content strings between UI and E2E tests.
- Remove some unnecessary `LABEL` definition for the `CREDIT_PERIOD_WITH_BUYER` field (the form uses `PAGE_TITLE` since it's a single field form.
- update some "broker" cypress selector naming conventions to be camelCase.
