### PR TITLE
chore(EMS-2674): No PDF - Return alternativeCurrencies from getCurrencies() 

### DIFF
--- a/e2e-tests/commands/insurance/assert-alternative-currency-form.js
+++ b/e2e-tests/commands/insurance/assert-alternative-currency-form.js
@@ -54,12 +54,24 @@ const assertAlternativeCurrencyForm = ({
 
     checkAutocompleteInput.hasWorkingClientSideJS(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID));
     checkAutocompleteInput.rendersInput(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID));
+  },
+  alternativeCurrencyShouldRender: () => {
+    const { option: option5 } = radios(FIELD_ID, ALTERNATIVE_CURRENCY_FIELD_ID);
+
+    option5.input().click();
+
     checkAutocompleteInput.rendersNoResultsMessage(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), 'test');
     // should not render radio values in alternate currency input
     checkAutocompleteInput.rendersNoResultsMessage(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), GBP.isoCode);
     checkAutocompleteInput.rendersNoResultsMessage(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), USD.isoCode);
     checkAutocompleteInput.rendersNoResultsMessage(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), JPY.isoCode);
     checkAutocompleteInput.rendersNoResultsMessage(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), EUR.isoCode);
+  },
+  alternativeCurrencyShouldNotRender: () => {
+    const { option: option5 } = radios(FIELD_ID, ALTERNATIVE_CURRENCY_FIELD_ID);
+
+    option5.input().click();
+
     checkAutocompleteInput.rendersSingleResult(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), 'Alg');
     checkAutocompleteInput.rendersMultipleResults(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), 'Be');
 

--- a/e2e-tests/commands/insurance/assert-alternative-currency-form.js
+++ b/e2e-tests/commands/insurance/assert-alternative-currency-form.js
@@ -55,7 +55,7 @@ const assertAlternativeCurrencyForm = ({
     checkAutocompleteInput.hasWorkingClientSideJS(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID));
     checkAutocompleteInput.rendersInput(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID));
   },
-  rendersAlternativeCurrencies: () => {
+  doesNotRenderSupportedCurrencies: () => {
     const { option: option5 } = radios(FIELD_ID, ALTERNATIVE_CURRENCY_FIELD_ID);
 
     option5.input().click();
@@ -67,7 +67,7 @@ const assertAlternativeCurrencyForm = ({
     checkAutocompleteInput.rendersNoResultsMessage(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), JPY.isoCode);
     checkAutocompleteInput.rendersNoResultsMessage(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), EUR.isoCode);
   },
-  doesNotRenderSupportedCurrencies: () => {
+  rendersAlternativeCurrencies: () => {
     const { option: option5 } = radios(FIELD_ID, ALTERNATIVE_CURRENCY_FIELD_ID);
 
     option5.input().click();

--- a/e2e-tests/commands/insurance/assert-alternative-currency-form.js
+++ b/e2e-tests/commands/insurance/assert-alternative-currency-form.js
@@ -4,6 +4,7 @@ import {
   GBP,
   JPY,
   USD,
+  AED,
 } from '../../fixtures/currencies';
 import checkAutocompleteInput from '../shared-commands/assertions/check-autocomplete-input';
 import { DZA } from '../../fixtures/countries';
@@ -54,11 +55,16 @@ const assertAlternativeCurrencyForm = ({
     checkAutocompleteInput.hasWorkingClientSideJS(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID));
     checkAutocompleteInput.rendersInput(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID));
     checkAutocompleteInput.rendersNoResultsMessage(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), 'test');
+    // should not render radio values in alternate currency input
+    checkAutocompleteInput.rendersNoResultsMessage(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), GBP.isoCode);
+    checkAutocompleteInput.rendersNoResultsMessage(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), USD.isoCode);
+    checkAutocompleteInput.rendersNoResultsMessage(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), JPY.isoCode);
+    checkAutocompleteInput.rendersNoResultsMessage(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), EUR.isoCode);
     checkAutocompleteInput.rendersSingleResult(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), 'Alg');
     checkAutocompleteInput.rendersMultipleResults(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), 'Be');
 
-    const expectedValue = `${GBP.name} (${GBP.isoCode})`;
-    checkAutocompleteInput.allowsUserToRemoveCountryAndSearchAgain(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), DZA.NAME, GBP.name, expectedValue);
+    const expectedValue = `${AED.name} (${AED.isoCode})`;
+    checkAutocompleteInput.allowsUserToRemoveCountryAndSearchAgain(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), DZA.NAME, AED.name, expectedValue);
   },
 });
 

