### PR TITLE
WIP - feat(EMS-2644-2645-2646): No PDF - Policy - Other company details - Form validation

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -258,6 +258,18 @@ export const ERROR_MESSAGES = {
       [FIELD_IDS.INSURANCE.POLICY.NEED_ANOTHER_COMPANY_TO_BE_INSURED]: {
         IS_EMPTY: 'Select if there is another company that needs to be insured in your policy',
       },
+      OTHER_COMPANY_TO_INSURE_NAME_TBC: {
+        [FIELD_IDS.INSURANCE.POLICY.OTHER_COMPANY_TO_INSURE_NAME_TBC.COMPANY_NAME]: {
+          IS_EMPTY: 'Enter the name of the other company',
+          ABOVE_MAXIMUM: 'The name of the other company cannot be more than 200 characters',
+        },
+        [FIELD_IDS.INSURANCE.POLICY.OTHER_COMPANY_TO_INSURE_NAME_TBC.COMPANY_NUMBER]: {
+          ABOVE_MAXIMUM: 'The registration number of the other company cannot be more than 100 characters',
+        },
+        [FIELD_IDS.INSURANCE.POLICY.OTHER_COMPANY_TO_INSURE_NAME_TBC.COUNTRY]: {
+          IS_EMPTY: 'Enter the country the other company is based in',
+        },
+      },
       [FIELD_IDS.INSURANCE.POLICY.BROKER.USING_BROKER]: {
         IS_EMPTY: 'Select whether you are using a broker to get this insurance',
       },

--- a/e2e-tests/content-strings/fields/insurance/policy/index.js
+++ b/e2e-tests/content-strings/fields/insurance/policy/index.js
@@ -202,12 +202,14 @@ export const POLICY_FIELDS = {
   OTHER_COMPANY_TO_INSURE_NAME_TBC: {
     [COMPANY_NAME]: {
       LABEL: 'Name of the other company',
+      MAXIMUM: 200,
     },
     [COMPANY_NUMBER]: {
-      LABEL: 'What country is the other company based in?',
+      LABEL: 'Registration number of the other company (optional)',
+      MAXIMUM: 100,
     },
     [COUNTRY]: {
-      LABEL: 'Registration number of the other company (optional)',
+      LABEL: 'What country is the other company based in?',
     },
   },
   BROKER: {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/validation/other-company-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/validation/other-company-details-validation.spec.js
@@ -1,0 +1,120 @@
+import { field as fieldSelector } from '../../../../../../../pages/shared';
+import { FIELD_VALUES } from '../../../../../../../constants';
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import { POLICY_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const ERRORS = ERROR_MESSAGES.INSURANCE.POLICY.OTHER_COMPANY_TO_INSURE_NAME_TBC;
+
+const {
+  ROOT,
+  POLICY: { OTHER_COMPANY_DETAILS },
+} = INSURANCE_ROUTES;
+
+const {
+  OTHER_COMPANY_TO_INSURE_NAME_TBC: { COMPANY_NAME, COMPANY_NUMBER, COUNTRY },
+} = POLICY_FIELD_IDS;
+
+const {
+  OTHER_COMPANY_TO_INSURE_NAME_TBC: {
+    [COMPANY_NAME]: { MAXIMUM: MAX_COMPANY_NAME_CHARACTERS },
+    [COMPANY_NUMBER]: { MAXIMUM: MAX_COMPANY_NUMBER_CHARACTERS },
+  },
+} = FIELDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Policy - Other company details page - Validation', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      // go to the page we want to test.
+      cy.startInsurancePolicySection({});
+
+      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitSingleContractPolicyForm({});
+      cy.completeAndSubmitTotalContractValueForm({});
+      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitPreCreditPeriodForm({});
+      cy.completeAndSubmitAnotherCompanyForm({ otherCompanyInvolved: true });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${OTHER_COMPANY_DETAILS}`;
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  // COMPANY_NAME
+  // COMPANY_NUMBER
+  // COUNTRY
+
+  describe(COMPANY_NAME, () => {
+    const FIELD_ID = COMPANY_NAME;
+    const ERROR = ERRORS[FIELD_ID];
+
+    const { field, numberOfExpectedErrors, errorIndex } = {
+      field: fieldSelector(FIELD_ID),
+      numberOfExpectedErrors: 2,
+      errorIndex: 0,
+    };
+
+    it(`should render validation errors when ${FIELD_ID} is left empty`, () => {
+      const value = '';
+
+      cy.submitAndAssertFieldErrors(field, value, errorIndex, numberOfExpectedErrors, ERROR.IS_EMPTY);
+    });
+
+    it(`should render validation errors when ${FIELD_ID} is over ${MAX_COMPANY_NAME_CHARACTERS} characters`, () => {
+      const value = 'a'.repeat(MAX_COMPANY_NAME_CHARACTERS + 1);
+
+      cy.submitAndAssertFieldErrors(field, value, errorIndex, numberOfExpectedErrors, ERROR.ABOVE_MAXIMUM);
+    });
+  });
+
+  describe(COUNTRY, () => {
+    const FIELD_ID = COUNTRY;
+    const ERROR = ERRORS[FIELD_ID];
+
+    const { field, numberOfExpectedErrors, errorIndex } = {
+      field: fieldSelector(FIELD_ID),
+      numberOfExpectedErrors: 2,
+      errorIndex: 1,
+    };
+
+    it(`should render validation errors when ${FIELD_ID} is left empty`, () => {
+      const value = '';
+
+      cy.submitAndAssertFieldErrors(field, value, errorIndex, numberOfExpectedErrors, ERROR.IS_EMPTY);
+    });
+  });
+
+  describe(COMPANY_NUMBER, () => {
+    const FIELD_ID = COMPANY_NUMBER;
+    const ERROR = ERRORS[FIELD_ID];
+
+    const { field, numberOfExpectedErrors, errorIndex } = {
+      field: fieldSelector(FIELD_ID),
+      numberOfExpectedErrors: 3,
+      errorIndex: 2,
+    };
+
+    it(`should render validation errors when ${FIELD_ID} is over ${MAX_COMPANY_NUMBER_CHARACTERS} characters`, () => {
+      const value = 'a'.repeat(MAX_COMPANY_NUMBER_CHARACTERS + 1);
+
+      cy.submitAndAssertFieldErrors(field, value, errorIndex, numberOfExpectedErrors, ERROR.ABOVE_MAXIMUM);
+    });
+  });
+});

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -257,6 +257,18 @@ export const ERROR_MESSAGES = {
       [FIELD_IDS.INSURANCE.POLICY.NEED_ANOTHER_COMPANY_TO_BE_INSURED]: {
         IS_EMPTY: 'Select if there is another company that needs to be insured in your policy',
       },
+      OTHER_COMPANY_TO_INSURE_NAME_TBC: {
+        [FIELD_IDS.INSURANCE.POLICY.OTHER_COMPANY_TO_INSURE_NAME_TBC.COMPANY_NAME]: {
+          IS_EMPTY: 'Enter the name of the other company',
+          ABOVE_MAXIMUM: 'The name of the other company cannot be more than 200 characters',
+        },
+        [FIELD_IDS.INSURANCE.POLICY.OTHER_COMPANY_TO_INSURE_NAME_TBC.COMPANY_NUMBER]: {
+          ABOVE_MAXIMUM: 'The registration number of the other company cannot be more than 100 characters',
+        },
+        [FIELD_IDS.INSURANCE.POLICY.OTHER_COMPANY_TO_INSURE_NAME_TBC.COUNTRY]: {
+          IS_EMPTY: 'Enter the country the other company is based in',
+        },
+      },
       [FIELD_IDS.INSURANCE.POLICY.BROKER.USING_BROKER]: {
         IS_EMPTY: 'Select whether you are using a broker to get this insurance',
       },

--- a/src/ui/server/content-strings/fields/insurance/policy/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy/index.ts
@@ -191,12 +191,14 @@ export const POLICY_FIELDS = {
   OTHER_COMPANY_TO_INSURE_NAME_TBC: {
     [COMPANY_NAME]: {
       LABEL: 'Name of the other company',
+      MAXIMUM: 200,
     },
     [COMPANY_NUMBER]: {
-      LABEL: 'What country is the other company based in?',
+      LABEL: 'Registration number of the other company (optional)',
+      MAXIMUM: 100,
     },
     [COUNTRY]: {
-      LABEL: 'Registration number of the other company (optional)',
+      LABEL: 'What country is the other company based in?',
     },
   },
   BROKER: {

--- a/src/ui/server/controllers/insurance/policy/other-company-details/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/index.ts
@@ -5,6 +5,8 @@ import { PAGES } from '../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import constructPayload from '../../../../helpers/construct-payload';
+import generateValidationErrors from './validation';
 import { Request, Response } from '../../../../../types';
 
 const {
@@ -43,6 +45,8 @@ export const pageVariables = {
 
 export const TEMPLATE = TEMPLATES.INSURANCE.POLICY.OTHER_COMPANY_DETAILS;
 
+export const FIELD_IDS = [COMPANY_NAME, COMPANY_NUMBER, COUNTRY];
+
 /**
  * get
  * Get the application and render the Policy - Other company details page
@@ -74,7 +78,7 @@ export const get = (req: Request, res: Response) => {
  * @param {Express.Response} Express response
  * @returns {Express.Response.redirect} Next part of the flow or error page
  */
-export const post = async (req: Request, res: Response) => {
+export const post = (req: Request, res: Response) => {
   const { application } = res.locals;
 
   if (!application) {
@@ -82,6 +86,23 @@ export const post = async (req: Request, res: Response) => {
   }
 
   const { referenceNumber } = req.params;
+
+  const payload = constructPayload(req.body, FIELD_IDS);
+
+  const validationErrors = generateValidationErrors(payload);
+
+  if (validationErrors) {
+    return res.render(TEMPLATE, {
+      ...insuranceCorePageVariables({
+        PAGE_CONTENT_STRINGS,
+        BACK_LINK: req.headers.referer,
+      }),
+      ...pageVariables,
+      userName: getUserNameFromSession(req.session.user),
+      submittedValues: payload,
+      validationErrors,
+    });
+  }
 
   return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${BROKER_ROOT}`);
 };

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/index.test.ts
@@ -1,0 +1,15 @@
+import validation from '.';
+import validationRules from './rules';
+import combineValidationRules from '../../../../../helpers/combine-validation-rules';
+
+describe('controllers/insurance/policy/other-company-details/validation', () => {
+  it('should return an array of results from rule functions', () => {
+    const mockFormBody = {};
+
+    const result = validation(mockFormBody);
+
+    const expected = combineValidationRules(validationRules, mockFormBody);
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/index.ts
@@ -1,0 +1,7 @@
+import validationRules from './rules';
+import combineValidationRules from '../../../../../helpers/combine-validation-rules';
+import { RequestBody, ValidationErrors } from '../../../../../../types';
+
+const validation = (formBody: RequestBody): ValidationErrors => combineValidationRules(validationRules, formBody) as ValidationErrors;
+
+export default validation;

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-name/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-name/index.test.ts
@@ -1,0 +1,30 @@
+import companyName from '.';
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import { POLICY_FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
+import providedAndMaxLength from '../../../../../../../shared-validation/provided-and-max-length';
+import { mockErrors } from '../../../../../../../test-mocks';
+
+const {
+  OTHER_COMPANY_TO_INSURE_NAME_TBC: { COMPANY_NAME: FIELD_ID },
+} = POLICY_FIELD_IDS;
+
+const {
+  OTHER_COMPANY_TO_INSURE_NAME_TBC: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
+} = ERROR_MESSAGES.INSURANCE.POLICY;
+
+const MAXIMUM = Number(POLICY_FIELDS.OTHER_COMPANY_TO_INSURE_NAME_TBC[FIELD_ID].MAXIMUM);
+
+describe('controllers/insurance/policy/other-company-details/validation/rules/company-name', () => {
+  const mockBody = {
+    [FIELD_ID]: '',
+  };
+
+  it('should return the result of providedAndMaxLength', () => {
+    const result = companyName(mockBody, mockErrors);
+
+    const expected = providedAndMaxLength(mockBody, FIELD_ID, ERROR_MESSAGES_OBJECT, mockErrors, MAXIMUM);
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-name/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-name/index.ts
@@ -1,0 +1,25 @@
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import { POLICY_FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
+import providedAndMaxLength from '../../../../../../../shared-validation/provided-and-max-length';
+import { RequestBody } from '../../../../../../../../types';
+
+const {
+  OTHER_COMPANY_TO_INSURE_NAME_TBC: { COMPANY_NAME: FIELD_ID },
+} = POLICY_FIELD_IDS;
+
+const {
+  OTHER_COMPANY_TO_INSURE_NAME_TBC: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
+} = ERROR_MESSAGES.INSURANCE.POLICY;
+
+const MAXIMUM = Number(POLICY_FIELDS.OTHER_COMPANY_TO_INSURE_NAME_TBC[FIELD_ID].MAXIMUM);
+
+/**
+ * validate the "company name" in other company details response body
+ * @param {Express.Request.body} responseBody containing an object with the company details response
+ * @param {Object} errors errorList
+ * @returns {object} object containing errors or blank object
+ */
+const companyName = (responseBody: RequestBody, errors: object) => providedAndMaxLength(responseBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MAXIMUM);
+
+export default companyName;

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-number/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-number/index.test.ts
@@ -1,0 +1,42 @@
+import companyNumber from '.';
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import { POLICY_FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
+import maxLengthValidation from '../../../../../../../shared-validation/max-length';
+import { mockErrors } from '../../../../../../../test-mocks';
+
+const {
+  OTHER_COMPANY_TO_INSURE_NAME_TBC: { COMPANY_NUMBER: FIELD_ID },
+} = POLICY_FIELD_IDS;
+
+const {
+  OTHER_COMPANY_TO_INSURE_NAME_TBC: {
+    [FIELD_ID]: { ABOVE_MAXIMUM: ERROR_MESSAGE },
+  },
+} = ERROR_MESSAGES.INSURANCE.POLICY;
+
+const MAXIMUM = Number(POLICY_FIELDS.OTHER_COMPANY_TO_INSURE_NAME_TBC[FIELD_ID].MAXIMUM);
+
+describe('controllers/insurance/policy/other-company-details/validation/rules/company-number', () => {
+  const mockBody = {
+    [FIELD_ID]: 'Mock company number',
+  };
+
+  describe('when a value is provided', () => {
+    it('should return the result of providedAndMaxLength', () => {
+      const result = companyNumber(mockBody, mockErrors);
+
+      const expected = maxLengthValidation(mockBody[FIELD_ID], FIELD_ID, ERROR_MESSAGE, mockErrors, MAXIMUM);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a value is NOT provided', () => {
+    it('should return the provided errors', () => {
+      const result = companyNumber({}, mockErrors);
+
+      expect(result).toEqual(mockErrors);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-number/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-number/index.ts
@@ -1,0 +1,34 @@
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import { POLICY_FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
+import { objectHasProperty } from '../../../../../../../helpers/object';
+import maxLengthValidation from '../../../../../../../shared-validation/max-length';
+import { RequestBody } from '../../../../../../../../types';
+
+const {
+  OTHER_COMPANY_TO_INSURE_NAME_TBC: { COMPANY_NUMBER: FIELD_ID },
+} = POLICY_FIELD_IDS;
+
+const {
+  OTHER_COMPANY_TO_INSURE_NAME_TBC: {
+    [FIELD_ID]: { ABOVE_MAXIMUM: ERROR_MESSAGE },
+  },
+} = ERROR_MESSAGES.INSURANCE.POLICY;
+
+const MAXIMUM = Number(POLICY_FIELDS.OTHER_COMPANY_TO_INSURE_NAME_TBC[FIELD_ID].MAXIMUM);
+
+/**
+ * validate the "company number" in other company details response body
+ * @param {Express.Request.body} responseBody containing an object with the company details response
+ * @param {Object} errors errorList
+ * @returns {object} object containing errors or blank object
+ */
+const companyNumber = (responseBody: RequestBody, errors: object) => {
+  if (objectHasProperty(responseBody, FIELD_ID)) {
+    return maxLengthValidation(responseBody[FIELD_ID], FIELD_ID, ERROR_MESSAGE, errors, MAXIMUM);
+  }
+
+  return errors;
+};
+
+export default companyNumber;

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/country/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/country/index.test.ts
@@ -1,0 +1,29 @@
+import country from '.';
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import emptyFieldValidation from '../../../../../../../shared-validation/empty-field';
+import { mockErrors, mockCountries } from '../../../../../../../test-mocks';
+
+const {
+  OTHER_COMPANY_TO_INSURE_NAME_TBC: { COUNTRY: FIELD_ID },
+} = POLICY_FIELD_IDS;
+
+const {
+  OTHER_COMPANY_TO_INSURE_NAME_TBC: {
+    [FIELD_ID]: { IS_EMPTY: ERROR_MESSAGE },
+  },
+} = ERROR_MESSAGES.INSURANCE.POLICY;
+
+describe('controllers/insurance/policy/other-company-details/validation/rules/country', () => {
+  const mockBody = {
+    [FIELD_ID]: mockCountries[0].name,
+  };
+
+  it('should return the result of providedAndMaxLength', () => {
+    const result = country(mockBody, mockErrors);
+
+    const expected = emptyFieldValidation(mockBody, FIELD_ID, ERROR_MESSAGE, mockErrors);
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/country/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/country/index.ts
@@ -1,0 +1,24 @@
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import emptyFieldValidation from '../../../../../../../shared-validation/empty-field';
+import { RequestBody } from '../../../../../../../../types';
+
+const {
+  OTHER_COMPANY_TO_INSURE_NAME_TBC: { COUNTRY: FIELD_ID },
+} = POLICY_FIELD_IDS;
+
+const {
+  OTHER_COMPANY_TO_INSURE_NAME_TBC: {
+    [FIELD_ID]: { IS_EMPTY: ERROR_MESSAGE },
+  },
+} = ERROR_MESSAGES.INSURANCE.POLICY;
+
+/**
+ * validate the "country" in other company details response body
+ * @param {Express.Request.body} responseBody containing an object with the company details response
+ * @param {Object} errors errorList
+ * @returns {object} object containing errors or blank object
+ */
+const country = (responseBody: RequestBody, errors: object) => emptyFieldValidation(responseBody, FIELD_ID, ERROR_MESSAGE, errors);
+
+export default country;

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/index.ts
@@ -1,0 +1,10 @@
+import companyNameRule from './company-name';
+import countryRule from './country';
+import companyNumberRule from './company-number';
+import { ValidationErrors } from '../../../../../../../types';
+
+const rules = [companyNameRule, countryRule, companyNumberRule];
+
+const validationRules = rules as Array<() => ValidationErrors>;
+
+export default validationRules;

--- a/src/ui/server/shared-validation/alpha-characters-and-max-length/index.test.ts
+++ b/src/ui/server/shared-validation/alpha-characters-and-max-length/index.test.ts
@@ -14,7 +14,7 @@ describe('shared-validation/alpha-characters-and-max-length', () => {
     [FIELD_ID]: '',
   } as RequestBody;
 
-  describe('when a name is empty', () => {
+  describe('when a value is empty', () => {
     it('should return the result of emptyFieldValidation', () => {
       const result = alphaCharactersAndMaxLength(mockBody, FIELD_ID, mockErrorMessagesObject, mockErrors, mockMaxLength);
 
@@ -24,7 +24,7 @@ describe('shared-validation/alpha-characters-and-max-length', () => {
     });
   });
 
-  describe('when a name contains a special character', () => {
+  describe('when a value contains a special character', () => {
     it('should return the result of alphaCharactersOnlyValidation', () => {
       mockBody[FIELD_ID] = 'a!';
 
@@ -36,7 +36,7 @@ describe('shared-validation/alpha-characters-and-max-length', () => {
     });
   });
 
-  describe('when a name contains a number', () => {
+  describe('when a value contains a number', () => {
     it('should return the result of alphaCharactersOnlyValidation', () => {
       mockBody[FIELD_ID] = 'a1';
 
@@ -48,7 +48,7 @@ describe('shared-validation/alpha-characters-and-max-length', () => {
     });
   });
 
-  describe('when a name is over the maximum', () => {
+  describe('when a value is over the maximum', () => {
     it('should return the result of maxLengthValidation', () => {
       mockBody[FIELD_ID] = 'a'.repeat(mockMaxLength + 1);
 
@@ -60,7 +60,7 @@ describe('shared-validation/alpha-characters-and-max-length', () => {
     });
   });
 
-  describe('when a name is valid', () => {
+  describe('when a value is valid', () => {
     it('should return the provided errors', () => {
       mockBody[FIELD_ID] = 'Mock name';
 

--- a/src/ui/server/shared-validation/provided-and-max-length/index.test.ts
+++ b/src/ui/server/shared-validation/provided-and-max-length/index.test.ts
@@ -1,0 +1,47 @@
+import providedAndMaxLength from '.';
+import maxLengthValidation from '../max-length';
+import emptyFieldValidation from '../empty-field';
+import { RequestBody } from '../../../types';
+import { mockErrors, mockErrorMessagesObject } from '../../test-mocks';
+
+const mockMaxLength = 20;
+
+describe('shared-validation/alpha-characters-and-max-length', () => {
+  const FIELD_ID = 'field';
+
+  const mockBody = {
+    [FIELD_ID]: '',
+  } as RequestBody;
+
+  describe('when a value is empty', () => {
+    it('should return the result of emptyFieldValidation', () => {
+      const result = providedAndMaxLength(mockBody, FIELD_ID, mockErrorMessagesObject, mockErrors, mockMaxLength);
+
+      const expected = emptyFieldValidation(mockBody, FIELD_ID, mockErrorMessagesObject.IS_EMPTY, mockErrors);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a value is over the maximum', () => {
+    it('should return the result of maxLengthValidation', () => {
+      mockBody[FIELD_ID] = 'a'.repeat(mockMaxLength + 1);
+
+      const result = providedAndMaxLength(mockBody, FIELD_ID, mockErrorMessagesObject, mockErrors, mockMaxLength);
+
+      const expected = maxLengthValidation(mockBody[FIELD_ID], FIELD_ID, mockErrorMessagesObject.ABOVE_MAXIMUM, mockErrors, mockMaxLength);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a value is valid', () => {
+    it('should return the provided errors', () => {
+      mockBody[FIELD_ID] = 'Mock name';
+
+      const result = providedAndMaxLength(mockBody, FIELD_ID, mockErrorMessagesObject, mockErrors, mockMaxLength);
+
+      expect(result).toEqual(mockErrors);
+    });
+  });
+});

--- a/src/ui/server/shared-validation/provided-and-max-length/index.ts
+++ b/src/ui/server/shared-validation/provided-and-max-length/index.ts
@@ -1,0 +1,27 @@
+import { objectHasProperty } from '../../helpers/object';
+import maxLengthValidation from '../max-length';
+import emptyFieldValidation from '../empty-field';
+import { RequestBody, ErrorMessageObject } from '../../../types';
+
+/**
+ * providedAndMaxLength
+ * Check if a field is:
+ * 1) Provided
+ * 2) Is not over a maximum length
+ * Returns generateValidationErrors if there are any errors.
+ * @param {RequestBody} formBody: Form body
+ * @param {String} fieldId: Field ID
+ * @param {String} errorMessage: Error message message
+ * @param {Object} errors: Object from previous validation errors
+ * @param {Integer} maxLength: Maximum length of characters
+ * @returns {Object} Validation errors
+ */
+const providedAndMaxLength = (formBody: RequestBody, fieldId: string, errorMessages: ErrorMessageObject, errors: object, maxLength: number) => {
+  if (!objectHasProperty(formBody, fieldId)) {
+    return emptyFieldValidation(formBody, fieldId, errorMessages.IS_EMPTY, errors);
+  }
+
+  return maxLengthValidation(formBody[fieldId], fieldId, errorMessages.ABOVE_MAXIMUM, errors, maxLength);
+};
+
+export default providedAndMaxLength;

--- a/src/ui/templates/insurance/policy/other-company-details.njk
+++ b/src/ui/templates/insurance/policy/other-company-details.njk
@@ -18,12 +18,21 @@
     }
   }) }}
 
+  {% if validationErrors.summary %}
+    {{ govukErrorSummary({
+      titleText: CONTENT_STRINGS.ERROR_MESSAGES.THERE_IS_A_PROBLEM,
+      errorList: validationErrors.summary,
+      attributes: {
+        'data-cy': 'error-summary'
+      }
+    }) }}
+  {% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
       <span class="govuk-caption-xl" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
 
       <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
-
     </div>
   </div>
 


### PR DESCRIPTION
# ⚠️ WIP / blocked

Need [this PR](https://github.com/UK-Export-Finance/exip/pull/1851) merged first.

## Introduction :pencil2:
This PR adds validation to the"Other company details" form in the policy section of a no PDF application.

## Resolution :heavy_check_mark:
- Update error message content strings.
- Add E2E test coverage.
- Update UI POST controller.
- Add validation rules.

## Miscellaneous :heavy_plus_sign:
- Fix some test description typos.
