### PR TITLE
feat(EMS-2718): No PDF - Business - Check your answers - Submit button, "save and back" cypress assertion command

### DIFF
--- a/e2e-tests/commands/insurance/assert-submit-and-save-buttons.js
+++ b/e2e-tests/commands/insurance/assert-submit-and-save-buttons.js
@@ -1,4 +1,4 @@
-import { submitButton, saveAndBackButton } from '../../pages/shared';
+import { submitButton } from '../../pages/shared';
 
 import { BUTTONS } from '../../content-strings';
 
@@ -8,7 +8,7 @@ import { BUTTONS } from '../../content-strings';
  */
 const assertSubmitAndSaveButtons = (submitButtonCopy = BUTTONS.CONTINUE) => {
   cy.checkText(submitButton(), submitButtonCopy);
-  cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+  cy.assertSaveAndBackButton();
 };
 
 export default assertSubmitAndSaveButtons;

--- a/e2e-tests/commands/shared-commands/assertions/assert-save-and-back-button-does-not-exist.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-save-and-back-button-does-not-exist.js
@@ -7,4 +7,5 @@ import { saveAndBackButton } from '../../../pages/shared';
 const assertSaveAndBackButtonDoesNotExist = () => {
   saveAndBackButton().should('not.exist');
 };
+
 export default assertSaveAndBackButtonDoesNotExist;

--- a/e2e-tests/commands/shared-commands/assertions/assert-save-and-back-button.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-save-and-back-button.js
@@ -1,0 +1,12 @@
+import { BUTTONS } from '../../../content-strings';
+import { saveAndBackButton } from '../../../pages/shared';
+
+/**
+ * assertSaveAndBackButton
+ * Check that a "Save and back" button exists.
+ */
+const assertSaveAndBackButton = () => {
+  cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+};
+
+export default assertSaveAndBackButton;

--- a/e2e-tests/commands/shared-commands/assertions/index.js
+++ b/e2e-tests/commands/shared-commands/assertions/index.js
@@ -16,6 +16,7 @@ import {
 } from './actions';
 
 Cypress.Commands.add('assertUrl', require('./assert-url'));
