### PR TITLE
fix(EMS-2809-2810-2811-2821): No PDF - Radio layout/alignment issues, missing "save and back" button

### DIFF
--- a/e2e-tests/constants/routes/insurance/policy.js
+++ b/e2e-tests/constants/routes/insurance/policy.js
@@ -40,6 +40,7 @@ export const POLICY = {
   ANOTHER_COMPANY: `${ROOT}/another-company`,
   ANOTHER_COMPANY_SAVE_AND_BACK: `${ROOT}/another-company/save-and-go-back`,
   OTHER_COMPANY_DETAILS: `${ROOT}/other-company-details`,
+  OTHER_COMPANY_DETAILS_SAVE_AND_BACK: `${ROOT}/other-company-details/save-and-go-back`,
   BROKER_ROOT,
   BROKER_SAVE_AND_BACK: `${BROKER_ROOT}/save-and-back`,
   BROKER_CHANGE: `${BROKER_ROOT}/change`,

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/changing-another-company-from-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/changing-another-company-from-yes-to-no.spec.js
@@ -5,7 +5,7 @@ import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const {
   ROOT,
-  POLICY: { OTHER_COMPANY_DETAILS },
+  POLICY: { OTHER_COMPANY_DETAILS, ANOTHER_COMPANY },
 } = INSURANCE_ROUTES;
 
 const {
@@ -19,6 +19,7 @@ const baseUrl = Cypress.config('baseUrl');
 context(`Insurance - Policy - Other company details page - Changing ${REQUESTED} from 'yes' to 'no'`, () => {
   let referenceNumber;
   let url;
+  let anotherCompanyUrl;
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
@@ -35,6 +36,7 @@ context(`Insurance - Policy - Other company details page - Changing ${REQUESTED}
       cy.completeAndSubmitAnotherCompanyForm({ otherCompanyInvolved: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${OTHER_COMPANY_DETAILS}`;
+      anotherCompanyUrl = `${baseUrl}${ROOT}/${referenceNumber}${ANOTHER_COMPANY}`;
 
       cy.assertUrl(url);
     });
@@ -58,8 +60,7 @@ context(`Insurance - Policy - Other company details page - Changing ${REQUESTED}
        * Go back to the "other company"
        * So we can change "yes" to no"
        */
-      cy.go('back');
-      cy.go('back');
+      cy.navigateToUrl(anotherCompanyUrl);
 
       cy.completeAndSubmitAnotherCompanyForm({ otherCompanyInvolved: false });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/other-company-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/other-company-details.spec.js
@@ -97,6 +97,10 @@ context(`Insurance - Policy - Other company details page - ${story}`, () => {
       cy.checkText(field.label(), FIELD_STRINGS[fieldId].LABEL);
       field.input().should('exist');
     });
+
+    it('renders a `save and back` button', () => {
+      cy.assertSaveAndBackButton();
+    });
   });
 
   describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-submit.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-submit.spec.js
@@ -75,7 +75,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
 
       const radioField = {
         ...field,
-        input: field.yesRadioInput,
+        input: field.noRadioInput,
       };
 
       cy.submitAndAssertRadioErrors(radioField, 0, expectedErrors, COMPANY_DETAILS_ERRORS[HAS_DIFFERENT_TRADING_NAME].IS_EMPTY);
@@ -86,7 +86,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
 
       const radioField = {
         ...field,
-        input: field.yesRadioInput,
+        input: field.noRadioInput,
       };
 
       cy.submitAndAssertRadioErrors(radioField, 1, expectedErrors, COMPANY_DETAILS_ERRORS[TRADING_ADDRESS].IS_EMPTY);
@@ -122,7 +122,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
         cy.clickSubmitButton();
       });
 
-      it(`should redirect to ${natureOfBusinessUrl}`, () => {
+      it(`should redirect to ${NATURE_OF_BUSINESS_ROOT}`, () => {
         cy.assertUrl(natureOfBusinessUrl);
       });
     });
@@ -136,7 +136,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
         cy.clickSubmitButton();
       });
 
-      it(`should redirect to ${natureOfBusinessUrl}`, () => {
+      it(`should redirect to ${NATURE_OF_BUSINESS_ROOT}`, () => {
         cy.assertUrl(natureOfBusinessUrl);
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-address-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-address-validation.spec.js
@@ -50,7 +50,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
 
     const radioField = {
       ...field,
-      input: field.yesRadioInput,
+      input: field.noRadioInput,
     };
 
     cy.submitAndAssertRadioErrors(radioField, 0, 1, COMPANY_DETAILS_ERRORS[TRADING_ADDRESS].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-name-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-name-validation.spec.js
@@ -50,7 +50,7 @@ describe("Insurance - Your business - Company details page- As an Exporter I wan
 
     const radioField = {
       ...field,
-      input: field.yesRadioInput,
+      input: field.noRadioInput,
     };
 
     cy.submitAndAssertRadioErrors(radioField, 0, 1, COMPANY_DETAILS_ERRORS[HAS_DIFFERENT_TRADING_NAME].IS_EMPTY);

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/connection-to-the-buyer-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/connection-to-the-buyer-page.spec.js
@@ -73,6 +73,10 @@ context('Insurance - Your Buyer - Connection with the buyer - As an exporter, I 
         cy.checkText(yesNoRadioHint(), CONTENT_STRINGS.HINT);
       });
 
+      it('renders `yes` and `no` radio buttons in the correct order', () => {
+        cy.assertYesNoRadiosOrder({ noRadioFirst: true });
+      });
+
       it('renders `yes` radio button', () => {
         yesRadio().input().should('exist');
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/validation/connection-to-the-buyer-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/validation/connection-to-the-buyer-validation.spec.js
@@ -1,4 +1,4 @@
-import { field, yesRadioInput } from '../../../../../../../pages/shared';
+import { field, noRadioInput, yesRadioInput } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
@@ -63,7 +63,7 @@ context('Insurance - Your Buyer - Connection to the buyer page - form validation
 
       const radioField = {
         ...field(CONNECTION_WITH_BUYER),
-        input: yesRadioInput,
+        input: noRadioInput,
       };
 
       cy.submitAndAssertRadioErrors(radioField, errorIndex, expectedErrorsCount, errorMessage);

--- a/e2e-tests/pages/your-business/company-details/companyDetails.js
+++ b/e2e-tests/pages/your-business/company-details/companyDetails.js
@@ -14,14 +14,14 @@ const companyDetails = {
   yourBusinessHeading: () => cy.get(`[data-cy="${YOUR_BUSINESS}-heading`),
   [HAS_DIFFERENT_TRADING_NAME]: {
     label: () => cy.get(`[data-cy="${HAS_DIFFERENT_TRADING_NAME}-legend"]`),
-    yesRadioInput: () => yesRadioInput().first(),
     noRadioInput: () => noRadioInput().first(),
+    yesRadioInput: () => yesRadioInput().first(),
     errorMessage: () => cy.get(`[data-cy="${HAS_DIFFERENT_TRADING_NAME}-error-message"]`),
   },
   [TRADING_ADDRESS]: {
     label: () => cy.get(`[data-cy="${TRADING_ADDRESS}-legend"]`),
-    yesRadioInput: () => yesRadioInput().eq(1),
     noRadioInput: () => noRadioInput().eq(1),
+    yesRadioInput: () => yesRadioInput().eq(1),
     errorMessage: () => cy.get(`[data-cy="${TRADING_ADDRESS}-error-message"]`),
   },
 };

--- a/src/ui/server/constants/routes/insurance/policy.ts
+++ b/src/ui/server/constants/routes/insurance/policy.ts
@@ -40,6 +40,7 @@ export const POLICY = {
   ANOTHER_COMPANY: `${ROOT}/another-company`,
   ANOTHER_COMPANY_SAVE_AND_BACK: `${ROOT}/another-company/save-and-go-back`,
   OTHER_COMPANY_DETAILS: `${ROOT}/other-company-details`,
+  OTHER_COMPANY_DETAILS_SAVE_AND_BACK: `${ROOT}/other-company-details/save-and-go-back`,
   BROKER_ROOT,
   BROKER_SAVE_AND_BACK: `${BROKER_ROOT}/save-and-back`,
   BROKER_CHANGE: `${BROKER_ROOT}/change`,

--- a/src/ui/server/controllers/insurance/business/company-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.test.ts
@@ -1,4 +1,4 @@
-import { pageVariables, get, post, TEMPLATE, FIELD_IDS } from '.';
+import { TEMPLATE, FIELD_IDS, pageVariables, HTML_FLAGS, get, post } from '.';
 import { ROUTES, TEMPLATES } from '../../../../constants';
 import BUSINESS_FIELD_IDS from '../../../../constants/field-ids/insurance/business';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
@@ -89,6 +89,17 @@ describe('controllers/insurance/business/companies-details', () => {
     });
   });
 
+  describe('HTML_FLAGS', () => {
+    it('should have correct properties', () => {
+      const expected = {
+        HORIZONTAL_RADIOS: true,
+        NO_RADIO_AS_FIRST_OPTION: true,
+      };
+
+      expect(HTML_FLAGS).toEqual(expected);
+    });
+  });
+
   describe('get', () => {
     describe('when application has populated company data', () => {
       it('should render the company-details template with correct variables', () => {
@@ -107,6 +118,7 @@ describe('controllers/insurance/business/companies-details', () => {
           ...insuranceCorePageVariables({
             PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
             BACK_LINK: req.headers.referer,
+            HTML_FLAGS,
           }),
           userName: getUserNameFromSession(req.session.user),
           ...pageVariables(referenceNumber),
@@ -161,6 +173,7 @@ describe('controllers/insurance/business/companies-details', () => {
           ...insuranceCorePageVariables({
             PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
             BACK_LINK: req.headers.referer,
+            HTML_FLAGS,
           }),
           userName: getUserNameFromSession(req.session.user),
           ...pageVariables(mockApplication.referenceNumber),

--- a/src/ui/server/controllers/insurance/business/company-details/index.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.ts
@@ -51,6 +51,15 @@ const pageVariables = (referenceNumber: number) => {
 };
 
 /**
+ * HTML_FLAGS
+ * Conditional flags for the nunjucks template to match design
+ */
+export const HTML_FLAGS = {
+  HORIZONTAL_RADIOS: true,
+  NO_RADIO_AS_FIRST_OPTION: true,
+};
+
+/**
  * gets the template for company details page
  * @param {Express.Request} Express request
  * @param {Express.Response} Express response
@@ -79,6 +88,7 @@ const get = (req: Request, res: Response) => {
       ...insuranceCorePageVariables({
         PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
         BACK_LINK: req.headers.referer,
+        HTML_FLAGS,
       }),
       userName: getUserNameFromSession(req.session.user),
       ...pageVariables(application.referenceNumber),
@@ -131,6 +141,7 @@ const post = async (req: Request, res: Response) => {
         ...insuranceCorePageVariables({
           PAGE_CONTENT_STRINGS: COMPANY_DETAILS,
           BACK_LINK: req.headers.referer,
+          HTML_FLAGS,
         }),
         userName: getUserNameFromSession(req.session.user),
         ...pageVariables(application.referenceNumber),

--- a/src/ui/server/controllers/insurance/business/credit-control/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/credit-control/index.test.ts
@@ -1,4 +1,4 @@
-import { FIELD_ID, TEMPLATE, PAGE_VARIABLES, get, post } from '.';
+import { FIELD_ID, TEMPLATE, PAGE_VARIABLES, HTML_FLAGS, get, post } from '.';
 import { ERROR_MESSAGES, PAGES } from '../../../../content-strings';
 import { FIELDS } from '../../../../content-strings/fields/insurance/your-business';
 import { TEMPLATES } from '../../../../constants';
@@ -63,6 +63,16 @@ describe('controllers/insurance/business/credit-control', () => {
     });
   });
 
+  describe('HTML_FLAGS', () => {
+    it('should have correct properties', () => {
+      const expected = {
+        HORIZONTAL_RADIOS: true,
+      };
+
+      expect(HTML_FLAGS).toEqual(expected);
+    });
+  });
+
   describe('get', () => {
     it('should render template', () => {
       get(req, res);
@@ -71,6 +81,7 @@ describe('controllers/insurance/business/credit-control', () => {
         ...singleInputPageVariables({
           ...PAGE_VARIABLES,
           BACK_LINK: req.headers.referer,
+          HTML_FLAGS,
         }),
         FIELD_HINT: FIELDS[FIELD_ID].HINT,
         userName: getUserNameFromSession(req.session.user),
@@ -113,6 +124,7 @@ describe('controllers/insurance/business/credit-control', () => {
           ...singleInputPageVariables({
             ...PAGE_VARIABLES,
             BACK_LINK: req.headers.referer,
+            HTML_FLAGS,
           }),
           FIELD_HINT: FIELDS[FIELD_ID].HINT,
           userName: getUserNameFromSession(req.session.user),

--- a/src/ui/server/controllers/insurance/business/credit-control/index.ts
+++ b/src/ui/server/controllers/insurance/business/credit-control/index.ts
@@ -31,6 +31,14 @@ export const PAGE_VARIABLES = {
 };
 
 /**
+ * HTML_FLAGS
+ * Conditional flags for the nunjucks template to match design
+ */
+export const HTML_FLAGS = {
+  HORIZONTAL_RADIOS: true,
+};
+
+/**
  * get
  * Render the credit control page
  * @param {Express.Request} Express request
@@ -51,6 +59,7 @@ export const get = (req: Request, res: Response) => {
       ...singleInputPageVariables({
         ...PAGE_VARIABLES,
         BACK_LINK: req.headers.referer,
+        HTML_FLAGS,
       }),
       FIELD_HINT: FIELDS[FIELD_ID].HINT,
       userName: getUserNameFromSession(req.session.user),
@@ -89,6 +98,7 @@ export const post = async (req: Request, res: Response) => {
         ...singleInputPageVariables({
           ...PAGE_VARIABLES,
           BACK_LINK: req.headers.referer,
+          HTML_FLAGS,
         }),
         FIELD_HINT: FIELDS[FIELD_ID].HINT,
         userName: getUserNameFromSession(req.session.user),

--- a/src/ui/server/controllers/insurance/policy/other-company-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/index.test.ts
@@ -13,13 +13,15 @@ import { mockReq, mockRes, mockApplication, mockCountries } from '../../../../te
 
 const {
   INSURANCE_ROOT,
-  POLICY: { BROKER_ROOT },
+  POLICY: { BROKER_ROOT, OTHER_COMPANY_DETAILS_SAVE_AND_BACK },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
 const {
   REQUESTED_JOINTLY_INSURED_PARTY: { COMPANY_NAME, COMPANY_NUMBER, COUNTRY },
 } = POLICY_FIELD_IDS;
+
+const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/other-company-details', () => {
   let req: Request;
@@ -50,7 +52,7 @@ describe('controllers/insurance/policy/other-company-details', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables;
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELDS: {
@@ -67,6 +69,7 @@ describe('controllers/insurance/policy/other-company-details', () => {
             ...FIELDS.REQUESTED_JOINTLY_INSURED_PARTY[COUNTRY],
           },
         },
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${OTHER_COMPANY_DETAILS_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -96,7 +99,7 @@ describe('controllers/insurance/policy/other-company-details', () => {
           PAGE_CONTENT_STRINGS,
           BACK_LINK: req.headers.referer,
         }),
-        ...pageVariables,
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
       };
 
@@ -134,7 +137,7 @@ describe('controllers/insurance/policy/other-company-details', () => {
             PAGE_CONTENT_STRINGS,
             BACK_LINK: req.headers.referer,
           }),
-          ...pageVariables,
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           submittedValues: payload,
           validationErrors: generateValidationErrors(payload),

--- a/src/ui/server/controllers/insurance/policy/other-company-details/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/index.ts
@@ -11,7 +11,7 @@ import { Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
-  POLICY: { BROKER_ROOT },
+  POLICY: { BROKER_ROOT, OTHER_COMPANY_DETAILS_SAVE_AND_BACK },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -23,10 +23,11 @@ export const PAGE_CONTENT_STRINGS = PAGES.INSURANCE.POLICY.OTHER_COMPANY_DETAILS
 
 /**
  * pageVariables
- * Page fields
+ * Page fields and "save and go back" URL
+ * @param {Number} Application reference number
  * @returns {Object} Page variables
  */
-export const pageVariables = {
+export const pageVariables = (referenceNumber: number) => ({
   FIELDS: {
     COMPANY_NAME: {
       ID: COMPANY_NAME,
@@ -41,7 +42,8 @@ export const pageVariables = {
       ...FIELDS.REQUESTED_JOINTLY_INSURED_PARTY[COUNTRY],
     },
   },
-};
+  SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${OTHER_COMPANY_DETAILS_SAVE_AND_BACK}`,
+});
 
 export const TEMPLATE = TEMPLATES.INSURANCE.POLICY.OTHER_COMPANY_DETAILS;
 
@@ -97,7 +99,7 @@ export const post = (req: Request, res: Response) => {
         PAGE_CONTENT_STRINGS,
         BACK_LINK: req.headers.referer,
       }),
-      ...pageVariables,
+      ...pageVariables(application.referenceNumber),
       userName: getUserNameFromSession(req.session.user),
       submittedValues: payload,
       validationErrors,

--- a/src/ui/server/controllers/insurance/policy/other-company-details/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/index.ts
@@ -68,7 +68,7 @@ export const get = (req: Request, res: Response) => {
       PAGE_CONTENT_STRINGS,
       BACK_LINK: req.headers.referer,
     }),
-    ...pageVariables,
+    ...pageVariables(application.referenceNumber),
     userName: getUserNameFromSession(req.session.user),
   });
 };

--- a/src/ui/server/controllers/insurance/your-buyer/connection-with-buyer/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/connection-with-buyer/index.test.ts
@@ -85,6 +85,7 @@ describe('controllers/insurance/your-buyer/connection-with-buyer', () => {
       const expected = {
         CONDITIONAL_YES_HTML: CONNECTION_WITH_BUYER_PARTIALS.CONDITIONAL_YES_HTML,
         HORIZONTAL_RADIOS: true,
+        NO_RADIO_AS_FIRST_OPTION: true,
       };
 
       expect(HTML_FLAGS).toEqual(expected);

--- a/src/ui/server/controllers/insurance/your-buyer/connection-with-buyer/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/connection-with-buyer/index.test.ts
@@ -55,6 +55,26 @@ describe('controllers/insurance/your-buyer/connection-with-buyer', () => {
     jest.resetAllMocks();
   });
 
+  describe('FIELD_IDS', () => {
+    it('should have the correct FIELD_IDS', () => {
+      const expected = [CONNECTION_WITH_BUYER, CONNECTION_WITH_BUYER_DESCRIPTION];
+
+      expect(FIELD_IDS).toEqual(expected);
+    });
+  });
+
+  describe('TEMPLATE', () => {
+    it('should have the correct template defined', () => {
+      expect(TEMPLATE).toEqual(SHARED_PAGES.SINGLE_RADIO);
+    });
+  });
+
+  describe('PAGE_CONTENT_STRINGS', () => {
+    it('should have the correct page content strings', () => {
+      expect(PAGE_CONTENT_STRINGS).toEqual(PAGES.INSURANCE.YOUR_BUYER.CONNECTION_WITH_BUYER);
+    });
+  });
+
   describe('pageVariables', () => {
     it('should have correct properties', () => {
       const result = pageVariables(mockApplication.referenceNumber);
@@ -89,26 +109,6 @@ describe('controllers/insurance/your-buyer/connection-with-buyer', () => {
       };
 
       expect(HTML_FLAGS).toEqual(expected);
-    });
-  });
-
-  describe('PAGE_CONTENT_STRINGS', () => {
-    it('should have the correct page content strings', () => {
-      expect(PAGE_CONTENT_STRINGS).toEqual(PAGES.INSURANCE.YOUR_BUYER.CONNECTION_WITH_BUYER);
-    });
-  });
-
-  describe('TEMPLATE', () => {
-    it('should have the correct template defined', () => {
-      expect(TEMPLATE).toEqual(SHARED_PAGES.SINGLE_RADIO);
-    });
-  });
-
-  describe('FIELD_IDS', () => {
-    it('should have the correct FIELD_IDS', () => {
-      const expected = [CONNECTION_WITH_BUYER, CONNECTION_WITH_BUYER_DESCRIPTION];
-
-      expect(FIELD_IDS).toEqual(expected);
     });
   });
 

--- a/src/ui/server/controllers/insurance/your-buyer/connection-with-buyer/index.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/connection-with-buyer/index.ts
@@ -62,6 +62,7 @@ export const pageVariables = (referenceNumber: number) => ({
 export const HTML_FLAGS = {
   CONDITIONAL_YES_HTML: CONNECTION_WITH_BUYER_PARTIALS.CONDITIONAL_YES_HTML,
   HORIZONTAL_RADIOS: true,
+  NO_RADIO_AS_FIRST_OPTION: true,
 };
 
 /**

--- a/src/ui/templates/insurance/your-business/company-details.njk
+++ b/src/ui/templates/insurance/your-business/company-details.njk
@@ -93,7 +93,8 @@
           errorMessage: validationErrors.errorList[FIELDS.YOUR_COMPANY.HAS_DIFFERENT_TRADING_NAME],
           dataCyLegend: FIELDS.YOUR_COMPANY.HAS_DIFFERENT_TRADING_NAME + '-legend',
           conditionalYesHtml: conditionalYesHtml,
-          horizontalRadios: true
+          horizontalRadios: HORIZONTAL_RADIOS,
+          noRadioAsFirstOption: NO_RADIO_AS_FIRST_OPTION
         }) }}
 
         {{ yesNoRadioButtons.render({
@@ -104,7 +105,8 @@
           submittedAnswer: submittedValues[FIELDS.YOUR_COMPANY.TRADING_ADDRESS],
           errorMessage: validationErrors.errorList[FIELDS.YOUR_COMPANY.TRADING_ADDRESS],
           dataCyLegend: FIELDS.YOUR_COMPANY.TRADING_ADDRESS + '-legend',
-          horizontalRadios: true
+          horizontalRadios: HORIZONTAL_RADIOS,
+          noRadioAsFirstOption: NO_RADIO_AS_FIRST_OPTION
         }) }}
 
         {{ govukInput({


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes some minor issues where some "yes/no" radios were in the incorrect order and the "Other company details" page had a missing "Save and back" button.

## Resolution :heavy_check_mark:
- Add `OTHER_COMPANY_DETAILS_SAVE_AND_BACK` route constant.
- Create `HTML_FLAGS` for the "Company details" and "Credit control" controllers, update "Company details" nunjucks template.
- Update "Other company details" controller to pass a `SAVE_AND_BACK_URL` via `pageVariables`.


## Miscellaneous :heavy_plus_sign:
- Update some unit test ordering.