--- a/e2e-tests/commands/insurance/assert-alternative-currency-form.js
+++ b/e2e-tests/commands/insurance/assert-alternative-currency-form.js
@@ -55,7 +55,7 @@ const assertAlternativeCurrencyForm = ({
     checkAutocompleteInput.hasWorkingClientSideJS(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID));
     checkAutocompleteInput.rendersInput(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID));
   },
-  alternativeCurrencyShouldRender: () => {
+  rendersAlternativeCurrencies: () => {
     const { option: option5 } = radios(FIELD_ID, ALTERNATIVE_CURRENCY_FIELD_ID);
 
     option5.input().click();
@@ -67,7 +67,7 @@ const assertAlternativeCurrencyForm = ({
     checkAutocompleteInput.rendersNoResultsMessage(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), JPY.isoCode);
     checkAutocompleteInput.rendersNoResultsMessage(countryInput.field(ALTERNATIVE_CURRENCY_FIELD_ID), EUR.isoCode);
   },
-  alternativeCurrencyShouldNotRender: () => {
+  doesNotRenderSupportedCurrencies: () => {
     const { option: option5 } = radios(FIELD_ID, ALTERNATIVE_CURRENCY_FIELD_ID);
 
     option5.input().click();

--- a/e2e-tests/fixtures/currencies.js
+++ b/e2e-tests/fixtures/currencies.js
@@ -2,6 +2,7 @@ export const EUR_CURRENCY_CODE = 'EUR';
 export const GBP_CURRENCY_CODE = 'GBP';
 export const USD_CURRENCY_CODE = 'USD';
 export const JPY_CURRENCY_CODE = 'JPY';
+export const AED_CURRENCY_CODE = 'AED';
 
 export const EUR = {
   name: 'Euros',
@@ -21,6 +22,11 @@ export const JPY = {
 export const USD = {
   name: 'US Dollars',
   isoCode: USD_CURRENCY_CODE,
+};
+
+export const AED = {
+  name: 'U.A.E. Dirham',
+  isoCode: AED_CURRENCY_CODE,
 };
 
 const mockCurrencies = [

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/alternative-currency/alternative-currency-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/alternative-currency/alternative-currency-page.spec.js
@@ -61,7 +61,7 @@ context('Insurance - Your Buyer - Alternative currency - As an exporter, I want 
 
   describe('page tests', () => {
     const {
-      radios, alternativeCurrencyInput, alternativeCurrencyShouldNotRender, alternativeCurrencyShouldRender,
+      radios, alternativeCurrencyInput, rendersAlternativeCurrencies, doesNotRenderSupportedCurrencies,
     } = assertAlternativeCurrencyForm({
       FIELD_ID: CURRENCY_CODE,
       LEGEND: YOUR_BUYER_FIELDS[CURRENCY_CODE].LEGEND,
@@ -86,11 +86,11 @@ context('Insurance - Your Buyer - Alternative currency - As an exporter, I want 
     });
 
     it('should not render invalid inputs or radio currencies in alternative currency input', () => {
-      alternativeCurrencyShouldNotRender();
+      doesNotRenderSupportedCurrencies();
     });
 
     it('should render valid alternate currencies in alternative currency input', () => {
-      alternativeCurrencyShouldRender();
+      rendersAlternativeCurrencies();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/alternative-currency/alternative-currency-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/alternative-currency/alternative-currency-page.spec.js
@@ -60,7 +60,9 @@ context('Insurance - Your Buyer - Alternative currency - As an exporter, I want 
   });
 
   describe('page tests', () => {
-    const { radios, alternativeCurrencyInput } = assertAlternativeCurrencyForm({
+    const {
+      radios, alternativeCurrencyInput, alternativeCurrencyShouldNotRender, alternativeCurrencyShouldRender,
+    } = assertAlternativeCurrencyForm({
       FIELD_ID: CURRENCY_CODE,
       LEGEND: YOUR_BUYER_FIELDS[CURRENCY_CODE].LEGEND,
       ALTERNATIVE_CURRENCY_FIELD_ID: ALTERNATIVE_CURRENCY_CODE,
@@ -81,6 +83,14 @@ context('Insurance - Your Buyer - Alternative currency - As an exporter, I want 
 
     it('renders alternative currency input', () => {
       alternativeCurrencyInput();
+    });
+
+    it('should not render invalid inputs or radio currencies in alternative currency input', () => {
+      alternativeCurrencyShouldNotRender();
+    });
+
+    it('should render valid alternate currencies in alternative currency input', () => {
+      alternativeCurrencyShouldRender();
     });
   });
 

--- a/src/api/custom-resolvers/queries/get-APIM-currencies/index.test.ts
+++ b/src/api/custom-resolvers/queries/get-APIM-currencies/index.test.ts
@@ -20,11 +20,11 @@ describe('custom-resolvers/get-APIM-currencies', () => {
       const response = await getApimCurrencies();
 
       const mappedSupported = mapCurrencies(mockCurrencies, false);
-      const mappedAll = mapCurrencies(mockCurrencies, true);
+      const mappedAlternative = mapCurrencies(mockCurrencies, true);
 
       const expected = {
         supportedCurrencies: mappedSupported,
-        allCurrencies: mappedAll,
+        alternativeCurrencies: mappedAlternative,
       };
 
       expect(response).toEqual(expected);

--- a/src/api/custom-resolvers/queries/get-APIM-currencies/index.ts
+++ b/src/api/custom-resolvers/queries/get-APIM-currencies/index.ts
@@ -15,7 +15,7 @@ const getApimCurrencies = async () => {
     if (response.data) {
       return {
         supportedCurrencies: mapCurrencies(response.data, false),
-        allCurrencies: mapCurrencies(response.data, true),
+        alternativeCurrencies: mapCurrencies(response.data, true),
       };
     }
 

--- a/src/api/custom-schema/type-defs.ts
+++ b/src/api/custom-schema/type-defs.ts
@@ -216,7 +216,7 @@ const typeDefs = `
 
   type GetApimCurrencyResponse {
     supportedCurrencies: [MappedCurrency]
-    allCurrencies: [MappedCurrency]
+    alternativeCurrencies: [MappedCurrency]
   }
 
   type Mutation {

--- a/src/api/helpers/map-currencies/index.test.ts
+++ b/src/api/helpers/map-currencies/index.test.ts
@@ -1,7 +1,7 @@
-import mapCurrencies, { getSupportedCurrencies } from '.';
+import mapCurrencies, { getSupportedCurrencies, getAlternativeCurrencies } from '.';
 import { FIELD_IDS, SUPPORTED_CURRENCIES } from '../../constants';
 import sortArrayAlphabetically from '../sort-array-alphabetically';
-import mockCurrencies from '../../test-mocks/mock-currencies';
+import mockCurrencies, { HKD } from '../../test-mocks/mock-currencies';
 
 describe('helpers/map-currencies', () => {
   describe('getSupportedCurrencies', () => {
@@ -14,8 +14,18 @@ describe('helpers/map-currencies', () => {
     });
   });
 
+  describe('getAlternativeCurrencies', () => {
+    it('should only return currencies not in SUPPORTED_CURRENCIES constants', () => {
+      const result = getAlternativeCurrencies(mockCurrencies);
+
+      const expected = [HKD];
+
+      expect(result).toEqual(expected);
+    });
+  });
+
   describe('mapCurrencies', () => {
-    describe('allCurrencies as "false"', () => {
+    describe('alternativeCurrencies as "false"', () => {
       it('should return an array of supported currencies sorted alphabetically', () => {
         const result = mapCurrencies(mockCurrencies, false);
 
@@ -27,11 +37,12 @@ describe('helpers/map-currencies', () => {
       });
     });
 
-    describe('allCurrencies as "true"', () => {
-      it('should return an array of all currencies sorted alphabetically', () => {
+    describe('alternativeCurrencies as "true"', () => {
+      it('should return an array of alternative currencies sorted alphabetically', () => {
         const result = mapCurrencies(mockCurrencies, true);
 
-        const expected = sortArrayAlphabetically(mockCurrencies, FIELD_IDS.NAME);
+        const currencies = getAlternativeCurrencies(mockCurrencies);
+        const expected = sortArrayAlphabetically(currencies, FIELD_IDS.NAME);
 
         expect(result).toEqual(expected);
       });

--- a/src/api/helpers/map-currencies/index.ts
+++ b/src/api/helpers/map-currencies/index.ts
@@ -15,21 +15,35 @@ export const getSupportedCurrencies = (currencies: Array<Currency>) => {
 };
 
 /**
+ * getAlternativeCurrencies
+ * Get alternate currencies - not in SUPPORTED_CURRENCIES
+ * @param {Array} Array of all possible currencies
+ * @returns {Array} Array of alternate currencies
+ */
+export const getAlternativeCurrencies = (currencies: Array<Currency>) => {
+  const alternate = currencies.filter((currency) => !SUPPORTED_CURRENCIES.includes(currency.isoCode));
+
+  return alternate;
+};
+
+/**
  * mapCurrencies
  * Map and sort currencies.
- * 1) if allCurrencies flag set, then will return all currencies
- * 2) if allCurrencies flag not set, then will filter supported currencies.
+ * 1) if alternativeCurrencies flag set, then will return all currencies
+ * 2) if alternativeCurrencies flag not set, then will filter supported currencies.
  * 3) Sort the currencies alphabetically.
  * @param {Array} Array of currency objects
- * @param {Boolean} allCurrencies if all currencies should be returned
+ * @param {Boolean} alternativeCurrencies if alternate currencies should be returned
  * @returns {Array} Array supported currencies
  */
-const mapCurrencies = (currencies: Array<Currency>, allCurrencies: boolean) => {
+const mapCurrencies = (currencies: Array<Currency>, alternativeCurrencies: boolean) => {
   let currenciesArray = currencies;
 
   // if not all currencies, then get the supported currencies only
-  if (!allCurrencies) {
+  if (!alternativeCurrencies) {
     currenciesArray = getSupportedCurrencies(currencies);
+  } else {
+    currenciesArray = getAlternativeCurrencies(currencies);
   }
 
   const sorted = sortArrayAlphabetically(currenciesArray, FIELD_IDS.NAME);

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -2704,5 +2704,5 @@ type MappedCurrency {
 
 type GetApimCurrencyResponse {
   supportedCurrencies: [MappedCurrency]
-  allCurrencies: [MappedCurrency]
+  alternativeCurrencies: [MappedCurrency]
 }

--- a/src/ui/server/controllers/insurance/check-your-answers/policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/policy/index.test.ts
@@ -141,7 +141,7 @@ describe('controllers/insurance/check-your-answers/policy', () => {
 
       describe('when the get currencies response does not return a populated array', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], allCurrencies: [] }));
+          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], alternativeCurrencies: [] }));
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 

--- a/src/ui/server/controllers/insurance/policy/check-your-answers/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/check-your-answers/index.test.ts
@@ -117,7 +117,7 @@ describe('controllers/insurance/policy/check-your-answers', () => {
 
       describe('when the get currencies response does not return a populated array', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], allCurrencies: [] }));
+          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], alternativeCurrencies: [] }));
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.test.ts
@@ -166,7 +166,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
 
       describe('when the get currencies response does not return a populated array', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], allCurrencies: [] }));
+          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], alternativeCurrencies: [] }));
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -302,7 +302,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
 
         describe('when the get currencies response does not return a populated array', () => {
           beforeEach(() => {
-            getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], allCurrencies: [] }));
+            getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], alternativeCurrencies: [] }));
             api.keystone.APIM.getCurrencies = getCurrenciesSpy;
           });
 

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.test.ts
@@ -242,7 +242,7 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
 
       describe('when the get currencies response does not return a populated array', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], allCurrencies: [] }));
+          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], alternativeCurrencies: [] }));
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -408,7 +408,7 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
 
         describe('when the get currencies response does not return a populated array', () => {
           beforeEach(() => {
-            getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], allCurrencies: [] }));
+            getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], alternativeCurrencies: [] }));
             api.keystone.APIM.getCurrencies = getCurrenciesSpy;
           });
 

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/index.test.ts
@@ -229,7 +229,7 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
 
       describe('when the get currencies response does not return a populated array', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], allCurrencies: [] }));
+          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], alternativeCurrencies: [] }));
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -412,7 +412,7 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
 
         describe('when the get currencies response does not return a populated array', () => {
           beforeEach(() => {
-            getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], allCurrencies: [] }));
+            getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], alternativeCurrencies: [] }));
             api.keystone.APIM.getCurrencies = getCurrenciesSpy;
           });
 

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
@@ -159,7 +159,7 @@ describe('controllers/insurance/policy/single-contract-policy//total-contract-va
 
       describe('when the get currencies response does not return a populated array', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], allCurrencies: [] }));
+          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], alternativeCurrencies: [] }));
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -294,7 +294,7 @@ describe('controllers/insurance/policy/single-contract-policy//total-contract-va
 
         describe('when the get currencies response does not return a populated array', () => {
           beforeEach(() => {
-            getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], allCurrencies: [] }));
+            getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], alternativeCurrencies: [] }));
             api.keystone.APIM.getCurrencies = getCurrenciesSpy;
           });
 

--- a/src/ui/server/controllers/insurance/your-buyer/alternative-currency/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/alternative-currency/index.test.ts
@@ -137,7 +137,7 @@ describe('controllers/insurance/your-buyer/alternative-currency', () => {
 
       describe('when the get currencies response does not return a populated array', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], allCurrencies: [] }));
+          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], alternativeCurrencies: [] }));
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -258,7 +258,7 @@ describe('controllers/insurance/your-buyer/alternative-currency', () => {
 
         describe('when the get currencies response does not return a populated array', () => {
           beforeEach(() => {
-            getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], allCurrencies: [] }));
+            getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], alternativeCurrencies: [] }));
             api.keystone.APIM.getCurrencies = getCurrenciesSpy;
           });
 

--- a/src/ui/server/controllers/insurance/your-buyer/alternative-currency/index.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/alternative-currency/index.ts
@@ -61,14 +61,14 @@ export const get = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    const { allCurrencies, supportedCurrencies } = await api.keystone.APIM.getCurrencies();
+    const { alternativeCurrencies, supportedCurrencies } = await api.keystone.APIM.getCurrencies();
 
-    if (!isPopulatedArray(supportedCurrencies) || !isPopulatedArray(allCurrencies)) {
+    if (!isPopulatedArray(supportedCurrencies) || !isPopulatedArray(alternativeCurrencies)) {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
     // TODO: Add  if (currencyValue) once data saving completed and change ''
-    const mappedCurrencies = mapCurrenciesAsSelectOptions(allCurrencies, '', true);
+    const mappedCurrencies = mapCurrenciesAsSelectOptions(alternativeCurrencies, '', true);
 
     return res.render(TEMPLATE, {
       ...insuranceCorePageVariables({
@@ -109,14 +109,14 @@ export const post = async (req: Request, res: Response) => {
     const validationErrors = generateValidationErrors(payload);
 
     if (validationErrors) {
-      const { allCurrencies, supportedCurrencies } = await api.keystone.APIM.getCurrencies();
+      const { alternativeCurrencies, supportedCurrencies } = await api.keystone.APIM.getCurrencies();
 
-      if (!isPopulatedArray(supportedCurrencies) || !isPopulatedArray(allCurrencies)) {
+      if (!isPopulatedArray(supportedCurrencies) || !isPopulatedArray(alternativeCurrencies)) {
         return res.redirect(PROBLEM_WITH_SERVICE);
       }
 
       // TODO: Add  if (currencyValue) once data saving completed and change ''
-      const mappedCurrencies = mapCurrenciesAsSelectOptions(allCurrencies, '', true);
+      const mappedCurrencies = mapCurrenciesAsSelectOptions(alternativeCurrencies, '', true);
 
       return res.render(TEMPLATE, {
         ...insuranceCorePageVariables({

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
@@ -343,7 +343,7 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
 
       describe('when the get currencies response does not return a populated array', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], allCurrencies: [] }));
+          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], alternativeCurrencies: [] }));
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -599,7 +599,7 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
 
       describe('when the get currencies response does not return a populated array', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], allCurrencies: [] }));
+          getCurrenciesSpy = jest.fn(() => Promise.resolve({ supportedCurrencies: [], alternativeCurrencies: [] }));
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 

--- a/src/ui/server/graphql/queries/APIM/currencies.ts
+++ b/src/ui/server/graphql/queries/APIM/currencies.ts
@@ -7,7 +7,7 @@ const getApimCurrencies = gql`
         isoCode
         name
       }
-      allCurrencies {
+      alternativeCurrencies {
         isoCode
         name
       }

--- a/src/ui/server/helpers/mappings/map-currencies/as-select-options/index.ts
+++ b/src/ui/server/helpers/mappings/map-currencies/as-select-options/index.ts
@@ -6,11 +6,11 @@ import { Currency } from '../../../../../types';
  * Map all currencies into the required structure for GOV select component.
  * @param {Array} currencies: Array of currency objects
  * @param {String} selectedValue: Selected currency
- * @param {Boolean} allCurrencies: if all currencies are being mapped - default to false
+ * @param {Boolean} alternativeCurrencies: if alternative currencies are being mapped - default to false
  * @returns {Array} Array of mapped and sorted currencies
  */
-const mapCurrenciesAsSelectOptions = (currencies: Array<Currency>, selectedValue?: string, allCurrencies = false) => {
-  const mappedCurrencies = mapAndSortCurrencies(currencies, selectedValue, allCurrencies);
+const mapCurrenciesAsSelectOptions = (currencies: Array<Currency>, selectedValue?: string, alternativeCurrencies = false) => {
+  const mappedCurrencies = mapAndSortCurrencies(currencies, selectedValue, alternativeCurrencies);
 
   if (!selectedValue) {
     const defaultOption = {

--- a/src/ui/server/helpers/mappings/map-currencies/as-select-options/map-and-sort-currencies/index.test.ts
+++ b/src/ui/server/helpers/mappings/map-currencies/as-select-options/map-and-sort-currencies/index.test.ts
@@ -6,7 +6,7 @@ const renderValueInText = true;
 const mockSelectedValue = mockCurrencies[1].isoCode;
 
 describe('server/helpers/mappings/map-currencies/as-select-options/map-and-sort-currencies', () => {
-  describe('allCurrencies as "false"', () => {
+  describe('alternativeCurrencies as "false"', () => {
     it('should return an array of mapped objects from mapSelectOption', () => {
       const result = mapAndSortCurrencies(mockCurrencies, mockSelectedValue, false);
 
@@ -18,7 +18,7 @@ describe('server/helpers/mappings/map-currencies/as-select-options/map-and-sort-
     });
   });
 
-  describe('allCurrencies as "true"', () => {
+  describe('alternativeCurrencies as "true"', () => {
     it('should return an array of mapped objects from mapSelectOption', () => {
       const result = mapAndSortCurrencies(mockCurrencies, mockSelectedValue, true);
 

--- a/src/ui/server/helpers/mappings/map-currencies/as-select-options/map-and-sort-currencies/index.ts
+++ b/src/ui/server/helpers/mappings/map-currencies/as-select-options/map-and-sort-currencies/index.ts
@@ -10,10 +10,10 @@ import { Currency } from '../../../../../../types';
  * if all currencies, then map all currencies into required structure
  * @param {Array} currencies: Array of currency objects
  * @param {String} selectedValue: Selected currency
- * @param {Boolean} allCurrencies: if all currencies need to be mapped
+ * @param {Boolean} alternativeCurrencies: if all currencies need to be mapped
  * @returns {Array} Mapped and sorted currencies
  */
-const mapAndSortCurrencies = (currencies: Array<Currency>, selectedValue?: string, allCurrencies?: boolean) => {
+const mapAndSortCurrencies = (currencies: Array<Currency>, selectedValue?: string, alternativeCurrencies?: boolean) => {
   const renderValueInText = true;
   let sortedCurrencies;
 
@@ -21,7 +21,7 @@ const mapAndSortCurrencies = (currencies: Array<Currency>, selectedValue?: strin
    * if not all currencies, then manually sorted to meet design
    * if all currencies, then map all currencies into the required structure for GOV select component
    */
-  if (!allCurrencies) {
+  if (!alternativeCurrencies) {
     /**
      * 1) Create an initial currencies object
      * 2) Loop over each currency

--- a/src/ui/server/test-mocks/mock-currencies.ts
+++ b/src/ui/server/test-mocks/mock-currencies.ts
@@ -29,7 +29,7 @@ const mockCurrencies = [EUR, HKD, JPY, GBP, USD] as Array<Currency>;
 
 export const mockCurrenciesResponse = {
   supportedCurrencies: mockCurrencies,
-  allCurrencies: mockCurrencies,
+  alternativeCurrencies: mockCurrencies,
 };
 
 export default mockCurrencies;


### PR DESCRIPTION
## Introduction :pencil2:
This PR returns alternative currencies instead of all currencies from API.  Removes supported currencies from alternative currencies

## Resolution :heavy_check_mark:
- Added `getAlternativeCurrencies` to remove currencies not in SUPPORTED_CURRENCIES
- Updated tests
- Updated all instances of allCurrencies to alternativeCurrencies
