### PR TITLE
fix(EMS-2808-2812): No PDF - Buyer - Radio order for trading history and prior trading history

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/traded-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/traded-with-buyer.spec.js
@@ -72,6 +72,10 @@ context('Insurance - Your Buyer - Traded with buyer page - As an exporter, I wan
       cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
     });
 
+    it('renders `yes` and `no` radio buttons in the correct order', () => {
+      cy.assertYesNoRadiosOrder({ noRadioFirst: true });
+    });
+
     it('renders `yes` radio button', () => {
       yesRadio().input().should('exist');
 
@@ -102,7 +106,7 @@ context('Insurance - Your Buyer - Traded with buyer page - As an exporter, I wan
       const expectedErrorsCount = 1;
 
       cy.submitAndAssertRadioErrors(
-        yesRadio(FIELD_ID),
+        noRadio(FIELD_ID),
         0,
         expectedErrorsCount,
         ERROR_MESSAGE.IS_EMPTY,

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/validation/trading-history-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/validation/trading-history-validation.spec.js
@@ -1,4 +1,4 @@
-import { yesRadio, noRadio } from '../../../../../../../pages/shared';
+import { noRadio } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
@@ -61,7 +61,7 @@ context('Insurance - Your Buyer - Trading history page - Validation', () => {
       );
 
       cy.submitAndAssertRadioErrors(
-        yesRadio(FAILED_PAYMENTS),
+        noRadio(FAILED_PAYMENTS),
         1,
         expectedErrorsCount,
         ERRORS[FAILED_PAYMENTS].IS_EMPTY,

--- a/src/ui/server/controllers/insurance/your-buyer/traded-with-buyer/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/traded-with-buyer/index.test.ts
@@ -58,6 +58,7 @@ describe('controllers/insurance/your-buyer/traded-with-buyer', () => {
     it('should have correct properties', () => {
       const expected = {
         HORIZONTAL_RADIOS: true,
+        NO_RADIO_AS_FIRST_OPTION: true,
       };
 
       expect(HTML_FLAGS).toEqual(expected);

--- a/src/ui/server/controllers/insurance/your-buyer/traded-with-buyer/index.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/traded-with-buyer/index.ts
@@ -37,6 +37,7 @@ export const pageVariables = (referenceNumber: number) => ({
  */
 export const HTML_FLAGS = {
   HORIZONTAL_RADIOS: true,
+  NO_RADIO_AS_FIRST_OPTION: true,
 };
 
 export const TEMPLATE = TEMPLATES.SHARED_PAGES.SINGLE_RADIO;

--- a/src/ui/templates/insurance/your-buyer/trading-history.njk
+++ b/src/ui/templates/insurance/your-buyer/trading-history.njk
@@ -79,6 +79,7 @@
             submittedAnswer: submittedValues[FIELDS.FAILED_PAYMENTS.ID] or application.buyer.buyerTradingHistory[FIELDS.FAILED_PAYMENTS.ID],
             errorMessage: validationErrors.errorList[FIELDS.FAILED_PAYMENTS.ID],
             dataCyLegend: FIELDS.FAILED_PAYMENTS.ID + '-legend',
+            noRadioAsFirstOption: true,
             horizontalRadios: true
           }) }}
         </div>


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes the radio order for trading-history and prior-trading-history page

## Resolution :heavy_check_mark:
* Added to HTML flags or to nunjucks for radio order
* Added and updated tests