### PR TITLE
chore(EMS-2641): No PDF - Policy - Another company - Data mapping

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/changing-another-company-from-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/changing-another-company-from-yes-to-no.spec.js
@@ -1,0 +1,76 @@
+import { field as fieldSelector } from '../../../../../../pages/shared';
+import { FIELD_VALUES } from '../../../../../../constants';
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+
+const {
+  ROOT,
+  POLICY: { OTHER_COMPANY_DETAILS },
+} = INSURANCE_ROUTES;
+
+const {
+  REQUESTED_JOINTLY_INSURED_PARTY: {
+    REQUESTED, COMPANY_NAME, COMPANY_NUMBER, COUNTRY,
+  },
+} = POLICY_FIELD_IDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context(`Insurance - Policy - Other company details page - Changing ${REQUESTED} from 'yes' to 'no'`, () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      // go to the page we want to test.
+      cy.startInsurancePolicySection({});
+
+      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitSingleContractPolicyForm({});
+      cy.completeAndSubmitTotalContractValueForm({});
+      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitPreCreditPeriodForm({});
+      cy.completeAndSubmitAnotherCompanyForm({ otherCompanyInvolved: true });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${OTHER_COMPANY_DETAILS}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe(`when changing ${REQUESTED} from 'yes' to 'no'`, () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      cy.completeAndSubmitOtherCompanyDetailsForm();
+
+      /**
+       * Go back to the "other company"
+       * So we can change "yes" to no"
+       */
+      cy.go('back');
+      cy.go('back');
+
+      cy.completeAndSubmitAnotherCompanyForm({ otherCompanyInvolved: false });
+
+      // Manually navigate to the "other company details" page
+      cy.navigateToUrl(url);
+    });
+
+    it('should not have fields populated on different name on policy page', () => {
+      cy.checkValue(fieldSelector(COMPANY_NAME), '');
+      cy.checkValue(fieldSelector(COMPANY_NUMBER), '');
+      cy.checkValue(fieldSelector(COUNTRY), '');
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/policy/another-company/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/another-company/index.test.ts
@@ -152,9 +152,11 @@ describe('controllers/insurance/policy/another-company', () => {
 
         const payload = constructPayload(req.body, [FIELD_ID]);
 
+        const sanitisedData = sanitiseData(payload);
+
         expect(mapAndSave.jointlyInsuredParty).toHaveBeenCalledTimes(1);
 
-        expect(mapAndSave.jointlyInsuredParty).toHaveBeenCalledWith(payload, mockApplication);
+        expect(mapAndSave.jointlyInsuredParty).toHaveBeenCalledWith(sanitisedData, mockApplication);
       });
 
       describe(`when ${FIELD_ID} is submitted as 'no'`, () => {

--- a/src/ui/server/controllers/insurance/policy/another-company/index.ts
+++ b/src/ui/server/controllers/insurance/policy/another-company/index.ts
@@ -133,7 +133,7 @@ export const post = async (req: Request, res: Response) => {
 
   try {
     // save the application
-    const saveResponse = await mapAndSave.jointlyInsuredParty(payload, application);
+    const saveResponse = await mapAndSave.jointlyInsuredParty(sanitisedData, application);
 
     if (!saveResponse) {
       return res.redirect(PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/policy/map-submitted-data/jointly-insured-party/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/map-submitted-data/jointly-insured-party/index.test.ts
@@ -1,0 +1,56 @@
+import POLICY_FIELD_IDS from '../../../../../constants/field-ids/insurance/policy';
+import { mockJointlyInsuredParty } from '../../../../../test-mocks';
+import mapSubmittedData from '.';
+
+const {
+  REQUESTED_JOINTLY_INSURED_PARTY: { REQUESTED, COMPANY_NAME, COMPANY_NUMBER, COUNTRY },
+} = POLICY_FIELD_IDS;
+
+describe('controllers/insurance/policy/map-submitted-data/jointly-insured-party', () => {
+  describe(`when ${REQUESTED} is false`, () => {
+    const mockBody = {
+      [REQUESTED]: false,
+      mockOtherField: true,
+    };
+
+    it('should return form data as provided', () => {
+      const result = mapSubmittedData(mockBody);
+
+      const expected = mockBody;
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when ${REQUESTED} is false`, () => {
+    it('should nullify all other fields', () => {
+      const mockBody = {
+        ...mockJointlyInsuredParty,
+        [REQUESTED]: false,
+      };
+
+      const result = mapSubmittedData(mockBody);
+
+      const expected = {
+        ...mockBody,
+        [COMPANY_NAME]: '',
+        [COMPANY_NUMBER]: '',
+        [COUNTRY]: null,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when ${REQUESTED} is not provided`, () => {
+    it('should return form data as provided', () => {
+      const mockBody = {};
+
+      const result = mapSubmittedData(mockBody);
+
+      const expected = mockBody;
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/policy/map-submitted-data/jointly-insured-party/index.ts
+++ b/src/ui/server/controllers/insurance/policy/map-submitted-data/jointly-insured-party/index.ts
@@ -1,10 +1,26 @@
+import POLICY_FIELD_IDS from '../../../../../constants/field-ids/insurance/policy';
 import { RequestBody } from '../../../../../../types';
+
+const {
+  REQUESTED_JOINTLY_INSURED_PARTY: { REQUESTED, COMPANY_NAME, COMPANY_NUMBER, COUNTRY },
+} = POLICY_FIELD_IDS;
 
 /**
  * mapSubmittedData
+ * if REQUESTED is false, wipe "other company"/"jointly insured party" data.
  * @param {Express.Request.body} Form data
  * @returns {Object} Page variables
  */
-const mapSubmittedData = (formBody: RequestBody): object => formBody;
+const mapSubmittedData = (formBody: RequestBody): object => {
+  const populatedData = formBody;
+
+  if (!populatedData[REQUESTED]) {
+    populatedData[COMPANY_NAME] = '';
+    populatedData[COMPANY_NUMBER] = '';
+    populatedData[COUNTRY] = null;
+  }
+
+  return populatedData;
+};
 
 export default mapSubmittedData;

--- a/src/ui/server/controllers/insurance/policy/map-submitted-data/policy-contact/index.ts
+++ b/src/ui/server/controllers/insurance/policy/map-submitted-data/policy-contact/index.ts
@@ -1,8 +1,8 @@
-import { RequestBody, Application, ApplicationPolicyContact } from '../../../../../../types';
 import POLICY_FIELD_IDS from '../../../../../constants/field-ids/insurance/policy';
 import ACCOUNT_FIELD_IDS from '../../../../../constants/field-ids/insurance/account';
 import hasPolicyContactChanged from '../../../../../helpers/has-policy-contact-changed';
 import isPolicyContactDataSameAsOwner from '../../../../../helpers/is-policy-contact-data-same-as-owner';
+import { RequestBody, Application, ApplicationPolicyContact } from '../../../../../../types';
 
 const {
   NAME_ON_POLICY: { NAME, POSITION, SAME_NAME, OTHER_NAME, IS_SAME_AS_OWNER },
@@ -41,9 +41,11 @@ const mapSubmittedData = (formBody: RequestBody, application: Application): obje
   }
 
   /**
-   * if NAME set to OTHER_NAME
-   * remove NAME
-   * if POSITION populated, then should be set to empty string to send to API
+   * If NAME is set to OTHER_NAME:
+   * - Set IS_SAME_AS_OWNER to false
+   * - Remove NAME
+   * If the policy contact has changed and is now the application owner,
+   * nullify policy contact values.
    */
   if (populatedData[NAME] === OTHER_NAME) {
     populatedData[IS_SAME_AS_OWNER] = false;
@@ -60,10 +62,18 @@ const mapSubmittedData = (formBody: RequestBody, application: Application): obje
     }
   }
 
+  /**
+   * If NAME is an empty string,
+   * Delete the field.
+   */
   if (populatedData[NAME] === '') {
     delete populatedData[NAME];
   }
 
+  /**
+   * If the policy contact is the same as the application owner,
+   * Set IS_SAME_AS_OWNER to true.
+   */
   if (samePolicyContact) {
     populatedData[IS_SAME_AS_OWNER] = true;
   }

--- a/src/ui/server/test-mocks/mock-jointly-insured-party.ts
+++ b/src/ui/server/test-mocks/mock-jointly-insured-party.ts
@@ -1,6 +1,11 @@
+import mockCountries from './mock-countries';
+
 const mockJointlyInsuredParty = {
   id: '123',
   requested: false,
+  companyName: 'Mock company name',
+  companyNumber: 'Mock company number',
+  country: mockCountries[0],
 };
 
 export default mockJointlyInsuredParty;


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the "Another company" form submission functionality so that if a user changes the answer from "yes" to "no", the previously submitted "Other company" fields are nullified.

## Resolution :heavy_check_mark:
- Add E2E test coverage.
- Update the "Another company" POST controller to call `mapAndSave` with `sanitisedData` instead of `payload`.
- Update `mapSubmittedData` to wipe some specific fields if `REQUESTED` is false.

## Miscellaneous :heavy_plus_sign:
- Improve "map policy contact" documentation.
