### PR TITLE
chore(EMS-2642): No PDF - Policy - Different name - Improve E2E test coverage

### DIFF
--- a/e2e-tests/commands/shared-commands/assertions/assert-different-name-on-policy-field-values.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-different-name-on-policy-field-values.js
@@ -1,0 +1,35 @@
+import { field as fieldSelector } from '../../../pages/shared';
+import { INSURANCE_FIELD_IDS } from '../../../constants/field-ids/insurance';
+
+const {
+  POLICY: {
+    DIFFERENT_NAME_ON_POLICY: {
+      POSITION,
+    },
+  },
+  ACCOUNT: {
+    FIRST_NAME, LAST_NAME, EMAIL,
+  },
+} = INSURANCE_FIELD_IDS;
+
+/**
+ * assertDifferentNameOnPolicyFieldValues
+ * Assert all field values in the "different name on policy" form.
+ * @param {String} expectedFirstName: First name
+ * @param {String} expectedLastName: Last name
+ * @param {String} expectedEmail: Email
+ * @param {String} expectedPosition: Position
+ */
+const assertDifferentNameOnPolicyFieldValues = ({
+  expectedFirstName = '',
+  expectedLastName = '',
+  expectedEmail = '',
+  expectedPosition = '',
+}) => {
+  cy.checkValue(fieldSelector(FIRST_NAME), expectedFirstName);
+  cy.checkValue(fieldSelector(LAST_NAME), expectedLastName);
+  cy.checkValue(fieldSelector(EMAIL), expectedEmail);
+  cy.checkValue(fieldSelector(POSITION), expectedPosition);
+};
+
+export default assertDifferentNameOnPolicyFieldValues;

--- a/e2e-tests/commands/shared-commands/assertions/index.js
+++ b/e2e-tests/commands/shared-commands/assertions/index.js
@@ -84,6 +84,8 @@ Cypress.Commands.add('assertGenericPolicySummaryListRows', require('./assert-gen
 Cypress.Commands.add('assertGenericSinglePolicySummaryListRows', require('./assert-generic-single-policy-summary-list-rows'));
 Cypress.Commands.add('assertGenericMultiplePolicySummaryListRows', require('./assert-generic-multiple-policy-summary-list-rows'));
 
+Cypress.Commands.add('assertDifferentNameOnPolicyFieldValues', require('./assert-different-name-on-policy-field-values'));
+
 Cypress.Commands.add('submitAndAssertChangeAnswersPageUrl', require('./submit-and-assert-change-answers-page-url'));
 
 Cypress.Commands.add('checkTaskStatus', require('./check-task-status'));

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/changing-from-different-name-to-same-name-then-back-to-different-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/changing-from-different-name-to-same-name-then-back-to-different-name.spec.js
@@ -18,7 +18,7 @@ const {
 
 const baseUrl = Cypress.config('baseUrl');
 
-context(`Insurance - Policy - Different name on Policy page - Changing ${SAME_NAME} to ${OTHER_NAME} should not populate fields on different name on policy page`, () => {
+context(`Insurance - Policy - Different name on Policy page - Changing ${OTHER_NAME} to ${SAME_NAME} and then back to ${OTHER_NAME} should not populate fields on different name on policy page`, () => {
   let referenceNumber;
   let url;
 
@@ -31,7 +31,8 @@ context(`Insurance - Policy - Different name on Policy page - Changing ${SAME_NA
       cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
-      cy.completeAndSubmitNameOnPolicyForm({});
+      cy.completeAndSubmitNameOnPolicyForm({ sameName: false });
+      cy.completeAndSubmitDifferentNameOnPolicyForm({});
       cy.completeAndSubmitPreCreditPeriodForm({});
       cy.completeAndSubmitAnotherCompanyForm({});
       cy.completeAndSubmitBrokerForm({});
@@ -50,9 +51,13 @@ context(`Insurance - Policy - Different name on Policy page - Changing ${SAME_NA
     cy.deleteApplication(referenceNumber);
   });
 
-  describe(`when changing from ${SAME_NAME} to ${OTHER_NAME}`, () => {
+  describe(`when changing from ${OTHER_NAME} to ${SAME_NAME} and then back to ${OTHER_NAME}`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
+
+      summaryList.field(NAME).changeLink().click();
+
+      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
 
       summaryList.field(NAME).changeLink().click();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
@@ -137,10 +137,12 @@ context('Insurance - Policy - Different name on Policy page - I want to enter th
     it('should should have submitted values when navigating back to page', () => {
       cy.navigateToUrl(url);
 
-      cy.checkValue(fieldSelector(FIRST_NAME), POLICY_CONTACT[FIRST_NAME]);
-      cy.checkValue(fieldSelector(LAST_NAME), POLICY_CONTACT[LAST_NAME]);
-      cy.checkValue(fieldSelector(EMAIL), POLICY_CONTACT[EMAIL]);
-      cy.checkValue(fieldSelector(POSITION), POLICY_CONTACT[POSITION]);
+      cy.assertDifferentNameOnPolicyFieldValues({
+        expectedFirstName: POLICY_CONTACT[FIRST_NAME],
+        expectedLastName: POLICY_CONTACT[LAST_NAME],
+        expectedEmail: POLICY_CONTACT[EMAIL],
+        expectedPosition: POLICY_CONTACT[POSITION],
+      });
     });
   });
 });


### PR DESCRIPTION
## Introduction :pencil2:
This PR ensures that the "different name on policy" feature of a no PDF application wipes the "different name" fields in the following scenario:

1) Submit "different name" as yes.
2) Submit different contact details.
3) Change and submit "different name" as no.
4) Go back, change and submit "different name" as yes.

## Resolution :heavy_check_mark:
- Add E2E test coverage.

## Miscellaneous :heavy_plus_sign:
- Create new DRY cypress command to assert the "different name on policy" field values, `assertDifferentNameOnPolicyFieldValues`.
- Minor test description improvements.
