### PR TITLE
chore(EMS-2719): No PDF - Currencies - Filter out "gold" currency from APIM

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -524,7 +524,8 @@ var EXTERNAL_API_DEFINITIONS = {
       YES: "Y",
       NO: "N"
     },
-    INVALID_COUNTRIES: ["EC Market n/k", "Non EC Market n/k", "Non UK", "Third Country", "Eastern and Southern African Trade and Development Bank"]
+    INVALID_COUNTRIES: ["EC Market n/k", "Non EC Market n/k", "Non UK", "Third Country", "Eastern and Southern African Trade and Development Bank"],
+    INVALID_CURRENCIES: ["Gold"]
   },
   COMPANIES_HOUSE: {
     COMPANY_STATUS: {
@@ -5057,6 +5058,13 @@ var APIM = {
 };
 var APIM_default = APIM;
 
+// helpers/filter-cis-entries/index.ts
+var filterCisEntries = (arr, invalidEntries, entityPropertyName) => {
+  const filtered = arr.filter((obj) => !invalidEntries.includes(obj[entityPropertyName]));
+  return filtered;
+};
+var filter_cis_entries_default = filterCisEntries;
+
 // helpers/map-CIS-countries/map-CIS-country/map-risk-category/index.ts
 var { CIS } = EXTERNAL_API_DEFINITIONS;
 var mapRiskCategory = (str) => {
@@ -5201,9 +5209,8 @@ var sort_array_alphabetically_default = sortArrayAlphabetically;
 
 // helpers/map-CIS-countries/index.ts
 var { CIS: CIS5 } = EXTERNAL_API_DEFINITIONS;
-var filterCisCountries = (countries) => countries.filter((country) => !CIS5.INVALID_COUNTRIES.includes(country.marketName));
 var mapCisCountries = (countries) => {
-  const filteredCountries = filterCisCountries(countries);
+  const filteredCountries = filter_cis_entries_default(countries, CIS5.INVALID_COUNTRIES, "marketName");
   const mapped = filteredCountries.map((country) => map_CIS_country_default(country));
   const sorted = sort_array_alphabetically_default(mapped, "name");
   return sorted;
@@ -5228,6 +5235,7 @@ var getApimCisCountries = async () => {
 var get_APIM_CIS_countries_default = getApimCisCountries;
 
 // helpers/map-currencies/index.ts
+var { CIS: CIS6 } = EXTERNAL_API_DEFINITIONS;
 var getSupportedCurrencies = (currencies) => {
   const supported = currencies.filter((currency) => SUPPORTED_CURRENCIES.find((currencyCode) => currency.isoCode === currencyCode));
   return supported;
@@ -5237,11 +5245,11 @@ var getAlternativeCurrencies = (currencies) => {
   return alternate;
 };
 var mapCurrencies = (currencies, alternativeCurrencies) => {
-  let currenciesArray = currencies;
+  let currenciesArray = filter_cis_entries_default(currencies, CIS6.INVALID_CURRENCIES, "name");
   if (!alternativeCurrencies) {
-    currenciesArray = getSupportedCurrencies(currencies);
+    currenciesArray = getSupportedCurrencies(currenciesArray);
   } else {
-    currenciesArray = getAlternativeCurrencies(currencies);
+    currenciesArray = getAlternativeCurrencies(currenciesArray);
   }
   const sorted = sort_array_alphabetically_default(currenciesArray, FIELD_IDS.NAME);
   return sorted;

--- a/src/api/constants/external-apis.ts
+++ b/src/api/constants/external-apis.ts
@@ -20,6 +20,7 @@ export const EXTERNAL_API_DEFINITIONS = {
       NO: 'N',
     },
     INVALID_COUNTRIES: ['EC Market n/k', 'Non EC Market n/k', 'Non UK', 'Third Country', 'Eastern and Southern African Trade and Development Bank'],
+    INVALID_CURRENCIES: ['Gold'],
   },
   COMPANIES_HOUSE: {
     COMPANY_STATUS: {

--- a/src/api/custom-resolvers/queries/get-APIM-CIS-countries/index.test.ts
+++ b/src/api/custom-resolvers/queries/get-APIM-CIS-countries/index.test.ts
@@ -2,7 +2,7 @@ import getApimCisCountries from '.';
 import APIM from '../../../integrations/APIM';
 import mapCisCountries from '../../../helpers/map-CIS-countries';
 import mockCisCountriesResponse from '../../../test-mocks/mock-APIM-CIS-countries-response';
-import mockCisCountries from '../../../test-mocks/mock-CIS-countries';
+import { mockCisCountries } from '../../../test-mocks';
 
 describe('custom-resolvers/get-APIM-CIS-countries', () => {
   jest.mock('../../../integrations/APIM');

--- a/src/api/custom-resolvers/queries/get-APIM-currencies/index.test.ts
+++ b/src/api/custom-resolvers/queries/get-APIM-currencies/index.test.ts
@@ -2,7 +2,7 @@ import getApimCurrencies from '.';
 import APIM from '../../../integrations/APIM';
 import mapCurrencies from '../../../helpers/map-currencies';
 import mockApimCurrenciesResponse from '../../../test-mocks/mock-APIM-currencies-response';
-import mockCurrencies from '../../../test-mocks/mock-currencies';
+import { mockCurrencies } from '../../../test-mocks';
 
 describe('custom-resolvers/get-APIM-currencies', () => {
   jest.mock('../../../integrations/APIM');

--- a/src/api/helpers/filter-cis-entries/index.test.ts
+++ b/src/api/helpers/filter-cis-entries/index.test.ts
@@ -1,0 +1,58 @@
+import filterCisEntries from '.';
+import { EXTERNAL_API_DEFINITIONS } from '../../constants';
+import { mockCisCountries, mockCurrencies } from '../../test-mocks';
+
+const { CIS } = EXTERNAL_API_DEFINITIONS;
+
+describe('helpers/filter-cis-entries', () => {
+  const { 1: initialMockCountry } = mockCisCountries;
+
+  const mockCountryBase = {
+    ...initialMockCountry,
+    marketName: initialMockCountry.marketName,
+  };
+
+  it('should return a list of countries without invalid countries defined in CIS.INVALID_COUNTRIES', () => {
+    const mockCountriesWithInvalid = [
+      mockCountryBase,
+      {
+        ...mockCountryBase,
+        marketName: 'EC Market n/k',
+      },
+      {
+        ...mockCountryBase,
+        marketName: 'Non EC Market n/k',
+      },
+      {
+        ...mockCountryBase,
+        marketName: 'Non UK',
+      },
+      {
+        ...mockCountryBase,
+        marketName: 'Third Country',
+      },
+    ];
+
+    const result = filterCisEntries(mockCountriesWithInvalid, CIS.INVALID_COUNTRIES, 'marketName');
+
+    const expected = [mockCountryBase];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should return a list of currencies without invalid currencies defined in CIS.INVALID_CURRENCIES', () => {
+    const mockCurrenciesWithInvalid = [
+      ...mockCurrencies,
+      {
+        name: 'Gold',
+        isoCode: 'XAU',
+      },
+    ];
+
+    const result = filterCisEntries(mockCurrenciesWithInvalid, CIS.INVALID_CURRENCIES, 'name');
+
+    const expected = mockCurrencies;
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/api/helpers/filter-cis-entries/index.ts
+++ b/src/api/helpers/filter-cis-entries/index.ts
@@ -1,0 +1,17 @@
+import { CisCountry, Currency } from '../../types';
+
+/**
+ * filterCisEntries
+ * Filter out countries or currencies from CIS API response that have an invalid name,
+ * that is not relevant or appropriate for an EXIP.
+ * E.g, "Gold" currency, "EC Market n/k" country.
+ * @param {Array<CisCountry> | Array<Currency>} All CIS countries or currencies
+ * @returns {Array} CIS countries/currencies without invalid entries.
+ */
+const filterCisEntries = (arr: Array<CisCountry> | Array<Currency>, invalidEntries: Array<string>, entityPropertyName: string) => {
+  const filtered = arr.filter((obj) => !invalidEntries.includes(obj[entityPropertyName]));
+
+  return filtered;
+};
+
+export default filterCisEntries;

--- a/src/api/helpers/map-CIS-countries/index.test.ts
+++ b/src/api/helpers/map-CIS-countries/index.test.ts
@@ -3,8 +3,8 @@ import mapCisCountry from './map-CIS-country';
 import { EXTERNAL_API_DEFINITIONS } from '../../constants';
 import filterCisEntries from '../filter-cis-entries';
 import sortArrayAlphabetically from '../sort-array-alphabetically';
-import mockCisCountries from '../../test-mocks/mock-CIS-countries';
 import { CisCountry } from '../../types';
+import { mockCisCountries } from '../../test-mocks';
 
 const { CIS } = EXTERNAL_API_DEFINITIONS;
 

--- a/src/api/helpers/map-CIS-countries/index.test.ts
+++ b/src/api/helpers/map-CIS-countries/index.test.ts
@@ -1,63 +1,23 @@
-import mapCisCountries, { filterCisCountries } from '.';
+import mapCisCountries from '.';
 import mapCisCountry from './map-CIS-country';
-import { EXTERNAL_API_DEFINITIONS, EXTERNAL_API_MAPPINGS } from '../../constants';
+import { EXTERNAL_API_DEFINITIONS } from '../../constants';
+import filterCisEntries from '../filter-cis-entries';
 import sortArrayAlphabetically from '../sort-array-alphabetically';
 import mockCisCountries from '../../test-mocks/mock-CIS-countries';
+import { CisCountry } from '../../types';
 
 const { CIS } = EXTERNAL_API_DEFINITIONS;
 
 describe('helpers/map-CIS-countries', () => {
-  const { 1: initialMockCountry } = mockCisCountries;
+  it('should return array of filtered, mapped and sorted objects', () => {
+    const filteredCountries = filterCisEntries(mockCisCountries, CIS.INVALID_COUNTRIES, 'marketName') as Array<CisCountry>;
 
-  const mockCountryBase = {
-    ...initialMockCountry,
-    marketName: initialMockCountry.marketName,
-    riskCategory: EXTERNAL_API_MAPPINGS.CIS.RISK.STANDARD,
-    isoCode: initialMockCountry.isoCode,
-    shortTermCoverAvailabilityDesc: CIS.SHORT_TERM_COVER_AVAILABLE.ILC,
-  };
+    const result = mapCisCountries(filteredCountries);
 
-  describe('filterCisCountries', () => {
-    it('should return a list of countries without invalid countries defined in INVALID_CIS_COUNTRIES', () => {
-      const mockCountriesWithInvalid = [
-        mockCountryBase,
-        {
-          ...mockCountryBase,
-          marketName: 'EC Market n/k',
-        },
-        {
-          ...mockCountryBase,
-          marketName: 'Non EC Market n/k',
-        },
-        {
-          ...mockCountryBase,
-          marketName: 'Non UK',
-        },
-        {
-          ...mockCountryBase,
-          marketName: 'Third Country',
-        },
-      ];
+    const mapped = filteredCountries.map((country) => mapCisCountry(country));
 
-      const result = filterCisCountries(mockCountriesWithInvalid);
+    const expected = sortArrayAlphabetically(mapped, 'name');
 
-      const expected = [mockCountryBase];
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('mapCisCountries', () => {
-    it('should returns array of filtered, mapped and sorted objects', () => {
-      const filteredCountries = filterCisCountries(mockCisCountries);
-
-      const result = mapCisCountries(filteredCountries);
-
-      const mapped = filteredCountries.map((country) => mapCisCountry(country));
-
-      const expected = sortArrayAlphabetically(mapped, 'name');
-
-      expect(result).toEqual(expected);
-    });
+    expect(result).toEqual(expected);
   });
 });

--- a/src/api/helpers/map-CIS-countries/index.ts
+++ b/src/api/helpers/map-CIS-countries/index.ts
@@ -1,4 +1,5 @@
 import { EXTERNAL_API_DEFINITIONS } from '../../constants';
+import filterCisEntries from '../filter-cis-entries';
 import mapCisCountry from './map-CIS-country';
 import sortArrayAlphabetically from '../sort-array-alphabetically';
 import { CisCountry, MappedCisCountry } from '../../types';
@@ -6,21 +7,16 @@ import { CisCountry, MappedCisCountry } from '../../types';
 const { CIS } = EXTERNAL_API_DEFINITIONS;
 
 /**
- * filterCisCountries
- * Filter out countries from CIS API that have an invalid name
- * @param {Array<CisCountry>} All CIS countries
- * @returns {Array} CIS countries without invalid country names
- */
-export const filterCisCountries = (countries: Array<CisCountry>) => countries.filter((country) => !CIS.INVALID_COUNTRIES.includes(country.marketName));
-
-/**
  * mapCisCountries
- * Map all CIS countries to cleaner structure
+ * Map and sort CIS countries.
+ * 1) Filter out invalid CIS countries.
+ * 2) Map the countries into a cleaner structure.
+ * 3) Sort the countries alphabetically.
  * @param {Array<CisCountry>} Array of CIS Countries
  * @returns {Array<MappedCisCountry>} Array of mapped countries
  */
-export const mapCisCountries = (countries: Array<CisCountry>): Array<MappedCisCountry> => {
-  const filteredCountries = filterCisCountries(countries);
+const mapCisCountries = (countries: Array<CisCountry>): Array<MappedCisCountry> => {
+  const filteredCountries = filterCisEntries(countries, CIS.INVALID_COUNTRIES, 'marketName') as Array<CisCountry>;
 
   const mapped = filteredCountries.map((country) => mapCisCountry(country));
 

--- a/src/api/helpers/map-CIS-countries/map-CIS-country/index.test.ts
+++ b/src/api/helpers/map-CIS-countries/map-CIS-country/index.test.ts
@@ -9,8 +9,8 @@ import applyForInsuranceOnline from './can-apply-for-insurance-online';
 import applyForInsuranceOffline from './can-apply-for-insurance-offline';
 import canApplyOffline from './can-apply-offline';
 import { EXTERNAL_API_DEFINITIONS, EXTERNAL_API_MAPPINGS } from '../../../constants';
-import mockCisCountries from '../../../test-mocks/mock-CIS-countries';
 import { MappedCisCountry } from '../../../types';
+import { mockCisCountries } from '../../../test-mocks';
 
 const { CIS } = EXTERNAL_API_DEFINITIONS;
 

--- a/src/api/helpers/map-currencies/index.test.ts
+++ b/src/api/helpers/map-currencies/index.test.ts
@@ -1,7 +1,11 @@
 import mapCurrencies, { getSupportedCurrencies, getAlternativeCurrencies } from '.';
-import { FIELD_IDS, SUPPORTED_CURRENCIES } from '../../constants';
+import { EXTERNAL_API_DEFINITIONS, FIELD_IDS, SUPPORTED_CURRENCIES } from '../../constants';
+import filterCisEntries from '../filter-cis-entries';
 import sortArrayAlphabetically from '../sort-array-alphabetically';
+import { Currency } from '../../types';
 import mockCurrencies, { HKD } from '../../test-mocks/mock-currencies';
+
+const { CIS } = EXTERNAL_API_DEFINITIONS;
 
 describe('helpers/map-currencies', () => {
   describe('getSupportedCurrencies', () => {
@@ -25,11 +29,13 @@ describe('helpers/map-currencies', () => {
   });
 
   describe('mapCurrencies', () => {
+    const filteredCurrencies = filterCisEntries(mockCurrencies, CIS.INVALID_CURRENCIES, 'name') as Array<Currency>;
+
     describe('alternativeCurrencies as "false"', () => {
-      it('should return an array of supported currencies sorted alphabetically', () => {
+      it('should return an array of filtered, supported currencies, sorted alphabetically', () => {
         const result = mapCurrencies(mockCurrencies, false);
 
-        const supportedCurrencies = getSupportedCurrencies(mockCurrencies);
+        const supportedCurrencies = getSupportedCurrencies(filteredCurrencies);
 
         const expected = sortArrayAlphabetically(supportedCurrencies, FIELD_IDS.NAME);
 
@@ -38,10 +44,11 @@ describe('helpers/map-currencies', () => {
     });
 
     describe('alternativeCurrencies as "true"', () => {
-      it('should return an array of alternative currencies sorted alphabetically', () => {
+      it('should return an array of filtered, alternative currencies, sorted alphabetically', () => {
         const result = mapCurrencies(mockCurrencies, true);
 
-        const currencies = getAlternativeCurrencies(mockCurrencies);
+        const currencies = getAlternativeCurrencies(filteredCurrencies);
+
         const expected = sortArrayAlphabetically(currencies, FIELD_IDS.NAME);
 
         expect(result).toEqual(expected);

--- a/src/api/helpers/map-currencies/index.ts
+++ b/src/api/helpers/map-currencies/index.ts
@@ -1,6 +1,9 @@
-import { FIELD_IDS, SUPPORTED_CURRENCIES } from '../../constants';
+import { EXTERNAL_API_DEFINITIONS, FIELD_IDS, SUPPORTED_CURRENCIES } from '../../constants';
+import filterCisEntries from '../filter-cis-entries';
 import sortArrayAlphabetically from '../sort-array-alphabetically';
 import { Currency } from '../../types';
+
+const { CIS } = EXTERNAL_API_DEFINITIONS;
 
 /**
  * getSupportedCurrencies
@@ -29,21 +32,21 @@ export const getAlternativeCurrencies = (currencies: Array<Currency>) => {
 /**
  * mapCurrencies
  * Map and sort currencies.
- * 1) if alternativeCurrencies flag set, then will return all currencies
- * 2) if alternativeCurrencies flag not set, then will filter supported currencies.
- * 3) Sort the currencies alphabetically.
+ * 1) Filter out invalid CIS currencies.
+ * 2) if alternativeCurrencies flag set, then will return all currencies.
+ * 3) if alternativeCurrencies flag not set, then will filter supported currencies.
+ * 4) Sort the currencies alphabetically.
  * @param {Array} Array of currency objects
  * @param {Boolean} alternativeCurrencies if alternate currencies should be returned
  * @returns {Array} Array supported currencies
  */
 const mapCurrencies = (currencies: Array<Currency>, alternativeCurrencies: boolean) => {
-  let currenciesArray = currencies;
+  let currenciesArray = filterCisEntries(currencies, CIS.INVALID_CURRENCIES, 'name') as Array<Currency>;
 
-  // if not all currencies, then get the supported currencies only
   if (!alternativeCurrencies) {
-    currenciesArray = getSupportedCurrencies(currencies);
+    currenciesArray = getSupportedCurrencies(currenciesArray);
   } else {
-    currenciesArray = getAlternativeCurrencies(currencies);
+    currenciesArray = getAlternativeCurrencies(currenciesArray);
   }
 
   const sorted = sortArrayAlphabetically(currenciesArray, FIELD_IDS.NAME);

--- a/src/api/integrations/APIM/index.test.ts
+++ b/src/api/integrations/APIM/index.test.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import APIM from '.';
 import { EXTERNAL_API_ENDPOINTS } from '../../constants';
-import mockCisCountries from '../../test-mocks/mock-CIS-countries';
+import { mockCisCountries } from '../../test-mocks';
 
 dotenv.config();
 

--- a/src/api/test-mocks/index.ts
+++ b/src/api/test-mocks/index.ts
@@ -2,6 +2,8 @@ import { Request, Response } from 'express';
 import { ACCOUNT, FIELD_IDS } from '../constants';
 import encryptPassword from '../helpers/encrypt-password';
 import application from './mock-application';
+import cisCountries from './mock-CIS-countries';
+import currencies from './mock-currencies';
 import company from './mock-company';
 import companySicCode from './mock-company-sic-code';
 import { Account } from '../types';
@@ -36,6 +38,8 @@ export const mockOTP = {
 
 export const mockApplication = application;
 
+export const mockCisCountries = cisCountries;
+
 export const mockCompany = company;
 export const mockCompanySicCode = companySicCode;
 
@@ -58,6 +62,8 @@ export const mockCountries = [
     isoCode: 'GRL',
   },
 ];
+
+export const mockCurrencies = currencies;
 
 export const mockApplicationDeclaration = {
   agreeToConfidentiality: true,


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the API's currency mapping to filter out the "gold" currency returned from APIM. Gold is not a valid/supported currency for No PDF EXIP application.

## Resolution :heavy_check_mark:
- Create `INVALID_CURRENCIES` constant.
- Create new helper function to filter out invalid countries and currencies received by APIM, `filterCisEntries`, removing the need for the `filterCisCountries` function.
- Update `mapCurrencies` to use `filterCisEntries`.

## Miscellaneous :heavy_plus_sign:
- Improve countries and currencies test mock imports.
