### PR TITLE
feat(EMS-2535): No PDF - Policy - Change from single to multiple - enhancements

### DIFF
--- a/e2e-tests/commands/insurance/change-policy-type-to-multiple-and-submit-contract-policy-form.js
+++ b/e2e-tests/commands/insurance/change-policy-type-to-multiple-and-submit-contract-policy-form.js
@@ -1,0 +1,22 @@
+import { summaryList } from '../../pages/shared';
+import { typeOfPolicyPage } from '../../pages/insurance/policy';
+import { POLICY as FIELD_IDS } from '../../constants/field-ids/insurance/policy';
+
+const {
+  TYPE_OF_POLICY: { POLICY_TYPE },
+} = FIELD_IDS;
+
+/**
+ * changePolicyTypeToMultipleAndSubmitContractPolicyForm
+ * 1) Change policy type to multiple and submit the "contract policy" form.
+ */
+const changePolicyTypeToMultipleAndSubmitContractPolicyForm = () => {
+  summaryList.field(POLICY_TYPE).changeLink().click();
+
+  typeOfPolicyPage[POLICY_TYPE].multiple.input().click();
+  cy.clickSubmitButton();
+
+  cy.completeAndSubmitMultipleContractPolicyForm();
+};
+
+export default changePolicyTypeToMultipleAndSubmitContractPolicyForm;

--- a/e2e-tests/constants/routes/insurance/policy.js
+++ b/e2e-tests/constants/routes/insurance/policy.js
@@ -21,6 +21,8 @@ export const POLICY = {
   MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE: `${ROOT}/multi-contract-policy/check-and-change`,
   MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE: `${ROOT}/multi-contract-policy/export-value`,
   MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_SAVE_AND_BACK: `${ROOT}/multi-contract-policy/export-value/save-and-go-back`,
+  MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE: `${ROOT}/multi-contract-policy/export-value/change`,
+  MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE: `${ROOT}/multi-contract-policy/export-value/check-and-change`,
   NAME_ON_POLICY: `${ROOT}/name-on-policy`,
   NAME_ON_POLICY_SAVE_AND_BACK: `${ROOT}/name-on-policy/save-and-go-back`,
   NAME_ON_POLICY_CHANGE: `${ROOT}/name-on-policy/change`,

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/change-your-answers-policy-type-change-single-to-multiple-policy-type-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/change-your-answers-policy-type-change-single-to-multiple-policy-type-summary-list.spec.js
@@ -116,22 +116,6 @@ context('Insurance - Change your answers - Policy - Change single to multiple po
         cy.navigateToUrl(checkYourAnswersUrl);
       });
 