+Cypress.Commands.add('assertSaveAndBackButton', require('./assert-save-and-back-button'));
 Cypress.Commands.add('assertSaveAndBackButtonDoesNotExist', require('./assert-save-and-back-button-does-not-exist'));
 Cypress.Commands.add('assertYesNoRadiosOrder', require('./assert-first-and-last-radios'));
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/check-your-answers-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/check-your-answers-policy-page.spec.js
@@ -1,8 +1,4 @@
-import {
-  headingCaption,
-  status,
-  saveAndBackButton,
-} from '../../../../../../pages/shared';
+import { headingCaption, status } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { BUTTONS, PAGES, TASKS } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -76,7 +72,7 @@ context('Insurance - Check your answers - Policy - I want to confirm my selectio
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/check-your-answers-your-business-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/check-your-answers-your-business-page.spec.js
@@ -1,8 +1,4 @@
-import {
-  headingCaption,
-  status,
-  saveAndBackButton,
-} from '../../../../../../pages/shared';
+import { headingCaption, status } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { BUTTONS, PAGES, TASKS } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -80,7 +76,7 @@ context('Insurance - Check your answers - Your business - I want to confirm my s
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/check-your-answers-your-buyer-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/check-your-answers-your-buyer-page.spec.js
@@ -1,8 +1,4 @@
-import {
-  headingCaption,
-  status,
-  saveAndBackButton,
-} from '../../../../../../pages/shared';
+import { headingCaption, status } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { BUTTONS, PAGES, TASKS } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -80,7 +76,7 @@ context('Insurance - Check your answers - Your buyer page - I want to confirm my
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
@@ -1,6 +1,5 @@
 import {
   headingCaption,
-  saveAndBackButton,
   yesRadio,
   yesRadioInput,
   noRadio,
@@ -8,7 +7,7 @@ import {
 } from '../../../../../../pages/shared';
 import { aboutGoodsOrServicesPage } from '../../../../../../pages/insurance/export-contract';
 import partials from '../../../../../../partials';
-import { BUTTONS, PAGES } from '../../../../../../content-strings';
+import { PAGES } from '../../../../../../content-strings';
 import { EXPORT_CONTRACT_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/export-contract';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
@@ -179,7 +178,7 @@ context('Insurance - Export contract - About goods or services page - Final dest
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/another-company.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/another-company.spec.js
@@ -5,13 +5,8 @@ import {
   yesNoRadioHint,
   noRadio,
   noRadioInput,
-  saveAndBackButton,
 } from '../../../../../../pages/shared';
-import {
-  BUTTONS,
-  ERROR_MESSAGES,
-  PAGES,
-} from '../../../../../../content-strings';
+import { ERROR_MESSAGES, PAGES } from '../../../../../../content-strings';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
@@ -104,7 +99,7 @@ context(`Insurance - Policy - Another company page - ${story}`, () => {
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
 
     describe(`renders ${FIELD_ID} label and inputs`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
@@ -1,9 +1,7 @@
 import { brokerPage } from '../../../../../../pages/insurance/policy';
 import partials from '../../../../../../partials';
-import { field as fieldSelector, saveAndBackButton } from '../../../../../../pages/shared';
-import {
-  PAGES, BUTTONS, ERROR_MESSAGES, LINKS,
-} from '../../../../../../content-strings';
+import { field as fieldSelector } from '../../../../../../pages/shared';
+import { PAGES, ERROR_MESSAGES, LINKS } from '../../../../../../content-strings';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
@@ -189,7 +187,7 @@ context('Insurance - Policy - Broker Page - As an Exporter I want to confirm if 
     });
 
     it('should display save and go back button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
@@ -1,12 +1,5 @@
-import {
-  headingCaption,
-  saveAndBackButton,
-  field as fieldSelector,
-} from '../../../../../../pages/shared';
-import {
-  BUTTONS,
-  PAGES,
-} from '../../../../../../content-strings';
+import { headingCaption, field as fieldSelector } from '../../../../../../pages/shared';
+import { PAGES } from '../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
 import { ACCOUNT_FIELDS } from '../../../../../../content-strings/fields/insurance/account';
 import { FIELD_VALUES } from '../../../../../../constants';
@@ -127,7 +120,7 @@ context('Insurance - Policy - Different name on Policy page - I want to enter th
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value.spec.js
@@ -1,15 +1,7 @@
-import {
-  field as fieldSelector,
-  headingCaption,
-  saveAndBackButton,
-} from '../../../../../../../pages/shared';
+import { field as fieldSelector, headingCaption } from '../../../../../../../pages/shared';
 import { multipleContractPolicyExportValuePage } from '../../../../../../../pages/insurance/policy';
 import partials from '../../../../../../../partials';
-import {
-  BUTTONS,
-  PAGES,
-  TASKS,
-} from '../../../../../../../content-strings';
+import { PAGES, TASKS } from '../../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
@@ -122,7 +114,7 @@ context('Insurance - Policy - Multiple contract policy - Export value page - As 
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -2,14 +2,9 @@ import {
   radios,
   field as fieldSelector,
   headingCaption,
-  saveAndBackButton,
 } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
-import {
-  BUTTONS,
-  PAGES,
-  TASKS,
-} from '../../../../../../content-strings';
+import { PAGES, TASKS } from '../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
@@ -117,7 +112,7 @@ context('Insurance - Policy - Multiple contract policy page - As an exporter, I 
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/name-on-policy-page.spec.js
@@ -1,12 +1,5 @@
-import {
-  headingCaption,
-  saveAndBackButton,
-  field,
-} from '../../../../../../pages/shared';
-import {
-  BUTTONS,
-  PAGES,
-} from '../../../../../../content-strings';
+import { headingCaption, field } from '../../../../../../pages/shared';
+import { PAGES } from '../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -115,7 +108,7 @@ context('Insurance - Policy - Name on Policy page - I want to enter the details 
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
@@ -5,12 +5,10 @@ import {
   noRadio,
   noRadioInput,
   field as fieldSelector,
-  saveAndBackButton,
   yesRadioInput,
 } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import {
-  BUTTONS,
   PAGES,
   CREDIT_PERIOD_WITH_BUYER as CREDIT_PERIOD_WITH_BUYER_STRINGS,
   TASKS,
@@ -92,7 +90,7 @@ context(`Insurance - Policy - Pre-credit period page - ${story}`, () => {
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
 
     describe(`renders ${NEED_PRE_CREDIT_PERIOD} label and inputs`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
@@ -2,14 +2,9 @@ import {
   radios,
   field as fieldSelector,
   headingCaption,
-  saveAndBackButton,
 } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
-import {
-  BUTTONS,
-  PAGES,
-  TASKS,
-} from '../../../../../../content-strings';
+import { PAGES, TASKS } from '../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -120,7 +115,7 @@ context('Insurance - Policy - Single contract policy page - As an exporter, I wa
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value.spec.js
@@ -1,14 +1,6 @@
-import {
-  field as fieldSelector,
-  headingCaption,
-  saveAndBackButton,
-} from '../../../../../../../pages/shared';
+import { field as fieldSelector, headingCaption } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
-import {
-  BUTTONS,
-  PAGES,
-  TASKS,
-} from '../../../../../../../content-strings';
+import { PAGES, TASKS } from '../../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -102,7 +94,7 @@ context('Insurance - Policy - Single contract policy - Total contract value page
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/type-of-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/type-of-policy.spec.js
@@ -1,12 +1,7 @@
-import {
-  field,
-  headingCaption,
-  saveAndBackButton,
-} from '../../../../../../pages/shared';
+import { field, headingCaption } from '../../../../../../pages/shared';
 import { insurance } from '../../../../../../pages';
 import partials from '../../../../../../partials';
 import {
-  BUTTONS,
   ERROR_MESSAGES,
   PAGES,
   TASKS,
@@ -109,7 +104,7 @@ context('Insurance - Policy - Type of policy page - As an exporter, I want to en
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/alternative-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/alternative-trading-address.spec.js
@@ -1,6 +1,6 @@
 import partials from '../../../../../../partials';
-import { field as fieldSelector, saveAndBackButton } from '../../../../../../pages/shared';
-import { PAGES, BUTTONS, ERROR_MESSAGES } from '../../../../../../content-strings';
+import { field as fieldSelector } from '../../../../../../pages/shared';
+import { PAGES, ERROR_MESSAGES } from '../../../../../../content-strings';
 import { EXPORTER_BUSINESS_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/business';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -111,7 +111,7 @@ context('Insurance - Your business - Alternative trading address page - I want t
     });
 
     it('should display save and go back button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-page.spec.js
@@ -1,4 +1,4 @@
-import { headingCaption } from '../../../../../../pages/shared';
+import { headingCaption, saveAndBackButton } from '../../../../../../pages/shared';
 import {
   BUTTONS,
   PAGES,
@@ -54,7 +54,7 @@ context('Insurance - Your Business - Check your answers - As an exporter, I want
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`,
       backLink: `${ROOT}/${referenceNumber}${CREDIT_CONTROL}`,
-      submitButtonCopy: BUTTONS.SAVE_AND_BACK,
+      hasAForm: false,
     });
   });
 
@@ -65,6 +65,10 @@ context('Insurance - Your Business - Check your answers - As an exporter, I want
 
     it('renders a heading caption', () => {
       cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
+    });
+
+    it('renders a `save and back` button', () => {
+      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-page.spec.js
@@ -1,8 +1,5 @@
-import { headingCaption, saveAndBackButton } from '../../../../../../pages/shared';
-import {
-  BUTTONS,
-  PAGES,
-} from '../../../../../../content-strings';
+import { headingCaption } from '../../../../../../pages/shared';
+import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const {
@@ -68,7 +65,7 @@ context('Insurance - Your Business - Check your answers - As an exporter, I want
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
@@ -3,11 +3,10 @@ import partials from '../../../../../../partials';
 import {
   body,
   field,
-  saveAndBackButton,
   yesRadioInput,
   noRadioInput,
 } from '../../../../../../pages/shared';
-import { PAGES, BUTTONS } from '../../../../../../content-strings';
+import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import assertCompaniesHouseSummaryList from '../../../../../../commands/insurance/assert-companies-house-summary-list';
@@ -152,7 +151,7 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
     });
 
     it('should display save and go back button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control.spec.js
@@ -1,12 +1,11 @@
 import partials from '../../../../../../partials';
 import {
-  saveAndBackButton,
   yesNoRadioHint,
   yesRadioInput,
   yesRadio,
   noRadio,
 } from '../../../../../../pages/shared';
-import { BUTTONS, ERROR_MESSAGES, PAGES } from '../../../../../../content-strings';
+import { ERROR_MESSAGES, PAGES } from '../../../../../../content-strings';
 import { EXPORTER_BUSINESS_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/business';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -89,7 +88,7 @@ context('Insurance - Your business - Credit control page - answer `yes` - As an 
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/nature-of-business-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/nature-of-business-page.spec.js
@@ -1,6 +1,6 @@
 import partials from '../../../../../../partials';
-import { field as fieldSelector, saveAndBackButton } from '../../../../../../pages/shared';
-import { PAGES, BUTTONS } from '../../../../../../content-strings';
+import { field as fieldSelector } from '../../../../../../pages/shared';
+import { PAGES } from '../../../../../../content-strings';
 import { EXPORTER_BUSINESS_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/business';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -105,7 +105,7 @@ context('Insurance - Your business - Nature of your business page - As an Export
     });
 
     it('should display save and go back button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
@@ -1,7 +1,7 @@
 import partials from '../../../../../../partials';
-import { field as fieldSelector, saveAndBackButton } from '../../../../../../pages/shared';
+import { field as fieldSelector } from '../../../../../../pages/shared';
 import { turnoverPage } from '../../../../../../pages/your-business';
-import { PAGES, BUTTONS } from '../../../../../../content-strings';
+import { PAGES } from '../../../../../../content-strings';
 import { EXPORTER_BUSINESS_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/business';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { EXPORTER_BUSINESS as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/business';
@@ -132,7 +132,7 @@ context('Insurance - Your business - Turnover page - As an Exporter I want to en
     });
 
     it('should render save and go back button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/company-or-organisation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/company-or-organisation.spec.js
@@ -2,10 +2,9 @@ import {
   countryInput,
   field as fieldSelector,
   headingCaption,
-  saveAndBackButton,
 } from '../../../../../../pages/shared';
 import { companyOrOrganisationPage } from '../../../../../../pages/insurance/your-buyer';
-import { BUTTONS, PAGES } from '../../../../../../content-strings';
+import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as YOUR_BUYER_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/your-buyer';
 import { YOUR_BUYER_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/your-buyer';
@@ -180,7 +179,7 @@ context('Insurance - Your Buyer - Company or organisation page - As an exporter,
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/connection-to-the-buyer-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/connection-to-the-buyer-page.spec.js
@@ -1,7 +1,7 @@
 import {
-  headingCaption, saveAndBackButton, field, yesRadio, noRadio, yesNoRadioHint, yesRadioInput, noRadioInput,
+  headingCaption, field, yesRadio, noRadio, yesNoRadioHint, yesRadioInput, noRadioInput,
 } from '../../../../../../pages/shared';
-import { BUTTONS, PAGES } from '../../../../../../content-strings';
+import { PAGES } from '../../../../../../content-strings';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/your-buyer';
 import { INSURANCE_ROUTES, INSURANCE_ROOT } from '../../../../../../constants/routes/insurance';
@@ -119,7 +119,7 @@ context('Insurance - Your Buyer - Connection with the buyer - As an exporter, I 
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/credit-insurance-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/credit-insurance-cover.spec.js
@@ -1,7 +1,7 @@
 import {
-  headingCaption, saveAndBackButton, yesRadio, noRadio, field as fieldSelector,
+  headingCaption, yesRadio, noRadio, field as fieldSelector,
 } from '../../../../../../pages/shared';
-import { BUTTONS, PAGES } from '../../../../../../content-strings';
+import { PAGES } from '../../../../../../content-strings';
 import { YOUR_BUYER_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/your-buyer';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -89,7 +89,7 @@ context('Insurance - Your Buyer - Credit insurance cover page - As an exporter, 
       });
 
       it('renders a `save and back` button', () => {
-        cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+        cy.assertSaveAndBackButton();
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/traded-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/traded-with-buyer.spec.js
@@ -1,7 +1,7 @@
 import {
-  headingCaption, saveAndBackButton, yesRadio, noRadio, yesRadioInput, noRadioInput,
+  headingCaption, yesRadio, noRadio, yesRadioInput, noRadioInput,
 } from '../../../../../../pages/shared';
-import { BUTTONS, PAGES, ERROR_MESSAGES } from '../../../../../../content-strings';
+import { PAGES, ERROR_MESSAGES } from '../../../../../../content-strings';
 import { ROUTES, FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROOT } from '../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/your-buyer';
@@ -89,7 +89,7 @@ context('Insurance - Your Buyer - Traded with buyer page - As an exporter, I wan
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-page.spec.js
@@ -1,7 +1,7 @@
 import {
-  headingCaption, intro, saveAndBackButton, yesRadio, noRadio, field, noRadioInput,
+  headingCaption, intro, yesRadio, noRadio, field, noRadioInput,
 } from '../../../../../../pages/shared';
-import { BUTTONS, PAGES, ERROR_MESSAGES } from '../../../../../../content-strings';
+import { PAGES, ERROR_MESSAGES } from '../../../../../../content-strings';
 import { YOUR_BUYER_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/your-buyer';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -115,7 +115,7 @@ context('Insurance - Your Buyer - Trading history page - As an exporter, I want 
     });
 
     it('renders a `save and back` button', () => {
-      cy.checkText(saveAndBackButton(), BUTTONS.SAVE_AND_BACK);
+      cy.assertSaveAndBackButton();
     });
   });
 

--- a/src/ui/templates/insurance/your-business/check-your-answers.njk
+++ b/src/ui/templates/insurance/your-business/check-your-answers.njk
@@ -2,7 +2,6 @@
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% import '../../components/group-of-summary-lists.njk' as groupOfSummaryLists %}
-{% import '../../components/form-buttons.njk' as formButtons %}
 
 {% block pageTitle %}
   {{ CONTENT_STRINGS.PAGE_TITLE }}
@@ -33,10 +32,7 @@
 
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-    {{ formButtons.render({
-      contentStrings: CONTENT_STRINGS.BUTTONS,
-      submitText: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK
-    }) }}
+    <a class="govuk-button" href="{{ SAVE_AND_BACK_URL }}" data-cy="save-and-back-button">{{ CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK }}</a>
 
   </form>
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the "Check your answers" page in the "Business" section of a no PDF application to have only a "Save and back" button.

Have also created a new cypress command to assert a "Save and back" button, since this is repeated throughout and will be required for new incoming forms.

## Resolution :heavy_check_mark:
- Update "Business - check your answers" nunjucks template to only render a "Save and back" button.
- Update E2E test.

## Miscellaneous :heavy_plus_sign:
- Create new `assertSaveAndBackButton` command.
- Update all E2E tests to use the new command.
