### PR TITLE
chore(tech): Various documentation, cypress command improvements

### DIFF
--- a/e2e-tests/commands/shared-commands/assertions/assert-section-start-content.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-section-start-content.js
@@ -1,5 +1,4 @@
 import {
-  intro,
   listIntro,
   listItem,
   listOutro,
@@ -14,7 +13,7 @@ import { BUTTONS } from '../../../content-strings';
  * Assert various pieces of content in a "section start" page.
  */
 const assertSectionStartContent = {
-  intro: (expectedText) => cy.checkText(intro(), expectedText),
+  intro: (expectedText) => cy.checkIntroText(expectedText),
   list: {
     intro: (expectedText) => cy.checkText(listIntro(), expectedText),
     items: (expectedItems) => {

--- a/e2e-tests/commands/shared-commands/assertions/check-completed-task-status.js
+++ b/e2e-tests/commands/shared-commands/assertions/check-completed-task-status.js
@@ -2,8 +2,13 @@ import { TASKS } from '../../../content-strings';
 
 const { STATUS: { COMPLETED } } = TASKS;
 
-export default (selector) => {
-  selector.invoke('text').then((text) => {
-    expect(text.trim()).equal(COMPLETED);
-  });
+/**
+ * checkCompletedTaskStatus
+ * Check an tasks has a "completed" status
+ * @param {Function} selector: Cypress selector
+ */
+const checkCompletedTaskStatus = (selector) => {
+  cy.checkText(selector, COMPLETED);
 };
+
+export default checkCompletedTaskStatus;

--- a/e2e-tests/commands/shared-commands/assertions/check-intro-text.js
+++ b/e2e-tests/commands/shared-commands/assertions/check-intro-text.js
@@ -5,7 +5,7 @@ import { intro } from '../../../pages/shared';
  * Check intro text element.
  * @param {String} expected: Expected text
  */
-const checkIntroText = (selector, expected) => {
+const checkIntroText = (expected) => {
   cy.checkText(intro(), expected);
 };
 

--- a/e2e-tests/commands/shared-commands/assertions/check-intro-text.js
+++ b/e2e-tests/commands/shared-commands/assertions/check-intro-text.js
@@ -1,0 +1,12 @@
+import { intro } from '../../../pages/shared';
+
+/**
+ * checkIntroText
+ * Check intro text element.
+ * @param {String} expected: Expected text
+ */
+const checkIntroText = (selector, expected) => {
+  cy.checkText(intro(), expected);
+};
+
+export default checkIntroText;

--- a/e2e-tests/commands/shared-commands/assertions/check-link.js
+++ b/e2e-tests/commands/shared-commands/assertions/check-link.js
@@ -1,5 +1,14 @@
-export default (selector, expectedHref, expectedText) => {
+/**
+ * checkLink
+ * Check an link's HREF and text
+ * @param {Function} selector: Cypress selector
+ * @param {String} expectedHref: Expected HREF
+ * @param {String} expectedText: Expected text
+ */
+const checkLink = (selector, expectedHref, expectedText) => {
   selector.should('have.attr', 'href', expectedHref);
 
   cy.checkText(selector, expectedText);
 };
+
+export default checkLink;

--- a/e2e-tests/commands/shared-commands/assertions/check-task-status.js
+++ b/e2e-tests/commands/shared-commands/assertions/check-task-status.js
@@ -1,5 +1,11 @@
-export default (task, status) => {
-  task.status().invoke('text').then((text) => {
-    expect(text.trim()).equal(status);
-  });
+/**
+ * checkTaskStatus
+ * Check an tasks's statuts
+ * @param {Object} task: Task field
+ * @param {String} status: Expected status
+ */
+const checkTaskStatus = (task, status) => {
+  cy.checkText(task.status(), status);
 };
+
+export default checkTaskStatus;

--- a/e2e-tests/commands/shared-commands/assertions/check-text.js
+++ b/e2e-tests/commands/shared-commands/assertions/check-text.js
@@ -1,5 +1,13 @@
-export default (selector, expectedMessage) => {
+/**
+ * checkText
+ * Check an element's text
+ * @param {Function} selector: Cypress selector
+ * @param {String} expected: Expected text
+ */
+const checkText = (selector, expected) => {
   selector.invoke('text').then((text) => {
-    expect(text.trim()).equal(expectedMessage);
+    expect(text.trim()).equal(expected);
   });
 };
+
+export default checkText;

--- a/e2e-tests/commands/shared-commands/assertions/check-value.js
+++ b/e2e-tests/commands/shared-commands/assertions/check-value.js
@@ -1,3 +1,11 @@
-export default (selector, expectedValue) => {
+/**
+ * checkValue
+ * Check an input's value
+ * @param {Function} selector: Cypress selector
+ * @param {String} expectedValue: Expected value
+ */
+const checkValue = (selector, expectedValue) => {
   selector.input().should('have.value', expectedValue);
 };
+
+export default checkValue;

--- a/e2e-tests/commands/shared-commands/assertions/index.js
+++ b/e2e-tests/commands/shared-commands/assertions/index.js
@@ -25,6 +25,7 @@ Cypress.Commands.add('assertNoRadioOptionIsChecked', require('./assert-no-radio-
 
 Cypress.Commands.add('assertHeadingWithCurrencyName', require('./assert-heading-with-currency-name'));
 Cypress.Commands.add('assertPrefix', require('./assert-prefix'));
+Cypress.Commands.add('assertPrefix', require('./assert-prefix'));
 
 Cypress.Commands.add('checkAnalyticsCookiesConsentAndAccept', analytics.checkAnalyticsCookiesConsentAndAccept);
 Cypress.Commands.add('checkAnalyticsCookieDoesNotExist', analytics.checkAnalyticsCookieDoesNotExist);
@@ -93,6 +94,7 @@ Cypress.Commands.add('checkTaskStatus', require('./check-task-status'));
 Cypress.Commands.add('checkTaskStatusCompleted', require('./check-completed-task-status'));
 
 Cypress.Commands.add('checkText', require('./check-text'));
+Cypress.Commands.add('checkIntroText', require('./check-intro-text'));
 
 Cypress.Commands.add('checkValue', require('./check-value'));
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/your-details/account-create-your-details.spec.js
@@ -1,5 +1,5 @@
 import { yourDetailsPage } from '../../../../../../../pages/insurance/account/create';
-import { field as fieldSelector, intro } from '../../../../../../../pages/shared';
+import { field as fieldSelector } from '../../../../../../../pages/shared';
 import { BUTTONS, PAGES } from '../../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { ACCOUNT_FIELDS } from '../../../../../../../content-strings/fields/insurance/account';
@@ -61,7 +61,7 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
     });
 
     it('renders intro text', () => {
-      cy.checkText(intro(), CONTENT_STRINGS.INTRO);
+      cy.checkIntroText(CONTENT_STRINGS.INTRO);
     });
 
     it('renders `first name` label and input', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/request-new-code/account-sign-in-request-new-code.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/request-new-code/account-sign-in-request-new-code.spec.js
@@ -1,4 +1,3 @@
-import { intro } from '../../../../../../../pages/shared';
 import { enterCodePage, requestNewCodePage } from '../../../../../../../pages/insurance/account/sign-in';
 import { BUTTONS, PAGES } from '../../../../../../../content-strings';
 import { INSURANCE_ROUTES as ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -51,7 +50,7 @@ context('Insurance - Account - Sign in - Request new code page - I want to enter
     });
 
     it('should render intro copy', () => {
-      cy.checkText(intro(), CONTENT_STRINGS.INTRO);
+      cy.checkIntroText(CONTENT_STRINGS.INTRO);
     });
 
     describe('expandable details - do not have access to email', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/application-submitted.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/application-submitted.spec.js
@@ -1,5 +1,4 @@
 import applicationSubmittedPage from '../../../../../pages/insurance/applicationSubmitted';
-import { intro } from '../../../../../pages/shared';
 import { PAGES, LINKS } from '../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
 
@@ -69,7 +68,7 @@ context('Insurance - application submitted page', () => {
     });
 
     it('renders intro copy', () => {
-      cy.checkText(intro(), CONTENT_STRINGS.INTRO);
+      cy.checkIntroText(CONTENT_STRINGS.INTRO);
     });
 
     describe('what happens next', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/complete-other-sections.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/complete-other-sections.spec.js
@@ -1,5 +1,4 @@
 import completeOtherSectionsPage from '../../../../pages/insurance/complete-other-sections';
-import { intro } from '../../../../pages/shared';
 import { PAGES } from '../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
 
@@ -54,7 +53,7 @@ context('Insurance - Complete other sections page', () => {
     });
 
     it('renders intro copy', () => {
-      cy.checkText(intro(), CONTENT_STRINGS.INTRO);
+      cy.checkIntroText(CONTENT_STRINGS.INTRO);
     });
 
     it('renders `can access other sections` copy', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-multiple-risks/cannot-apply-multiple-risks.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-multiple-risks/cannot-apply-multiple-risks.spec.js
@@ -1,8 +1,4 @@
-import {
-  intro,
-  listItem,
-  yesRadio,
-} from '../../../../../../pages/shared';
+import { listItem, yesRadio } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../../commands/forms';
@@ -63,7 +59,7 @@ context('Insurance - Cannot apply - multiple risks page - as an exporter, I want
     });
 
     it('renders intro copy', () => {
-      cy.checkText(intro(), CONTENT_STRINGS.INTRO);
+      cy.checkIntroText(CONTENT_STRINGS.INTRO);
     });
 
     it('renders list items', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/check-if-eligible.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/check-if-eligible.spec.js
@@ -1,4 +1,3 @@
-import { intro } from '../../../../../pages/shared';
 import { PAGES } from '../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
 import { checkIfEligiblePage } from '../../../../../pages/insurance/eligibility';
@@ -42,7 +41,7 @@ context('Insurance Eligibility - check if eligible page', () => {
     });
 
     it('should render intro text', () => {
-      cy.checkText(intro(), CONTENT_STRINGS.INTRO);
+      cy.checkIntroText(CONTENT_STRINGS.INTRO);
     });
 
     it('should render `we will ask questions` list items', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/long-term-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/long-term-cover.spec.js
@@ -1,4 +1,3 @@
-import { intro } from '../../../../../pages/shared';
 import { PAGES } from '../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../commands/forms';
@@ -61,7 +60,7 @@ context('Insurance - Eligibility - Long term cover page - I want to check if I c
     });
 
     it('should render intro text', () => {
-      cy.checkText(intro(), CONTENT_STRINGS.INTRO);
+      cy.checkIntroText(CONTENT_STRINGS.INTRO);
     });
 
     it('should render `apply through PDF` copy and link', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
@@ -1,5 +1,5 @@
 import partials from '../../../../../../partials';
-import { field as fieldSelector, intro } from '../../../../../../pages/shared';
+import { field as fieldSelector } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -79,7 +79,7 @@ context("Insurance - Policy - Broker details page - As an exporter, I want to pr
     });
 
     it('renders intro text', () => {
-      cy.checkText(intro(), CONTENT_STRINGS.INTRO);
+      cy.checkIntroText(CONTENT_STRINGS.INTRO);
     });
 
     it(`renders ${NAME} label and input`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
@@ -89,11 +89,8 @@ context('Insurance - Policy - Broker page - Save and back', () => {
 
       cy.startInsurancePolicySection({});
 
-      // go through 5 policy forms.
-      cy.clickSubmitButtonMultipleTimes({ count: 5 });
-
-      // TODO: once EMS-2586 is complete, this can be replaced with clickSubmitButtonMultipleTimes.
-      cy.completeAndSubmitAnotherCompanyForm({});
+      // go through 6 policy forms.
+      cy.clickSubmitButtonMultipleTimes({ count: 6 });
 
       cy.assertRadioOptionIsChecked(yesRadioInput());
     });
@@ -117,11 +114,8 @@ context('Insurance - Policy - Broker page - Save and back', () => {
 
       cy.startInsurancePolicySection({});
 
-      // go through 5 policy forms.
-      cy.clickSubmitButtonMultipleTimes({ count: 5 });
-
-      // TODO: once EMS-2586 is complete, this can be replaced with clickSubmitButtonMultipleTimes.
-      cy.completeAndSubmitAnotherCompanyForm({});
+      // go through 6 policy forms.
+      cy.clickSubmitButtonMultipleTimes({ count: 6 });
 
       cy.assertRadioOptionIsChecked(noRadioInput());
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/start.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/start.spec.js
@@ -1,5 +1,4 @@
 import { insurance } from '../../../../pages';
-import { intro } from '../../../../pages/shared';
 import { BUTTONS, LINKS, PAGES } from '../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
 
@@ -44,7 +43,7 @@ context('Insurance Eligibility - start page', () => {
     });
 
     it('renders an intro', () => {
-      cy.checkText(intro(), CONTENT_STRINGS.INTRO);
+      cy.checkIntroText(CONTENT_STRINGS.INTRO);
     });
 
     describe('`you will need` list', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-page.spec.js
@@ -1,5 +1,5 @@
 import {
-  headingCaption, intro, yesRadio, noRadio, field, yesRadioInput,
+  headingCaption, yesRadio, noRadio, field, yesRadioInput,
 } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
@@ -73,7 +73,7 @@ context('Insurance - Your Buyer - Trading history page - As an exporter, I want 
     });
 
     it('renders an intro', () => {
-      cy.checkText(intro(), CONTENT_STRINGS.INTRO);
+      cy.checkIntroText(CONTENT_STRINGS.INTRO);
     });
 
     describe(OUTSTANDING_PAYMENTS, () => {

--- a/src/ui/server/controllers/insurance/business/alternative-trading-address/validation/rules/alternative-trading-address.ts
+++ b/src/ui/server/controllers/insurance/business/alternative-trading-address/validation/rules/alternative-trading-address.ts
@@ -17,8 +17,8 @@ export const MAXIMUM = 1000;
  * validates alternative trading address input
  * errors if empty or more than 1000 characters
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const alternativeTradingAddress = (formBody: RequestBody, errors: object) => {
   // if body is empty

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/index.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/index.ts
@@ -5,8 +5,8 @@ import combineValidationRules from '../../../../../../helpers/combine-validation
 /**
  * validates company details page response
  * throws validation errors if any fields are not completed or incorrectly completed
- * @param {Express.Request.body} responseBody containing an object with the company details response body
- * @returns {object} object containing errors or blank object
+ * @param {Express.Request.body} formBody: containing an object with the company details response body
+ * @returns {Object} Errors or empty object
  */
 const validation = (formBody: RequestBody): ValidationErrors => combineValidationRules(companyDetailsResponseRules, formBody) as ValidationErrors;
 

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/company-website.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/company-website.ts
@@ -13,8 +13,8 @@ const { EXPORTER_BUSINESS } = ERROR_MESSAGES.INSURANCE;
 /**
  * validates website input is the correct format
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const companyWebsite = (formBody: RequestBody, errors: object) => {
   let updatedErrors = errors;

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/different-trading-name.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/different-trading-name.ts
@@ -15,8 +15,8 @@ const {
  * validates alternative trading name field
  * checks if response has been provided
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const differentTradingName = (formBody: RequestBody, errors: object) => {
   // if HAS_DIFFERENT_TRADING_NAME radio is yes then check validation

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/phone-number.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/phone-number.ts
@@ -13,8 +13,8 @@ const { EXPORTER_BUSINESS } = ERROR_MESSAGES.INSURANCE;
 /**
  * validates phone number input is the correct format
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const phoneNumber = (formBody: RequestBody, errors: object) => {
   let updatedErrors = errors;

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-address.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-address.ts
@@ -14,9 +14,9 @@ const ERROR_MESSAGE = EXPORTER_BUSINESS[FIELD_ID];
 /**
  * validates tradingAddress in company details response body
  * throws validation errors if there is no tradingAddress property
- * @param {Express.Request.body} responseBody containing an object with the company details response
- * @param {Object} errors errorList
- * @returns {object} object containing errors or blank object
+ * @param {Express.Request.body} formBody: containing an object with the company details response
+ * @param {Object} errors: errorList
+ * @returns {Object} Errors or empty object
  */
 const tradingAddress = (formBody: RequestBody, errors: object) => emptyFieldValidation(formBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
 

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-name.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-name.ts
@@ -14,9 +14,9 @@ const ERROR_MESSAGE = EXPORTER_BUSINESS[FIELD_ID];
 /**
  * validates tradingName in company details response body
  * throws validation errors if there is no tradingName property
- * @param {Express.Request.body} responseBody containing an object with the company details response
- * @param {Object} errors errorList
- * @returns {object} object containing errors or blank object
+ * @param {Express.Request.body} formBody: containing an object with the company details response
+ * @param {Object} errors: errorList
+ * @returns {Object} Errors or empty object
  */
 const tradingName = (formBody: RequestBody, errors: object) => emptyFieldValidation(formBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
 

--- a/src/ui/server/controllers/insurance/business/nature-of-business/validation/rules/employees-uk.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/validation/rules/employees-uk.ts
@@ -21,8 +21,8 @@ const MINIMUM = 1;
  * validates number of uk employees input
  * only allows number without decimal
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const employeesUK = (formBody: RequestBody, errors: object) => {
   if (!objectHasProperty(formBody, FIELD_ID)) {

--- a/src/ui/server/controllers/insurance/business/nature-of-business/validation/rules/goods-or-services.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/validation/rules/goods-or-services.ts
@@ -18,8 +18,8 @@ export const MAXIMUM = 1000;
  * validates goods or services input
  * errors if empty or more than 1000 characters
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const goodsOrServices = (formBody: RequestBody, errors: object) => {
   // if body is empty

--- a/src/ui/server/controllers/insurance/business/nature-of-business/validation/rules/years-exporting.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/validation/rules/years-exporting.ts
@@ -17,8 +17,8 @@ const {
  * validates years exporting input
  * only allows number without decimal
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const yearsExporting = (formBody: RequestBody, errors: object) => {
   if (!objectHasProperty(formBody, FIELD_ID)) {

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/estimated-annual-turnover.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/estimated-annual-turnover.ts
@@ -17,8 +17,8 @@ const {
  * validates number of estimated annual turnover input
  * only allows number without decimal
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const estimatedAnnualTurnover = (formBody: RequestBody, errors: object) => {
   if (!objectHasProperty(formBody, FIELD_ID)) {

--- a/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/validation/rules/percentage-of-turnover.ts
@@ -23,8 +23,8 @@ const errorMessages = {
  * only numbers without decimals, special characters or commas
  * only allows numbers between 0 and 100
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const percentageTurnover = (formBody: RequestBody, errors: object) => percentageNumberValidation(formBody, FIELD_ID, errors, errorMessages);
 

--- a/src/ui/server/controllers/insurance/feedback/feedback-form/validation/rules/improve-service.ts
+++ b/src/ui/server/controllers/insurance/feedback/feedback-form/validation/rules/improve-service.ts
@@ -16,8 +16,8 @@ export const MAXIMUM = 1200;
  * validates improve service field
  * checks if answer has been provided
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const improveService = (formBody: RequestBody, errors: object) => {
   // if field has a value

--- a/src/ui/server/controllers/insurance/feedback/feedback-form/validation/rules/other-comments.ts
+++ b/src/ui/server/controllers/insurance/feedback/feedback-form/validation/rules/other-comments.ts
@@ -16,8 +16,8 @@ export const MAXIMUM = 1200;
  * validates other comments field
  * checks if answer has been provided
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const otherComments = (formBody: RequestBody, errors: object) => {
   // if field has a value

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/email.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/email.ts
@@ -13,8 +13,8 @@ const {
  * validates email field
  * checks if response has been provided
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const email = (formBody: RequestBody, errors: object) => emailValidation(FIELD_ID, formBody[FIELD_ID], ERROR_MESSAGES_OBJECT, errors);
 

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/first-name.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/first-name.ts
@@ -13,8 +13,8 @@ const {
  * validates last name field
  * checks if response has been provided
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const firstName = (formBody: RequestBody, errors: object) => nameValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
 

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/last-name.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/last-name.ts
@@ -13,8 +13,8 @@ const {
  * validates last name field
  * checks if response has been provided
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const lastName = (formBody: RequestBody, errors: object) => nameValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
 

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/position.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/position.ts
@@ -15,8 +15,8 @@ const {
  * validates position field
  * checks if response has been provided
  * @param {RequestBody} formBody
- * @param {object} errors
- * @returns {object} errors
+ * @param {Object} errors
+ * @returns {Object} errors
  */
 const position = (formBody: RequestBody, errors: object) => emptyFieldValidation(formBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
 

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-name/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-name/index.ts
@@ -16,9 +16,9 @@ const MAXIMUM = Number(POLICY_FIELDS.REQUESTED_JOINTLY_INSURED_PARTY[FIELD_ID].M
 
 /**
  * validate the "company name" in other company details response body
- * @param {Express.Request.body} responseBody: containing an object with the company details response
+ * @param {Express.Request.body} formBody: containing an object with the company details response
  * @param {Object} errors: errorList
- * @returns {Object} Object containing errors or blank object
+ * @returns {Object} Errors or empty object
  */
 const companyName = (responseBody: RequestBody, errors: object) => providedAndMaxLength(responseBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MAXIMUM);
 

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-number/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-number/index.ts
@@ -19,13 +19,13 @@ const MAXIMUM = Number(POLICY_FIELDS.REQUESTED_JOINTLY_INSURED_PARTY[FIELD_ID].M
 
 /**
  * validate the "company number" in other company details response body
- * @param {Express.Request.body} responseBody: containing an object with the company details response
+ * @param {Express.Request.body} formBody: containing an object with the company details response
  * @param {Object} errors: errorList
- * @returns {Object} Object containing errors or blank object
+ * @returns {Object} Errors or empty object
  */
-const companyNumber = (responseBody: RequestBody, errors: object) => {
-  if (objectHasProperty(responseBody, FIELD_ID)) {
-    return maxLengthValidation(responseBody[FIELD_ID], FIELD_ID, ERROR_MESSAGE, errors, MAXIMUM);
+const companyNumber = (formBody: RequestBody, errors: object) => {
+  if (objectHasProperty(formBody, FIELD_ID)) {
+    return maxLengthValidation(formBody[FIELD_ID], FIELD_ID, ERROR_MESSAGE, errors, MAXIMUM);
   }
 
   return errors;

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/country/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/country/index.ts
@@ -15,10 +15,10 @@ const {
 
 /**
  * validate the "country" in other company details response body
- * @param {Express.Request.body} responseBody: containing an object with the company details response
+ * @param {Express.Request.body} formBody: containing an object with the company details response
  * @param {Object} errors: errorList
- * @returns {Object} Object containing errors or blank object
+ * @returns {Object} Errors or empty object
  */
-const country = (responseBody: RequestBody, errors: object) => emptyFieldValidation(responseBody, FIELD_ID, ERROR_MESSAGE, errors);
+const country = (formBody: RequestBody, errors: object) => emptyFieldValidation(formBody, FIELD_ID, ERROR_MESSAGE, errors);
 
 export default country;

--- a/src/ui/server/helpers/combine-validation-rules/index.ts
+++ b/src/ui/server/helpers/combine-validation-rules/index.ts
@@ -5,8 +5,8 @@ import { ValidationErrors } from '../../../types';
  * combineValidationRules
  * combine multiple validation rule results into a single object
  * throws validation errors if any fields are not completed or incorrectly completed
- * @param {Express.Request.body} responseBody containing an object with the company details response body
- * @returns {object} object containing errors from multiple fields/rules, or a blank object
+ * @param {Express.Request.body} formBody: containing an object with the company details response body
+ * @returns {Object} Errors or empty object
  */
 /* eslint-disable no-unused-vars, prettier/prettier */
 const combineValidationRules = (rules: Array<(formBody: object, errors: ValidationErrors) => ValidationErrors>, data: object) => {

--- a/src/ui/server/helpers/companies-house-search/index.ts
+++ b/src/ui/server/helpers/companies-house-search/index.ts
@@ -5,7 +5,7 @@ import { CompaniesHouseResponse } from '../../../types';
  * helper which takes a companies house number and makes api call to get data from companies house.
  * runs validation on response and returns companyResponse or validation errors or apiError
  * @param {Integer} Companies House number
- * @returns {object} Mapped company, with or without an apiError flag
+ * @returns {Object} Mapped company, with or without an apiError flag
  */
 const search = async (companyNumber: string): Promise<CompaniesHouseResponse> => {
   let response = {} as CompaniesHouseResponse;

--- a/src/ui/server/helpers/get-data-to-save/index.ts
+++ b/src/ui/server/helpers/get-data-to-save/index.ts
@@ -2,9 +2,9 @@ import getValidFields from '../get-valid-fields';
 
 /**
  * helper function to return valid fields if there is an errorList, else returns all fields
- * @param {object} formBody
- * @param {object} errorList
- * @returns {object} dataToSave
+ * @param {Object} formBody
+ * @param {Object} errorList
+ * @returns {Object} dataToSave
  */
 const getDataToSave = (formBody: object, errorList?: object) => {
   const { ...formData } = formBody;

--- a/src/ui/server/helpers/get-name-email-position-from-owner-and-policy/index.ts
+++ b/src/ui/server/helpers/get-name-email-position-from-owner-and-policy/index.ts
@@ -16,7 +16,7 @@ const { FIRST_NAME, LAST_NAME, EMAIL } = ACCOUNT_FIELD_IDS;
  * adds value to NAME field for showing if radio is selected
  * @param {ApplicationOwner} owner
  * @param {ApplicationPolicyContact} policyContact
- * @returns {object}
+ * @returns {Object}
  */
 const getNameEmailPositionFromOwnerAndPolicy = (owner: ApplicationOwner, policyContact: ApplicationPolicyContact) => {
   const firstName = replaceCharacterCodesWithCharacters(owner[FIRST_NAME]);

--- a/src/ui/server/helpers/percentage-number-validation/index.ts
+++ b/src/ui/server/helpers/percentage-number-validation/index.ts
@@ -13,9 +13,9 @@ const MAXIMUM = 100;
  * returns validation error if is not a number, has a decimal place, special characters, a comma, is empty or is below 0 or above 100.
  * @param {RequestBody} formBody
  * @param {String} field fieldId of the field being checked
- * @param {object} errors
+ * @param {Object} errors
  * @param {ErrorMessageObject} errorMessages object with different error messages
- * @returns {object} errors
+ * @returns {Object} errors
  */
 const percentageNumberValidation = (formBody: RequestBody, field: string, errors: object, errorMessages: ErrorMessageObject) => {
   const { IS_EMPTY, INCORRECT_FORMAT, BELOW_MINIMUM, ABOVE_MAXIMUM } = errorMessages;

--- a/src/ui/server/helpers/whole-number-validation/index.ts
+++ b/src/ui/server/helpers/whole-number-validation/index.ts
@@ -8,11 +8,11 @@ import { stripCommas } from '../string';
  * if allowNegativeNumbers is set to true, then will return validation error if number below 0.
  * returns validation error if is not a number, has a decimal place or special characters.
  * @param {RequestBody} formBody
- * @param {object} errors
+ * @param {Object} errors
  * @param {string} errorMessage
  * @param {string} field fieldId of the field being checked
  * @param {Boolean} allowNegativeValue false as default, if true then allows for negative numbers below 0.
- * @returns {object} errors
+ * @returns {Object} errors
  */
 const wholeNumberValidation = (formBody: RequestBody, errors: object, errorMessage: string, field: string, allowNegativeValue = false) => {
   // strip commas - commas are valid.

--- a/src/ui/server/shared-validation/max-length/index.ts
+++ b/src/ui/server/shared-validation/max-length/index.ts
@@ -6,9 +6,9 @@ import isAboveMaxLength from '../../helpers/is-above-max-length';
  * @param {string} fieldBody
  * @param {string} fieldId
  * @param {string} errorMessage
- * @param {object} errors
+ * @param {Object} errors
  * @param {number} maximum
- * @returns {object} errors
+ * @returns {Object} errors
  */
 const maxLengthValidation = (fieldBody: string, fieldId: string, errorMessage: string, errors: object, maximum: number) => {
   let updatedErrors = errors;

--- a/src/ui/server/shared-validation/phone-number/index.ts
+++ b/src/ui/server/shared-validation/phone-number/index.ts
@@ -35,8 +35,8 @@ const phoneNumberPatternValidation = (phoneNumber: string) => {
  * @param {string} phoneNumber
  * @param {string} fieldId
  * @param {string} errorMessage
- * @param {object} errors
- * @returns {object} updatedErrors
+ * @param {Object} errors
+ * @returns {Object} updatedErrors
  */
 const validatePhoneNumber = (phoneNumber: string, fieldId: string, errorMessage: string, errors: object) => {
   let updatedErrors = errors;


### PR DESCRIPTION
## Introduction :pencil2:
This PR introduces a myriad of minor cypress command and documentation improvements.

## Resolution :heavy_check_mark:
- Create new, DRY `checkIntroText` cypress command.
- Add missing documentation to some cypress commands.
- Fix/update some incorrect `object` (vs `Object`) documentation.
- Fix/align some UI validation functions documentation.

## Miscellaneous :heavy_plus_sign:
- Improve some cypress command constants/exports, for better readability.
- Update some cypress commands to use `checkText`.
- Address a TODO comment.