-      // it(POLICY_TYPE, () => {
-      //   checkSummaryList.multipleContractPolicy[POLICY_TYPE]();
-      // });
-
-      // it(TOTAL_MONTHS_OF_COVER, () => {
-      //   checkSummaryList.multipleContractPolicy[TOTAL_MONTHS_OF_COVER]();
-      // });
-
-      // it(TOTAL_SALES_TO_BUYER, () => {
-      //   checkSummaryList.multipleContractPolicy[TOTAL_SALES_TO_BUYER]();
-      // });
-
-      // it(MAXIMUM_BUYER_WILL_OWE, () => {
-      //   checkSummaryList.multipleContractPolicy[MAXIMUM_BUYER_WILL_OWE]();
-      // });
-
       it(POLICY_TYPE, () => {
         cy.assertSummaryListRowValue(summaryList, POLICY_TYPE, FIELD_VALUES.POLICY_TYPE.MULTIPLE);
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/change-your-answers-policy-type-change-single-to-multiple-policy-type-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/change-your-answers-policy-type-change-single-to-multiple-policy-type-summary-list.spec.js
@@ -1,16 +1,17 @@
 import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
-import { DEFAULT } from '../../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { summaryList } from '../../../../../../../pages/shared';
-import { typeOfPolicyPage } from '../../../../../../../pages/insurance/policy';
+import formatCurrency from '../../../../../../../helpers/format-currency';
 import application from '../../../../../../../fixtures/application';
 
 const {
   ROOT,
   POLICY: {
     TYPE_OF_POLICY_CHECK_AND_CHANGE,
+    MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE,
+    MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE,
   },
   CHECK_YOUR_ANSWERS,
 } = INSURANCE_ROUTES;
@@ -39,8 +40,9 @@ const task = taskList.submitApplication.tasks.checkAnswers;
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Change your answers - Policy - Change single to multiple policy type - Summary List', () => {
-  let checkYourAnswersUrl;
   let referenceNumber;
+  let checkYourAnswersUrl;
+  let exportValueUrl;
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
@@ -49,7 +51,11 @@ context('Insurance - Change your answers - Policy - Change single to multiple po
 
       task.link().click();
 
-      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY}`;
+      const applicationRouteUrl = `${ROOT}/${referenceNumber}`;
+
+      checkYourAnswersUrl = `${baseUrl}${applicationRouteUrl}${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY}`;
+      exportValueUrl = `${baseUrl}${applicationRouteUrl}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE}`;
+
       cy.assertUrl(checkYourAnswersUrl);
     });
   });
@@ -79,25 +85,52 @@ context('Insurance - Change your answers - Policy - Change single to multiple po
   });
 
   describe('after submitting a new policy type (multiple) and completing (now required) fields for a multiple policy', () => {
-    it(`should redirect to ${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY}`, () => {
+    beforeEach(() => {
       cy.navigateToUrl(checkYourAnswersUrl);
+      cy.changePolicyTypeToMultipleAndSubmitContractPolicyForm();
+    });
 
-      summaryList.field(fieldId).changeLink().click();
-
-      typeOfPolicyPage[fieldId].multiple.input().click();
-      cy.clickSubmitButton();
-
-      cy.completeAndSubmitMultipleContractPolicyForm();
-
-      const expectedUrl = `${checkYourAnswersUrl}#heading`;
+    it(`should redirect to ${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE} with heading anchor`, () => {
+      const expectedUrl = `${exportValueUrl}#heading`;
 
       cy.assertUrl(expectedUrl);
     });
 
-    describe('should render new answers and change links for new multiple policy fields', () => {
+    describe(`after completing (now required) ${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE} fields for a multiple policy`, () => {
+      beforeEach(() => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+        cy.changePolicyTypeToMultipleAndSubmitContractPolicyForm();
+
+        cy.completeAndSubmitExportValueForm();
+      });
+
+      it(`should redirect to ${CHECK_YOUR_ANSWERS.TYPE_OF_POLICY}`, () => {
+        const expectedUrl = `${checkYourAnswersUrl}#heading`;
+
+        cy.assertUrl(expectedUrl);
+      });
+    });
+
+    describe('render new answers and change links for new multiple policy fields', () => {
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);
       });
+
+      // it(POLICY_TYPE, () => {
+      //   checkSummaryList.multipleContractPolicy[POLICY_TYPE]();
+      // });
+
+      // it(TOTAL_MONTHS_OF_COVER, () => {
+      //   checkSummaryList.multipleContractPolicy[TOTAL_MONTHS_OF_COVER]();
+      // });
+
+      // it(TOTAL_SALES_TO_BUYER, () => {
+      //   checkSummaryList.multipleContractPolicy[TOTAL_SALES_TO_BUYER]();
+      // });
+
+      // it(MAXIMUM_BUYER_WILL_OWE, () => {
+      //   checkSummaryList.multipleContractPolicy[MAXIMUM_BUYER_WILL_OWE]();
+      // });
 
       it(POLICY_TYPE, () => {
         cy.assertSummaryListRowValue(summaryList, POLICY_TYPE, FIELD_VALUES.POLICY_TYPE.MULTIPLE);
@@ -114,23 +147,24 @@ context('Insurance - Change your answers - Policy - Change single to multiple po
       it(TOTAL_SALES_TO_BUYER, () => {
         fieldId = TOTAL_SALES_TO_BUYER;
 
-        // const expectedValue = formatCurrency(application.POLICY[fieldId]);
+        const expectedValue = formatCurrency(application.POLICY[fieldId]);
 
-        cy.assertSummaryListRowValue(summaryList, fieldId, DEFAULT.EMPTY);
+        cy.assertSummaryListRowValue(summaryList, fieldId, expectedValue);
       });
 
       it(MAXIMUM_BUYER_WILL_OWE, () => {
         fieldId = MAXIMUM_BUYER_WILL_OWE;
 
-        // const expectedMaximumBuyerWillOwe = formatCurrency(application.POLICY[fieldId]);
+        const expectedMaximumBuyerWillOwe = formatCurrency(application.POLICY[fieldId]);
 
-        cy.assertSummaryListRowValue(summaryList, fieldId, DEFAULT.EMPTY);
+        cy.assertSummaryListRowValue(summaryList, fieldId, expectedMaximumBuyerWillOwe);
 
         // check the change link
-        // summaryList.field(MAXIMUM_BUYER_WILL_OWE).changeLink().click();
-        // cy.assertChangeAnswersPageUrl({
-        //   referenceNumber, route: MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE, fieldId: MAXIMUM_BUYER_WILL_OWE, fragmentSuffix: 'label',
-        // });
+        summaryList.field(MAXIMUM_BUYER_WILL_OWE).changeLink().click();
+
+        cy.assertChangeAnswersPageUrl({
+          referenceNumber, route: MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE, fieldId: MAXIMUM_BUYER_WILL_OWE, fragmentSuffix: 'label',
+        });
       });
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/change-your-answers-change-policy-type-single-to-multiple.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/change-your-answers-change-policy-type-single-to-multiple.spec.js
@@ -9,6 +9,7 @@ const {
   POLICY: {
     CHECK_YOUR_ANSWERS,
     TYPE_OF_POLICY_CHANGE,
+    MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE,
   },
 } = INSURANCE_ROUTES;
 
@@ -20,15 +21,23 @@ const {
         TOTAL_MONTHS_OF_COVER,
       },
     },
-    // TODO: EMS-2541
-    // EXPORT_VALUE: {
-    //   MULTIPLE: {
-    //     TOTAL_SALES_TO_BUYER,
-    //     MAXIMUM_BUYER_WILL_OWE,
-    //   },
-    // },
+    EXPORT_VALUE: {
+      MULTIPLE: {
+        TOTAL_SALES_TO_BUYER,
+        MAXIMUM_BUYER_WILL_OWE,
+      },
+    },
   },
 } = INSURANCE_FIELD_IDS;
+
+const changePolicyTypeAndSubmitContractPolicyForm = () => {
+  summaryList.field(POLICY_TYPE).changeLink().click();
+
+  typeOfPolicyPage[POLICY_TYPE].multiple.input().click();
+  cy.clickSubmitButton();
+
+  cy.completeAndSubmitMultipleContractPolicyForm();
+};
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -36,6 +45,7 @@ context('Insurance - Policy - Change your answers - Policy type - single to mult
   let referenceNumber;
   let checkYourAnswersUrl;
   let typeOfPolicyUrl;
+  let exportValueUrl;
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
@@ -47,6 +57,7 @@ context('Insurance - Policy - Change your answers - Policy type - single to mult
 
       checkYourAnswersUrl = `${baseUrl}${applicationRouteUrl}${CHECK_YOUR_ANSWERS}`;
       typeOfPolicyUrl = `${baseUrl}${applicationRouteUrl}${TYPE_OF_POLICY_CHANGE}`;
+      exportValueUrl = `${baseUrl}${applicationRouteUrl}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE}`;
 
       cy.assertUrl(checkYourAnswersUrl);
     });
@@ -77,22 +88,31 @@ context('Insurance - Policy - Change your answers - Policy type - single to mult
   describe('after submitting a new policy type (multiple) and completing (now required) fields for a multiple policy', () => {
     beforeEach(() => {
       cy.navigateToUrl(checkYourAnswersUrl);
-
-      summaryList.field(POLICY_TYPE).changeLink().click();
-
-      typeOfPolicyPage[POLICY_TYPE].multiple.input().click();
-      cy.clickSubmitButton();
-
-      cy.completeAndSubmitMultipleContractPolicyForm();
+      changePolicyTypeAndSubmitContractPolicyForm();
     });
 
-    it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
-      const expectedUrl = `${checkYourAnswersUrl}#heading`;
+    it(`should redirect to ${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE} with heading anchor`, () => {
+      const expectedUrl = `${exportValueUrl}#heading`;
 
       cy.assertUrl(expectedUrl);
     });
 
-    describe('should render new answers and change links for new multiple policy fields', () => {
+    describe(`after completing (now required) ${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE} fields for a multiple policy`, () => {
+      beforeEach(() => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+        changePolicyTypeAndSubmitContractPolicyForm();
+
+        cy.completeAndSubmitExportValueForm();
+      });
+
+      it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+        const expectedUrl = `${checkYourAnswersUrl}#heading`;
+
+        cy.assertUrl(expectedUrl);
+      });
+    });
+
+    describe('render new answers and change links for new multiple policy fields', () => {
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);
       });
@@ -105,15 +125,13 @@ context('Insurance - Policy - Change your answers - Policy type - single to mult
         checkSummaryList.multipleContractPolicy[TOTAL_MONTHS_OF_COVER]();
       });
 
-      // TODO: EMS-2541
+      it(TOTAL_SALES_TO_BUYER, () => {
+        checkSummaryList.multipleContractPolicy[TOTAL_SALES_TO_BUYER]();
+      });
 
-      // it(TOTAL_SALES_TO_BUYER, () => {
-      //   checkSummaryList.multipleContractPolicy[TOTAL_SALES_TO_BUYER]();
-      // });
-
-      // it(MAXIMUM_BUYER_WILL_OWE, () => {
-      //   checkSummaryList.multipleContractPolicy[MAXIMUM_BUYER_WILL_OWE]();
-      // });
+      it(MAXIMUM_BUYER_WILL_OWE, () => {
+        checkSummaryList.multipleContractPolicy[MAXIMUM_BUYER_WILL_OWE]();
+      });
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/change-your-answers-change-policy-type-single-to-multiple.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/change-your-answers-change-policy-type-single-to-multiple.spec.js
@@ -1,5 +1,4 @@
 import { summaryList } from '../../../../../../pages/shared';
-import { typeOfPolicyPage } from '../../../../../../pages/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import checkSummaryList from '../../../../../../commands/insurance/check-policy-summary-list';
@@ -29,15 +28,6 @@ const {
     },
   },
 } = INSURANCE_FIELD_IDS;
