### PR TITLE
fix(EMS-2786-2789): No PDF - Policy - Different name on policy - Form validation

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -246,7 +246,7 @@ export const ERROR_MESSAGES = {
           INCORRECT_FORMAT: "The policy holder's last name must not include any numbers or symbols",
         },
         [FIELD_IDS.INSURANCE.ACCOUNT.EMAIL]: {
-          IS_EMPTY: "Enter the email address of the person you want named on the policy",
+          IS_EMPTY: 'Enter the email address of the person you want named on the policy',
           INCORRECT_FORMAT: "Enter the policy holder's email address in the correct format, like name@example.com",
           ABOVE_MAXIMUM: "The policy holder's email cannot be more than 300 characters",
         },

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -252,6 +252,8 @@ export const ERROR_MESSAGES = {
         },
         [FIELD_IDS.INSURANCE.POLICY.DIFFERENT_NAME_ON_POLICY.POSITION]: {
           IS_EMPTY: "Enter the policy holder's position at the company",
+          ABOVE_MAXIMUM: "The description of the policy holder's role at the company cannot be more than 50 characters",
+          INCORRECT_FORMAT: "The policy holder's position at the company must not include any numbers or symbols",
         },
       },
       [FIELD_IDS.INSURANCE.POLICY.NEED_PRE_CREDIT_PERIOD]: {

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -246,8 +246,9 @@ export const ERROR_MESSAGES = {
           INCORRECT_FORMAT: "The policy holder's last name must not include any numbers or symbols",
         },
         [FIELD_IDS.INSURANCE.ACCOUNT.EMAIL]: {
-          IS_EMPTY: "Enter the policy holder's email address in the correct format, like name@example.com",
+          IS_EMPTY: "Enter the email address of the person you want named on the policy",
           INCORRECT_FORMAT: "Enter the policy holder's email address in the correct format, like name@example.com",
+          ABOVE_MAXIMUM: "The policy holder's email cannot be more than 300 characters",
         },
         [FIELD_IDS.INSURANCE.POLICY.DIFFERENT_NAME_ON_POLICY.POSITION]: {
           IS_EMPTY: "Enter the policy holder's position at the company",

--- a/e2e-tests/content-strings/fields/insurance/policy/index.js
+++ b/e2e-tests/content-strings/fields/insurance/policy/index.js
@@ -166,6 +166,7 @@ export const POLICY_FIELDS = {
   DIFFERENT_NAME_ON_POLICY: {
     [DIFFERENT_NAME_ON_POLICY.POSITION]: {
       LABEL: 'Position at company',
+      MAXIMUM: 50,
     },
     [EMAIL]: {
       SUMMARY: {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/validation/different-name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/validation/different-name-on-policy-validation.spec.js
@@ -156,6 +156,7 @@ context('Insurance - Policy - Different name on Policy page - Validation', () =>
       errorMessages: ERRORS[FIELD_ID],
       totalExpectedErrors: 4,
       totalExpectedOtherErrorsWithValidEmail: 3,
+      assertMaximumLength: true,
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/validation/different-name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/validation/different-name-on-policy-validation.spec.js
@@ -1,6 +1,7 @@
 import { field as fieldSelector } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { ACCOUNT_FIELDS } from '../../../../../../../content-strings/fields/insurance/account';
+import { POLICY_FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
@@ -31,6 +32,14 @@ const {
     NAME: { CHARACTERS: MAX_NAME_CHARACTERS },
   },
 } = ACCOUNT_FIELDS;
+
+const {
+  DIFFERENT_NAME_ON_POLICY: {
+    [POSITION]: {
+      MAXIMUM: MAX_POSITION_CHARACTERS,
+    },
+  },
+} = POLICY_FIELDS;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -170,13 +179,38 @@ context('Insurance - Policy - Different name on Policy page - Validation', () =>
       errorIndex: 3,
     };
 
+    const { field, numberOfExpectedErrors, errorIndex } = ERROR_ASSERTIONS;
+
     it(`should render validation errors when ${FIELD_ID} left empty`, () => {
       const errorMessage = ERROR.IS_EMPTY;
 
-      const { field, numberOfExpectedErrors, errorIndex } = ERROR_ASSERTIONS;
       const value = '';
 
       cy.submitAndAssertFieldErrors(field, value, errorIndex, numberOfExpectedErrors, errorMessage);
+    });
+
+    it(`should render validation errors when ${FIELD_ID} is over ${MAX_POSITION_CHARACTERS} characters`, () => {
+      const value = 'a'.repeat(MAX_POSITION_CHARACTERS + 1);
+
+      cy.submitAndAssertFieldErrors(field, value, errorIndex, numberOfExpectedErrors, ERROR.ABOVE_MAXIMUM);
+    });
+
+    it(`should render validation errors when ${FIELD_ID} contains a special character`, () => {
+      const value = 'a!';
+
+      cy.submitAndAssertFieldErrors(field, value, errorIndex, numberOfExpectedErrors, ERROR.INCORRECT_FORMAT);
+    });
+
+    it(`should render validation errors when ${FIELD_ID} contains a number`, () => {
+      const value = 'a1';
+
+      cy.submitAndAssertFieldErrors(field, value, errorIndex, numberOfExpectedErrors, ERROR.INCORRECT_FORMAT);
+    });
+
+    it(`should render validation errors when ${FIELD_ID} contains a number and special character`, () => {
+      const value = 'a1!';
+
+      cy.submitAndAssertFieldErrors(field, value, errorIndex, numberOfExpectedErrors, ERROR.INCORRECT_FORMAT);
     });
   });
 });

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -245,8 +245,9 @@ export const ERROR_MESSAGES = {
           INCORRECT_FORMAT: "The policy holder's last name must not include any numbers or symbols",
         },
         [FIELD_IDS.INSURANCE.ACCOUNT.EMAIL]: {
-          IS_EMPTY: "Enter the policy holder's email address in the correct format, like name@example.com",
+          IS_EMPTY: "Enter the email address of the person you want named on the policy",
           INCORRECT_FORMAT: "Enter the policy holder's email address in the correct format, like name@example.com",
+          ABOVE_MAXIMUM: "The policy holder's email cannot be more than 300 characters",
         },
         [FIELD_IDS.INSURANCE.POLICY.DIFFERENT_NAME_ON_POLICY.POSITION]: {
           IS_EMPTY: "Enter the policy holder's position at the company",

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -245,7 +245,7 @@ export const ERROR_MESSAGES = {
           INCORRECT_FORMAT: "The policy holder's last name must not include any numbers or symbols",
         },
         [FIELD_IDS.INSURANCE.ACCOUNT.EMAIL]: {
-          IS_EMPTY: "Enter the email address of the person you want named on the policy",
+          IS_EMPTY: 'Enter the email address of the person you want named on the policy',
           INCORRECT_FORMAT: "Enter the policy holder's email address in the correct format, like name@example.com",
           ABOVE_MAXIMUM: "The policy holder's email cannot be more than 300 characters",
         },

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -251,6 +251,8 @@ export const ERROR_MESSAGES = {
         },
         [FIELD_IDS.INSURANCE.POLICY.DIFFERENT_NAME_ON_POLICY.POSITION]: {
           IS_EMPTY: "Enter the policy holder's position at the company",
+          ABOVE_MAXIMUM: "The description of the policy holder's role at the company cannot be more than 50 characters",
+          INCORRECT_FORMAT: "The policy holder's position at the company must not include any numbers or symbols",
         },
       },
       [FIELD_IDS.INSURANCE.POLICY.NEED_PRE_CREDIT_PERIOD]: {

--- a/src/ui/server/content-strings/fields/insurance/policy/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy/index.ts
@@ -162,6 +162,7 @@ export const POLICY_FIELDS = {
   DIFFERENT_NAME_ON_POLICY: {
     [DIFFERENT_NAME_ON_POLICY.POSITION]: {
       LABEL: 'Position at company',
+      MAXIMUM: 50,
     },
     [EMAIL]: {
       SUMMARY: {

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/position.test.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/position.test.ts
@@ -1,7 +1,7 @@
-import position from './position';
-import { ERROR_MESSAGES } from '../../../../../../content-strings';
+import position, { MAXIMUM } from './position';
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/policy';
-import emptyFieldValidation from '../../../../../../shared-validation/empty-field';
+import { ERROR_MESSAGES } from '../../../../../../content-strings';
+import alphaCharactersAndMaxLengthValidation from '../../../../../../shared-validation/alpha-characters-and-max-length';
 import { RequestBody } from '../../../../../../../types';
 import { mockErrors } from '../../../../../../test-mocks';
 
@@ -18,10 +18,10 @@ describe('controllers/insurance/policy/different-name-on-policy/validation/rules
     [FIELD_ID]: '',
   } as RequestBody;
 
-  it('should return the result of emptyFieldValidation', () => {
+  it('should return the result of alphaCharactersAndMaxLengthValidation', () => {
     const response = position(mockBody, mockErrors);
 
-    const expected = emptyFieldValidation(mockBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors);
+    const expected = alphaCharactersAndMaxLengthValidation(mockBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors, MAXIMUM);
 
     expect(response).toEqual(expected);
   });

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/position.test.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/position.test.ts
@@ -10,7 +10,7 @@ const {
 } = FIELD_IDS;
 
 const {
-  DIFFERENT_NAME_ON_POLICY: { [FIELD_ID]: ERROR_MESSAGE },
+  DIFFERENT_NAME_ON_POLICY: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
 } = ERROR_MESSAGES.INSURANCE.POLICY;
 
 describe('controllers/insurance/policy/different-name-on-policy/validation/rules/position', () => {
@@ -21,7 +21,7 @@ describe('controllers/insurance/policy/different-name-on-policy/validation/rules
   it('should return the result of alphaCharactersAndMaxLengthValidation', () => {
     const response = position(mockBody, mockErrors);
 
-    const expected = alphaCharactersAndMaxLengthValidation(mockBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, mockErrors, MAXIMUM);
+    const expected = alphaCharactersAndMaxLengthValidation(mockBody, FIELD_ID, ERROR_MESSAGES_OBJECT, mockErrors, MAXIMUM);
 
     expect(response).toEqual(expected);
   });

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/position.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/validation/rules/position.ts
@@ -1,15 +1,20 @@
-import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/policy';
+import { ERROR_MESSAGES } from '../../../../../../content-strings';
+import { POLICY_FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
+import alphaCharactersAndMaxLengthValidation from '../../../../../../shared-validation/alpha-characters-and-max-length';
 import { RequestBody } from '../../../../../../../types';
-import emptyFieldValidation from '../../../../../../shared-validation/empty-field';
 
 const {
   DIFFERENT_NAME_ON_POLICY: { POSITION: FIELD_ID },
 } = FIELD_IDS;
 
 const {
-  DIFFERENT_NAME_ON_POLICY: { [FIELD_ID]: ERROR_MESSAGE },
+  DIFFERENT_NAME_ON_POLICY: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
 } = ERROR_MESSAGES.INSURANCE.POLICY;
+
+const { DIFFERENT_NAME_ON_POLICY } = POLICY_FIELDS;
+
+export const MAXIMUM = Number(DIFFERENT_NAME_ON_POLICY[FIELD_ID].MAXIMUM);
 
 /**
  * validates position field
@@ -18,6 +23,6 @@ const {
  * @param {Object} errors
  * @returns {Object} errors
  */
-const position = (formBody: RequestBody, errors: object) => emptyFieldValidation(formBody, FIELD_ID, ERROR_MESSAGE.IS_EMPTY, errors);
+const position = (formBody: RequestBody, errors: object) => alphaCharactersAndMaxLengthValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MAXIMUM);
 
 export default position;

--- a/src/ui/templates/insurance/policy/different-name-on-policy.njk
+++ b/src/ui/templates/insurance/policy/different-name-on-policy.njk
@@ -54,7 +54,7 @@
         }) %}
 
           {{ personalDetailsInput.render({
-            class: "govuk-input--width-11",
+            class: "govuk-!-width-one-half",
             fieldId: FIELDS.FIRST_NAME.ID,
             label: FIELDS.FIRST_NAME.LABEL,
             labelClass: "govuk-label--s",
@@ -63,7 +63,7 @@
           }) }}
 
           {{ personalDetailsInput.render({
-            class: "govuk-input--width-11",
+            class: "govuk-!-width-one-half",
             fieldId: FIELDS.LAST_NAME.ID,
             label: FIELDS.LAST_NAME.LABEL,
             labelClass: "govuk-label--s",
@@ -72,7 +72,7 @@
           }) }}
 
           {{ personalDetailsInput.render({
-            class: "govuk-input--width-11",
+            class: "govuk-!-width-one-half",
             fieldId: FIELDS.EMAIL_ADDRESS.ID,
             label: FIELDS.EMAIL_ADDRESS.LABEL,
             labelClass: "govuk-label--s",
@@ -81,7 +81,7 @@
           }) }}
 
           {{ personalDetailsInput.render({
-            class: "govuk-input--width-11",
+            class: "govuk-!-width-one-half",
             fieldId: FIELDS.POSITION.ID,
             label: FIELDS.POSITION.LABEL,
             labelClass: "govuk-label--s",


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes/adds some missing validation rules in the "Different name on policy" form.

## Resolution :heavy_check_mark:
- Update error messages content strings.
- Add `MAXIMUM` definition for the "position" field.
- Update the "position" validation to call/consume `alphaCharactersAndMaxLengthValidation` instead of `emptyFieldValidation`.
- Add E2E test coverage.

## Miscellaneous :heavy_plus_sign:
- Fix a styling (form input width) issue in the "Different name on policy" form.
