### PR TITLE
chore(EMS-2779): No PDF - Cypress command to click a "Save and back" button

### DIFF
--- a/e2e-tests/commands/insurance/complete-business-section.js
+++ b/e2e-tests/commands/insurance/complete-business-section.js
@@ -1,5 +1,3 @@
-import { saveAndBackButton } from '../../pages/shared';
-
 /**
  * completeBusinessSection
  * Complete the "business" section
@@ -21,7 +19,7 @@ const completeBusinessSection = ({ viaTaskList, differentTradingAddress = false,
   cy.completeAndSubmitCreditControlForm({});
 
   if (submitCheckYourAnswers) {
-    saveAndBackButton().click();
+    cy.clickSaveAndBackButton();
   }
 };
 

--- a/e2e-tests/commands/shared-commands/form/click-save-and-back-button.js
+++ b/e2e-tests/commands/shared-commands/form/click-save-and-back-button.js
@@ -1,0 +1,11 @@
+import { saveAndBackButton } from '../../../pages/shared';
+
+/**
+ * clickSaveAndBackButton
+ * Click the "save and back" button.
+ */
+const clickSaveAndBackButton = () => {
+  saveAndBackButton().click();
+};
+
+export default clickSaveAndBackButton;

--- a/e2e-tests/commands/shared-commands/form/index.js
+++ b/e2e-tests/commands/shared-commands/form/index.js
@@ -3,6 +3,7 @@ Cypress.Commands.add('changeAnswerSelectField', require('./change-answer-select-
 Cypress.Commands.add('changeAnswerRadioField', require('./change-answer-radio-field'));
 Cypress.Commands.add('clickSubmitButton', require('./click-submit-button'));
 Cypress.Commands.add('clickSubmitButtonMultipleTimes', require('./click-submit-button-multiple-times'));
+Cypress.Commands.add('clickSaveAndBackButton', require('./click-save-and-back-button'));
 
 Cypress.Commands.add('submitAndAssertFieldErrors', require('./submit-and-assert-field-errors'));
 Cypress.Commands.add('assertFieldErrors', require('./assert-field-errors'));

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/save-and-back.spec.js
@@ -1,4 +1,3 @@
-import { saveAndBackButton } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { TASKS } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
@@ -43,7 +42,7 @@ context('Insurance - Check your answers - Policy page - Save and back', () => {
   });
 
   it(`should redirect to ${ALL_SECTIONS}`, () => {
-    saveAndBackButton().click();
+    cy.clickSaveAndBackButton();
 
     cy.assertUrl(allSectionsUrl);
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/save-and-back.spec.js
@@ -1,4 +1,3 @@
-import { saveAndBackButton } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { TASKS } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -46,7 +45,7 @@ context('Insurance - Check your answers - Your business page - Save and back', (
   });
 
   it(`should redirect to ${ALL_SECTIONS}`, () => {
-    saveAndBackButton().click();
+    cy.clickSaveAndBackButton();
 
     cy.assertUrl(allSectionsUrl);
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/save-and-back.spec.js
@@ -1,8 +1,4 @@
-import {
-  saveAndBackButton,
-  yesRadioInput,
-  noRadioInput,
-} from '../../../../../../../pages/shared';
+import { yesRadioInput, noRadioInput } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { TASKS } from '../../../../../../../content-strings';
 import { FIELD_VALUES } from '../../../../../../../constants';
@@ -65,7 +61,7 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - Save a
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -85,7 +81,7 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - Save a
 
       yesRadioInput().click();
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -109,7 +105,7 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - Save a
 
       noRadioInput().click();
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/save-and-back.spec.js
@@ -1,8 +1,4 @@
-import {
-  saveAndBackButton,
-  yesRadioInput,
-  noRadioInput,
-} from '../../../../../../../pages/shared';
+import { yesRadioInput, noRadioInput } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { TASKS } from '../../../../../../../content-strings';
 import { FIELD_VALUES } from '../../../../../../../constants';
@@ -66,7 +62,7 @@ context('Insurance - Declarations - Exporting with code of conduct page - Save a
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -86,7 +82,7 @@ context('Insurance - Declarations - Exporting with code of conduct page - Save a
 
       yesRadioInput().click();
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -110,7 +106,7 @@ context('Insurance - Declarations - Exporting with code of conduct page - Save a
 
       noRadioInput().click();
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { singleInputField, saveAndBackButton } from '../../../../../../pages/shared';
+import { singleInputField } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { TASKS } from '../../../../../../content-strings';
 import { FIELD_IDS } from '../../../../../../constants';
@@ -57,7 +57,7 @@ context('Insurance - Declarations - Anti-bribery page - Save and go back', () =>
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -77,7 +77,7 @@ context('Insurance - Declarations - Anti-bribery page - Save and go back', () =>
 
       singleInputField(FIELD_ID).input().click();
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/confidentiality/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/confidentiality/save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { singleInputField, saveAndBackButton } from '../../../../../../pages/shared';
+import { singleInputField } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { TASKS } from '../../../../../../content-strings';
 import { FIELD_IDS } from '../../../../../../constants';
@@ -51,7 +51,7 @@ context('Insurance - Declarations - Confidentiality page - Save and go back', ()
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -71,7 +71,7 @@ context('Insurance - Declarations - Confidentiality page - Save and go back', ()
 
       singleInputField(FIELD_ID).input().click();
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/confirmation-and-acknowledgements/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/confirmation-and-acknowledgements/save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { singleInputField, saveAndBackButton } from '../../../../../../pages/shared';
+import { singleInputField } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { TASKS } from '../../../../../../content-strings';
 import { FIELD_IDS } from '../../../../../../constants';
@@ -56,7 +56,7 @@ context('Insurance - Declarations - Confirmation and acknowledgements page - Sav
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -76,7 +76,7 @@ context('Insurance - Declarations - Confirmation and acknowledgements page - Sav
 
       singleInputField(FIELD_ID).input().click();
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/how-your-data-will-be-used/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/how-your-data-will-be-used/save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { singleInputField, saveAndBackButton } from '../../../../../../pages/shared';
+import { singleInputField } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { TASKS } from '../../../../../../content-strings';
 import { FIELD_IDS } from '../../../../../../constants';
@@ -57,7 +57,7 @@ context('Insurance - Declarations - How your data will be used page - Save and g
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -77,7 +77,7 @@ context('Insurance - Declarations - How your data will be used page - Save and g
 
       singleInputField(FIELD_ID).input().click();
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/save-and-back.spec.js
@@ -1,4 +1,3 @@
-import { saveAndBackButton } from '../../../../../../pages/shared';
 import { aboutGoodsOrServicesPage } from '../../../../../../pages/insurance/export-contract';
 import partials from '../../../../../../partials';
 import { TASKS } from '../../../../../../content-strings';
@@ -55,7 +54,7 @@ context('Insurance - Export contract - About goods or services page - Save and g
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -75,7 +74,7 @@ context('Insurance - Export contract - About goods or services page - Save and g
 
       // submit the form via 'save and go back' button
       cy.keyboardInput(aboutGoodsOrServicesPage[DESCRIPTION].textarea(), application.EXPORT_CONTRACT[DESCRIPTION]);
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -93,7 +92,7 @@ context('Insurance - Export contract - About goods or services page - Save and g
 
       // submit the form via 'save and go back' button
       cy.keyboardInput(aboutGoodsOrServicesPage[DESCRIPTION].textarea(), application.EXPORT_CONTRACT[DESCRIPTION]);
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
 
       // go back to the page via the task list
       cy.startInsuranceExportContractSection({});
@@ -110,13 +109,13 @@ context('Insurance - Export contract - About goods or services page - Save and g
 
       // submit a value
       cy.keyboardInput(field.textarea(), 'Test');
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
 
       // go back to the page
       cy.clickBackLink();
 
       field.textarea().clear();
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-about-goods-or-services-final-destination-known-to-unknown.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-about-goods-or-services-final-destination-known-to-unknown.spec.js
@@ -1,4 +1,4 @@
-import { saveAndBackButton, summaryList } from '../../../../../../pages/shared';
+import { summaryList } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -65,7 +65,7 @@ context('Insurance - Export contract - Change your answers - About goods or serv
 
     describe(`when going back to ${ALL_SECTIONS}`, () => {
       it('should retain a `completed` status tag', () => {
-        saveAndBackButton().click();
+        cy.clickSaveAndBackButton();
 
         cy.checkTaskStatusCompleted(task.status());
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
@@ -1,6 +1,6 @@
 import { brokerPage } from '../../../../../../pages/insurance/policy';
 import partials from '../../../../../../partials';
-import { field, saveAndBackButton } from '../../../../../../pages/shared';
+import { field } from '../../../../../../pages/shared';
 import { TASKS } from '../../../../../../content-strings';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -74,7 +74,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
     it(`should redirect to ${ALL_SECTIONS} retain the "insurance policy" task status as "in progress"`, () => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
 
       cy.assertUrl(allSectionsUrl);
 
@@ -90,7 +90,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
 
       cy.keyboardInput(field(NAME).input(), application.EXPORTER_BROKER[NAME]);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
 
       cy.assertUrl(allSectionsUrl);
 
@@ -134,7 +134,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
         cy.keyboardInput(field(EMAIL).input(), application.EXPORTER_BROKER[EMAIL]);
         cy.keyboardInput(field(POSTCODE).input(), application.EXPORTER_BROKER[POSTCODE]);
 
-        saveAndBackButton().click();
+        cy.clickSaveAndBackButton();
 
         cy.assertUrl(allSectionsUrl);
 
@@ -169,7 +169,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
 
         brokerPage[USING_BROKER].noRadioInput().click();
 
-        saveAndBackButton().click();
+        cy.clickSaveAndBackButton();
 
         cy.assertUrl(allSectionsUrl);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-multiple-contract-policy.spec.js
@@ -1,5 +1,4 @@
 import partials from '../../../../../partials';
-import { saveAndBackButton } from '../../../../../pages/shared';
 import { TASKS } from '../../../../../content-strings';
 import { FIELD_VALUES, ROUTES } from '../../../../../constants';
 
@@ -36,7 +35,7 @@ context('Insurance - Policy - Complete the entire section as a multiple contract
       cy.completeAndSubmitBrokerForm({});
 
       // go back to the all sections page
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-single-contract-policy.spec.js
@@ -1,5 +1,4 @@
 import partials from '../../../../../partials';
-import { saveAndBackButton } from '../../../../../pages/shared';
 import { TASKS } from '../../../../../content-strings';
 import { FIELD_VALUES, ROUTES } from '../../../../../constants';
 
@@ -34,7 +33,7 @@ context('Insurance - Policy - Complete the entire section as a single contract p
       cy.completeAndSubmitBrokerForm({});
 
       // go back to the all sections page
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { field, saveAndBackButton } from '../../../../../../pages/shared';
+import { field } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
@@ -68,7 +68,7 @@ context('Insurance - Policy - Different name on policy - Save and go back', () =
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -96,7 +96,7 @@ context('Insurance - Policy - Different name on policy - Save and go back', () =
       cy.keyboardInput(field(FIRST_NAME).input(), POLICY_CONTACT[FIRST_NAME]);
       cy.keyboardInput(field(LAST_NAME).input(), POLICY_CONTACT[LAST_NAME]);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -122,7 +122,7 @@ context('Insurance - Policy - Different name on policy - Save and go back', () =
       cy.navigateToUrl(url);
 
       cy.completeDifferentNameOnPolicyForm({});
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { field as fieldSelector, saveAndBackButton } from '../../../../../../../pages/shared';
+import { field as fieldSelector } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { TASKS } from '../../../../../../../content-strings';
 import { FIELD_VALUES } from '../../../../../../../constants';
@@ -65,7 +65,7 @@ context('Insurance - Policy - Multiple contract policy Export value page - Save 
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -86,7 +86,7 @@ context('Insurance - Policy - Multiple contract policy Export value page - Save 
 
       cy.keyboardInput(field.input(), invalidValue);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -103,7 +103,7 @@ context('Insurance - Policy - Multiple contract policy Export value page - Save 
 
         cy.keyboardInput(field.input(), invalidValue);
 
-        saveAndBackButton().click();
+        cy.clickSaveAndBackButton();
 
         cy.startInsurancePolicySection({});
 
@@ -125,7 +125,7 @@ context('Insurance - Policy - Multiple contract policy Export value page - Save 
 
       cy.keyboardInput(field.input(), application.POLICY[TOTAL_SALES_TO_BUYER]);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -152,7 +152,7 @@ context('Insurance - Policy - Multiple contract policy Export value page - Save 
       cy.navigateToUrl(url);
 
       cy.completeExportValueForm();
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     describe('when going back to the page', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/save-and-back.spec.js
@@ -1,4 +1,3 @@
-import { saveAndBackButton } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { TASKS } from '../../../../../../content-strings';
 import { FIELD_VALUES } from '../../../../../../constants';
@@ -49,7 +48,7 @@ context('Insurance - Policy - Multiple contract policy page - Save and go back',
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { field, saveAndBackButton } from '../../../../../../pages/shared';
+import { field } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
@@ -64,7 +64,7 @@ context('Insurance - Policy - Name on policy - Save and go back', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -81,7 +81,7 @@ context('Insurance - Policy - Name on policy - Save and go back', () => {
       cy.navigateToUrl(url);
 
       cy.completeAndSubmitNameOnPolicyForm({ sameName: false, submit: false });
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -104,7 +104,7 @@ context('Insurance - Policy - Name on policy - Save and go back', () => {
       cy.navigateToUrl(url);
 
       field(SAME_NAME).input().click();
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -129,7 +129,7 @@ context('Insurance - Policy - Name on policy - Save and go back', () => {
       cy.navigateToUrl(url);
 
       cy.completeNameOnPolicyForm({ sameName: true });
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { field as fieldSelector, saveAndBackButton } from '../../../../../../pages/shared';
+import { field as fieldSelector } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { TASKS } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -61,7 +61,7 @@ context('Insurance - Policy - Pre-credit period page - Save and go back', () => 
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -81,7 +81,7 @@ context('Insurance - Policy - Pre-credit period page - Save and go back', () => 
 
       cy.completePreCreditPeriodForm({ needPreCreditPeriod: false });
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -111,7 +111,7 @@ context('Insurance - Policy - Pre-credit period page - Save and go back', () => 
         description: 'a'.repeat(MAXIMUM + 1),
       });
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -139,7 +139,7 @@ context('Insurance - Policy - Pre-credit period page - Save and go back', () => 
 
       cy.completePreCreditPeriodForm({ needPreCreditPeriod: true });
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { field as fieldSelector, saveAndBackButton } from '../../../../../../pages/shared';
+import { field as fieldSelector } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { TASKS } from '../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
@@ -60,7 +60,7 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -91,7 +91,7 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
       cy.keyboardInput(field.monthInput(), month);
       cy.keyboardInput(field.yearInput(), yesterday.getFullYear());
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -125,7 +125,7 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
       cy.keyboardInput(field.monthInput(), month);
       cy.keyboardInput(field.yearInput(), new Date(futureDate).getFullYear());
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { field as fieldSelector, saveAndBackButton } from '../../../../../../../pages/shared';
+import { field as fieldSelector } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { TASKS } from '../../../../../../../content-strings';
 import { FIELD_VALUES } from '../../../../../../../constants';
@@ -62,7 +62,7 @@ context('Insurance - Policy - Single contract policy - Total contract value page
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -83,7 +83,7 @@ context('Insurance - Policy - Single contract policy - Total contract value page
 
       cy.keyboardInput(field.input(), invalidValue);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -100,7 +100,7 @@ context('Insurance - Policy - Single contract policy - Total contract value page
 
         cy.keyboardInput(field.input(), invalidValue);
 
-        saveAndBackButton().click();
+        cy.clickSaveAndBackButton();
 
         cy.startInsurancePolicySection({});
 
@@ -122,7 +122,7 @@ context('Insurance - Policy - Single contract policy - Total contract value page
 
       cy.keyboardInput(field.input(), application.POLICY[TOTAL_CONTRACT_VALUE]);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/save-and-back.spec.js
@@ -1,4 +1,3 @@
-import { saveAndBackButton } from '../../../../../../pages/shared';
 import { insurance } from '../../../../../../pages';
 import partials from '../../../../../../partials';
 import { TASKS } from '../../../../../../content-strings';
@@ -39,7 +38,7 @@ context('Insurance - Policy - Type of policy page - Save and go back', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, () => {
@@ -59,12 +58,12 @@ context('Insurance - Policy - Type of policy page - Save and go back', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
 
       cy.startInsurancePolicySection({});
 
       multiplePolicyField.input().click();
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ROUTES.INSURANCE.ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/save-and-back.spec.js
@@ -1,5 +1,5 @@
 import partials from '../../../../../../partials/insurance';
-import { saveAndBackButton, field } from '../../../../../../pages/shared';
+import { field } from '../../../../../../pages/shared';
 import { TASKS } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { EXPORTER_BUSINESS_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/business';
@@ -63,7 +63,7 @@ context('Insurance - Your business - Alternative trading address - Save and go b
     before(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -83,7 +83,7 @@ context('Insurance - Your business - Alternative trading address - Save and go b
 
       field(FULL_ADDRESS).textarea().type('a'.repeat(MAXIMUM + 1));
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
 
       cy.assertUrl(allSectionsUrl);
     });
@@ -107,7 +107,7 @@ context('Insurance - Your business - Alternative trading address - Save and go b
 
       field(FULL_ADDRESS).textarea().type(DIFFERENT_TRADING_ADDRESS[FULL_ADDRESS]);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
 
       cy.assertUrl(allSectionsUrl);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-page.spec.js
@@ -1,4 +1,4 @@
-import { headingCaption, saveAndBackButton } from '../../../../../../pages/shared';
+import { headingCaption } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
@@ -74,7 +74,7 @@ context('Insurance - Your Business - Check your answers - As an exporter, I want
       it(`should redirect to ${ALL_SECTIONS}`, () => {
         cy.navigateToUrl(url);
 
-        saveAndBackButton().click();
+        cy.clickSaveAndBackButton();
 
         cy.assertUrl(allSectionsUrl);
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-save-and-back.spec.js
@@ -1,6 +1,4 @@
-import {
-  field, saveAndBackButton, yesRadioInput,
-} from '../../../../../../pages/shared';
+import { field, yesRadioInput } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import {
   INVALID_PHONE_NUMBERS, WEBSITE_EXAMPLES, VALID_PHONE_NUMBERS,
@@ -67,7 +65,7 @@ describe('Insurance - Your business - Company details page - Save and go back', 
 
       yesRadioInput().first().click();
       yesRadioInput().eq(1).click();
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
 
       cy.assertUrl(`${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`);
       cy.checkTaskStatus(task, IN_PROGRESS);
@@ -89,7 +87,7 @@ describe('Insurance - Your business - Company details page - Save and go back', 
 
       cy.completeCompanyDetailsForm(companyDetailsFormVariables);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
 
       cy.assertUrl(`${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`);
       cy.checkTaskStatus(task, IN_PROGRESS);
@@ -113,7 +111,7 @@ describe('Insurance - Your business - Company details page - Save and go back', 
 
       cy.completeCompanyDetailsForm(companyDetailsFormVariables);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
 
       cy.assertUrl(`${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`);
       cy.checkTaskStatus(task, IN_PROGRESS);
@@ -140,7 +138,7 @@ describe('Insurance - Your business - Company details page - Save and go back', 
 
       cy.completeCompanyDetailsForm(companyDetailsFormVariables);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
 
       cy.assertUrl(`${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`);
       cy.checkTaskStatus(task, IN_PROGRESS);

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/save-and-back.spec.js
@@ -1,5 +1,5 @@
 import partials from '../../../../../../partials/insurance';
-import { saveAndBackButton, noRadioInput, yesRadioInput } from '../../../../../../pages/shared';
+import { noRadioInput, yesRadioInput } from '../../../../../../pages/shared';
 import { TASKS } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
@@ -48,7 +48,7 @@ context('Insurance - Your business - Credit control - Save and go back', () => {
     before(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -67,7 +67,7 @@ context('Insurance - Your business - Credit control - Save and go back', () => {
       cy.navigateToUrl(url);
 
       yesRadioInput().click();
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
 
       cy.assertUrl(allSectionsUrl);
     });
@@ -90,7 +90,7 @@ context('Insurance - Your business - Credit control - Save and go back', () => {
       cy.navigateToUrl(url);
 
       noRadioInput().click();
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
 
       cy.assertUrl(allSectionsUrl);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/save-and-back.spec.js
@@ -1,5 +1,5 @@
 import partials from '../../../../../../partials';
-import { field, saveAndBackButton } from '../../../../../../pages/shared';
+import { field } from '../../../../../../pages/shared';
 import { TASKS } from '../../../../../../content-strings';
 import { ROUTES, FIELD_IDS } from '../../../../../../constants';
 import application from '../../../../../../fixtures/application';
@@ -56,7 +56,7 @@ context('Insurance - Your business - Nature of your business page - Save and bac
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -76,7 +76,7 @@ context('Insurance - Your business - Nature of your business page - Save and bac
 
       cy.keyboardInput(field(GOODS_OR_SERVICES).textarea(), application.EXPORTER_BUSINESS[GOODS_OR_SERVICES]);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -109,7 +109,7 @@ context('Insurance - Your business - Nature of your business page - Save and bac
       cy.keyboardInput(field(YEARS_EXPORTING).input(), application.EXPORTER_BUSINESS[YEARS_EXPORTING]);
       cy.keyboardInput(field(EMPLOYEES_UK).input(), application.EXPORTER_BUSINESS[EMPLOYEES_UK]);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/save-and-back.spec.js
@@ -1,5 +1,5 @@
 import partials from '../../../../../../partials';
-import { field, saveAndBackButton } from '../../../../../../pages/shared';
+import { field } from '../../../../../../pages/shared';
 import { TASKS } from '../../../../../../content-strings';
 import { ROUTES, FIELD_IDS } from '../../../../../../constants';
 import application from '../../../../../../fixtures/application';
@@ -58,7 +58,7 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -76,7 +76,7 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
 
       cy.keyboardInput(field(ESTIMATED_ANNUAL_TURNOVER).input(), application.EXPORTER_BUSINESS[ESTIMATED_ANNUAL_TURNOVER]);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -105,7 +105,7 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
       cy.keyboardInput(field(ESTIMATED_ANNUAL_TURNOVER).input(), application.EXPORTER_BUSINESS[ESTIMATED_ANNUAL_TURNOVER]);
       cy.keyboardInput(field(PERCENTAGE_TURNOVER).input(), application.EXPORTER_BUSINESS[PERCENTAGE_TURNOVER]);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { field, saveAndBackButton } from '../../../../../../pages/shared';
+import { field } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { companyOrOrganisationPage } from '../../../../../../pages/insurance/your-buyer';
 import { TASKS } from '../../../../../../content-strings';
@@ -64,7 +64,7 @@ context('Insurance - Your buyer - Company or organisation - Save and back', () =
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -85,7 +85,7 @@ context('Insurance - Your buyer - Company or organisation - Save and back', () =
 
       cy.keyboardInput(field(NAME).input(), BUYER[NAME]);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -126,7 +126,7 @@ context('Insurance - Your buyer - Company or organisation - Save and back', () =
       cy.keyboardInput(field(EMAIL).input(), BUYER[EMAIL]);
       companyOrOrganisationPage[CAN_CONTACT_BUYER].yesRadioInput().click();
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/save-and-back/no-connection-to-the-buyer-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/save-and-back/no-connection-to-the-buyer-save-and-back.spec.js
@@ -1,4 +1,3 @@
-import { saveAndBackButton } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { TASKS } from '../../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -43,7 +42,7 @@ context('Insurance - Your buyer - Connection to buyer - No connection to buyer -
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -62,7 +61,7 @@ context('Insurance - Your buyer - Connection to buyer - No connection to buyer -
 
       cy.completeConnectionToTheBuyerForm({});
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/save-and-back/yes-connection-to-the-buyer-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/save-and-back/yes-connection-to-the-buyer-save-and-back.spec.js
@@ -1,8 +1,4 @@
-import {
-  saveAndBackButton,
-  yesRadioInput,
-  field,
-} from '../../../../../../../pages/shared';
+import { yesRadioInput, field } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { TASKS } from '../../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -55,7 +51,7 @@ context('Insurance - Your buyer - Connection to buyer - Has connection to buyer 
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -76,7 +72,7 @@ context('Insurance - Your buyer - Connection to buyer - Has connection to buyer 
 
       yesRadioInput().click();
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -104,7 +100,7 @@ context('Insurance - Your buyer - Connection to buyer - Has connection to buyer 
 
       cy.completeConnectionToTheBuyerForm({ hasConnectionToBuyer: true });
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/save-and-back.spec.js
@@ -1,4 +1,3 @@
-import { saveAndBackButton } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { TASKS } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -47,7 +46,7 @@ context('Insurance - Your buyer - Working with buyer - Save and back', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {
@@ -65,7 +64,7 @@ context('Insurance - Your buyer - Working with buyer - Save and back', () => {
       cy.navigateToUrl(url);
 
       cy.completeTradedWithBuyerForm({ exporterHasTradedWithBuyer: true });
-      saveAndBackButton().click();
+      cy.clickSaveAndBackButton();
     });
 
     it(`should redirect to ${ALL_SECTIONS}`, () => {


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds a new cypress command to click a "Save and back" to be DRY and avoid import noise in E2E tests.

This button click is used throughout the services and will only increase.

## Resolution :heavy_check_mark:
- Add new `clickSaveAndBackButton` command.
- Update all appropriate E2E tests.

