### PR TITLE
fix(EMS-2667-2778): No PDF - Policy - Different name on policy - validation

### DIFF
--- a/database/exip.sql
+++ b/database/exip.sql
@@ -881,7 +881,7 @@ CREATE TABLE `PolicyContact` (
   `firstName` varchar(300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `lastName` varchar(300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `email` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `position` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `position` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `isSameAsOwner` tinyint(1) DEFAULT NULL,
   `application` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -242,7 +242,7 @@ export const ERROR_MESSAGES = {
           INCORRECT_FORMAT: "The policy holder's last name must not include any numbers or symbols",
         },
         [FIELD_IDS.INSURANCE.ACCOUNT.EMAIL]: {
-          INCORRECT_FORMAT: 'Enter the email address of the person you want named on the policy',
+          INCORRECT_FORMAT: "Enter the policy holder's email address in the correct format, like name@example.com",
         },
         [FIELD_IDS.INSURANCE.POLICY.DIFFERENT_NAME_ON_POLICY.POSITION]: {
           IS_EMPTY: "Enter the policy holder's position at the company",

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -1157,7 +1157,9 @@ var lists = {
         db: { nativeType: "VarChar(300)" }
       }),
       email: (0, import_fields.text)(),
-      position: (0, import_fields.text)(),
+      position: (0, import_fields.text)({
+        db: { nativeType: "VarChar(50)" }
+      }),
       isSameAsOwner: nullable_checkbox_default()
     },
     access: import_access.allowAll

--- a/src/api/schema.prisma
+++ b/src/api/schema.prisma
@@ -122,7 +122,7 @@ model PolicyContact {
   firstName                      String        @default("") @mysql.VarChar(300)
   lastName                       String        @default("") @mysql.VarChar(300)
   email                          String        @default("")
-  position                       String        @default("")
+  position                       String        @default("") @mysql.VarChar(50)
   isSameAsOwner                  Boolean?
   from_Application_policyContact Application[] @relation("Application_policyContact")
 

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -313,7 +313,9 @@ export const lists = {
         db: { nativeType: 'VarChar(300)' },
       }),
       email: text(),
-      position: text(),
+      position: text({
+        db: { nativeType: 'VarChar(50)' },
+      }),
       isSameAsOwner: nullableCheckbox(),
     },
     access: allowAll,

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -241,7 +241,7 @@ export const ERROR_MESSAGES = {
           INCORRECT_FORMAT: "The policy holder's last name must not include any numbers or symbols",
         },
         [FIELD_IDS.INSURANCE.ACCOUNT.EMAIL]: {
-          INCORRECT_FORMAT: 'Enter the email address of the person you want named on the policy',
+          INCORRECT_FORMAT: "Enter the policy holder's email address in the correct format, like name@example.com",
         },
         [FIELD_IDS.INSURANCE.POLICY.DIFFERENT_NAME_ON_POLICY.POSITION]: {
           IS_EMPTY: "Enter the policy holder's position at the company",


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes 2x issues in the "Different name on policy" form where:
- The email validation error messages was incorrect.
- The "position" field had an invalid `varchar`.

## Resolution :heavy_check_mark:
- Update error message content strings.
- Update DB dump.
