### PR TITLE
chore(validation): No PDF - Clean UI validation rules

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -194,6 +194,7 @@ export const ERROR_MESSAGES = {
             INVALID_DATE: 'Policy completion date must be a real date',
           },
           [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.SINGLE.TOTAL_CONTRACT_VALUE]: {
+            IS_EMPTY: 'Enter the total value of the contract you want to insure as a whole number - do not enter decimals',
             INCORRECT_FORMAT: 'Enter the total value of the contract you want to insure as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'The total value of the contract you want to insure must be 1 or more',
           },
@@ -210,10 +211,13 @@ export const ERROR_MESSAGES = {
       EXPORT_VALUE: {
         MULTIPLE: {
           [FIELD_IDS.INSURANCE.POLICY.EXPORT_VALUE.MULTIPLE.TOTAL_SALES_TO_BUYER]: {
+            IS_EMPTY: 'Enter your estimated total sales to your buyer during this time as a whole number - do not enter decimals',
             INCORRECT_FORMAT: 'Enter your estimated total sales to your buyer during this time as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your total sales must be 1 or more',
           },
           [FIELD_IDS.INSURANCE.POLICY.EXPORT_VALUE.MULTIPLE.MAXIMUM_BUYER_WILL_OWE]: {
+            IS_EMPTY:
+              'Enter your estimate for the maximum amount your buyer will owe you at any single point during this time as a whole number - do not enter decimals',
             INCORRECT_FORMAT:
               'Enter your estimate for the maximum amount your buyer will owe you at any single point during this time as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your estimated maximum amount your buyer will owe you at any single point during this time must be 1 or more',

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "husky": "^9.0.8",
         "jest": "^29.7.0",
         "lint-staged": "^15.2.1",
-        "prettier": "^3.2.4",
+        "prettier": "^3.2.5",
         "sort-package-json": "^2.7.0",
         "ts-jest": "^29.1.2",
         "typescript": "^5.3.3"
@@ -17144,9 +17144,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
-      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "husky": "^9.0.8",
     "jest": "^29.7.0",
     "lint-staged": "^15.2.1",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "sort-package-json": "^2.7.0",
     "ts-jest": "^29.1.2",
     "typescript": "^5.3.3"

--- a/src/api/package-lock.json
+++ b/src/api/package-lock.json
@@ -51,7 +51,7 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-prettier": "5.1.3",
         "jest": "^29.7.0",
-        "prettier": "^3.2.4",
+        "prettier": "^3.2.5",
         "spectaql": "^2.3.0",
         "ts-jest": "^29.1.2"
       },
@@ -20756,9 +20756,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
-      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-prettier": "5.1.3",
     "jest": "^29.7.0",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "spectaql": "^2.3.0",
     "ts-jest": "^29.1.2"
   },

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -80,7 +80,7 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-prettier": "5.1.3",
         "jest": "29.6.2",
-        "prettier": "^3.2.4",
+        "prettier": "^3.2.5",
         "ts-jest": "^29.1.2"
       },
       "engines": {
@@ -11671,9 +11671,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
-      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -93,7 +93,7 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-prettier": "5.1.3",
     "jest": "29.6.2",
-    "prettier": "^3.2.4",
+    "prettier": "^3.2.5",
     "ts-jest": "^29.1.2"
   },
   "engines": {

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -193,6 +193,7 @@ export const ERROR_MESSAGES = {
             INVALID_DATE: 'Policy completion date must be a real date',
           },
           [FIELD_IDS.INSURANCE.POLICY.CONTRACT_POLICY.SINGLE.TOTAL_CONTRACT_VALUE]: {
+            IS_EMPTY: 'Enter the total value of the contract you want to insure as a whole number - do not enter decimals',
             INCORRECT_FORMAT: 'Enter the total value of the contract you want to insure as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'The total value of the contract you want to insure must be 1 or more',
           },
@@ -209,10 +210,13 @@ export const ERROR_MESSAGES = {
       EXPORT_VALUE: {
         MULTIPLE: {
           [FIELD_IDS.INSURANCE.POLICY.EXPORT_VALUE.MULTIPLE.TOTAL_SALES_TO_BUYER]: {
+            IS_EMPTY: 'Enter your estimated total sales to your buyer during this time as a whole number - do not enter decimals',
             INCORRECT_FORMAT: 'Enter your estimated total sales to your buyer during this time as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your total sales must be 1 or more',
           },
           [FIELD_IDS.INSURANCE.POLICY.EXPORT_VALUE.MULTIPLE.MAXIMUM_BUYER_WILL_OWE]: {
+            IS_EMPTY:
+              'Enter your estimate for the maximum amount your buyer will owe you at any single point during this time as a whole number - do not enter decimals',
             INCORRECT_FORMAT:
               'Enter your estimate for the maximum amount your buyer will owe you at any single point during this time as a whole number - do not enter decimals',
             BELOW_MINIMUM: 'Your estimated maximum amount your buyer will owe you at any single point during this time must be 1 or more',

--- a/src/ui/server/controllers/insurance/business/alternative-trading-address/validation/rules/alternative-trading-address.ts
+++ b/src/ui/server/controllers/insurance/business/alternative-trading-address/validation/rules/alternative-trading-address.ts
@@ -16,17 +16,17 @@ export const MAXIMUM = 1000;
 /**
  * validates alternative trading address input
  * errors if empty or more than 1000 characters
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const alternativeTradingAddress = (responseBody: RequestBody, errors: object) => {
+const alternativeTradingAddress = (formBody: RequestBody, errors: object) => {
   // if body is empty
-  if (!objectHasProperty(responseBody, FIELD_ID)) {
+  if (!objectHasProperty(formBody, FIELD_ID)) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
   }
 
-  return maxLengthValidation(responseBody[FIELD_ID], FIELD_ID, ERROR_MESSAGE.ABOVE_MAXIMUM, errors, MAXIMUM);
+  return maxLengthValidation(formBody[FIELD_ID], FIELD_ID, ERROR_MESSAGE.ABOVE_MAXIMUM, errors, MAXIMUM);
 };
 
 export default alternativeTradingAddress;

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/company-website.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/company-website.ts
@@ -12,17 +12,17 @@ const {
 const { EXPORTER_BUSINESS } = ERROR_MESSAGES.INSURANCE;
 /**
  * validates website input is the correct format
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const companyWebsite = (responseBody: RequestBody, errors: object) => {
+const companyWebsite = (formBody: RequestBody, errors: object) => {
   let updatedErrors = errors;
 
   // as field is optional, only validate if it is not an empty string
-  if (objectHasProperty(responseBody, WEBSITE)) {
+  if (objectHasProperty(formBody, WEBSITE)) {
     // adds 'http://' to url for validation
-    const url = isStringWithHttp(responseBody[WEBSITE]);
+    const url = isStringWithHttp(formBody[WEBSITE]);
     const errorMessage = EXPORTER_BUSINESS[WEBSITE].INCORRECT_FORMAT;
     // validates input
     updatedErrors = validateWebsiteAddress(url, WEBSITE, errorMessage, updatedErrors);

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/different-trading-name.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/different-trading-name.ts
@@ -14,14 +14,14 @@ const {
 /**
  * validates alternative trading name field
  * checks if response has been provided
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const differentTradingName = (responseBody: RequestBody, errors: object) => {
+const differentTradingName = (formBody: RequestBody, errors: object) => {
   // if HAS_DIFFERENT_TRADING_NAME radio is yes then check validation
-  if (responseBody[HAS_DIFFERENT_TRADING_NAME] === 'true') {
-    return emptyFieldValidation(responseBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+  if (formBody[HAS_DIFFERENT_TRADING_NAME] === 'true') {
+    return emptyFieldValidation(formBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
   }
 
   return errors;

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/phone-number.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/phone-number.ts
@@ -12,18 +12,18 @@ const { EXPORTER_BUSINESS } = ERROR_MESSAGES.INSURANCE;
 
 /**
  * validates phone number input is the correct format
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const phoneNumber = (responseBody: RequestBody, errors: object) => {
+const phoneNumber = (formBody: RequestBody, errors: object) => {
   let updatedErrors = errors;
 
   // as field is optional, only validate if it is not an empty string
-  if (objectHasProperty(responseBody, PHONE_NUMBER)) {
+  if (objectHasProperty(formBody, PHONE_NUMBER)) {
     const errorMessage = EXPORTER_BUSINESS[PHONE_NUMBER].INCORRECT_FORMAT;
     // validates input
-    updatedErrors = validatePhoneNumber(responseBody[PHONE_NUMBER], PHONE_NUMBER, errorMessage, updatedErrors);
+    updatedErrors = validatePhoneNumber(formBody[PHONE_NUMBER], PHONE_NUMBER, errorMessage, updatedErrors);
   }
 
   return updatedErrors;

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-address.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-address.ts
@@ -18,6 +18,6 @@ const ERROR_MESSAGE = EXPORTER_BUSINESS[FIELD_ID];
  * @param {Object} errors errorList
  * @returns {object} object containing errors or blank object
  */
-const tradingAddress = (responseBody: RequestBody, errors: object) => emptyFieldValidation(responseBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+const tradingAddress = (formBody: RequestBody, errors: object) => emptyFieldValidation(formBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
 
 export default tradingAddress;

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-name.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-name.ts
@@ -18,6 +18,6 @@ const ERROR_MESSAGE = EXPORTER_BUSINESS[FIELD_ID];
  * @param {Object} errors errorList
  * @returns {object} object containing errors or blank object
  */
-const tradingName = (responseBody: RequestBody, errors: object) => emptyFieldValidation(responseBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+const tradingName = (formBody: RequestBody, errors: object) => emptyFieldValidation(formBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
 
 export default tradingName;

--- a/src/ui/server/controllers/insurance/business/nature-of-business/validation/rules/employees-uk.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/validation/rules/employees-uk.ts
@@ -20,18 +20,18 @@ const MINIMUM = 1;
 /**
  * validates number of uk employees input
  * only allows number without decimal
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const employeesUK = (responseBody: RequestBody, errors: object) => {
-  if (!objectHasProperty(responseBody, FIELD_ID)) {
+const employeesUK = (formBody: RequestBody, errors: object) => {
+  if (!objectHasProperty(formBody, FIELD_ID)) {
     const errorMessage = ERROR_MESSAGE.IS_EMPTY;
 
     return generateValidationErrors(FIELD_ID, errorMessage, errors);
   }
 
-  const value = responseBody[FIELD_ID];
+  const value = formBody[FIELD_ID];
   const valueWithoutCommas = stripCommas(value);
 
   // checks if value is below set minimum
@@ -42,7 +42,7 @@ const employeesUK = (responseBody: RequestBody, errors: object) => {
   }
 
   const errorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
-  return wholeNumberValidation(responseBody, errors, errorMessage, FIELD_ID);
+  return wholeNumberValidation(formBody, errors, errorMessage, FIELD_ID);
 };
 
 export default employeesUK;

--- a/src/ui/server/controllers/insurance/business/nature-of-business/validation/rules/goods-or-services.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/validation/rules/goods-or-services.ts
@@ -17,18 +17,18 @@ export const MAXIMUM = 1000;
 /**
  * validates goods or services input
  * errors if empty or more than 1000 characters
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const goodsOrServices = (responseBody: RequestBody, errors: object) => {
+const goodsOrServices = (formBody: RequestBody, errors: object) => {
   // if body is empty
-  if (!objectHasProperty(responseBody, FIELD_ID)) {
+  if (!objectHasProperty(formBody, FIELD_ID)) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
   }
 
   // check if the field is above the maximum
-  if (responseBody[FIELD_ID].length > MAXIMUM) {
+  if (formBody[FIELD_ID].length > MAXIMUM) {
     return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.ABOVE_MAXIMUM, errors);
   }
 

--- a/src/ui/server/controllers/insurance/business/nature-of-business/validation/rules/years-exporting.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/validation/rules/years-exporting.ts
@@ -16,19 +16,19 @@ const {
 /**
  * validates years exporting input
  * only allows number without decimal
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const yearsExporting = (responseBody: RequestBody, errors: object) => {
-  if (!objectHasProperty(responseBody, FIELD_ID)) {
+const yearsExporting = (formBody: RequestBody, errors: object) => {
+  if (!objectHasProperty(formBody, FIELD_ID)) {
     const errorMessage = ERROR_MESSAGE.IS_EMPTY;
 
     return generateValidationErrors(FIELD_ID, errorMessage, errors);
   }
 
   const errorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
-  return wholeNumberValidation(responseBody, errors, errorMessage, FIELD_ID);
+  return wholeNumberValidation(formBody, errors, errorMessage, FIELD_ID);
 };
 
 export default yearsExporting;

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/estimated-annual-turnover.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/estimated-annual-turnover.ts
@@ -16,12 +16,12 @@ const {
 /**
  * validates number of estimated annual turnover input
  * only allows number without decimal
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const estimatedAnnualTurnover = (responseBody: RequestBody, errors: object) => {
-  if (!objectHasProperty(responseBody, FIELD_ID)) {
+const estimatedAnnualTurnover = (formBody: RequestBody, errors: object) => {
+  if (!objectHasProperty(formBody, FIELD_ID)) {
     const errorMessage = ERROR_MESSAGE.IS_EMPTY;
 
     return generateValidationErrors(FIELD_ID, errorMessage, errors);
@@ -31,7 +31,7 @@ const estimatedAnnualTurnover = (responseBody: RequestBody, errors: object) => {
 
   const allowNegativeValue = true;
 
-  return wholeNumberValidation(responseBody, errors, errorMessage, FIELD_ID, allowNegativeValue);
+  return wholeNumberValidation(formBody, errors, errorMessage, FIELD_ID, allowNegativeValue);
 };
 
 export default estimatedAnnualTurnover;

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.ts
@@ -22,10 +22,10 @@ const errorMessages = {
  * validates percentage turnover
  * only numbers without decimals, special characters or commas
  * only allows numbers between 0 and 100
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const percentageTurnover = (responseBody: RequestBody, errors: object) => percentageNumberValidation(responseBody, FIELD_ID, errors, errorMessages);
+const percentageTurnover = (formBody: RequestBody, errors: object) => percentageNumberValidation(formBody, FIELD_ID, errors, errorMessages);
 
 export default percentageTurnover;

--- a/src/ui/server/controllers/insurance/feedback/feedback-form/validation/rules/improve-service.ts
+++ b/src/ui/server/controllers/insurance/feedback/feedback-form/validation/rules/improve-service.ts
@@ -15,15 +15,15 @@ export const MAXIMUM = 1200;
 /**
  * validates improve service field
  * checks if answer has been provided
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const improveService = (responseBody: RequestBody, errors: object) => {
+const improveService = (formBody: RequestBody, errors: object) => {
   // if field has a value
-  if (objectHasProperty(responseBody, FIELD_ID)) {
+  if (objectHasProperty(formBody, FIELD_ID)) {
     // checks field is not over maximum characters
-    return maxLengthValidation(responseBody[FIELD_ID], FIELD_ID, ERROR_MESSAGE, errors, MAXIMUM);
+    return maxLengthValidation(formBody[FIELD_ID], FIELD_ID, ERROR_MESSAGE, errors, MAXIMUM);
   }
 
   return errors;

--- a/src/ui/server/controllers/insurance/feedback/feedback-form/validation/rules/other-comments.ts
+++ b/src/ui/server/controllers/insurance/feedback/feedback-form/validation/rules/other-comments.ts
@@ -15,15 +15,15 @@ export const MAXIMUM = 1200;
 /**
  * validates other comments field
  * checks if answer has been provided
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const otherComments = (responseBody: RequestBody, errors: object) => {
+const otherComments = (formBody: RequestBody, errors: object) => {
   // if field has a value
-  if (objectHasProperty(responseBody, FIELD_ID)) {
+  if (objectHasProperty(formBody, FIELD_ID)) {
     // checks field is not over maximum characters
-    return maxLengthValidation(responseBody[FIELD_ID], FIELD_ID, ERROR_MESSAGE, errors, MAXIMUM);
+    return maxLengthValidation(formBody[FIELD_ID], FIELD_ID, ERROR_MESSAGE, errors, MAXIMUM);
   }
 
   return errors;

--- a/src/ui/server/controllers/insurance/policy/broker/validation/rules/broker-address-line-one.ts
+++ b/src/ui/server/controllers/insurance/policy/broker/validation/rules/broker-address-line-one.ts
@@ -14,13 +14,13 @@ const {
 /**
  * validates address line 1 field
  * checks if response has been provided
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const brokerAddressLineOne = (responseBody: RequestBody, errors: object) => {
-  if (responseBody[USING_BROKER] === true) {
-    return emptyFieldValidation(responseBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+const brokerAddressLineOne = (formBody: RequestBody, errors: object) => {
+  if (formBody[USING_BROKER] === true) {
+    return emptyFieldValidation(formBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
   }
 
   return errors;

--- a/src/ui/server/controllers/insurance/policy/broker/validation/rules/broker-email.ts
+++ b/src/ui/server/controllers/insurance/policy/broker/validation/rules/broker-email.ts
@@ -14,16 +14,16 @@ const {
 /**
  * validates email field
  * checks if response has been provided
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const brokerEmail = (responseBody: RequestBody, errors: object) => {
-  if (responseBody[USING_BROKER] === true) {
+const brokerEmail = (formBody: RequestBody, errors: object) => {
+  if (formBody[USING_BROKER] === true) {
     const errorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
 
     // checks email is valid
-    return emailValidation(FIELD_ID, responseBody[FIELD_ID], errorMessage, errors);
+    return emailValidation(FIELD_ID, formBody[FIELD_ID], errorMessage, errors);
   }
 
   return errors;

--- a/src/ui/server/controllers/insurance/policy/broker/validation/rules/broker-name.ts
+++ b/src/ui/server/controllers/insurance/policy/broker/validation/rules/broker-name.ts
@@ -14,14 +14,14 @@ const {
 /**
  * validates broker name field
  * checks if response has been provided
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const brokerName = (responseBody: RequestBody, errors: object) => {
+const brokerName = (formBody: RequestBody, errors: object) => {
   // if USING_BROKER radio is yes then check validation
-  if (responseBody[USING_BROKER] === true) {
-    return emptyFieldValidation(responseBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+  if (formBody[USING_BROKER] === true) {
+    return emptyFieldValidation(formBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
   }
 
   return errors;

--- a/src/ui/server/controllers/insurance/policy/broker/validation/rules/broker-postcode.ts
+++ b/src/ui/server/controllers/insurance/policy/broker/validation/rules/broker-postcode.ts
@@ -14,14 +14,14 @@ const {
 /**
  * validates postcode field
  * checks if response has been provided
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const brokerPostcode = (responseBody: RequestBody, errors: object) => {
-  if (responseBody[USING_BROKER] === true) {
+const brokerPostcode = (formBody: RequestBody, errors: object) => {
+  if (formBody[USING_BROKER] === true) {
     // validates if postcode is empty or the wrong format
-    return postCodeValidation(FIELD_ID, responseBody[FIELD_ID], ERROR_MESSAGE.IS_EMPTY, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
+    return postCodeValidation(FIELD_ID, formBody[FIELD_ID], ERROR_MESSAGE.IS_EMPTY, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
   }
 
   return errors;

--- a/src/ui/server/controllers/insurance/policy/broker/validation/rules/broker-town.ts
+++ b/src/ui/server/controllers/insurance/policy/broker/validation/rules/broker-town.ts
@@ -14,14 +14,14 @@ const {
 /**
  * validates broker town field
  * checks if response has been provided
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const brokerTown = (responseBody: RequestBody, errors: object) => {
+const brokerTown = (formBody: RequestBody, errors: object) => {
   // if USING_BROKER radio is yes then check validation
-  if (responseBody[USING_BROKER] === true) {
-    return emptyFieldValidation(responseBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+  if (formBody[USING_BROKER] === true) {
+    return emptyFieldValidation(formBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
   }
 
   return errors;

--- a/src/ui/server/controllers/insurance/policy/broker/validation/rules/using-broker.ts
+++ b/src/ui/server/controllers/insurance/policy/broker/validation/rules/using-broker.ts
@@ -14,20 +14,20 @@ const {
 /**
  * validates using broker field
  * checks if response has been provided
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const isUsingBrokerRules = (responseBody: RequestBody, errors: object) => {
+const isUsingBrokerRules = (formBody: RequestBody, errors: object) => {
   /**
    * Answer is allowed to be false
    * Since this is a yes/no question
    */
-  if (responseBody[FIELD_ID] === false) {
+  if (formBody[FIELD_ID] === false) {
     return errors;
   }
 
-  return emptyFieldValidation(responseBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+  return emptyFieldValidation(formBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
 };
 
 export default isUsingBrokerRules;

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/email-address.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/email-address.ts
@@ -14,10 +14,10 @@ const errorMessage = ERROR_MESSAGE.INCORRECT_FORMAT;
 /**
  * validates email field
  * checks if response has been provided
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const emailAddress = (responseBody: RequestBody, errors: object) => emailValidation(FIELD_ID, responseBody[FIELD_ID], errorMessage, errors);
+const emailAddress = (formBody: RequestBody, errors: object) => emailValidation(FIELD_ID, formBody[FIELD_ID], errorMessage, errors);
 
 export default emailAddress;

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/first-name.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/first-name.ts
@@ -12,10 +12,10 @@ const {
 /**
  * validates last name field
  * checks if response has been provided
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const firstName = (responseBody: RequestBody, errors: object) => nameValidation(responseBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
+const firstName = (formBody: RequestBody, errors: object) => nameValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
 
 export default firstName;

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/last-name.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/last-name.ts
@@ -12,10 +12,10 @@ const {
 /**
  * validates last name field
  * checks if response has been provided
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const lastName = (responseBody: RequestBody, errors: object) => nameValidation(responseBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
+const lastName = (formBody: RequestBody, errors: object) => nameValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
 
 export default lastName;

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/position.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/position.ts
@@ -14,10 +14,10 @@ const {
 /**
  * validates position field
  * checks if response has been provided
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @returns {object} errors
  */
-const position = (responseBody: RequestBody, errors: object) => emptyFieldValidation(responseBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+const position = (formBody: RequestBody, errors: object) => emptyFieldValidation(formBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
 
 export default position;

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/validation/rules/maximum-buyer-will-owe.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/validation/rules/maximum-buyer-will-owe.test.ts
@@ -1,7 +1,7 @@
-import maximumBuyerWillOweRules from './maximum-buyer-will-owe';
+import maximumBuyerWillOweRules, { MINIMUM } from './maximum-buyer-will-owe';
 import INSURANCE_FIELD_IDS from '../../../../../../../constants/field-ids/insurance';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../../helpers/validation';
+import wholeNumberAboveMinimumValidation from '../../../../../../../shared-validation/whole-number-above-minimum';
 import { mockErrors } from '../../../../../../../test-mocks';
 
 const {
@@ -16,102 +16,20 @@ const {
   INSURANCE: {
     POLICY: {
       EXPORT_VALUE: {
-        MULTIPLE: { [FIELD_ID]: ERROR_MESSAGE },
+        MULTIPLE: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
       },
     },
   },
 } = ERROR_MESSAGES;
 
 describe('controllers/insurance/policy/multiple-contract-policy/export-value/validation/rules/maximum-buyer-will-owe', () => {
-  describe('when the field is not provided', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {};
+  it('should return the result of wholeNumberAboveMinimumValidation', () => {
+    const mockSubmittedData = {};
 
-      const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
+    const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
+    const expected = wholeNumberAboveMinimumValidation(mockSubmittedData, FIELD_ID, ERROR_MESSAGES_OBJECT, mockErrors, MINIMUM);
 
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when maximum buyer will owe is not a number', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: 'One hundred!',
-      };
-
-      const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when maximum buyer will owe contains a decimal', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '123.456',
-      };
-
-      const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when maximum buyer will owe contains a comma and decimal', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '123,456.78',
-      };
-
-      const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when maximum buyer will owe is below the minimum', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '0',
-      };
-
-      const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when there are no validation errors', () => {
-    it('should return the provided errors object', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '10000',
-      };
-
-      const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
-
-      expect(result).toEqual(mockErrors);
-    });
-  });
-
-  describe('when there are no validation errors and the value contains a comma', () => {
-    it('should return the provided errors object', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '10,000',
-      };
-
-      const result = maximumBuyerWillOweRules(mockSubmittedData, mockErrors);
-
-      expect(result).toEqual(mockErrors);
-    });
+    expect(result).toEqual(expected);
   });
 });

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/validation/rules/maximum-buyer-will-owe.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/validation/rules/maximum-buyer-will-owe.ts
@@ -1,9 +1,7 @@
 import INSURANCE_FIELD_IDS from '../../../../../../../constants/field-ids/insurance';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../../helpers/validation';
-import { objectHasProperty } from '../../../../../../../helpers/object';
-import { RequestBody } from '../../../../../../../../types';
 import wholeNumberAboveMinimumValidation from '../../../../../../../shared-validation/whole-number-above-minimum';
+import { RequestBody } from '../../../../../../../../types';
 
 const {
   POLICY: {
@@ -17,13 +15,13 @@ const {
   INSURANCE: {
     POLICY: {
       EXPORT_VALUE: {
-        MULTIPLE: { [FIELD_ID]: ERROR_MESSAGE },
+        MULTIPLE: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
       },
     },
   },
 } = ERROR_MESSAGES;
 
-const MINIMUM = 1;
+export const MINIMUM = 1;
 
 /**
  * maximumBuyerWillOweRules
@@ -33,14 +31,7 @@ const MINIMUM = 1;
  * @param {Object} Errors object from previous validation errors
  * @returns {Object} Validation errors
  */
-const maximumBuyerWillOweRules = (formBody: RequestBody, errors: object) => {
-  // check if the field is empty.
-  if (!objectHasProperty(formBody, FIELD_ID)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
-  }
-
-  // checks if value is a whole number or below minimum
-  return wholeNumberAboveMinimumValidation(formBody, FIELD_ID, ERROR_MESSAGE, errors, MINIMUM);
-};
+const maximumBuyerWillOweRules = (formBody: RequestBody, errors: object) =>
+  wholeNumberAboveMinimumValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MINIMUM);
 
 export default maximumBuyerWillOweRules;

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/validation/rules/total-sales-to-buyer.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/validation/rules/total-sales-to-buyer.test.ts
@@ -1,7 +1,7 @@
-import totalSalesToBuyerRules from './total-sales-to-buyer';
+import totalSalesToBuyerRules, { MINIMUM } from './total-sales-to-buyer';
 import INSURANCE_FIELD_IDS from '../../../../../../../constants/field-ids/insurance';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../../helpers/validation';
+import wholeNumberAboveMinimumValidation from '../../../../../../../shared-validation/whole-number-above-minimum';
 import { mockErrors } from '../../../../../../../test-mocks';
 
 const {
@@ -16,102 +16,20 @@ const {
   INSURANCE: {
     POLICY: {
       EXPORT_VALUE: {
-        MULTIPLE: { [FIELD_ID]: ERROR_MESSAGE },
+        MULTIPLE: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
       },
     },
   },
 } = ERROR_MESSAGES;
 
 describe('controllers/insurance/policy/multiple-contract-policy/export-value/validation/rules/total-sales-to-buyer', () => {
-  describe('when the field is not provided', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {};
+  it('should return the result of wholeNumberAboveMinimumValidation', () => {
+    const mockSubmittedData = {};
 
-      const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
+    const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
+    const expected = wholeNumberAboveMinimumValidation(mockSubmittedData, FIELD_ID, ERROR_MESSAGES_OBJECT, mockErrors, MINIMUM);
 
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when total sales to buyer is not a number', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: 'One hundred!',
-      };
-
-      const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when total sales to buyer contains a decimal', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '123.456',
-      };
-
-      const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when total sales to buyer contains a comma and decimal', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '123,456.78',
-      };
-
-      const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when total sales to buyer is below the minimum', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '0',
-      };
-
-      const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when there are no validation errors', () => {
-    it('should return the provided errors object', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '10,000',
-      };
-
-      const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
-
-      expect(result).toEqual(mockErrors);
-    });
-  });
-
-  describe('when there are no validation errors and the value contains a comma', () => {
-    it('should return the provided errors object', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '10,000',
-      };
-
-      const result = totalSalesToBuyerRules(mockSubmittedData, mockErrors);
-
-      expect(result).toEqual(mockErrors);
-    });
+    expect(result).toEqual(expected);
   });
 });

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/validation/rules/total-sales-to-buyer.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/validation/rules/total-sales-to-buyer.ts
@@ -1,9 +1,7 @@
 import INSURANCE_FIELD_IDS from '../../../../../../../constants/field-ids/insurance';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../../helpers/validation';
-import { objectHasProperty } from '../../../../../../../helpers/object';
-import { RequestBody } from '../../../../../../../../types';
 import wholeNumberAboveMinimumValidation from '../../../../../../../shared-validation/whole-number-above-minimum';
+import { RequestBody } from '../../../../../../../../types';
 
 const {
   POLICY: {
@@ -17,13 +15,13 @@ const {
   INSURANCE: {
     POLICY: {
       EXPORT_VALUE: {
-        MULTIPLE: { [FIELD_ID]: ERROR_MESSAGE },
+        MULTIPLE: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
       },
     },
   },
 } = ERROR_MESSAGES;
 
-const MINIMUM = 1;
+export const MINIMUM = 1;
 
 /**
  * totalSalesToBuyerRules
@@ -33,14 +31,7 @@ const MINIMUM = 1;
  * @param {Object} Errors object from previous validation errors
  * @returns {Object} Validation errors
  */
-const totalSalesToBuyerRules = (formBody: RequestBody, errors: object) => {
-  // check if the field is empty.
-  if (!objectHasProperty(formBody, FIELD_ID)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
-  }
-
-  // checks if value is whole number or below minimum
-  return wholeNumberAboveMinimumValidation(formBody, FIELD_ID, ERROR_MESSAGE, errors, MINIMUM);
-};
+const totalSalesToBuyerRules = (formBody: RequestBody, errors: object) =>
+  wholeNumberAboveMinimumValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MINIMUM);
 
 export default totalSalesToBuyerRules;

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/validation/rules/total-contract-value.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/validation/rules/total-contract-value.test.ts
@@ -1,8 +1,11 @@
 import totalContractValueRules from './total-contract-value';
+import { APPLICATION } from '../../../../../../../constants';
 import INSURANCE_FIELD_IDS from '../../../../../../../constants/field-ids/insurance';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../../helpers/validation';
+import wholeNumberAboveMinimumValidation from '../../../../../../../shared-validation/whole-number-above-minimum';
 import { mockErrors } from '../../../../../../../test-mocks';
+
+const { MINIMUM } = APPLICATION.POLICY.TOTAL_VALUE_OF_CONTRACT;
 
 const {
   POLICY: {
@@ -16,102 +19,20 @@ const {
   INSURANCE: {
     POLICY: {
       CONTRACT_POLICY: {
-        SINGLE: { [FIELD_ID]: ERROR_MESSAGE },
+        SINGLE: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
       },
     },
   },
 } = ERROR_MESSAGES;
 
 describe('controllers/insurance/policy/single-contract-policy//total-contract-value/validation/rules/total-contract-value', () => {
-  describe('when the field is not provided', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {};
+  it('should return the result of wholeNumberAboveMinimumValidation', () => {
+    const mockSubmittedData = {};
 
-      const result = totalContractValueRules(mockSubmittedData, mockErrors);
+    const result = totalContractValueRules(mockSubmittedData, mockErrors);
 
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
+    const expected = wholeNumberAboveMinimumValidation(mockSubmittedData, FIELD_ID, ERROR_MESSAGES_OBJECT, mockErrors, MINIMUM);
 
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when total contract value is not a number', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: 'One hundred!',
-      };
-
-      const result = totalContractValueRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when total contract value contains a decimal', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '123.456',
-      };
-
-      const result = totalContractValueRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when total contract value contains a comma and decimal', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '123,456.78',
-      };
-
-      const result = totalContractValueRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when total contract value is below the minimum', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '0',
-      };
-
-      const result = totalContractValueRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when there are no validation errors', () => {
-    it('should return the provided errors object', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '40000',
-      };
-
-      const result = totalContractValueRules(mockSubmittedData, mockErrors);
-
-      expect(result).toEqual(mockErrors);
-    });
-  });
-
-  describe('when there are no validation errors and the value contains a comma', () => {
-    it('should return the provided errors object', () => {
-      const mockSubmittedData = {
-        [FIELD_ID]: '40,000',
-      };
-
-      const result = totalContractValueRules(mockSubmittedData, mockErrors);
-
-      expect(result).toEqual(mockErrors);
-    });
+    expect(result).toEqual(expected);
   });
 });

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/validation/rules/total-contract-value.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/validation/rules/total-contract-value.ts
@@ -1,10 +1,8 @@
 import { APPLICATION } from '../../../../../../../constants';
 import INSURANCE_FIELD_IDS from '../../../../../../../constants/field-ids/insurance';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../../helpers/validation';
-import { objectHasProperty } from '../../../../../../../helpers/object';
-import { RequestBody } from '../../../../../../../../types';
 import wholeNumberAboveMinimumValidation from '../../../../../../../shared-validation/whole-number-above-minimum';
+import { RequestBody } from '../../../../../../../../types';
 
 const { MINIMUM } = APPLICATION.POLICY.TOTAL_VALUE_OF_CONTRACT;
 
@@ -20,7 +18,7 @@ const {
   INSURANCE: {
     POLICY: {
       CONTRACT_POLICY: {
-        SINGLE: { [FIELD_ID]: ERROR_MESSAGE },
+        SINGLE: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
       },
     },
   },
@@ -34,14 +32,7 @@ const {
  * @param {Object} Errors object from previous validation errors
  * @returns {Object} Validation errors
  */
-const totalContractValueRules = (formBody: RequestBody, errors: object) => {
-  // check if the field is empty.
-  if (!objectHasProperty(formBody, FIELD_ID)) {
-    return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.INCORRECT_FORMAT, errors);
-  }
-
-  // checks if value is whole number or below minimum
-  return wholeNumberAboveMinimumValidation(formBody, FIELD_ID, ERROR_MESSAGE, errors, MINIMUM);
-};
+const totalContractValueRules = (formBody: RequestBody, errors: object) =>
+  wholeNumberAboveMinimumValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MINIMUM);
 
 export default totalContractValueRules;

--- a/src/ui/server/controllers/insurance/your-buyer/trading-history/validation/rules/amount-overdue.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/trading-history/validation/rules/amount-overdue.test.ts
@@ -1,123 +1,36 @@
-import amountOverdueRules from './amount-overdue';
+import amountOverdueRules, { MINIMUM } from './amount-overdue';
 import YOUR_BUYER_FIELD_IDS from '../../../../../../constants/field-ids/insurance/your-buyer';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../helpers/validation';
-import wholeNumberValidation from '../../../../../../helpers/whole-number-validation';
+import wholeNumberAboveMinimumValidation from '../../../../../../shared-validation/whole-number-above-minimum';
 import { mockErrors } from '../../../../../../test-mocks';
 
 const { OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE: FIELD_ID } = YOUR_BUYER_FIELD_IDS;
 
 const {
   INSURANCE: {
-    YOUR_BUYER: { [FIELD_ID]: ERROR_MESSAGE },
+    YOUR_BUYER: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
   },
 } = ERROR_MESSAGES;
 
 describe('controllers/insurance/your-buyer/trading-history/validation/rules/amount-overdue', () => {
+  describe(`when ${OUTSTANDING_PAYMENTS} is "true"`, () => {
+    it('should return the result of wholeNumberAboveMinimumValidation', () => {
+      const mockSubmittedData = {
+        [OUTSTANDING_PAYMENTS]: 'true',
+      };
+
+      const result = amountOverdueRules(mockSubmittedData, mockErrors);
+
+      const expected = wholeNumberAboveMinimumValidation(mockSubmittedData, FIELD_ID, ERROR_MESSAGES_OBJECT, mockErrors, MINIMUM);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
   describe(`when ${OUTSTANDING_PAYMENTS} is not "true"`, () => {
     it('should return the provided errors object', () => {
       const mockSubmittedData = {
         [OUTSTANDING_PAYMENTS]: 'false',
-      };
-
-      const result = amountOverdueRules(mockSubmittedData, mockErrors);
-
-      expect(result).toEqual(mockErrors);
-    });
-  });
-
-  describe('when the field is not provided', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [OUTSTANDING_PAYMENTS]: 'true',
-      };
-
-      const result = amountOverdueRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe(`when ${FIELD_ID} is not a number`, () => {
-    it('should return `wholeNumberValidation`', () => {
-      const mockSubmittedData = {
-        [OUTSTANDING_PAYMENTS]: 'true',
-        [FIELD_ID]: 'One hundred!',
-      };
-
-      const result = amountOverdueRules(mockSubmittedData, mockErrors);
-
-      const expected = wholeNumberValidation(mockSubmittedData, mockErrors, ERROR_MESSAGE.INCORRECT_FORMAT, FIELD_ID);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe(`when ${FIELD_ID} contains a decimal`, () => {
-    it('should return `wholeNumberValidation`', () => {
-      const mockSubmittedData = {
-        [OUTSTANDING_PAYMENTS]: 'true',
-        [FIELD_ID]: '123.456',
-      };
-
-      const result = amountOverdueRules(mockSubmittedData, mockErrors);
-
-      const expected = wholeNumberValidation(mockSubmittedData, mockErrors, ERROR_MESSAGE.INCORRECT_FORMAT, FIELD_ID);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe(`when ${FIELD_ID} contains a comma and decimal`, () => {
-    it('should return `wholeNumberValidation`', () => {
-      const mockSubmittedData = {
-        [OUTSTANDING_PAYMENTS]: 'true',
-        [FIELD_ID]: '123,456.78',
-      };
-
-      const result = amountOverdueRules(mockSubmittedData, mockErrors);
-
-      const expected = wholeNumberValidation(mockSubmittedData, mockErrors, ERROR_MESSAGE.INCORRECT_FORMAT, FIELD_ID);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe(`when ${FIELD_ID} is below the minimum`, () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [OUTSTANDING_PAYMENTS]: 'true',
-        [FIELD_ID]: '0',
-      };
-
-      const result = amountOverdueRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when there are no validation errors', () => {
-    it('should return the provided errors object', () => {
-      const mockSubmittedData = {
-        [OUTSTANDING_PAYMENTS]: 'true',
-        [FIELD_ID]: '10,000',
-      };
-
-      const result = amountOverdueRules(mockSubmittedData, mockErrors);
-
-      expect(result).toEqual(mockErrors);
-    });
-  });
-
-  describe('when there are no validation errors and the value contains a comma', () => {
-    it('should return the provided errors object', () => {
-      const mockSubmittedData = {
-        [OUTSTANDING_PAYMENTS]: 'true',
-        [FIELD_ID]: '10,000',
       };
 
       const result = amountOverdueRules(mockSubmittedData, mockErrors);

--- a/src/ui/server/controllers/insurance/your-buyer/trading-history/validation/rules/amount-overdue.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/trading-history/validation/rules/amount-overdue.ts
@@ -1,19 +1,17 @@
 import YOUR_BUYER_FIELD_IDS from '../../../../../../constants/field-ids/insurance/your-buyer';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../helpers/validation';
-import { objectHasProperty } from '../../../../../../helpers/object';
-import { RequestBody } from '../../../../../../../types';
 import wholeNumberAboveMinimumValidation from '../../../../../../shared-validation/whole-number-above-minimum';
+import { RequestBody } from '../../../../../../../types';
 
 const { OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE: FIELD_ID } = YOUR_BUYER_FIELD_IDS;
 
 const {
   INSURANCE: {
-    YOUR_BUYER: { [FIELD_ID]: ERROR_MESSAGE },
+    YOUR_BUYER: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
   },
 } = ERROR_MESSAGES;
 
-const MINIMUM = 1;
+export const MINIMUM = 1;
 
 /**
  * amountOverdueRules
@@ -25,13 +23,7 @@ const MINIMUM = 1;
  */
 const amountOverdueRules = (formBody: RequestBody, errors: object) => {
   if (formBody[OUTSTANDING_PAYMENTS] === 'true') {
-    // check if the field is empty.
-    if (!objectHasProperty(formBody, FIELD_ID)) {
-      return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
-    }
-
-    // checks if value is a whole number or below minimum
-    return wholeNumberAboveMinimumValidation(formBody, FIELD_ID, ERROR_MESSAGE, errors, MINIMUM);
+    return wholeNumberAboveMinimumValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MINIMUM);
   }
 
   return errors;

--- a/src/ui/server/controllers/insurance/your-buyer/trading-history/validation/rules/total-outstanding.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/trading-history/validation/rules/total-outstanding.test.ts
@@ -1,123 +1,36 @@
-import totalOutstandingRules from './total-outstanding';
+import totalOutstandingRules, { MINIMUM } from './total-outstanding';
 import YOUR_BUYER_FIELD_IDS from '../../../../../../constants/field-ids/insurance/your-buyer';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../helpers/validation';
-import wholeNumberValidation from '../../../../../../helpers/whole-number-validation';
+import wholeNumberAboveMinimumValidation from '../../../../../../shared-validation/whole-number-above-minimum';
 import { mockErrors } from '../../../../../../test-mocks';
 
 const { OUTSTANDING_PAYMENTS, TOTAL_OUTSTANDING_PAYMENTS: FIELD_ID } = YOUR_BUYER_FIELD_IDS;
 
 const {
   INSURANCE: {
-    YOUR_BUYER: { [FIELD_ID]: ERROR_MESSAGE },
+    YOUR_BUYER: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
   },
 } = ERROR_MESSAGES;
 
 describe('controllers/insurance/your-buyer/trading-history/validation/rules/total-outstanding', () => {
+  describe(`when ${OUTSTANDING_PAYMENTS} is "true"`, () => {
+    it('should return the result of wholeNumberAboveMinimumValidation', () => {
+      const mockSubmittedData = {
+        [OUTSTANDING_PAYMENTS]: 'true',
+      };
+
+      const result = totalOutstandingRules(mockSubmittedData, mockErrors);
+
+      const expected = wholeNumberAboveMinimumValidation(mockSubmittedData, FIELD_ID, ERROR_MESSAGES_OBJECT, mockErrors, MINIMUM);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
   describe(`when ${OUTSTANDING_PAYMENTS} is not "true"`, () => {
     it('should return the provided errors object', () => {
       const mockSubmittedData = {
         [OUTSTANDING_PAYMENTS]: 'false',
-      };
-
-      const result = totalOutstandingRules(mockSubmittedData, mockErrors);
-
-      expect(result).toEqual(mockErrors);
-    });
-  });
-
-  describe('when the field is not provided', () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [OUTSTANDING_PAYMENTS]: 'true',
-      };
-
-      const result = totalOutstandingRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe(`when ${FIELD_ID} is not a number`, () => {
-    it('should return `wholeNumberValidation`', () => {
-      const mockSubmittedData = {
-        [OUTSTANDING_PAYMENTS]: 'true',
-        [FIELD_ID]: 'One hundred!',
-      };
-
-      const result = totalOutstandingRules(mockSubmittedData, mockErrors);
-
-      const expected = wholeNumberValidation(mockSubmittedData, mockErrors, ERROR_MESSAGE.INCORRECT_FORMAT, FIELD_ID);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe(`when ${FIELD_ID} contains a decimal`, () => {
-    it('should return `wholeNumberValidation`', () => {
-      const mockSubmittedData = {
-        [OUTSTANDING_PAYMENTS]: 'true',
-        [FIELD_ID]: '123.456',
-      };
-
-      const result = totalOutstandingRules(mockSubmittedData, mockErrors);
-
-      const expected = wholeNumberValidation(mockSubmittedData, mockErrors, ERROR_MESSAGE.INCORRECT_FORMAT, FIELD_ID);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe(`when ${FIELD_ID} contains a comma and decimal`, () => {
-    it('should return `wholeNumberValidation`', () => {
-      const mockSubmittedData = {
-        [OUTSTANDING_PAYMENTS]: 'true',
-        [FIELD_ID]: '123,456.78',
-      };
-
-      const result = totalOutstandingRules(mockSubmittedData, mockErrors);
-
-      const expected = wholeNumberValidation(mockSubmittedData, mockErrors, ERROR_MESSAGE.INCORRECT_FORMAT, FIELD_ID);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe(`when ${FIELD_ID} is below the minimum`, () => {
-    it('should return validation error', () => {
-      const mockSubmittedData = {
-        [OUTSTANDING_PAYMENTS]: 'true',
-        [FIELD_ID]: '0',
-      };
-
-      const result = totalOutstandingRules(mockSubmittedData, mockErrors);
-
-      const expected = generateValidationErrors(FIELD_ID, ERROR_MESSAGE.BELOW_MINIMUM, mockErrors);
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when there are no validation errors', () => {
-    it('should return the provided errors object', () => {
-      const mockSubmittedData = {
-        [OUTSTANDING_PAYMENTS]: 'true',
-        [FIELD_ID]: '10,000',
-      };
-
-      const result = totalOutstandingRules(mockSubmittedData, mockErrors);
-
-      expect(result).toEqual(mockErrors);
-    });
-  });
-
-  describe('when there are no validation errors and the value contains a comma', () => {
-    it('should return the provided errors object', () => {
-      const mockSubmittedData = {
-        [OUTSTANDING_PAYMENTS]: 'true',
-        [FIELD_ID]: '10,000',
       };
 
       const result = totalOutstandingRules(mockSubmittedData, mockErrors);

--- a/src/ui/server/controllers/insurance/your-buyer/trading-history/validation/rules/total-outstanding.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/trading-history/validation/rules/total-outstanding.ts
@@ -1,7 +1,5 @@
 import YOUR_BUYER_FIELD_IDS from '../../../../../../constants/field-ids/insurance/your-buyer';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
-import generateValidationErrors from '../../../../../../helpers/validation';
-import { objectHasProperty } from '../../../../../../helpers/object';
 import { RequestBody } from '../../../../../../../types';
 import wholeNumberAboveMinimumValidation from '../../../../../../shared-validation/whole-number-above-minimum';
 
@@ -9,11 +7,11 @@ const { OUTSTANDING_PAYMENTS, TOTAL_OUTSTANDING_PAYMENTS: FIELD_ID } = YOUR_BUYE
 
 const {
   INSURANCE: {
-    YOUR_BUYER: { [FIELD_ID]: ERROR_MESSAGE },
+    YOUR_BUYER: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
   },
 } = ERROR_MESSAGES;
 
-const MINIMUM = 1;
+export const MINIMUM = 1;
 
 /**
  * totalOutstandingRules
@@ -25,13 +23,7 @@ const MINIMUM = 1;
  */
 const totalOutstandingRules = (formBody: RequestBody, errors: object) => {
   if (formBody[OUTSTANDING_PAYMENTS] === 'true') {
-    // check if the field is empty.
-    if (!objectHasProperty(formBody, FIELD_ID)) {
-      return generateValidationErrors(FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
-    }
-
-    // checks if value is a whole number or below minimum
-    return wholeNumberAboveMinimumValidation(formBody, FIELD_ID, ERROR_MESSAGE, errors, MINIMUM);
+    return wholeNumberAboveMinimumValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MINIMUM);
   }
 
   return errors;

--- a/src/ui/server/helpers/percentage-number-validation/index.ts
+++ b/src/ui/server/helpers/percentage-number-validation/index.ts
@@ -11,21 +11,21 @@ const MAXIMUM = 100;
  * validates if field is empty or not
  * validates if field is whole number and between 0 and 100.
  * returns validation error if is not a number, has a decimal place, special characters, a comma, is empty or is below 0 or above 100.
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {String} field fieldId of the field being checked
  * @param {object} errors
  * @param {ErrorMessageObject} errorMessages object with different error messages
  * @returns {object} errors
  */
-const percentageNumberValidation = (responseBody: RequestBody, field: string, errors: object, errorMessages: ErrorMessageObject) => {
+const percentageNumberValidation = (formBody: RequestBody, field: string, errors: object, errorMessages: ErrorMessageObject) => {
   const { IS_EMPTY, INCORRECT_FORMAT, BELOW_MINIMUM, ABOVE_MAXIMUM } = errorMessages;
 
   // if empty then return validation error
-  if (!objectHasProperty(responseBody, field)) {
+  if (!objectHasProperty(formBody, field)) {
     return generateValidationErrors(field, IS_EMPTY, errors);
   }
 
-  const value = responseBody[field];
+  const value = formBody[field];
 
   const isFieldANumber = isNumber(value);
   const hasDecimal = numberHasDecimal(Number(value));

--- a/src/ui/server/helpers/whole-number-validation/index.ts
+++ b/src/ui/server/helpers/whole-number-validation/index.ts
@@ -7,16 +7,16 @@ import { stripCommas } from '../string';
  * validates if field is whole number and above 0 and handles commas in the input.
  * if allowNegativeNumbers is set to true, then will return validation error if number below 0.
  * returns validation error if is not a number, has a decimal place or special characters.
- * @param {RequestBody} responseBody
+ * @param {RequestBody} formBody
  * @param {object} errors
  * @param {string} errorMessage
  * @param {string} field fieldId of the field being checked
  * @param {Boolean} allowNegativeValue false as default, if true then allows for negative numbers below 0.
  * @returns {object} errors
  */
-const wholeNumberValidation = (responseBody: RequestBody, errors: object, errorMessage: string, field: string, allowNegativeValue = false) => {
+const wholeNumberValidation = (formBody: RequestBody, errors: object, errorMessage: string, field: string, allowNegativeValue = false) => {
   // strip commas - commas are valid.
-  const numberWithoutCommas = stripCommas(responseBody[field]);
+  const numberWithoutCommas = stripCommas(formBody[field]);
 
   const isFieldANumber = isNumber(numberWithoutCommas);
   const hasDecimal = numberHasDecimal(Number(numberWithoutCommas));

--- a/src/ui/server/shared-validation/whole-number-above-minimum/index.test.ts
+++ b/src/ui/server/shared-validation/whole-number-above-minimum/index.test.ts
@@ -12,33 +12,47 @@ describe('shared-validation/whole-number-above-minimum', () => {
     [FIELD_ID]: '0',
   } as RequestBody;
 
+  describe('when a number is not provided', () => {
+    it('should return validation errors', () => {
+      const mockEmptyBody = {};
+
+      const result = wholeNumberAboveMinimumValidation(mockEmptyBody, FIELD_ID, mockErrorMessagesObject, mockErrors, MINIMUM);
+
+      const expected = generateValidationErrors(FIELD_ID, mockErrorMessagesObject.IS_EMPTY, mockErrors);
+;
+      expect(result).toEqual(expected);
+    });
+  });
+
   describe('when the provided number is below minimum', () => {
     it('should return validation errors', () => {
-      const response = wholeNumberAboveMinimumValidation(mockBody, FIELD_ID, mockErrorMessagesObject, mockErrors, MINIMUM);
+      const result = wholeNumberAboveMinimumValidation(mockBody, FIELD_ID, mockErrorMessagesObject, mockErrors, MINIMUM);
 
       const expected = generateValidationErrors(FIELD_ID, mockErrorMessagesObject.BELOW_MINIMUM, mockErrors);
 
-      expect(response).toEqual(expected);
+      expect(result).toEqual(expected);
     });
   });
 
   describe('when the provided number is not a whole number', () => {
     it('should return the result of "wholeNumberValidation"', () => {
       mockBody[FIELD_ID] = '1!';
-      const response = wholeNumberAboveMinimumValidation(mockBody, FIELD_ID, mockErrorMessagesObject, mockErrors, MINIMUM);
+
+      const result = wholeNumberAboveMinimumValidation(mockBody, FIELD_ID, mockErrorMessagesObject, mockErrors, MINIMUM);
 
       const expected = generateValidationErrors(FIELD_ID, mockErrorMessagesObject.INCORRECT_FORMAT, mockErrors);
 
-      expect(response).toEqual(expected);
+      expect(result).toEqual(expected);
     });
   });
 
   describe('when the provided number is at minimum', () => {
     it('should return provided errors object', () => {
       mockBody[FIELD_ID] = '1';
-      const response = wholeNumberValidation(mockBody, mockErrors, mockErrorMessagesObject.INCORRECT_FORMAT, FIELD_ID);
 
-      expect(response).toEqual(mockErrors);
+      const result = wholeNumberValidation(mockBody, mockErrors, mockErrorMessagesObject.INCORRECT_FORMAT, FIELD_ID);
+
+      expect(result).toEqual(mockErrors);
     });
   });
 
@@ -46,9 +60,9 @@ describe('shared-validation/whole-number-above-minimum', () => {
     it('should return provided errors object', () => {
       mockBody[FIELD_ID] = '200';
 
-      const response = wholeNumberAboveMinimumValidation(mockBody, FIELD_ID, mockErrorMessagesObject, mockErrors, MINIMUM);
+      const result = wholeNumberAboveMinimumValidation(mockBody, FIELD_ID, mockErrorMessagesObject, mockErrors, MINIMUM);
 
-      expect(response).toEqual(mockErrors);
+      expect(result).toEqual(mockErrors);
     });
   });
 });

--- a/src/ui/server/shared-validation/whole-number-above-minimum/index.test.ts
+++ b/src/ui/server/shared-validation/whole-number-above-minimum/index.test.ts
@@ -19,7 +19,7 @@ describe('shared-validation/whole-number-above-minimum', () => {
       const result = wholeNumberAboveMinimumValidation(mockEmptyBody, FIELD_ID, mockErrorMessagesObject, mockErrors, MINIMUM);
 
       const expected = generateValidationErrors(FIELD_ID, mockErrorMessagesObject.IS_EMPTY, mockErrors);
-;
+
       expect(result).toEqual(expected);
     });
   });

--- a/src/ui/server/shared-validation/whole-number-above-minimum/index.ts
+++ b/src/ui/server/shared-validation/whole-number-above-minimum/index.ts
@@ -1,12 +1,12 @@
 import { RequestBody, ErrorMessageObject } from '../../../types';
+import { objectHasProperty } from '../../helpers/object';
 import { stripCommas } from '../../helpers/string';
 import generateValidationErrors from '../../helpers/validation';
 import wholeNumberValidation from '../../helpers/whole-number-validation';
 
 /**
  * wholeNumberAboveMinimumValidation
- * Check if a number is below minimum
- * Returns validationErrors or null.
+ * Check if a number is provided and below a minimum.
  * @param {RequestBody} formBody
  * @param {String} fieldId
  * @param {String} errorMessage
@@ -16,6 +16,10 @@ import wholeNumberValidation from '../../helpers/whole-number-validation';
  */
 const wholeNumberAboveMinimumValidation = (formBody: RequestBody, fieldId: string, errorMessage: ErrorMessageObject, errors: object, minimum: number) => {
   let updatedErrors = errors;
+
+  if (!objectHasProperty(formBody, fieldId)) {
+    return generateValidationErrors(fieldId, errorMessage.IS_EMPTY, errors);
+  }
 
   // strip commas - commas are valid.
   const numberWithoutCommas = stripCommas(formBody[fieldId]);


### PR DESCRIPTION
## Introduction :pencil2:
This PR cleans up various UI validation rules so that they have the same `RequestBody` param name and the consumption of `wholeNumberAboveMinimumValidation` is simplified.

## Resolution :heavy_check_mark:
- Rename all UI validation rules with a param called `responseBody`, to `formBody`.
- Update `wholeNumberAboveMinimum` validation rule to check if a value is provided.
- Update all consumptions of  `wholeNumberAboveMinimum` to export a `MINIMUM` value. Remove unnecessary unit tests handled by `wholeNumberAboveMinimum`.

## Miscellaneous :heavy_plus_sign:
- Bump `prettier` dependency`.