-
-const changePolicyTypeAndSubmitContractPolicyForm = () => {
-  summaryList.field(POLICY_TYPE).changeLink().click();
-
-  typeOfPolicyPage[POLICY_TYPE].multiple.input().click();
-  cy.clickSubmitButton();
-
-  cy.completeAndSubmitMultipleContractPolicyForm();
-};
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -88,7 +78,7 @@ context('Insurance - Policy - Change your answers - Policy type - single to mult
   describe('after submitting a new policy type (multiple) and completing (now required) fields for a multiple policy', () => {
     beforeEach(() => {
       cy.navigateToUrl(checkYourAnswersUrl);
-      changePolicyTypeAndSubmitContractPolicyForm();
+      cy.changePolicyTypeToMultipleAndSubmitContractPolicyForm();
     });
 
     it(`should redirect to ${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE} with heading anchor`, () => {
@@ -100,7 +90,7 @@ context('Insurance - Policy - Change your answers - Policy type - single to mult
     describe(`after completing (now required) ${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE} fields for a multiple policy`, () => {
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);
-        changePolicyTypeAndSubmitContractPolicyForm();
+        cy.changePolicyTypeToMultipleAndSubmitContractPolicyForm();
 
         cy.completeAndSubmitExportValueForm();
       });

--- a/e2e-tests/insurance/cypress/support/application/policy/index.js
+++ b/e2e-tests/insurance/cypress/support/application/policy/index.js
@@ -24,6 +24,7 @@ Cypress.Commands.add('completeBusinessSection', require('../../../../../commands
 Cypress.Commands.add('completeBuyerSection', require('../../../../../commands/insurance/complete-buyer-section'));
 Cypress.Commands.add('completePolicySection', require('../../../../../commands/insurance/complete-policy-section'));
 Cypress.Commands.add('completeExportContractSection', require('../../../../../commands/insurance/complete-export-contract-section'));
+Cypress.Commands.add('changePolicyTypeToMultipleAndSubmitContractPolicyForm', require('../../../../../commands/insurance/change-policy-type-to-multiple-and-submit-contract-policy-form'));
 
 Cypress.Commands.add('completePrepareApplicationSinglePolicyType', require('../../../../../commands/insurance/complete-prepare-application-section-single-policy-type'));
 Cypress.Commands.add('completePrepareApplicationMultiplePolicyType', require('../../../../../commands/insurance/complete-prepare-application-section-multiple-policy-type'));

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -1134,6 +1134,13 @@ var lists = {
       maximumBuyerWillOwe: (0, import_fields.integer)()
     },
     hooks: {
+      resolveInput: async ({ operation, resolvedData, context }) => {
+        const modifiedData = resolvedData;
+        if (resolvedData.policyType === "Multiple contract policy") {
+          modifiedData.contractCompletionDate = null;
+        }
+        return modifiedData;
+      },
       afterOperation: async ({ item, context }) => {
         if (item?.applicationId) {
           await update_application_default.timestamp(context, item.applicationId);

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -1134,13 +1134,6 @@ var lists = {
       maximumBuyerWillOwe: (0, import_fields.integer)()
     },
     hooks: {
-      resolveInput: async ({ operation, resolvedData, context }) => {
-        const modifiedData = resolvedData;
-        if (resolvedData.policyType === "Multiple contract policy") {
-          modifiedData.contractCompletionDate = null;
-        }
-        return modifiedData;
-      },
       afterOperation: async ({ item, context }) => {
         if (item?.applicationId) {
           await update_application_default.timestamp(context, item.applicationId);

--- a/src/ui/server/constants/routes/insurance/policy.ts
+++ b/src/ui/server/constants/routes/insurance/policy.ts
@@ -21,6 +21,8 @@ export const POLICY = {
   MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE: `${ROOT}/multi-contract-policy/check-and-change`,
   MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE: `${ROOT}/multi-contract-policy/export-value`,
   MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_SAVE_AND_BACK: `${ROOT}/multi-contract-policy/export-value/save-and-go-back`,
+  MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE: `${ROOT}/multi-contract-policy/export-value/change`,
+  MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE: `${ROOT}/multi-contract-policy/export-value/check-and-change`,
   NAME_ON_POLICY: `${ROOT}/name-on-policy`,
   NAME_ON_POLICY_SAVE_AND_BACK: `${ROOT}/name-on-policy/save-and-go-back`,
   NAME_ON_POLICY_CHANGE: `${ROOT}/name-on-policy/change`,

--- a/src/ui/server/controllers/insurance/policy/map-submitted-data/policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/map-submitted-data/policy/index.test.ts
@@ -1,13 +1,21 @@
 import mapSubmittedData from '.';
 import POLICY_FIELD_IDS from '../../../../../constants/field-ids/insurance/policy';
 import createTimestampFromNumbers from '../../../../../helpers/date/create-timestamp-from-numbers';
-
-const { CONTRACT_POLICY, NEED_PRE_CREDIT_PERIOD, CREDIT_PERIOD_WITH_BUYER } = POLICY_FIELD_IDS;
+import { mockApplication, mockApplicationMultiplePolicy } from '../../../../../test-mocks';
 
 const {
-  REQUESTED_START_DATE,
-  SINGLE: { CONTRACT_COMPLETION_DATE },
-} = CONTRACT_POLICY;
+  POLICY_TYPE,
+  CONTRACT_POLICY: {
+    REQUESTED_START_DATE,
+    SINGLE: { CONTRACT_COMPLETION_DATE, TOTAL_CONTRACT_VALUE },
+    MULTIPLE: { TOTAL_MONTHS_OF_COVER },
+  },
+  EXPORT_VALUE: {
+    MULTIPLE: { TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE },
+  },
+  NEED_PRE_CREDIT_PERIOD,
+  CREDIT_PERIOD_WITH_BUYER,
+} = POLICY_FIELD_IDS;
 
 describe('controllers/insurance/policy/map-submitted-data/policy', () => {
   let date = new Date();
@@ -122,6 +130,48 @@ describe('controllers/insurance/policy/map-submitted-data/policy', () => {
       const expected = {
         ...mockBody,
         [CREDIT_PERIOD_WITH_BUYER]: '',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when ${POLICY_TYPE} is single`, () => {
+    it('should return an object with wiped multiple policy specific fields', () => {
+      const mockBody = {
+        ...mockApplication.policy,
+        [MAXIMUM_BUYER_WILL_OWE]: mockApplicationMultiplePolicy.policy[MAXIMUM_BUYER_WILL_OWE],
+        [TOTAL_MONTHS_OF_COVER]: mockApplicationMultiplePolicy.policy[TOTAL_MONTHS_OF_COVER],
+        [TOTAL_SALES_TO_BUYER]: mockApplicationMultiplePolicy.policy[TOTAL_SALES_TO_BUYER],
+      };
+
+      const result = mapSubmittedData(mockBody);
+
+      const expected = {
+        ...mockBody,
+        [MAXIMUM_BUYER_WILL_OWE]: '',
+        [TOTAL_MONTHS_OF_COVER]: '',
+        [TOTAL_SALES_TO_BUYER]: '',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when ${POLICY_TYPE} is multiple`, () => {
+    it('should return an object with wiped single policy specific fields', () => {
+      const mockBody = {
+        ...mockApplicationMultiplePolicy.policy,
+        [CONTRACT_COMPLETION_DATE]: mockApplication.policy[CONTRACT_COMPLETION_DATE],
+        [TOTAL_CONTRACT_VALUE]: mockApplication.policy[TOTAL_CONTRACT_VALUE],
+      };
+
+      const result = mapSubmittedData(mockBody);
+
+      const expected = {
+        ...mockBody,
+        [CONTRACT_COMPLETION_DATE]: null,
+        [TOTAL_CONTRACT_VALUE]: '',
       };
 
       expect(result).toEqual(expected);

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.test.ts
@@ -23,6 +23,8 @@ const {
     MULTIPLE_CONTRACT_POLICY_CHANGE,
     MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE,
     MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE,
+    MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE,
+    MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE,
     CHECK_YOUR_ANSWERS,
   },
   CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY: CHECK_AND_CHANGE_ROUTE },
@@ -39,7 +41,28 @@ const {
     POLICY_CURRENCY_CODE,
     ALTERNATIVE_POLICY_CURRENCY_CODE,
   },
+  EXPORT_VALUE: {
+    MULTIPLE: { TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE },
+  },
 } = POLICY_FIELD_IDS;
+
+const applicationWithTotalSalesAndMaximumWillOwe = {
+  ...mockApplication,
+  policy: {
+    ...mockApplication.policy,
+    [TOTAL_SALES_TO_BUYER]: '1234',
+    [MAXIMUM_BUYER_WILL_OWE]: '5678',
+  },
+};
+
+const applicationWithoutTotalSalesAndMaximumWillOwe = {
+  ...mockApplication,
+  policy: {
+    ...mockApplication.policy,
+    [TOTAL_SALES_TO_BUYER]: null,
+    [MAXIMUM_BUYER_WILL_OWE]: null,
+  },
+};
 
 describe('controllers/insurance/policy/multiple-contract-policy', () => {
   let req: Request;
@@ -295,26 +318,62 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
       });
 
       describe("when the url's last substring is `change`", () => {
-        it(`should redirect to ${CHECK_YOUR_ANSWERS}`, async () => {
-          req.originalUrl = MULTIPLE_CONTRACT_POLICY_CHANGE;
+        describe(`when an application already has ${TOTAL_SALES_TO_BUYER} and ${MAXIMUM_BUYER_WILL_OWE}`, () => {
+          it(`should redirect to ${CHECK_YOUR_ANSWERS}`, async () => {
+            res.locals.application = applicationWithTotalSalesAndMaximumWillOwe;
 
-          await post(req, res);
+            req.originalUrl = MULTIPLE_CONTRACT_POLICY_CHANGE;
 
-          const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_YOUR_ANSWERS}`;
+            await post(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(expected);
+            const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_YOUR_ANSWERS}`;
+
+            expect(res.redirect).toHaveBeenCalledWith(expected);
+          });
+        });
+
+        describe(`when an application does NOT already have ${TOTAL_SALES_TO_BUYER} and ${MAXIMUM_BUYER_WILL_OWE}`, () => {
+          it(`should redirect to ${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE}`, async () => {
+            res.locals.application = applicationWithoutTotalSalesAndMaximumWillOwe;
+
+            req.originalUrl = MULTIPLE_CONTRACT_POLICY_CHANGE;
+
+            await post(req, res);
+
+            const expected = `${INSURANCE_ROOT}/${refNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE}`;
+
+            expect(res.redirect).toHaveBeenCalledWith(expected);
+          });
         });
       });
 
       describe("when the url's last substring is `check-and-change`", () => {
-        it(`should redirect to ${CHECK_AND_CHANGE_ROUTE}`, async () => {
-          req.originalUrl = MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE;
+        describe(`when an application already has ${TOTAL_SALES_TO_BUYER} and ${MAXIMUM_BUYER_WILL_OWE}`, () => {
+          it(`should redirect to ${CHECK_AND_CHANGE_ROUTE}`, async () => {
+            res.locals.application = applicationWithTotalSalesAndMaximumWillOwe;
 
-          await post(req, res);
+            req.originalUrl = MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE;
 
-          const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_AND_CHANGE_ROUTE}`;
+            await post(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(expected);
+            const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_AND_CHANGE_ROUTE}`;
+
+            expect(res.redirect).toHaveBeenCalledWith(expected);
+          });
+        });
+
+        describe(`when an application does NOT already have ${TOTAL_SALES_TO_BUYER} and ${MAXIMUM_BUYER_WILL_OWE}`, () => {
+          it(`should redirect to ${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE}`, async () => {
+            res.locals.application = applicationWithoutTotalSalesAndMaximumWillOwe;
+
+            req.originalUrl = MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE;
+
+            await post(req, res);
+
+            const expected = `${INSURANCE_ROOT}/${refNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE}`;
+
+            expect(res.redirect).toHaveBeenCalledWith(expected);
+          });
         });
       });
     });

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.ts
@@ -18,7 +18,13 @@ import { Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
-  POLICY: { MULTIPLE_CONTRACT_POLICY_SAVE_AND_BACK, MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE, CHECK_YOUR_ANSWERS },
+  POLICY: {
+    MULTIPLE_CONTRACT_POLICY_SAVE_AND_BACK,
+    MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE,
+    MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE,
+    MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE,
+    CHECK_YOUR_ANSWERS,
+  },
   CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY: CHECK_AND_CHANGE_ROUTE },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
@@ -32,6 +38,9 @@ const {
     MULTIPLE: { TOTAL_MONTHS_OF_COVER },
     POLICY_CURRENCY_CODE,
     ALTERNATIVE_POLICY_CURRENCY_CODE,
+  },
+  EXPORT_VALUE: {
+    MULTIPLE: { TOTAL_SALES_TO_BUYER, MAXIMUM_BUYER_WILL_OWE },
   },
 } = POLICY_FIELD_IDS;
 
@@ -123,6 +132,8 @@ export const post = async (req: Request, res: Response) => {
     return res.redirect(PROBLEM_WITH_SERVICE);
   }
 
+  const { policy } = application;
+
   const { referenceNumber } = req.params;
   const refNumber = Number(referenceNumber);
 
@@ -165,11 +176,33 @@ export const post = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
+    const hasTotalSalesAndMaximumWillOwe = policy[TOTAL_SALES_TO_BUYER] && policy[MAXIMUM_BUYER_WILL_OWE];
+
+    /**
+     * If the route is a "change" route,
+     * and the application has no TOTAL_SALES_TO_BUYER or MAXIMUM_BUYER_WILL_OWE saved (specifically required for a "multiple" policy type),
+     * redirect to the EXPORT_VALUE form.
+     * Otherwise, redirect to "check your answers".
+     */
     if (isChangeRoute(req.originalUrl)) {
+      if (!hasTotalSalesAndMaximumWillOwe) {
+        return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE}`);
+      }
+
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`);
     }
 
+    /**
+     * If the route is a "change" route,
+     * and the application has no TOTAL_SALES_TO_BUYER or MAXIMUM_BUYER_WILL_OWE saved (specifically required for a "multiple" policy type),
+     * redirect to the EXPORT_VALUE form.
+     * Otherwise, redirect to "check and change".
+     */
     if (isCheckAndChangeRoute(req.originalUrl)) {
+      if (!hasTotalSalesAndMaximumWillOwe) {
+        return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE}`);
+      }
+
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`);
     }
 

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.ts
@@ -193,7 +193,7 @@ export const post = async (req: Request, res: Response) => {
     }
 
     /**
-     * If the route is a "change" route,
+     * If the route is a "check and change" route,
      * and the application has no TOTAL_SALES_TO_BUYER or MAXIMUM_BUYER_WILL_OWE saved (specifically required for a "multiple" policy type),
      * redirect to the EXPORT_VALUE form.
      * Otherwise, redirect to "check and change".

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/index.ts
@@ -14,7 +14,6 @@ import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/policy';
 import isChangeRoute from '../../../../helpers/is-change-route';
 import isCheckAndChangeRoute from '../../../../helpers/is-check-and-change-route';
-import { isSinglePolicyType } from '../../../../helpers/policy-type';
 import { Request, Response } from '../../../../../types';
 
 const {
@@ -40,7 +39,6 @@ const {
     POLICY_CURRENCY_CODE,
     ALTERNATIVE_POLICY_CURRENCY_CODE,
   },
-  POLICY_TYPE,
 } = POLICY_FIELD_IDS;
 
 /**
@@ -181,17 +179,16 @@ export const post = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    const isSinglePolicyWithoutTotalContractValue = isSinglePolicyType(policy[POLICY_TYPE]) && !policy[TOTAL_CONTRACT_VALUE];
+    const hasTotalContractValue = policy[TOTAL_CONTRACT_VALUE];
 
     /**
      * If the route is a "change" route,
-     * the application is a "single" policy type.
-     * and there is no TOTAL_CONTRACT_VALUE saved,
+     * and the application has no TOTAL_CONTRACT_VALUE saved (specifically required for a "single" policy type),
      * redirect to the TOTAL_CONTRACT_VALUE form.
      * Otherwise, redirect to "check your answers".
      */
     if (isChangeRoute(req.originalUrl)) {
-      if (isSinglePolicyWithoutTotalContractValue) {
+      if (!hasTotalContractValue) {
         return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_CHANGE}`);
       }
 
@@ -200,13 +197,12 @@ export const post = async (req: Request, res: Response) => {
 
     /**
      * If the route is a "check and change" route,
-     * the application is a "single" policy type.
-     * and there is no TOTAL_CONTRACT_VALUE saved,
+     * and there is no TOTAL_CONTRACT_VALUE saved (specifically required for a "single" policy type),
      * redirect to the TOTAL_CONTRACT_VALUE form.
      * Otherwise, redirect to "check and change" route.
      */
     if (isCheckAndChangeRoute(req.originalUrl)) {
-      if (isSinglePolicyWithoutTotalContractValue) {
+      if (!hasTotalContractValue) {
         return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_CHECK_AND_CHANGE}`);
       }
 

--- a/src/ui/server/helpers/sanitise-data/index.test.ts
+++ b/src/ui/server/helpers/sanitise-data/index.test.ts
@@ -135,6 +135,17 @@ describe('server/helpers/sanitise-data', () => {
       });
     });
 
+    describe('when the field value is null', () => {
+      it('should return null', () => {
+        const mockKey = 'a';
+        const mockValue = null;
+
+        const result = sanitiseFormField(mockKey, mockValue);
+
+        expect(result).toEqual(null);
+      });
+    });
+
     describe('when the field value is an object with values', () => {
       it('should return the result of sanitiseObject', () => {
         const mockKey = 'a';

--- a/src/ui/server/helpers/sanitise-data/index.ts
+++ b/src/ui/server/helpers/sanitise-data/index.ts
@@ -93,7 +93,7 @@ export const shouldIncludeAndSanitiseField = (key: string, value: string) => {
  * @param {String | Boolean | Object | Array} Form field value
  * @returns {String | Boolean | Object | Array}
  */
-export const sanitiseFormField = (key: string, value: string | boolean | ObjectType | Array<string>) => {
+export const sanitiseFormField = (key: string, value: string | boolean | null | ObjectType | Array<string>) => {
   if (Array.isArray(value)) {
     return sanitiseArrayOfStrings(key, value);
   }
@@ -104,6 +104,15 @@ export const sanitiseFormField = (key: string, value: string | boolean | ObjectT
 
   if (isAString(value)) {
     return sanitiseValue({ key, value: String(value) });
+  }
+
+  /**
+   * If a value is null, it should be remain null.
+   * Either, a null value has been submitted from a UI form,
+   * Or it is intentionally being set to null during data mapping.
+   */
+  if (value === null) {
+    return null;
   }
 
   const objectWithKeysAndValues = isAnObjectWithKeysAndValues(value);

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -21,8 +21,8 @@ describe('routes/insurance', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(141);
-    expect(post).toHaveBeenCalledTimes(129);
+    expect(get).toHaveBeenCalledTimes(143);
+    expect(post).toHaveBeenCalledTimes(131);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);

--- a/src/ui/server/routes/insurance/policy/index.test.ts
+++ b/src/ui/server/routes/insurance/policy/index.test.ts
@@ -38,8 +38,8 @@ describe('routes/insurance/policy', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(28);
-    expect(post).toHaveBeenCalledTimes(36);
+    expect(get).toHaveBeenCalledTimes(30);
+    expect(post).toHaveBeenCalledTimes(38);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.ROOT}`, policyRootGet);
 
@@ -109,6 +109,22 @@ describe('routes/insurance/policy', () => {
     expect(post).toHaveBeenCalledWith(
       `/:referenceNumber${INSURANCE_ROUTES.POLICY.MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_SAVE_AND_BACK}`,
       multipleContractPolicyExportValueSaveAndBackPost,
+    );
+    expect(get).toHaveBeenCalledWith(
+      `/:referenceNumber${INSURANCE_ROUTES.POLICY.MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE}`,
+      multipleContractPolicyExportValueGet,
+    );
+    expect(post).toHaveBeenCalledWith(
+      `/:referenceNumber${INSURANCE_ROUTES.POLICY.MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE}`,
+      multipleContractPolicyExportValuePost,
+    );
+    expect(get).toHaveBeenCalledWith(
+      `/:referenceNumber${INSURANCE_ROUTES.POLICY.MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE}`,
+      multipleContractPolicyExportValueGet,
+    );
+    expect(post).toHaveBeenCalledWith(
+      `/:referenceNumber${INSURANCE_ROUTES.POLICY.MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE}`,
+      multipleContractPolicyExportValuePost,
     );
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.NAME_ON_POLICY}`, nameOnPolicyGet);

--- a/src/ui/server/routes/insurance/policy/index.ts
+++ b/src/ui/server/routes/insurance/policy/index.ts
@@ -89,6 +89,16 @@ insurancePolicyRouter.post(
   `/:referenceNumber${INSURANCE_ROUTES.POLICY.MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_SAVE_AND_BACK}`,
   multipleContractPolicyExportValueSaveAndBackPost,
 );
+insurancePolicyRouter.get(`/:referenceNumber${INSURANCE_ROUTES.POLICY.MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE}`, multipleContractPolicyExportValueGet);
+insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE}`, multipleContractPolicyExportValuePost);
+insurancePolicyRouter.get(
+  `/:referenceNumber${INSURANCE_ROUTES.POLICY.MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE}`,
+  multipleContractPolicyExportValueGet,
+);
+insurancePolicyRouter.post(
+  `/:referenceNumber${INSURANCE_ROUTES.POLICY.MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE}`,
+  multipleContractPolicyExportValuePost,
+);
 
 insurancePolicyRouter.get(`/:referenceNumber${INSURANCE_ROUTES.POLICY.NAME_ON_POLICY}`, nameOnPolicyGet);
 insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.NAME_ON_POLICY}`, nameOnPolicyPost);


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the ability to change a "single contract policy" to a "multiple contract policy", so that when this occurs, a 3rd multiple policy related form is required to be completed before a user is redirected back to a "check or change your answers" page.

This can occur from:
- Policy - check your answers
- Insurance - check "policy" answers.

As part of this PR, have also update some policy data mapping so that if a policy is changed from single to multiple (or vice versa), single or multiple specific fields will be wiped.

## Resolution :heavy_check_mark:
- Add "check and change" UI routes for the `EXPORT_VALUE` (multiple policy specific field).
- Update "multiple contract policy" POST controller to redirect to `EXPORT_VALUE` if the route is a "change" or "check and change" route.
- Update the policy `mapSubmittedData` function to wipe single/multiple specific fields.
- Update `sanitiseFormField` to return a `null` if the provided value is `null`. Otherwise, it's not possible to nullify date values.
- Update E2E test coverage.

## Miscellaneous :heavy_plus_sign:
- Simplify some conditions and documentation in the "single contract policy" POST controller.
