### PR TITLE
chore(EMS-2838): No PDF - click and assert unchecked yes/no radio button cypress commands

### DIFF
--- a/e2e-tests/commands/insurance/complete-about-goods-or-services-form.js
+++ b/e2e-tests/commands/insurance/complete-about-goods-or-services-form.js
@@ -28,7 +28,7 @@ const completeAboutGoodsOrServicesForm = ({
   cy.keyboardInput(aboutGoodsOrServicesPage[DESCRIPTION].textarea(), description);
 
   if (finalDestinationKnown) {
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
 
     if (includeFinalDestination) {
       cy.keyboardInput(countryInput.field(FINAL_DESTINATION).input(), COUNTRY_APPLICATION_SUPPORT.ONLINE.NAME);

--- a/e2e-tests/commands/insurance/complete-about-goods-or-services-form.js
+++ b/e2e-tests/commands/insurance/complete-about-goods-or-services-form.js
@@ -28,7 +28,7 @@ const completeAboutGoodsOrServicesForm = ({
   cy.keyboardInput(aboutGoodsOrServicesPage[DESCRIPTION].textarea(), description);
 
   if (finalDestinationKnown) {
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
 
     if (includeFinalDestination) {
       cy.keyboardInput(countryInput.field(FINAL_DESTINATION).input(), COUNTRY_APPLICATION_SUPPORT.ONLINE.NAME);

--- a/e2e-tests/commands/insurance/complete-about-goods-or-services-form.js
+++ b/e2e-tests/commands/insurance/complete-about-goods-or-services-form.js
@@ -1,10 +1,6 @@
 import { INSURANCE_FIELD_IDS } from '../../constants/field-ids/insurance';
 import { aboutGoodsOrServicesPage } from '../../pages/insurance/export-contract';
-import {
-  countryInput,
-  noRadio,
-  yesRadio,
-} from '../../pages/shared';
+import { countryInput } from '../../pages/shared';
 import application from '../../fixtures/application';
 import { COUNTRY_APPLICATION_SUPPORT } from '../../fixtures/countries';
 
@@ -32,13 +28,13 @@ const completeAboutGoodsOrServicesForm = ({
   cy.keyboardInput(aboutGoodsOrServicesPage[DESCRIPTION].textarea(), description);
 
   if (finalDestinationKnown) {
-    yesRadio().input().click();
+    cy.clickYesRadioInput();
 
     if (includeFinalDestination) {
       cy.keyboardInput(countryInput.field(FINAL_DESTINATION).input(), COUNTRY_APPLICATION_SUPPORT.ONLINE.NAME);
     }
   } else {
-    noRadio().input().click();
+    cy.clickNoRadioInput();
   }
 };
 

--- a/e2e-tests/commands/insurance/complete-and-submit-another-company-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-another-company-form.js
@@ -5,7 +5,7 @@
  */
 const completeAndSubmitAnotherCompanyForm = ({ otherCompanyInvolved = false }) => {
   if (otherCompanyInvolved) {
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
   } else {
     cy.clickNoRadioInput();
   }

--- a/e2e-tests/commands/insurance/complete-and-submit-another-company-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-another-company-form.js
@@ -1,5 +1,3 @@
-import { noRadioInput, yesRadioInput } from '../../pages/shared';
-
 /**
  * completeAndSubmitAnotherCompanyForm
  * Complete and submit the "Another company" form
@@ -7,9 +5,9 @@ import { noRadioInput, yesRadioInput } from '../../pages/shared';
  */
 const completeAndSubmitAnotherCompanyForm = ({ otherCompanyInvolved = false }) => {
   if (otherCompanyInvolved) {
-    yesRadioInput().click();
+    cy.clickYesRadioInput();
   } else {
-    noRadioInput().click();
+    cy.clickNoRadioInput();
   }
 
   cy.clickSubmitButton();

--- a/e2e-tests/commands/insurance/complete-and-submit-another-company-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-another-company-form.js
@@ -5,7 +5,7 @@
  */
 const completeAndSubmitAnotherCompanyForm = ({ otherCompanyInvolved = false }) => {
   if (otherCompanyInvolved) {
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
   } else {
     cy.clickNoRadioInput();
   }

--- a/e2e-tests/commands/insurance/complete-and-submit-broker-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-broker-form.js
@@ -7,7 +7,7 @@ const completeAndSubmitBrokerForm = ({
   usingBroker = false,
 }) => {
   if (usingBroker) {
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
   } else {
     cy.clickNoRadioInput();
   }

--- a/e2e-tests/commands/insurance/complete-and-submit-broker-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-broker-form.js
@@ -7,7 +7,7 @@ const completeAndSubmitBrokerForm = ({
   usingBroker = false,
 }) => {
   if (usingBroker) {
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
   } else {
     cy.clickNoRadioInput();
   }

--- a/e2e-tests/commands/insurance/complete-and-submit-broker-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-broker-form.js
@@ -1,5 +1,3 @@
-import { yesRadioInput, noRadioInput } from '../../pages/shared';
-
 /**
  * completeAndSubmitBrokerForm
  * Complete and submit "using broker" form
@@ -9,9 +7,9 @@ const completeAndSubmitBrokerForm = ({
   usingBroker = false,
 }) => {
   if (usingBroker) {
-    yesRadioInput().click();
+    cy.clickYesRadioInput();
   } else {
-    noRadioInput().click();
+    cy.clickNoRadioInput();
   }
 
   cy.clickSubmitButton();

--- a/e2e-tests/commands/insurance/complete-and-submit-credit-control-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-credit-control-form.js
@@ -5,7 +5,7 @@
  */
 const completeAndSubmitCreditControlForm = ({ hasCreditControlProcess = true }) => {
   if (hasCreditControlProcess) {
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
   } else {
     cy.clickNoRadioInput();
   }

--- a/e2e-tests/commands/insurance/complete-and-submit-credit-control-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-credit-control-form.js
@@ -5,7 +5,7 @@
  */
 const completeAndSubmitCreditControlForm = ({ hasCreditControlProcess = true }) => {
   if (hasCreditControlProcess) {
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
   } else {
     cy.clickNoRadioInput();
   }

--- a/e2e-tests/commands/insurance/complete-and-submit-credit-control-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-credit-control-form.js
@@ -1,5 +1,3 @@
-import { noRadioInput, yesRadioInput } from '../../pages/shared';
-
 /**
  * completeAndSubmitCreditControlForm
  * complete and submit the "credit control" form.
@@ -7,9 +5,9 @@ import { noRadioInput, yesRadioInput } from '../../pages/shared';
  */
 const completeAndSubmitCreditControlForm = ({ hasCreditControlProcess = true }) => {
   if (hasCreditControlProcess) {
-    yesRadioInput().click();
+    cy.clickYesRadioInput();
   } else {
-    noRadioInput().click();
+    cy.clickNoRadioInput();
   }
 
   cy.clickSubmitButton();

--- a/e2e-tests/commands/insurance/complete-company-details-form.js
+++ b/e2e-tests/commands/insurance/complete-company-details-form.js
@@ -31,7 +31,7 @@ const completeCompaniesDetailsForm = ({
   completeDifferentTradingName = true,
 }) => {
   if (differentTradingName) {
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
   } else {
     cy.clickNoRadioInput();
   }

--- a/e2e-tests/commands/insurance/complete-company-details-form.js
+++ b/e2e-tests/commands/insurance/complete-company-details-form.js
@@ -1,5 +1,5 @@
 import { INSURANCE_FIELD_IDS } from '../../constants/field-ids/insurance';
-import { field, yesRadioInput, noRadioInput } from '../../pages/shared';
+import { field } from '../../pages/shared';
 import application from '../../fixtures/application';
 
 const { YOUR_COMPANY } = application;
@@ -31,9 +31,9 @@ const completeCompaniesDetailsForm = ({
   completeDifferentTradingName = true,
 }) => {
   if (differentTradingName) {
-    yesRadioInput().first().click();
+    cy.clickYesRadioInput(0);
   } else {
-    noRadioInput().first().click();
+    cy.clickNoRadioInput();
   }
 
   if (differentTradingName && completeDifferentTradingName) {
@@ -41,9 +41,9 @@ const completeCompaniesDetailsForm = ({
   }
 
   if (differentTradingAddress) {
-    yesRadioInput().eq(1).click();
+    cy.clickYesRadioInput(1);
   } else {
-    noRadioInput().eq(1).click();
+    cy.clickNoRadioInput(1);
   }
 
   if (phoneNumber) {

--- a/e2e-tests/commands/insurance/complete-pre-credit-period-form.js
+++ b/e2e-tests/commands/insurance/complete-pre-credit-period-form.js
@@ -1,4 +1,4 @@
-import { noRadioInput, yesRadioInput, field } from '../../pages/shared';
+import { field } from '../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../constants/field-ids/insurance/policy';
 import mockApplication from '../../fixtures/application';
 
@@ -14,13 +14,13 @@ const completePreCreditPeriodForm = ({
   description = mockApplication.POLICY[CREDIT_PERIOD_WITH_BUYER],
 }) => {
   if (needPreCreditPeriod) {
-    yesRadioInput().click();
+    cy.clickYesRadioInput();
 
     const descriptionField = field(CREDIT_PERIOD_WITH_BUYER);
 
     cy.keyboardInput(descriptionField.textarea(), description);
   } else {
-    noRadioInput().click();
+    cy.clickNoRadioInput();
   }
 };
 

--- a/e2e-tests/commands/insurance/complete-pre-credit-period-form.js
+++ b/e2e-tests/commands/insurance/complete-pre-credit-period-form.js
@@ -14,7 +14,7 @@ const completePreCreditPeriodForm = ({
   description = mockApplication.POLICY[CREDIT_PERIOD_WITH_BUYER],
 }) => {
   if (needPreCreditPeriod) {
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
 
     const descriptionField = field(CREDIT_PERIOD_WITH_BUYER);
 

--- a/e2e-tests/commands/insurance/complete-pre-credit-period-form.js
+++ b/e2e-tests/commands/insurance/complete-pre-credit-period-form.js
@@ -14,7 +14,7 @@ const completePreCreditPeriodForm = ({
   description = mockApplication.POLICY[CREDIT_PERIOD_WITH_BUYER],
 }) => {
   if (needPreCreditPeriod) {
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
 
     const descriptionField = field(CREDIT_PERIOD_WITH_BUYER);
 

--- a/e2e-tests/commands/insurance/declarations/complete-and-submit-anti-bribery-code-of-conduct-form.js
+++ b/e2e-tests/commands/insurance/declarations/complete-and-submit-anti-bribery-code-of-conduct-form.js
@@ -1,4 +1,3 @@
-import { yesRadio, noRadio } from '../../../pages/shared';
 import { FIELD_VALUES } from '../../../constants';
 
 /**
@@ -7,9 +6,9 @@ import { FIELD_VALUES } from '../../../constants';
  */
 export default (answer) => {
   if (answer === FIELD_VALUES.NO) {
-    noRadio().input().click();
+    cy.clickNoRadioInput();
   } else {
-    yesRadio().input().click();
+    cy.clickYesRadioInput();
   }
 
   cy.clickSubmitButton();

--- a/e2e-tests/commands/insurance/declarations/complete-and-submit-anti-bribery-code-of-conduct-form.js
+++ b/e2e-tests/commands/insurance/declarations/complete-and-submit-anti-bribery-code-of-conduct-form.js
@@ -8,7 +8,7 @@ export default (answer) => {
   if (answer === FIELD_VALUES.NO) {
     cy.clickNoRadioInput();
   } else {
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
   }
 
   cy.clickSubmitButton();

--- a/e2e-tests/commands/insurance/declarations/complete-and-submit-anti-bribery-code-of-conduct-form.js
+++ b/e2e-tests/commands/insurance/declarations/complete-and-submit-anti-bribery-code-of-conduct-form.js
@@ -8,7 +8,7 @@ export default (answer) => {
   if (answer === FIELD_VALUES.NO) {
     cy.clickNoRadioInput();
   } else {
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
   }
 
   cy.clickSubmitButton();

--- a/e2e-tests/commands/insurance/declarations/complete-and-submit-anti-bribery-exporting-with-code-of-conduct-form.js
+++ b/e2e-tests/commands/insurance/declarations/complete-and-submit-anti-bribery-exporting-with-code-of-conduct-form.js
@@ -1,4 +1,3 @@
-import { yesRadio, noRadio } from '../../../pages/shared';
 import { FIELD_VALUES } from '../../../constants';
 
 /**
@@ -7,9 +6,9 @@ import { FIELD_VALUES } from '../../../constants';
  */
 const completeAndSubmitAntiBriberyExportingWithCodeOfConductForm = (answer) => {
   if (answer === FIELD_VALUES.NO) {
-    noRadio().input().click();
+    cy.clickNoRadioInput();
   } else {
-    yesRadio().input().click();
+    cy.clickYesRadioInput();
   }
 
   cy.clickSubmitButton();

--- a/e2e-tests/commands/insurance/declarations/complete-and-submit-anti-bribery-exporting-with-code-of-conduct-form.js
+++ b/e2e-tests/commands/insurance/declarations/complete-and-submit-anti-bribery-exporting-with-code-of-conduct-form.js
@@ -8,7 +8,7 @@ const completeAndSubmitAntiBriberyExportingWithCodeOfConductForm = (answer) => {
   if (answer === FIELD_VALUES.NO) {
     cy.clickNoRadioInput();
   } else {
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
   }
 
   cy.clickSubmitButton();

--- a/e2e-tests/commands/insurance/declarations/complete-and-submit-anti-bribery-exporting-with-code-of-conduct-form.js
+++ b/e2e-tests/commands/insurance/declarations/complete-and-submit-anti-bribery-exporting-with-code-of-conduct-form.js
@@ -8,7 +8,7 @@ const completeAndSubmitAntiBriberyExportingWithCodeOfConductForm = (answer) => {
   if (answer === FIELD_VALUES.NO) {
     cy.clickNoRadioInput();
   } else {
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
   }
 
   cy.clickSubmitButton();

--- a/e2e-tests/commands/insurance/eligibility/forms.js
+++ b/e2e-tests/commands/insurance/eligibility/forms.js
@@ -24,7 +24,7 @@ const {
  */
 const selectRadioAndSubmit = (answer) => {
   if (answer === FIELD_VALUES.YES) {
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
   }
 
   if (answer === FIELD_VALUES.NO) {

--- a/e2e-tests/commands/insurance/eligibility/forms.js
+++ b/e2e-tests/commands/insurance/eligibility/forms.js
@@ -24,7 +24,7 @@ const {
  */
 const selectRadioAndSubmit = (answer) => {
   if (answer === FIELD_VALUES.YES) {
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
   }
 
   if (answer === FIELD_VALUES.NO) {

--- a/e2e-tests/commands/insurance/eligibility/forms.js
+++ b/e2e-tests/commands/insurance/eligibility/forms.js
@@ -1,7 +1,5 @@
 import { FIELD_VALUES } from '../../../constants';
-import {
-  yesRadio, noRadio, field,
-} from '../../../pages/shared';
+import { field } from '../../../pages/shared';
 import { INSURANCE_FIELD_IDS } from '../../../constants/field-ids/insurance';
 import { FIELDS_ELIGIBILITY } from '../../../content-strings/fields/insurance/eligibility';
 
@@ -26,11 +24,11 @@ const {
  */
 const selectRadioAndSubmit = (answer) => {
   if (answer === FIELD_VALUES.YES) {
-    yesRadio().input().click();
+    cy.clickYesRadioInput();
   }
 
   if (answer === FIELD_VALUES.NO) {
-    noRadio().input().click();
+    cy.clickNoRadioInput();
   }
 
   cy.clickSubmitButton();

--- a/e2e-tests/commands/insurance/submit-eligibility-and-start-account-creation.js
+++ b/e2e-tests/commands/insurance/submit-eligibility-and-start-account-creation.js
@@ -1,10 +1,9 @@
 import submitInsuranceEligibilityAnswersHappyPath from './eligibility/submit-answers-happy-path';
-import { noRadioInput } from '../../pages/shared';
 
 export default () => {
   submitInsuranceEligibilityAnswersHappyPath();
 
   // submit "I do not already have an account"
-  noRadioInput().click();
+  cy.clickNoRadioInput();
   cy.clickSubmitButton();
 };

--- a/e2e-tests/commands/insurance/submit-eligibility-and-start-account-sign-in.js
+++ b/e2e-tests/commands/insurance/submit-eligibility-and-start-account-sign-in.js
@@ -4,6 +4,6 @@ export default () => {
   submitInsuranceEligibilityAnswersHappyPath();
 
   // submit "I already have an account"
-  cy.clickYesRadioInput(0);
+  cy.clickYesRadioInput();
   cy.clickSubmitButton();
 };

--- a/e2e-tests/commands/insurance/submit-eligibility-and-start-account-sign-in.js
+++ b/e2e-tests/commands/insurance/submit-eligibility-and-start-account-sign-in.js
@@ -4,6 +4,6 @@ export default () => {
   submitInsuranceEligibilityAnswersHappyPath();
 
   // submit "I already have an account"
-  cy.clickYesRadioInput();
+  cy.clickYesRadioInput(0);
   cy.clickSubmitButton();
 };

--- a/e2e-tests/commands/insurance/submit-eligibility-and-start-account-sign-in.js
+++ b/e2e-tests/commands/insurance/submit-eligibility-and-start-account-sign-in.js
@@ -1,10 +1,9 @@
 import submitInsuranceEligibilityAnswersHappyPath from './eligibility/submit-answers-happy-path';
-import { yesRadioInput } from '../../pages/shared';
 
 export default () => {
   submitInsuranceEligibilityAnswersHappyPath();
 
   // submit "I already have an account"
-  yesRadioInput().click();
+  cy.clickYesRadioInput();
   cy.clickSubmitButton();
 };

--- a/e2e-tests/commands/insurance/your-buyer/complete-buyer-financial-information-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-buyer-financial-information-form.js
@@ -1,5 +1,3 @@
-import { yesRadioInput, noRadioInput } from '../../../pages/shared';
-
 /**
  * completeBuyerFinancialInformationForm
  * Completes the "buyer financial information" form.
@@ -8,9 +6,9 @@ import { yesRadioInput, noRadioInput } from '../../../pages/shared';
  */
 const completeBuyerFinancialInformationForm = ({ exporterHasBuyerFinancialAccounts = false }) => {
   if (exporterHasBuyerFinancialAccounts) {
-    yesRadioInput().click();
+    cy.clickYesRadioInput();
   } else {
-    noRadioInput().click();
+    cy.clickNoRadioInput();
   }
 };
 

--- a/e2e-tests/commands/insurance/your-buyer/complete-buyer-financial-information-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-buyer-financial-information-form.js
@@ -6,7 +6,7 @@
  */
 const completeBuyerFinancialInformationForm = ({ exporterHasBuyerFinancialAccounts = false }) => {
   if (exporterHasBuyerFinancialAccounts) {
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
   } else {
     cy.clickNoRadioInput();
   }

--- a/e2e-tests/commands/insurance/your-buyer/complete-buyer-financial-information-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-buyer-financial-information-form.js
@@ -6,7 +6,7 @@
  */
 const completeBuyerFinancialInformationForm = ({ exporterHasBuyerFinancialAccounts = false }) => {
   if (exporterHasBuyerFinancialAccounts) {
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
   } else {
     cy.clickNoRadioInput();
   }

--- a/e2e-tests/commands/insurance/your-buyer/complete-connection-to-the-buyer-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-connection-to-the-buyer-form.js
@@ -17,7 +17,7 @@ const completeConnectionToTheBuyerForm = ({
   description = application.BUYER[CONNECTION_WITH_BUYER_DESCRIPTION],
 }) => {
   if (hasConnectionToBuyer) {
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
     cy.keyboardInput(field(CONNECTION_WITH_BUYER_DESCRIPTION).textarea(), description);
   } else {
     cy.clickNoRadioInput();

--- a/e2e-tests/commands/insurance/your-buyer/complete-connection-to-the-buyer-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-connection-to-the-buyer-form.js
@@ -1,7 +1,5 @@
 import { INSURANCE_FIELD_IDS } from '../../../constants/field-ids/insurance';
-import {
-  yesRadioInput, noRadioInput, field,
-} from '../../../pages/shared';
+import { field } from '../../../pages/shared';
 import application from '../../../fixtures/application';
 
 const {
@@ -19,10 +17,10 @@ const completeConnectionToTheBuyerForm = ({
   description = application.BUYER[CONNECTION_WITH_BUYER_DESCRIPTION],
 }) => {
   if (hasConnectionToBuyer) {
-    yesRadioInput().click();
+    cy.clickYesRadioInput();
     cy.keyboardInput(field(CONNECTION_WITH_BUYER_DESCRIPTION).textarea(), description);
   } else {
-    noRadioInput().click();
+    cy.clickNoRadioInput();
   }
 };
 

--- a/e2e-tests/commands/insurance/your-buyer/complete-connection-to-the-buyer-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-connection-to-the-buyer-form.js
@@ -17,7 +17,7 @@ const completeConnectionToTheBuyerForm = ({
   description = application.BUYER[CONNECTION_WITH_BUYER_DESCRIPTION],
 }) => {
   if (hasConnectionToBuyer) {
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
     cy.keyboardInput(field(CONNECTION_WITH_BUYER_DESCRIPTION).textarea(), description);
   } else {
     cy.clickNoRadioInput();

--- a/e2e-tests/commands/insurance/your-buyer/complete-credit-insurance-cover-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-credit-insurance-cover-form.js
@@ -1,4 +1,4 @@
-import { yesRadioInput, noRadioInput, field } from '../../../pages/shared';
+import { field } from '../../../pages/shared';
 import { YOUR_BUYER as FIELD_IDS } from '../../../constants/field-ids/insurance/your-buyer';
 import application from '../../../fixtures/application';
 
@@ -20,10 +20,10 @@ const completeCreditInsuranceCoverForm = ({
   const fieldId = PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER;
 
   if (hasHadCreditInsuranceCover) {
-    yesRadioInput().click();
+    cy.clickYesRadioInput();
     cy.keyboardInput(field(fieldId).textarea(), creditInsuranceCoverDescription);
   } else {
-    noRadioInput().click();
+    cy.clickNoRadioInput();
   }
 };
 

--- a/e2e-tests/commands/insurance/your-buyer/complete-credit-insurance-cover-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-credit-insurance-cover-form.js
@@ -20,7 +20,7 @@ const completeCreditInsuranceCoverForm = ({
   const fieldId = PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER;
 
   if (hasHadCreditInsuranceCover) {
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
     cy.keyboardInput(field(fieldId).textarea(), creditInsuranceCoverDescription);
   } else {
     cy.clickNoRadioInput();

--- a/e2e-tests/commands/insurance/your-buyer/complete-credit-insurance-cover-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-credit-insurance-cover-form.js
@@ -20,7 +20,7 @@ const completeCreditInsuranceCoverForm = ({
   const fieldId = PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER;
 
   if (hasHadCreditInsuranceCover) {
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
     cy.keyboardInput(field(fieldId).textarea(), creditInsuranceCoverDescription);
   } else {
     cy.clickNoRadioInput();

--- a/e2e-tests/commands/insurance/your-buyer/complete-traded-with-buyer-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-traded-with-buyer-form.js
@@ -6,7 +6,7 @@
  */
 const completeTradedWithBuyerForm = ({ exporterHasTradedWithBuyer = false }) => {
   if (exporterHasTradedWithBuyer) {
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
   } else {
     cy.clickNoRadioInput();
   }

--- a/e2e-tests/commands/insurance/your-buyer/complete-traded-with-buyer-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-traded-with-buyer-form.js
@@ -6,7 +6,7 @@
  */
 const completeTradedWithBuyerForm = ({ exporterHasTradedWithBuyer = false }) => {
   if (exporterHasTradedWithBuyer) {
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
   } else {
     cy.clickNoRadioInput();
   }

--- a/e2e-tests/commands/insurance/your-buyer/complete-traded-with-buyer-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-traded-with-buyer-form.js
@@ -1,5 +1,3 @@
-import { yesRadioInput, noRadioInput } from '../../../pages/shared';
-
 /**
  * completeTradedWithBuyerForm
  * Completes the "traded with buyer" form.
@@ -8,9 +6,9 @@ import { yesRadioInput, noRadioInput } from '../../../pages/shared';
  */
 const completeTradedWithBuyerForm = ({ exporterHasTradedWithBuyer = false }) => {
   if (exporterHasTradedWithBuyer) {
-    yesRadioInput().click();
+    cy.clickYesRadioInput();
   } else {
-    noRadioInput().click();
+    cy.clickNoRadioInput();
   }
 };
 

--- a/e2e-tests/commands/insurance/your-buyer/complete-trading-history-with-buyer-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-trading-history-with-buyer-form.js
@@ -18,7 +18,7 @@ const completeTradingHistoryWithBuyerForm = ({
   outstandingPayments = false, failedToPay = false, amountOverDue = BUYER[TOTAL_AMOUNT_OVERDUE], totalOutstanding = BUYER[TOTAL_OUTSTANDING_PAYMENTS],
 }) => {
   if (outstandingPayments) {
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
 
     cy.keyboardInput(field(TOTAL_AMOUNT_OVERDUE).input(), amountOverDue);
     cy.keyboardInput(field(TOTAL_OUTSTANDING_PAYMENTS).input(), totalOutstanding);

--- a/e2e-tests/commands/insurance/your-buyer/complete-trading-history-with-buyer-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-trading-history-with-buyer-form.js
@@ -1,4 +1,4 @@
-import { yesRadioInput, noRadioInput, field } from '../../../pages/shared';
+import { field } from '../../../pages/shared';
 import { YOUR_BUYER as FIELD_IDS } from '../../../constants/field-ids/insurance/your-buyer';
 import application from '../../../fixtures/application';
 
@@ -18,17 +18,18 @@ const completeTradingHistoryWithBuyerForm = ({
   outstandingPayments = false, failedToPay = false, amountOverDue = BUYER[TOTAL_AMOUNT_OVERDUE], totalOutstanding = BUYER[TOTAL_OUTSTANDING_PAYMENTS],
 }) => {
   if (outstandingPayments) {
-    yesRadioInput().first().click();
+    cy.clickYesRadioInput(0);
+
     cy.keyboardInput(field(TOTAL_AMOUNT_OVERDUE).input(), amountOverDue);
     cy.keyboardInput(field(TOTAL_OUTSTANDING_PAYMENTS).input(), totalOutstanding);
   } else {
-    noRadioInput().first().click();
+    cy.clickNoRadioInput();
   }
 
   if (failedToPay) {
-    yesRadioInput().last().click();
+    cy.clickYesRadioInput(1);
   } else {
-    noRadioInput().last().click();
+    cy.clickNoRadioInput(1);
   }
 };
 

--- a/e2e-tests/commands/quote/forms.js
+++ b/e2e-tests/commands/quote/forms.js
@@ -21,12 +21,12 @@ export const completeAndSubmitBuyerBodyForm = () => {
 };
 
 export const completeAndSubmitExporterLocationForm = () => {
-  cy.clickYesRadioInput(0);
+  cy.clickYesRadioInput();
   cy.clickSubmitButton();
 };
 
 export const completeAndSubmitUkContentForm = () => {
-  cy.clickYesRadioInput(0);
+  cy.clickYesRadioInput();
   cy.clickSubmitButton();
 };
 

--- a/e2e-tests/commands/quote/forms.js
+++ b/e2e-tests/commands/quote/forms.js
@@ -1,8 +1,4 @@
-import {
-  field,
-  yesRadio,
-  noRadio,
-} from '../../pages/shared';
+import { field } from '../../pages/shared';
 import { policyTypePage, tellUsAboutYourPolicyPage } from '../../pages/quote';
 import { FIELD_IDS } from '../../constants';
 import { GBP_CURRENCY_CODE } from '../../fixtures/currencies';
@@ -20,17 +16,17 @@ const {
 } = FIELD_IDS;
 
 export const completeAndSubmitBuyerBodyForm = () => {
-  noRadio().input().click();
+  cy.clickNoRadioInput();
   cy.clickSubmitButton();
 };
 
 export const completeAndSubmitExporterLocationForm = () => {
-  yesRadio().input().click();
+  cy.clickYesRadioInput();
   cy.clickSubmitButton();
 };
 
 export const completeAndSubmitUkContentForm = () => {
-  yesRadio().input().click();
+  cy.clickYesRadioInput();
   cy.clickSubmitButton();
 };
 

--- a/e2e-tests/commands/quote/forms.js
+++ b/e2e-tests/commands/quote/forms.js
@@ -21,12 +21,12 @@ export const completeAndSubmitBuyerBodyForm = () => {
 };
 
 export const completeAndSubmitExporterLocationForm = () => {
-  cy.clickYesRadioInput();
+  cy.clickYesRadioInput(0);
   cy.clickSubmitButton();
 };
 
 export const completeAndSubmitUkContentForm = () => {
-  cy.clickYesRadioInput();
+  cy.clickYesRadioInput(0);
   cy.clickSubmitButton();
 };
 

--- a/e2e-tests/commands/shared-commands/assertions/assert-no-radio-option-is-not-checked.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-no-radio-option-is-not-checked.js
@@ -1,0 +1,12 @@
+import { noRadioInput } from '../../../pages/shared';
+
+/**
+ * assertNoRadioOptionIsNotChecked
+ * Assert that a "no" radio option is not checked.
+ * @param {Integer} index: Optional radio index
+ */
+const assertNoRadioOptionIsNotChecked = (index) => {
+  cy.assertRadioOptionIsNotChecked(noRadioInput(), index);
+};
+
+export default assertNoRadioOptionIsNotChecked;

--- a/e2e-tests/commands/shared-commands/assertions/assert-radio-option-is-not-checked.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-radio-option-is-not-checked.js
@@ -1,0 +1,10 @@
+/**
+ * assertRadioOptionIsNotChecked
+ * Assert that a radio option is not checked.
+ * @param {Function} input: Cypress selector
+ */
+const assertRadioOptionIsNotChecked = (input) => {
+  input.should('not.be.checked');
+};
+
+export default assertRadioOptionIsNotChecked;

--- a/e2e-tests/commands/shared-commands/assertions/assert-unchecked-yes-no-radios.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-unchecked-yes-no-radios.js
@@ -1,12 +1,10 @@
-import { yesRadioInput, noRadioInput } from '../../../pages/shared';
-
 /**
  * assertUncheckedYesNoRadios
  * Check that both "yes" and "no" inputs are unchecked
  */
 const assertUncheckedYesNoRadios = () => {
-  yesRadioInput().should('not.be.checked');
-  noRadioInput().should('not.be.checked');
+  cy.assertYesRadioOptionIsNotChecked();
+  cy.assertNoRadioOptionIsNotChecked();
 };
 
 export default assertUncheckedYesNoRadios;

--- a/e2e-tests/commands/shared-commands/assertions/assert-yes-radio-option-is-not-checked.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-yes-radio-option-is-not-checked.js
@@ -1,0 +1,12 @@
+import { yesRadioInput } from '../../../pages/shared';
+
+/**
+ * assertYesRadioOptionIsNotChecked
+ * Assert that a "yes" radio option is not checked.
+ * @param {Integer} index: Optional radio index
+ */
+const assertYesRadioOptionIsNotChecked = (index) => {
+  cy.assertRadioOptionIsNotChecked(yesRadioInput(), index);
+};
+
+export default assertYesRadioOptionIsNotChecked;

--- a/e2e-tests/commands/shared-commands/assertions/index.js
+++ b/e2e-tests/commands/shared-commands/assertions/index.js
@@ -17,7 +17,6 @@ Cypress.Commands.add('assertNoRadioOptionIsChecked', require('./assert-no-radio-
 
 Cypress.Commands.add('assertHeadingWithCurrencyName', require('./assert-heading-with-currency-name'));
 Cypress.Commands.add('assertPrefix', require('./assert-prefix'));
-Cypress.Commands.add('assertPrefix', require('./assert-prefix'));
 
 Cypress.Commands.add('checkAriaLabel', require('./check-aria-label'));
 Cypress.Commands.add('checkLink', require('./check-link'));

--- a/e2e-tests/commands/shared-commands/assertions/index.js
+++ b/e2e-tests/commands/shared-commands/assertions/index.js
@@ -13,7 +13,9 @@ Cypress.Commands.add('assertSaveAndBackButtonDoesNotExist', require('./assert-sa
 Cypress.Commands.add('assertYesNoRadiosOrder', require('./assert-first-and-last-radios'));
 Cypress.Commands.add('assertRadioOptionIsChecked', require('./assert-radio-option-is-checked'));
 Cypress.Commands.add('assertYesRadioOptionIsChecked', require('./assert-yes-radio-option-is-checked'));
+Cypress.Commands.add('assertYesRadioOptionIsNotChecked', require('./assert-yes-radio-option-is-not-checked'));
 Cypress.Commands.add('assertNoRadioOptionIsChecked', require('./assert-no-radio-option-is-checked'));
+Cypress.Commands.add('assertNoRadioOptionIsNotChecked', require('./assert-no-radio-option-is-not-checked'));
 
 Cypress.Commands.add('assertHeadingWithCurrencyName', require('./assert-heading-with-currency-name'));
 Cypress.Commands.add('assertPrefix', require('./assert-prefix'));

--- a/e2e-tests/commands/shared-commands/assertions/index.js
+++ b/e2e-tests/commands/shared-commands/assertions/index.js
@@ -12,6 +12,7 @@ Cypress.Commands.add('assertSaveAndBackButton', require('./assert-save-and-back-
 Cypress.Commands.add('assertSaveAndBackButtonDoesNotExist', require('./assert-save-and-back-button-does-not-exist'));
 Cypress.Commands.add('assertYesNoRadiosOrder', require('./assert-first-and-last-radios'));
 Cypress.Commands.add('assertRadioOptionIsChecked', require('./assert-radio-option-is-checked'));
+Cypress.Commands.add('assertRadioOptionIsNotChecked', require('./assert-radio-option-is-not-checked'));
 Cypress.Commands.add('assertYesRadioOptionIsChecked', require('./assert-yes-radio-option-is-checked'));
 Cypress.Commands.add('assertYesRadioOptionIsNotChecked', require('./assert-yes-radio-option-is-not-checked'));
 Cypress.Commands.add('assertNoRadioOptionIsChecked', require('./assert-no-radio-option-is-checked'));

--- a/e2e-tests/commands/shared-commands/click-events/click-no-radio-input.js
+++ b/e2e-tests/commands/shared-commands/click-events/click-no-radio-input.js
@@ -1,0 +1,9 @@
+/**
+ * clickNoRadioInput
+ * Click a "no" radio input.
+ */
+const clickNoRadioInput = () => {
+  cy.clickNoRadioInput();
+};
+
+export default clickNoRadioInput;

--- a/e2e-tests/commands/shared-commands/click-events/click-no-radio-input.js
+++ b/e2e-tests/commands/shared-commands/click-events/click-no-radio-input.js
@@ -5,7 +5,7 @@ import { noRadioInput } from '../../../pages/shared';
  * Click a "no" radio input.
  * @param {Integer} index: Optional radio index
  */
-const clickNoRadioInput = (index) => {
+const clickNoRadioInput = (index = 0) => {
   noRadioInput().eq(index).click();
 };
 

--- a/e2e-tests/commands/shared-commands/click-events/click-no-radio-input.js
+++ b/e2e-tests/commands/shared-commands/click-events/click-no-radio-input.js
@@ -1,9 +1,12 @@
+import { noRadioInput } from '../../../pages/shared';
+
 /**
  * clickNoRadioInput
  * Click a "no" radio input.
+ * @param {Integer} index: Optional radio index
  */
-const clickNoRadioInput = () => {
-  cy.clickNoRadioInput();
+const clickNoRadioInput = (index) => {
+  noRadioInput().eq(index).click();
 };
 
 export default clickNoRadioInput;

--- a/e2e-tests/commands/shared-commands/click-events/click-yes-radio-input.js
+++ b/e2e-tests/commands/shared-commands/click-events/click-yes-radio-input.js
@@ -1,9 +1,12 @@
+import { yesRadioInput } from '../../../pages/shared';
+
 /**
  * clickYesRadioInput
  * Click a "yes" radio input.
+ * * @param {Integer} index: Optional radio index
  */
-const clickYesRadioInput = () => {
-  cy.clickYesRadioInput();
+const clickYesRadioInput = (index) => {
+  yesRadioInput().eq(index).click();
 };
 
 export default clickYesRadioInput;

--- a/e2e-tests/commands/shared-commands/click-events/click-yes-radio-input.js
+++ b/e2e-tests/commands/shared-commands/click-events/click-yes-radio-input.js
@@ -1,0 +1,9 @@
+/**
+ * clickYesRadioInput
+ * Click a "yes" radio input.
+ */
+const clickYesRadioInput = () => {
+  cy.clickYesRadioInput();
+};
+
+export default clickYesRadioInput;

--- a/e2e-tests/commands/shared-commands/click-events/click-yes-radio-input.js
+++ b/e2e-tests/commands/shared-commands/click-events/click-yes-radio-input.js
@@ -5,7 +5,7 @@ import { yesRadioInput } from '../../../pages/shared';
  * Click a "yes" radio input.
  * * @param {Integer} index: Optional radio index
  */
-const clickYesRadioInput = (index) => {
+const clickYesRadioInput = (index = 0) => {
   yesRadioInput().eq(index).click();
 };
 

--- a/e2e-tests/commands/shared-commands/click-events/index.js
+++ b/e2e-tests/commands/shared-commands/click-events/index.js
@@ -2,6 +2,8 @@ import analytics from '../../analytics';
 
 Cypress.Commands.add('clickLinkAndAssertUrl', require('./click-link-and-assert-url'));
 Cypress.Commands.add('clickBackLink', require('./click-back-link'));
+Cypress.Commands.add('clickYesRadioInput', require('./click-yes-radio-input'));
+Cypress.Commands.add('clickNoRadioInput', require('./click-no-radio-input'));
 
 Cypress.Commands.add('rejectAnalyticsCookies', analytics.rejectAnalyticsCookies);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/change-your-answers-change-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/change-your-answers-change-broker.spec.js
@@ -220,7 +220,7 @@ context.skip('Insurance - Check your answers - Policy - Broker - Summary list', 
 
         summaryList.field(fieldId).changeLink().click();
 
-        brokerPage[fieldId].noRadioInput().click();
+        brokerPage[fieldId].cy.clickNoRadioInput();
 
         cy.clickSubmitButton();
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer.spec.js
@@ -1,4 +1,4 @@
-import { status, summaryList, noRadioInput } from '../../../../../../../pages/shared';
+import { status, summaryList } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -171,7 +171,7 @@ context('Insurance - Check your answers - Working with buyer - Your buyer page- 
 
         summaryList.field(fieldId).changeLink().click();
 
-        noRadioInput().click();
+        cy.clickNoRadioInput();
 
         cy.clickSubmitButton();
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-no.spec.js
@@ -1,4 +1,4 @@
-import { noRadioInput, backLink } from '../../../../../../../pages/shared';
+import { backLink } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 
@@ -43,7 +43,7 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - As an 
 
     cy.navigateToUrl(url);
 
-    noRadioInput().click();
+    cy.clickNoRadioInput();
     cy.clickSubmitButton();
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-yes.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - As an 
 
     cy.navigateToUrl(url);
 
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
     cy.clickSubmitButton();
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-yes.spec.js
@@ -1,4 +1,4 @@
-import { yesRadioInput, backLink } from '../../../../../../../pages/shared';
+import { backLink } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 
@@ -43,7 +43,7 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - As an 
 
     cy.navigateToUrl(url);
 
-    yesRadioInput().click();
+    cy.clickYesRadioInput();
     cy.clickSubmitButton();
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-yes.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - As an 
 
     cy.navigateToUrl(url);
 
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
     cy.clickSubmitButton();
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
@@ -110,7 +110,7 @@ context("Insurance - Declarations - Anti-bribery - Code of conduct page - As an 
     });
 
     it('should display conditional `we will email you` hint when selecting the "yes" radio', () => {
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
 
       codeOfConductPage.revealText().should('be.visible');
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
@@ -110,7 +110,7 @@ context("Insurance - Declarations - Anti-bribery - Code of conduct page - As an 
     });
 
     it('should display conditional `we will email you` hint when selecting the "yes" radio', () => {
-      cy.clickYesRadioInput();
+      cy.clickYesRadioInput(0);
 
       codeOfConductPage.revealText().should('be.visible');
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
@@ -110,7 +110,7 @@ context("Insurance - Declarations - Anti-bribery - Code of conduct page - As an 
     });
 
     it('should display conditional `we will email you` hint when selecting the "yes" radio', () => {
-      yesRadio().input().click();
+      cy.clickYesRadioInput();
 
       codeOfConductPage.revealText().should('be.visible');
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/save-and-back.spec.js
@@ -1,4 +1,3 @@
-import { yesRadioInput, noRadioInput } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -76,7 +75,7 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - Save a
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      yesRadioInput().click();
+      cy.clickYesRadioInput();
 
       cy.clickSaveAndBackButton();
     });
@@ -100,7 +99,7 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - Save a
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      noRadioInput().click();
+      cy.clickNoRadioInput();
 
       cy.clickSaveAndBackButton();
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/save-and-back.spec.js
@@ -75,7 +75,7 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - Save a
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
 
       cy.clickSaveAndBackButton();
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/save-and-back.spec.js
@@ -75,7 +75,7 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - Save a
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput();
+      cy.clickYesRadioInput(0);
 
       cy.clickSaveAndBackButton();
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/save-and-back.spec.js
@@ -76,7 +76,7 @@ context('Insurance - Declarations - Exporting with code of conduct page - Save a
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
 
       cy.clickSaveAndBackButton();
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/save-and-back.spec.js
@@ -1,4 +1,3 @@
-import { yesRadioInput, noRadioInput } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -77,7 +76,7 @@ context('Insurance - Declarations - Exporting with code of conduct page - Save a
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      yesRadioInput().click();
+      cy.clickYesRadioInput();
 
       cy.clickSaveAndBackButton();
     });
@@ -101,7 +100,7 @@ context('Insurance - Declarations - Exporting with code of conduct page - Save a
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      noRadioInput().click();
+      cy.clickNoRadioInput();
 
       cy.clickSaveAndBackButton();
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/save-and-back.spec.js
@@ -76,7 +76,7 @@ context('Insurance - Declarations - Exporting with code of conduct page - Save a
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput();
+      cy.clickYesRadioInput(0);
 
       cy.clickSaveAndBackButton();
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-multiple-risks/cannot-apply-multiple-risks.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-multiple-risks/cannot-apply-multiple-risks.spec.js
@@ -33,7 +33,7 @@ context('Insurance - Cannot apply - multiple risks page - as an exporter, I want
     cy.completeCoverPeriodForm({});
     cy.completeUkGoodsAndServicesForm();
 
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
     cy.clickSubmitButton();
 
     cy.assertUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-multiple-risks/cannot-apply-multiple-risks.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-multiple-risks/cannot-apply-multiple-risks.spec.js
@@ -1,4 +1,4 @@
-import { listItem, yesRadio } from '../../../../../../pages/shared';
+import { listItem } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../../commands/forms';
@@ -33,7 +33,7 @@ context('Insurance - Cannot apply - multiple risks page - as an exporter, I want
     cy.completeCoverPeriodForm({});
     cy.completeUkGoodsAndServicesForm();
 
-    yesRadio().input().click();
+    cy.clickYesRadioInput();
     cy.clickSubmitButton();
 
     cy.assertUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-multiple-risks/cannot-apply-multiple-risks.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-multiple-risks/cannot-apply-multiple-risks.spec.js
@@ -33,7 +33,7 @@ context('Insurance - Cannot apply - multiple risks page - as an exporter, I want
     cy.completeCoverPeriodForm({});
     cy.completeUkGoodsAndServicesForm();
 
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
     cy.clickSubmitButton();
 
     cy.assertUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/change-your-answers/change-your-answers-end-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/change-your-answers/change-your-answers-end-buyer.spec.js
@@ -58,7 +58,7 @@ context('Insurance - Eligibility - Change your answers - End buyer - As an expor
 
       summaryList.field(fieldId).changeLink().click();
 
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/change-your-answers/change-your-answers-end-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/change-your-answers/change-your-answers-end-buyer.spec.js
@@ -58,7 +58,7 @@ context('Insurance - Eligibility - Change your answers - End buyer - As an expor
 
       summaryList.field(fieldId).changeLink().click();
 
-      cy.clickYesRadioInput();
+      cy.clickYesRadioInput(0);
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/change-your-answers/change-your-answers-end-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/change-your-answers/change-your-answers-end-buyer.spec.js
@@ -1,6 +1,6 @@
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
-import { summaryList, yesRadio } from '../../../../../../pages/shared';
+import { summaryList } from '../../../../../../pages/shared';
 
 const { HAS_END_BUYER } = INSURANCE_FIELD_IDS.ELIGIBILITY;
 
@@ -58,7 +58,7 @@ context('Insurance - Eligibility - Change your answers - End buyer - As an expor
 
       summaryList.field(fieldId).changeLink().click();
 
-      yesRadio().input().click();
+      cy.clickYesRadioInput();
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/change-your-answers/change-your-answers-exporter-location.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/change-your-answers/change-your-answers-exporter-location.spec.js
@@ -1,6 +1,6 @@
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
-import { summaryList, noRadio } from '../../../../../../pages/shared';
+import { summaryList } from '../../../../../../pages/shared';
 
 const { VALID_EXPORTER_LOCATION } = INSURANCE_FIELD_IDS.ELIGIBILITY;
 
@@ -58,7 +58,7 @@ context('Insurance - Eligibility - Change your answers - Exporter location - As 
 
       summaryList.field(fieldId).changeLink().click();
 
-      noRadio().input().click();
+      cy.clickNoRadioInput();
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/change-your-answers/change-your-answers-has-companies-house-number.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/change-your-answers/change-your-answers-has-companies-house-number.spec.js
@@ -1,6 +1,6 @@
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
-import { summaryList, noRadio } from '../../../../../../pages/shared';
+import { summaryList } from '../../../../../../pages/shared';
 
 const { HAS_COMPANIES_HOUSE_NUMBER } = INSURANCE_FIELD_IDS.ELIGIBILITY;
 
@@ -58,7 +58,7 @@ context('Insurance - Eligibility - Change your answers - Has companies house num
 
       summaryList.field(fieldId).changeLink().click();
 
-      noRadio().input().click();
+      cy.clickNoRadioInput();
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/change-your-answers/change-your-answers-uk-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/change-your-answers/change-your-answers-uk-goods-or-services.spec.js
@@ -1,6 +1,6 @@
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
-import { summaryList, noRadio } from '../../../../../../pages/shared';
+import { summaryList } from '../../../../../../pages/shared';
 
 const { HAS_MINIMUM_UK_GOODS_OR_SERVICES } = INSURANCE_FIELD_IDS.ELIGIBILITY;
 
@@ -58,7 +58,7 @@ context('Insurance - Eligibility - Change your answers - UK goods or services - 
 
       summaryList.field(fieldId).changeLink().click();
 
-      noRadio().input().click();
+      cy.clickNoRadioInput();
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
@@ -1,4 +1,4 @@
-import { backLink, noRadioInput } from '../../../../../../pages/shared';
+import { backLink } from '../../../../../../pages/shared';
 import { LINKS } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
@@ -51,7 +51,7 @@ context('Insurance - Eligibility - Companies house number page - I want to check
 
       cy.clickBackLink();
 
-      noRadioInput().should('not.be.checked');
+      cy.assertNoRadioOptionIsNotChecked();
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house-number/companies-house-number-answer-no.spec.js
@@ -1,6 +1,4 @@
-import {
-  backLink, noRadio, noRadioInput,
-} from '../../../../../../pages/shared';
+import { backLink, noRadioInput } from '../../../../../../pages/shared';
 import { LINKS } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
@@ -27,7 +25,7 @@ context('Insurance - Eligibility - Companies house number page - I want to check
 
     cy.navigateToUrl(url);
 
-    noRadio().input().click();
+    cy.clickNoRadioInput();
     cy.clickSubmitButton();
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house-number/companies-house-number.spec.js
@@ -83,7 +83,7 @@ context('Insurance - Eligibility - Companies house number page - I want to check
       beforeEach(() => {
         cy.navigateToUrl(url);
 
-        yesRadio().input().click();
+        cy.clickYesRadioInput();
         cy.clickSubmitButton();
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house-number/companies-house-number.spec.js
@@ -83,7 +83,7 @@ context('Insurance - Eligibility - Companies house number page - I want to check
       beforeEach(() => {
         cy.navigateToUrl(url);
 
-        cy.clickYesRadioInput(0);
+        cy.clickYesRadioInput();
         cy.clickSubmitButton();
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house-number/companies-house-number.spec.js
@@ -83,7 +83,7 @@ context('Insurance - Eligibility - Companies house number page - I want to check
       beforeEach(() => {
         cy.navigateToUrl(url);
 
-        cy.clickYesRadioInput();
+        cy.clickYesRadioInput(0);
         cy.clickSubmitButton();
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/end-buyer/end-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/end-buyer/end-buyer.spec.js
@@ -147,7 +147,7 @@ context('Insurance - End buyer page - as an exporter, I want to confirm if payme
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/end-buyer/end-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/end-buyer/end-buyer.spec.js
@@ -124,7 +124,7 @@ context('Insurance - End buyer page - as an exporter, I want to confirm if payme
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      noRadio().input().click();
+      cy.clickNoRadioInput();
       cy.clickSubmitButton();
     });
 
@@ -147,7 +147,7 @@ context('Insurance - End buyer page - as an exporter, I want to confirm if payme
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      yesRadio().input().click();
+      cy.clickYesRadioInput();
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/end-buyer/end-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/end-buyer/end-buyer.spec.js
@@ -147,7 +147,7 @@ context('Insurance - End buyer page - as an exporter, I want to confirm if payme
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput();
+      cy.clickYesRadioInput(0);
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location-answer-no.spec.js
@@ -1,5 +1,5 @@
 import {
-  backLink, cannotApplyPage, noRadio, noRadioInput,
+  backLink, cannotApplyPage, noRadioInput,
 } from '../../../../../../pages/shared';
 import { PAGES, LINKS } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -30,7 +30,7 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
 
     cy.navigateToUrl(url);
 
-    noRadio().input().click();
+    cy.clickNoRadioInput();
     cy.clickSubmitButton();
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location-answer-no.spec.js
@@ -1,6 +1,4 @@
-import {
-  backLink, cannotApplyPage, noRadioInput,
-} from '../../../../../../pages/shared';
+import { backLink, cannotApplyPage } from '../../../../../../pages/shared';
 import { PAGES, LINKS } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
@@ -59,7 +57,7 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
     it('should NOT have the originally submitted answer selected', () => {
       cy.clickBackLink();
 
-      noRadioInput().should('not.be.checked');
+      cy.assertNoRadioOptionIsNotChecked();
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
@@ -79,7 +79,7 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
 
     describe('when submitting the answer as `yes`', () => {
       beforeEach(() => {
-        cy.clickYesRadioInput(0);
+        cy.clickYesRadioInput();
         cy.clickSubmitButton();
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
@@ -79,7 +79,7 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
 
     describe('when submitting the answer as `yes`', () => {
       beforeEach(() => {
-        yesRadio().input().click();
+        cy.clickYesRadioInput();
         cy.clickSubmitButton();
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
@@ -79,7 +79,7 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
 
     describe('when submitting the answer as `yes`', () => {
       beforeEach(() => {
-        cy.clickYesRadioInput();
+        cy.clickYesRadioInput(0);
         cy.clickSubmitButton();
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/have-an-account/have-an-account-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/have-an-account/have-an-account-answer-no.spec.js
@@ -1,4 +1,3 @@
-import { noRadioInput } from '../../../../../../pages/shared';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const {
@@ -24,7 +23,7 @@ context('Insurance - Eligibility - Have an account page - I want to confirm if I
   });
 
   it(`should redirect to ${CREATE.YOUR_DETAILS}`, () => {
-    noRadioInput().click();
+    cy.clickNoRadioInput();
     cy.clickSubmitButton();
 
     const expected = `${baseUrl}${CREATE.YOUR_DETAILS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/have-an-account/have-an-account.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/have-an-account/have-an-account.spec.js
@@ -94,7 +94,7 @@ context('Insurance - Eligibility - Have an account page - I want to confirm that
       it(`should redirect to ${SIGN_IN.ROOT}`, () => {
         cy.navigateToUrl(url);
 
-        cy.clickYesRadioInput(0);
+        cy.clickYesRadioInput();
         cy.clickSubmitButton();
 
         const expected = `${baseUrl}${SIGN_IN.ROOT}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/have-an-account/have-an-account.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/have-an-account/have-an-account.spec.js
@@ -94,7 +94,7 @@ context('Insurance - Eligibility - Have an account page - I want to confirm that
       it(`should redirect to ${SIGN_IN.ROOT}`, () => {
         cy.navigateToUrl(url);
 
-        cy.clickYesRadioInput();
+        cy.clickYesRadioInput(0);
         cy.clickSubmitButton();
 
         const expected = `${baseUrl}${SIGN_IN.ROOT}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/have-an-account/have-an-account.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/have-an-account/have-an-account.spec.js
@@ -1,6 +1,4 @@
-import {
-  yesRadioInput, yesRadio, yesNoRadioHint, noRadio,
-} from '../../../../../../pages/shared';
+import { yesRadio, yesNoRadioHint, noRadio } from '../../../../../../pages/shared';
 import {
   ERROR_MESSAGES,
   FIELDS,
@@ -96,7 +94,7 @@ context('Insurance - Eligibility - Have an account page - I want to confirm that
       it(`should redirect to ${SIGN_IN.ROOT}`, () => {
         cy.navigateToUrl(url);
 
-        yesRadioInput().click();
+        cy.clickYesRadioInput();
         cy.clickSubmitButton();
 
         const expected = `${baseUrl}${SIGN_IN.ROOT}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
@@ -1,9 +1,11 @@
-import { backLink, cannotApplyPage, noRadioInput } from '../../../../../../pages/shared';
+import { backLink, cannotApplyPage } from '../../../../../../pages/shared';
 import { PAGES, LINKS } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../../commands/forms';
 
 const CONTENT_STRINGS = PAGES.QUOTE.CANNOT_APPLY;
+
+const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - UK goods or services page - as an exporter, I want to check if my export value is eligible for UKEF credit insurance cover - submit `no - UK goods/services is below the minimum`', () => {
   beforeEach(() => {
@@ -28,13 +30,13 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
   });
 
   it('redirects to exit page', () => {
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY}`;
+    const expectedUrl = `${baseUrl}${ROUTES.INSURANCE.ELIGIBILITY.CANNOT_APPLY}`;
 
     cy.assertUrl(expectedUrl);
   });
 
   it('renders a back link with correct url', () => {
-    const expectedHref = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES}`;
+    const expectedHref = `${baseUrl}${ROUTES.INSURANCE.ELIGIBILITY.UK_GOODS_OR_SERVICES}`;
 
     cy.checkLink(
       backLink(),
@@ -52,7 +54,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
     it('should NOT have the originally submitted answer selected', () => {
       cy.clickBackLink();
 
-      noRadioInput().should('not.be.checked');
+      cy.assertNoRadioOptionIsNotChecked();
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
@@ -1,6 +1,4 @@
-import {
-  backLink, cannotApplyPage, noRadio, noRadioInput,
-} from '../../../../../../pages/shared';
+import { backLink, cannotApplyPage, noRadioInput } from '../../../../../../pages/shared';
 import { PAGES, LINKS } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../../commands/forms';
@@ -21,7 +19,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
     cy.completeAndSubmitTotalValueInsuredForm({});
     cy.completeCoverPeriodForm({});
 
-    noRadio().input().click();
+    cy.clickNoRadioInput();
     cy.clickSubmitButton();
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -139,7 +139,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -139,7 +139,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput();
+      cy.clickYesRadioInput(0);
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -139,7 +139,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      yesRadio().input().click();
+      cy.clickYesRadioInput();
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
@@ -142,7 +142,7 @@ context('Insurance - Export contract - About goods or services page - Final dest
         beforeEach(() => {
           cy.navigateToUrl(url);
 
-          yesRadio().input().click();
+          cy.clickYesRadioInput();
         });
 
         it('has working client side JS', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
@@ -142,7 +142,7 @@ context('Insurance - Export contract - About goods or services page - Final dest
         beforeEach(() => {
           cy.navigateToUrl(url);
 
-          cy.clickYesRadioInput(0);
+          cy.clickYesRadioInput();
         });
 
         it('has working client side JS', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
@@ -142,7 +142,7 @@ context('Insurance - Export contract - About goods or services page - Final dest
         beforeEach(() => {
           cy.navigateToUrl(url);
 
-          cy.clickYesRadioInput();
+          cy.clickYesRadioInput(0);
         });
 
         it('has working client side JS', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { yesRadioInput, noRadioInput } from '../../../../../../pages/shared';
+import { noRadioInput } from '../../../../../../pages/shared';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
@@ -68,7 +68,7 @@ context('Insurance - Policy - Another company page - Save and back', () => {
     it(`should redirect to ${ALL_SECTIONS} and change the "insurance policy" task status to "completed"`, () => {
       cy.navigateToUrl(url);
 
-      yesRadioInput().click();
+      cy.clickYesRadioInput();
 
       cy.clickSaveAndBackButton();
 
@@ -94,7 +94,7 @@ context('Insurance - Policy - Another company page - Save and back', () => {
     it(`should redirect to ${ALL_SECTIONS} and change the "insurance policy" task status to "Completed"`, () => {
       cy.navigateToUrl(url);
 
-      noRadioInput().click();
+      cy.clickNoRadioInput();
 
       cy.clickSaveAndBackButton();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/save-and-back.spec.js
@@ -67,7 +67,7 @@ context('Insurance - Policy - Another company page - Save and back', () => {
     it(`should redirect to ${ALL_SECTIONS} and change the "insurance policy" task status to "completed"`, () => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
 
       cy.clickSaveAndBackButton();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/save-and-back.spec.js
@@ -1,4 +1,3 @@
-import { noRadioInput } from '../../../../../../pages/shared';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
@@ -68,7 +67,7 @@ context('Insurance - Policy - Another company page - Save and back', () => {
     it(`should redirect to ${ALL_SECTIONS} and change the "insurance policy" task status to "completed"`, () => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput();
+      cy.clickYesRadioInput(0);
 
       cy.clickSaveAndBackButton();
 
@@ -112,7 +111,6 @@ context('Insurance - Policy - Another company page - Save and back', () => {
       // go through 5 policy forms.
       cy.clickSubmitButtonMultipleTimes({ count: 5 });
 
-      cy.assertRadioOptionIsChecked(noRadioInput());
       cy.assertNoRadioOptionIsChecked();
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
@@ -67,7 +67,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
     it(`should redirect to ${ALL_SECTIONS} and change the "insurance policy" task status to "completed"`, () => {
       cy.navigateToUrl(url);
 
-      yesRadioInput().click();
+      cy.clickYesRadioInput();
 
       cy.clickSaveAndBackButton();
 
@@ -92,7 +92,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
     it(`should redirect to ${ALL_SECTIONS} and change the "insurance policy" task status to "Completed"`, () => {
       cy.navigateToUrl(url);
 
-      noRadioInput().click();
+      cy.clickNoRadioInput();
 
       cy.clickSaveAndBackButton();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
@@ -66,7 +66,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
     it(`should redirect to ${ALL_SECTIONS} and change the "insurance policy" task status to "completed"`, () => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
 
       cy.clickSaveAndBackButton();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
@@ -1,4 +1,3 @@
-import { yesRadioInput, noRadioInput } from '../../../../../../pages/shared';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
@@ -67,7 +66,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
     it(`should redirect to ${ALL_SECTIONS} and change the "insurance policy" task status to "completed"`, () => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput();
+      cy.clickYesRadioInput(0);
 
       cy.clickSaveAndBackButton();
 
@@ -84,7 +83,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
       // go through 6 policy forms.
       cy.clickSubmitButtonMultipleTimes({ count: 6 });
 
-      cy.assertRadioOptionIsChecked(yesRadioInput());
+      cy.assertYesRadioOptionIsChecked();
     });
   });
 
@@ -109,7 +108,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
       // go through 6 policy forms.
       cy.clickSubmitButtonMultipleTimes({ count: 6 });
 
-      cy.assertRadioOptionIsChecked(noRadioInput());
+      cy.assertNoRadioOptionIsChecked();
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/change-your-answers-change-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/change-your-answers-change-broker.spec.js
@@ -217,7 +217,7 @@ context.skip('Insurance - Policy - Change your answers - Broker - As an exporter
 
         summaryList.field(fieldId).changeLink().click();
 
-        brokerPage[fieldId].noRadioInput().click();
+        brokerPage[fieldId].cy.clickNoRadioInput();
 
         cy.clickSubmitButton();
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
@@ -121,7 +121,7 @@ context(`Insurance - Policy - Pre-credit period page - ${story}`, () => {
 
       describe(`when clicking ${NEED_PRE_CREDIT_PERIOD} 'yes' radio`, () => {
         it(`should render ${fieldId} label and input`, () => {
-          cy.clickYesRadioInput(0);
+          cy.clickYesRadioInput();
 
           field.textarea().should('be.visible');
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
@@ -121,7 +121,7 @@ context(`Insurance - Policy - Pre-credit period page - ${story}`, () => {
 
       describe(`when clicking ${NEED_PRE_CREDIT_PERIOD} 'yes' radio`, () => {
         it(`should render ${fieldId} label and input`, () => {
-          cy.clickYesRadioInput();
+          cy.clickYesRadioInput(0);
 
           field.textarea().should('be.visible');
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
@@ -121,7 +121,7 @@ context(`Insurance - Policy - Pre-credit period page - ${story}`, () => {
 
       describe(`when clicking ${NEED_PRE_CREDIT_PERIOD} 'yes' radio`, () => {
         it(`should render ${fieldId} label and input`, () => {
-          yesRadio().input().click();
+          cy.clickYesRadioInput();
 
           field.textarea().should('be.visible');
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/validation/pre-credit-period-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/validation/pre-credit-period-validation.spec.js
@@ -1,8 +1,4 @@
-import {
-  yesRadio,
-  noRadio,
-  field as fieldSelector,
-} from '../../../../../../../pages/shared';
+import { noRadio, field as fieldSelector } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
@@ -73,7 +69,7 @@ context('Insurance - Policy - Pre-credit period page - validation', () => {
   describe(`when ${NEED_PRE_CREDIT_PERIOD} is 'no'`, () => {
     it('should not render any validation errors', () => {
       cy.navigateToUrl(url);
-      noRadio().input().click();
+      cy.clickNoRadioInput();
 
       partials.errorSummaryListItems().should('not.exist');
     });
@@ -83,7 +79,7 @@ context('Insurance - Policy - Pre-credit period page - validation', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      yesRadio().input().click();
+      cy.clickYesRadioInput();
     });
 
     it(`should render a validation error when ${CREDIT_PERIOD_WITH_BUYER} is not provided`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/validation/pre-credit-period-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/validation/pre-credit-period-validation.spec.js
@@ -79,7 +79,7 @@ context('Insurance - Policy - Pre-credit period page - validation', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput();
+      cy.clickYesRadioInput(0);
     });
 
     it(`should render a validation error when ${CREDIT_PERIOD_WITH_BUYER} is not provided`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/validation/pre-credit-period-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/validation/pre-credit-period-validation.spec.js
@@ -79,7 +79,7 @@ context('Insurance - Policy - Pre-credit period page - validation', () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
     });
 
     it(`should render a validation error when ${CREDIT_PERIOD_WITH_BUYER} is not provided`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
@@ -118,7 +118,7 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
     });
 
     it(`should display conditional ${DIFFERENT_TRADING_NAME} input when selecting the trading name "yes" radio`, () => {
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
 
       field(DIFFERENT_TRADING_NAME).input().should('be.visible');
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
@@ -118,7 +118,7 @@ context('Insurance - Your business - Company details page - As an Exporter I wan
     });
 
     it(`should display conditional ${DIFFERENT_TRADING_NAME} input when selecting the trading name "yes" radio`, () => {
-      yesRadioInput().first().click();
+      cy.clickYesRadioInput(0);
 
       field(DIFFERENT_TRADING_NAME).input().should('be.visible');
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-save-and-back.spec.js
@@ -56,7 +56,7 @@ describe('Insurance - Your business - Company details page - Save and go back', 
     it('should not display validation errors and redirect to task list with status of "In progress"', () => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
       cy.clickYesRadioInput(1);
       cy.clickSaveAndBackButton();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { field, yesRadioInput } from '../../../../../../pages/shared';
+import { field } from '../../../../../../pages/shared';
 import {
   INVALID_PHONE_NUMBERS, WEBSITE_EXAMPLES, VALID_PHONE_NUMBERS,
 } from '../../../../../../constants';
@@ -56,8 +56,8 @@ describe('Insurance - Your business - Company details page - Save and go back', 
     it('should not display validation errors and redirect to task list with status of "In progress"', () => {
       cy.navigateToUrl(url);
 
-      yesRadioInput().first().click();
-      yesRadioInput().eq(1).click();
+      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput(1);
       cy.clickSaveAndBackButton();
 
       cy.assertUrl(`${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`);

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-submit-different-trading-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-submit-different-trading-name.spec.js
@@ -78,7 +78,7 @@ describe(`Insurance - Your business - Company details page - submit ${DIFFERENT_
       cy.assertNoRadioOptionIsChecked(0);
 
       // check input is not populated
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
       cy.checkValue(field(DIFFERENT_TRADING_NAME), '');
     });
   });
@@ -101,7 +101,7 @@ describe(`Insurance - Your business - Company details page - submit ${DIFFERENT_
       cy.navigateToUrl(url);
 
       // check input is not populated
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
       cy.checkValue(field(DIFFERENT_TRADING_NAME), '');
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-submit-different-trading-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-submit-different-trading-name.spec.js
@@ -1,6 +1,4 @@
-import {
-  yesRadioInput, field,
-} from '../../../../../../pages/shared';
+import { field } from '../../../../../../pages/shared';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
@@ -80,7 +78,7 @@ describe(`Insurance - Your business - Company details page - submit ${DIFFERENT_
       cy.assertNoRadioOptionIsChecked(0);
 
       // check input is not populated
-      yesRadioInput().first().click();
+      cy.clickYesRadioInput(0);
       cy.checkValue(field(DIFFERENT_TRADING_NAME), '');
     });
   });
@@ -103,7 +101,7 @@ describe(`Insurance - Your business - Company details page - submit ${DIFFERENT_
       cy.navigateToUrl(url);
 
       // check input is not populated
-      yesRadioInput().first().click();
+      cy.clickYesRadioInput(0);
       cy.checkValue(field(DIFFERENT_TRADING_NAME), '');
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-address-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-address-validation.spec.js
@@ -35,7 +35,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
 
     cy.navigateToUrl(url);
 
-    cy.clickNoRadioInput(0);
+    cy.clickNoRadioInput();
 
     cy.clickSubmitButton();
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-address-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-address-validation.spec.js
@@ -1,5 +1,4 @@
 import { companyDetails } from '../../../../../../../pages/your-business';
-import { noRadioInput } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { ROUTES, FIELD_IDS } from '../../../../../../../constants';
 
@@ -36,7 +35,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
 
     cy.navigateToUrl(url);
 
-    noRadioInput().first().click();
+    cy.clickNoRadioInput(0);
 
     cy.clickSubmitButton();
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-name-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-name-validation.spec.js
@@ -1,5 +1,4 @@
 import { companyDetails } from '../../../../../../../pages/your-business';
-import { yesRadioInput } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { ROUTES, FIELD_IDS } from '../../../../../../../constants';
 
@@ -36,7 +35,7 @@ describe("Insurance - Your business - Company details page- As an Exporter I wan
 
     cy.navigateToUrl(url);
 
-    yesRadioInput().eq(1).click();
+    cy.clickYesRadioInput(1);
 
     cy.clickSubmitButton();
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/save-and-back.spec.js
@@ -59,7 +59,7 @@ context('Insurance - Your business - Credit control - Save and go back', () => {
     it(`should redirect to ${ALL_SECTIONS}`, () => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
       cy.clickSaveAndBackButton();
 
       cy.assertUrl(allSectionsUrl);

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/save-and-back.spec.js
@@ -1,4 +1,3 @@
-import { noRadioInput, yesRadioInput } from '../../../../../../pages/shared';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const {
@@ -60,7 +59,7 @@ context('Insurance - Your business - Credit control - Save and go back', () => {
     it(`should redirect to ${ALL_SECTIONS}`, () => {
       cy.navigateToUrl(url);
 
-      yesRadioInput().click();
+      cy.clickYesRadioInput();
       cy.clickSaveAndBackButton();
 
       cy.assertUrl(allSectionsUrl);
@@ -83,7 +82,7 @@ context('Insurance - Your business - Credit control - Save and go back', () => {
     it(`should redirect to ${ALL_SECTIONS}`, () => {
       cy.navigateToUrl(url);
 
-      noRadioInput().click();
+      cy.clickNoRadioInput();
       cy.clickSaveAndBackButton();
 
       cy.assertUrl(allSectionsUrl);

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/save-and-back.spec.js
@@ -59,7 +59,7 @@ context('Insurance - Your business - Credit control - Save and go back', () => {
     it(`should redirect to ${ALL_SECTIONS}`, () => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput();
+      cy.clickYesRadioInput(0);
       cy.clickSaveAndBackButton();
 
       cy.assertUrl(allSectionsUrl);

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer.spec.js
@@ -1,5 +1,5 @@
 import { FIELD_IDS, FIELD_VALUES, ROUTES } from '../../../../../../constants';
-import { summaryList, noRadioInput } from '../../../../../../pages/shared';
+import { summaryList } from '../../../../../../pages/shared';
 import application from '../../../../../../fixtures/application';
 
 const {
@@ -129,7 +129,7 @@ context('Insurance - Your buyer - Change your answers - Company or organisation 
 
         summaryList.field(fieldId).changeLink().click();
 
-        noRadioInput().click();
+        cy.clickNoRadioInput();
 
         cy.clickSubmitButton();
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/connection-to-the-buyer-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/connection-to-the-buyer-page.spec.js
@@ -1,5 +1,5 @@
 import {
-  headingCaption, field, yesRadio, noRadio, yesNoRadioHint, yesRadioInput,
+  headingCaption, field, yesRadio, noRadio, yesNoRadioHint,
 } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { FIELD_VALUES } from '../../../../../../constants';
@@ -105,7 +105,7 @@ context('Insurance - Your Buyer - Connection with the buyer - As an exporter, I 
 
       describe(`when clicking the 'yes' ${CONNECTION_WITH_BUYER} radio`, () => {
         beforeEach(() => {
-          yesRadioInput().click();
+          cy.clickYesRadioInput();
         });
 
         it('renders a label', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/connection-to-the-buyer-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/connection-to-the-buyer-page.spec.js
@@ -109,7 +109,7 @@ context('Insurance - Your Buyer - Connection with the buyer - As an exporter, I 
 
       describe(`when clicking the 'yes' ${CONNECTION_WITH_BUYER} radio`, () => {
         beforeEach(() => {
-          cy.clickYesRadioInput();
+          cy.clickYesRadioInput(0);
         });
 
         it('renders a label', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/connection-to-the-buyer-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/connection-to-the-buyer-page.spec.js
@@ -109,7 +109,7 @@ context('Insurance - Your Buyer - Connection with the buyer - As an exporter, I 
 
       describe(`when clicking the 'yes' ${CONNECTION_WITH_BUYER} radio`, () => {
         beforeEach(() => {
-          cy.clickYesRadioInput(0);
+          cy.clickYesRadioInput();
         });
 
         it('renders a label', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/save-and-back/yes-connection-to-the-buyer-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/save-and-back/yes-connection-to-the-buyer-save-and-back.spec.js
@@ -64,7 +64,7 @@ context('Insurance - Your buyer - Connection to buyer - Has connection to buyer 
 
       cy.completeConnectionToTheBuyerForm({});
 
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
 
       cy.clickSaveAndBackButton();
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/save-and-back/yes-connection-to-the-buyer-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/save-and-back/yes-connection-to-the-buyer-save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { yesRadioInput, field } from '../../../../../../../pages/shared';
+import { field } from '../../../../../../../pages/shared';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as YOUR_BUYER_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
 import application from '../../../../../../../fixtures/application';
@@ -64,7 +64,7 @@ context('Insurance - Your buyer - Connection to buyer - Has connection to buyer 
 
       cy.completeConnectionToTheBuyerForm({});
 
-      yesRadioInput().click();
+      cy.clickYesRadioInput();
 
       cy.clickSaveAndBackButton();
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/save-and-back/yes-connection-to-the-buyer-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/save-and-back/yes-connection-to-the-buyer-save-and-back.spec.js
@@ -64,7 +64,7 @@ context('Insurance - Your buyer - Connection to buyer - Has connection to buyer 
 
       cy.completeConnectionToTheBuyerForm({});
 
-      cy.clickYesRadioInput();
+      cy.clickYesRadioInput(0);
 
       cy.clickSaveAndBackButton();
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/validation/connection-to-the-buyer-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/validation/connection-to-the-buyer-validation.spec.js
@@ -75,7 +75,7 @@ context('Insurance - Your Buyer - Connection to the buyer page - form validation
     const textareaField = { ...field(fieldId), input: field(fieldId).textarea };
 
     beforeEach(() => {
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
     });
 
     it(`should render a validation error and retain the submitted value when ${fieldId} is empty`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/validation/connection-to-the-buyer-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/validation/connection-to-the-buyer-validation.spec.js
@@ -75,7 +75,7 @@ context('Insurance - Your Buyer - Connection to the buyer page - form validation
     const textareaField = { ...field(fieldId), input: field(fieldId).textarea };
 
     beforeEach(() => {
-      yesRadioInput().click();
+      cy.clickYesRadioInput();
     });
 
     it(`should render a validation error and retain the submitted value when ${fieldId} is empty`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/validation/connection-to-the-buyer-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-to-the-buyer/validation/connection-to-the-buyer-validation.spec.js
@@ -75,7 +75,7 @@ context('Insurance - Your Buyer - Connection to the buyer page - form validation
     const textareaField = { ...field(fieldId), input: field(fieldId).textarea };
 
     beforeEach(() => {
-      cy.clickYesRadioInput();
+      cy.clickYesRadioInput(0);
     });
 
     it(`should render a validation error and retain the submitted value when ${fieldId} is empty`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/credit-insurance-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/credit-insurance-cover.spec.js
@@ -106,7 +106,7 @@ context('Insurance - Your Buyer - Credit insurance cover page - As an exporter, 
 
       describe(`when clicking ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER} 'yes' radio`, () => {
         it(`should render ${fieldId} label, hint and input`, () => {
-          cy.clickYesRadioInput(0);
+          cy.clickYesRadioInput();
 
           field.textarea().should('be.visible');
 
@@ -174,7 +174,7 @@ context('Insurance - Your Buyer - Credit insurance cover page - As an exporter, 
 
           cy.assertNoRadioOptionIsChecked();
 
-          cy.clickYesRadioInput(0);
+          cy.clickYesRadioInput();
 
           const field = fieldSelector(PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER).textarea();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/credit-insurance-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/credit-insurance-cover.spec.js
@@ -1,5 +1,5 @@
 import {
-  headingCaption, yesRadio, noRadio, field as fieldSelector, yesRadioInput,
+  headingCaption, yesRadio, noRadio, field as fieldSelector,
 } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { YOUR_BUYER_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/your-buyer';
@@ -106,7 +106,7 @@ context('Insurance - Your Buyer - Credit insurance cover page - As an exporter, 
 
       describe(`when clicking ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER} 'yes' radio`, () => {
         it(`should render ${fieldId} label, hint and input`, () => {
-          cy.clickYesRadioInput();
+          cy.clickYesRadioInput(0);
 
           field.textarea().should('be.visible');
 
@@ -174,7 +174,7 @@ context('Insurance - Your Buyer - Credit insurance cover page - As an exporter, 
 
           cy.assertNoRadioOptionIsChecked();
 
-          yesRadioInput().click();
+          cy.clickYesRadioInput(0);
 
           const field = fieldSelector(PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER).textarea();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/credit-insurance-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/credit-insurance-cover.spec.js
@@ -103,7 +103,7 @@ context('Insurance - Your Buyer - Credit insurance cover page - As an exporter, 
 
       describe(`when clicking ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER} 'yes' radio`, () => {
         it(`should render ${fieldId} label, hint and input`, () => {
-          yesRadio().input().click();
+          cy.clickYesRadioInput();
 
           field.textarea().should('be.visible');
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/save-and-back/credit-insurance-cover-answer-yes-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/save-and-back/credit-insurance-cover-answer-yes-save-and-back.spec.js
@@ -66,7 +66,7 @@ context('Insurance - Your buyer - Credit insurance cover - Save and back - Yes',
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
 
       cy.clickSaveAndBackButton();
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/save-and-back/credit-insurance-cover-answer-yes-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/save-and-back/credit-insurance-cover-answer-yes-save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { yesRadioInput, field } from '../../../../../../../pages/shared';
+import { field } from '../../../../../../../pages/shared';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as YOUR_BUYER_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
 import application from '../../../../../../../fixtures/application';
@@ -66,7 +66,7 @@ context('Insurance - Your buyer - Credit insurance cover - Save and back - Yes',
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      yesRadioInput().click();
+      cy.clickYesRadioInput(0);
 
       cy.clickSaveAndBackButton();
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/validation/credit-insurance-cover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/validation/credit-insurance-cover-validation.spec.js
@@ -77,7 +77,7 @@ context('Insurance - Your Buyer - Credit insurance cover - form validation', () 
     const textareaField = { ...field(fieldId), input: field(fieldId).textarea };
 
     beforeEach(() => {
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
     });
 
     it(`should render a validation error when ${fieldId} is empty`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/validation/credit-insurance-cover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/validation/credit-insurance-cover-validation.spec.js
@@ -1,4 +1,4 @@
-import { field, noRadioInput, yesRadioInput } from '../../../../../../../pages/shared';
+import { field, noRadioInput } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
@@ -77,7 +77,7 @@ context('Insurance - Your Buyer - Credit insurance cover - form validation', () 
     const textareaField = { ...field(fieldId), input: field(fieldId).textarea };
 
     beforeEach(() => {
-      yesRadioInput().click();
+      cy.clickYesRadioInput();
     });
 
     it(`should render a validation error when ${fieldId} is empty`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/validation/credit-insurance-cover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/validation/credit-insurance-cover-validation.spec.js
@@ -77,7 +77,7 @@ context('Insurance - Your Buyer - Credit insurance cover - form validation', () 
     const textareaField = { ...field(fieldId), input: field(fieldId).textarea };
 
     beforeEach(() => {
-      cy.clickYesRadioInput();
+      cy.clickYesRadioInput(0);
     });
 
     it(`should render a validation error when ${fieldId} is empty`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/save-and-back/trading-history-no-outstanding-payments-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/save-and-back/trading-history-no-outstanding-payments-save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { saveAndBackButton, noRadioInput } from '../../../../../../../pages/shared';
+import { saveAndBackButton } from '../../../../../../../pages/shared';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 
 const {
@@ -59,7 +59,7 @@ context('Insurance - Your buyer - Trading history - No outstanding payments - Sa
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      noRadioInput().first().click();
+      cy.clickNoRadioInput(0);
 
       saveAndBackButton().click();
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/save-and-back/trading-history-no-outstanding-payments-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/save-and-back/trading-history-no-outstanding-payments-save-and-back.spec.js
@@ -59,7 +59,7 @@ context('Insurance - Your buyer - Trading history - No outstanding payments - Sa
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.clickNoRadioInput(0);
+      cy.clickNoRadioInput();
 
       saveAndBackButton().click();
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/save-and-back/trading-history-yes-outstanding-payments-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/save-and-back/trading-history-yes-outstanding-payments-save-and-back.spec.js
@@ -1,8 +1,4 @@
-import {
-  saveAndBackButton,
-  yesRadioInput,
-  field,
-} from '../../../../../../../pages/shared';
+import { saveAndBackButton, field } from '../../../../../../../pages/shared';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
 import application from '../../../../../../../fixtures/application';
@@ -69,7 +65,7 @@ context('Insurance - Your buyer - Trading history - Yes outstanding payments - S
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      yesRadioInput().first().click();
+      cy.clickYesRadioInput(0);
       cy.keyboardInput(field(TOTAL_OUTSTANDING_PAYMENTS).input(), BUYER[TOTAL_OUTSTANDING_PAYMENTS]);
 
       saveAndBackButton().click();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/save-and-back/trading-history-yes-outstanding-payments-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/save-and-back/trading-history-yes-outstanding-payments-save-and-back.spec.js
@@ -65,7 +65,7 @@ context('Insurance - Your buyer - Trading history - Yes outstanding payments - S
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
       cy.keyboardInput(field(TOTAL_OUTSTANDING_PAYMENTS).input(), BUYER[TOTAL_OUTSTANDING_PAYMENTS]);
 
       saveAndBackButton().click();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-change-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-change-currency.spec.js
@@ -3,7 +3,6 @@ import {
   SYMBOLS, USD_CURRENCY_CODE, EUR_CURRENCY_CODE, JPY_CURRENCY_CODE,
 } from '../../../../../../fixtures/currencies';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/your-buyer';
-import { yesRadioInput } from '../../../../../../pages/shared';
 
 const {
   ROOT,
@@ -37,7 +36,7 @@ context('Insurance - Your Buyer - Trading history page - Currency symbol when ch
     cy.saveSession();
     cy.navigateToUrl(url);
     // press outstanding payments radio
-    yesRadioInput().first().click();
+    cy.clickYesRadioInput(0);
   });
 
   after(() => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-change-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-change-currency.spec.js
@@ -36,7 +36,7 @@ context('Insurance - Your Buyer - Trading history page - Currency symbol when ch
     cy.saveSession();
     cy.navigateToUrl(url);
     // press outstanding payments radio
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
   });
 
   after(() => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-page.spec.js
@@ -1,5 +1,5 @@
 import {
-  headingCaption, yesRadio, noRadio, field, yesRadioInput,
+  headingCaption, yesRadio, noRadio, field,
 } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
@@ -121,7 +121,7 @@ context('Insurance - Your Buyer - Trading history page - As an exporter, I want 
 
       describe(`when clicking the 'yes' ${OUTSTANDING_PAYMENTS} radio`, () => {
         beforeEach(() => {
-          yesRadioInput().first().click();
+          cy.clickYesRadioInput(0);
         });
 
         it('should render a heading', () => {
@@ -239,7 +239,7 @@ context('Insurance - Your Buyer - Trading history page - As an exporter, I want 
             cy.assertNoRadioOptionIsChecked(0);
 
             // click first radio input to display optional fields
-            yesRadioInput().first().click();
+            cy.clickYesRadioInput(0);
 
             cy.checkValue(field(TOTAL_OUTSTANDING_PAYMENTS), '');
             cy.checkValue(field(TOTAL_AMOUNT_OVERDUE), '');

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-page.spec.js
@@ -121,7 +121,7 @@ context('Insurance - Your Buyer - Trading history page - As an exporter, I want 
 
       describe(`when clicking the 'yes' ${OUTSTANDING_PAYMENTS} radio`, () => {
         beforeEach(() => {
-          cy.clickYesRadioInput(0);
+          cy.clickYesRadioInput();
         });
 
         it('should render a heading', () => {
@@ -239,7 +239,7 @@ context('Insurance - Your Buyer - Trading history page - As an exporter, I want 
             cy.assertNoRadioOptionIsChecked(0);
 
             // click first radio input to display optional fields
-            cy.clickYesRadioInput(0);
+            cy.clickYesRadioInput();
 
             cy.checkValue(field(TOTAL_OUTSTANDING_PAYMENTS), '');
             cy.checkValue(field(TOTAL_AMOUNT_OVERDUE), '');

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/validation/trading-history-outstanding-payments-yes-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/validation/trading-history-outstanding-payments-yes-validation.spec.js
@@ -70,7 +70,7 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
   describe(`when leaving ${TOTAL_AMOUNT_OVERDUE} and ${TOTAL_OUTSTANDING_PAYMENTS} empty`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
       cy.clickYesRadioInput(1);
     });
 
@@ -82,7 +82,7 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
   describe(`when entering a value which is not a number for ${TOTAL_AMOUNT_OVERDUE} and ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
       cy.clickYesRadioInput(1);
     });
 
@@ -96,7 +96,7 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
   describe(`when entering a value with a decimal place for ${TOTAL_AMOUNT_OVERDUE} and ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
       cy.clickYesRadioInput(1);
     });
 
@@ -110,7 +110,7 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
   describe(`when entering a value with a comma and decimal place for ${TOTAL_AMOUNT_OVERDUE} and ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
       cy.clickYesRadioInput(1);
     });
 
@@ -124,7 +124,7 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
   describe(`when entering a value below the minimum for ${TOTAL_AMOUNT_OVERDUE} and ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
       cy.clickYesRadioInput(1);
     });
 
@@ -138,7 +138,7 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
   describe(`when entering a value with a special character for ${TOTAL_AMOUNT_OVERDUE} and ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput();
       cy.clickYesRadioInput(1);
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/validation/trading-history-outstanding-payments-yes-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/validation/trading-history-outstanding-payments-yes-validation.spec.js
@@ -1,4 +1,4 @@
-import { yesRadioInput, field } from '../../../../../../../pages/shared';
+import { field } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
@@ -70,8 +70,8 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
   describe(`when leaving ${TOTAL_AMOUNT_OVERDUE} and ${TOTAL_OUTSTANDING_PAYMENTS} empty`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-      yesRadioInput().first().click();
-      yesRadioInput().eq(1).click();
+      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput(1);
     });
 
     it('should render validation errors', () => {
@@ -82,8 +82,8 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
   describe(`when entering a value which is not a number for ${TOTAL_AMOUNT_OVERDUE} and ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-      yesRadioInput().first().click();
-      yesRadioInput().eq(1).click();
+      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput(1);
     });
 
     it('should render validation errors', () => {
@@ -96,8 +96,8 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
   describe(`when entering a value with a decimal place for ${TOTAL_AMOUNT_OVERDUE} and ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-      yesRadioInput().first().click();
-      yesRadioInput().eq(1).click();
+      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput(1);
     });
 
     it('should render validation errors', () => {
@@ -110,8 +110,8 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
   describe(`when entering a value with a comma and decimal place for ${TOTAL_AMOUNT_OVERDUE} and ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-      yesRadioInput().first().click();
-      yesRadioInput().eq(1).click();
+      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput(1);
     });
 
     it('should render validation errors', () => {
@@ -124,8 +124,8 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
   describe(`when entering a value below the minimum for ${TOTAL_AMOUNT_OVERDUE} and ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-      yesRadioInput().first().click();
-      yesRadioInput().eq(1).click();
+      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput(1);
     });
 
     it('should render validation errors', () => {
@@ -138,8 +138,8 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
   describe(`when entering a value with a special character for ${TOTAL_AMOUNT_OVERDUE} and ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
-      yesRadioInput().first().click();
-      yesRadioInput().eq(1).click();
+      cy.clickYesRadioInput(0);
+      cy.clickYesRadioInput(1);
     });
 
     it('should render validation errors', () => {

--- a/e2e-tests/pages/insurance/your-buyer/companyOrOrganisation.js
+++ b/e2e-tests/pages/insurance/your-buyer/companyOrOrganisation.js
@@ -1,10 +1,5 @@
 import { YOUR_BUYER as FIELD_IDS } from '../../../constants/field-ids/insurance/your-buyer';
-import {
-  field,
-  yesRadioInput,
-  noRadioInput,
-  yesNoRadioHint,
-} from '../../shared';
+import { field, yesNoRadioHint } from '../../shared';
 
 const {
   COMPANY_OR_ORGANISATION: { COUNTRY, CAN_CONTACT_BUYER },
@@ -14,8 +9,6 @@ const companyOrOrganisation = {
   [COUNTRY]: () => cy.get(`[data-cy="${COUNTRY}"]`),
   [CAN_CONTACT_BUYER]: {
     ...field(CAN_CONTACT_BUYER),
-    yesRadioInput: () => yesRadioInput().first(),
-    noRadioInput: () => noRadioInput().first(),
     yesNoRadioHint,
   },
 };

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/buyer-body/buyer-body-answer-yes.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/buyer-body/buyer-body-answer-yes.spec.js
@@ -25,7 +25,7 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
 
     cy.navigateToUrl(url);
 
-    cy.clickYesRadioInput();
+    cy.clickYesRadioInput(0);
     cy.clickSubmitButton();
   });
 

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/buyer-body/buyer-body-answer-yes.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/buyer-body/buyer-body-answer-yes.spec.js
@@ -1,4 +1,4 @@
-import { backLink, yesRadio } from '../../../../../../pages/shared';
+import { backLink } from '../../../../../../pages/shared';
 import { getAQuoteByEmailPage } from '../../../../../../pages/quote';
 import { PAGES, LINKS } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
@@ -25,7 +25,7 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
 
     cy.navigateToUrl(url);
 
-    yesRadio().input().click();
+    cy.clickYesRadioInput();
     cy.clickSubmitButton();
   });
 

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/buyer-body/buyer-body-answer-yes.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/buyer-body/buyer-body-answer-yes.spec.js
@@ -25,7 +25,7 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
 
     cy.navigateToUrl(url);
 
-    cy.clickYesRadioInput(0);
+    cy.clickYesRadioInput();
     cy.clickSubmitButton();
   });
 

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/buyer-body/buyer-body.spec.js
@@ -94,7 +94,7 @@ context('Buyer body page - as an exporter, I want to check if I can get an EXIP 
 
     describe('when submitting the answer as `no`', () => {
       it(`should redirect to ${EXPORTER_LOCATION}`, () => {
-        noRadio().input().click();
+        cy.clickNoRadioInput();
         cy.clickSubmitButton();
 
         const expectedUrl = `${baseUrl}${EXPORTER_LOCATION}`;

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/cannot-apply-page.spec.js
@@ -1,6 +1,4 @@
-import {
-  actions, cannotApplyPage, noRadio,
-} from '../../../../../pages/shared';
+import { actions, cannotApplyPage } from '../../../../../pages/shared';
 import { PAGES, LINKS } from '../../../../../content-strings';
 import { ROUTES } from '../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../commands/forms';
@@ -25,7 +23,7 @@ context('Cannot apply exit page', () => {
 
     cy.assertUrl(expectedUrl);
 
-    noRadio().input().click();
+    cy.clickNoRadioInput();
     cy.clickSubmitButton();
 
     expectedUrl = `${baseUrl}${CANNOT_APPLY}`;

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/exporter-location/exporter-location-answer-no.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/exporter-location/exporter-location-answer-no.spec.js
@@ -1,6 +1,4 @@
-import {
-  backLink, cannotApplyPage, noRadio,
-} from '../../../../../../pages/shared';
+import { backLink, cannotApplyPage } from '../../../../../../pages/shared';
 import { PAGES, LINKS } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../../commands/forms';
@@ -30,7 +28,7 @@ context('Exporter location page - as an exporter, I want to check if my company 
 
     cy.navigateToUrl(url);
 
-    noRadio().input().click();
+    cy.clickNoRadioInput();
     cy.clickSubmitButton();
   });
 

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
@@ -80,7 +80,7 @@ context('Exporter location page - as an exporter, I want to check if my company 
 
     describe('when submitting the answer as `yes`', () => {
       it(`should redirect to ${UK_GOODS_OR_SERVICES}`, () => {
-        yesRadio().input().click();
+        cy.clickYesRadioInput();
         cy.clickSubmitButton();
 
         const expectedUrl = `${baseUrl}${UK_GOODS_OR_SERVICES}`;

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
@@ -80,7 +80,7 @@ context('Exporter location page - as an exporter, I want to check if my company 
 
     describe('when submitting the answer as `yes`', () => {
       it(`should redirect to ${UK_GOODS_OR_SERVICES}`, () => {
-        cy.clickYesRadioInput();
+        cy.clickYesRadioInput(0);
         cy.clickSubmitButton();
 
         const expectedUrl = `${baseUrl}${UK_GOODS_OR_SERVICES}`;

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/exporter-location/exporter-location.spec.js
@@ -80,7 +80,7 @@ context('Exporter location page - as an exporter, I want to check if my company 
 
     describe('when submitting the answer as `yes`', () => {
       it(`should redirect to ${UK_GOODS_OR_SERVICES}`, () => {
-        cy.clickYesRadioInput(0);
+        cy.clickYesRadioInput();
         cy.clickSubmitButton();
 
         const expectedUrl = `${baseUrl}${UK_GOODS_OR_SERVICES}`;

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
@@ -1,6 +1,4 @@
-import {
-  backLink, cannotApplyPage, noRadio,
-} from '../../../../../../pages/shared';
+import { backLink, cannotApplyPage } from '../../../../../../pages/shared';
 import { PAGES, LINKS } from '../../../../../../content-strings';
 import { ROUTES } from '../../../../../../constants';
 import { completeAndSubmitBuyerCountryForm } from '../../../../../../commands/forms';
@@ -25,7 +23,7 @@ context('UK goods or services page - as an exporter, I want to check if my expor
 
     cy.assertUrl(url);
 
-    noRadio().input().click();
+    cy.clickNoRadioInput();
     cy.clickSubmitButton();
   });
 

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -111,7 +111,7 @@ context('UK goods or services page - as an exporter, I want to check if my expor
       it(`should redirect to ${POLICY_TYPE}`, () => {
         cy.navigateToUrl(url);
 
-        cy.clickYesRadioInput(0);
+        cy.clickYesRadioInput();
         cy.clickSubmitButton();
 
         const expectedUrl = `${baseUrl}${POLICY_TYPE}`;

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -111,7 +111,7 @@ context('UK goods or services page - as an exporter, I want to check if my expor
       it(`should redirect to ${POLICY_TYPE}`, () => {
         cy.navigateToUrl(url);
 
-        cy.clickYesRadioInput();
+        cy.clickYesRadioInput(0);
         cy.clickSubmitButton();
 
         const expectedUrl = `${baseUrl}${POLICY_TYPE}`;

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -111,7 +111,7 @@ context('UK goods or services page - as an exporter, I want to check if my expor
       it(`should redirect to ${POLICY_TYPE}`, () => {
         cy.navigateToUrl(url);
 
-        yesRadio().input().click();
+        cy.clickYesRadioInput();
         cy.clickSubmitButton();
 
         const expectedUrl = `${baseUrl}${POLICY_TYPE}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@commitlint/cli": "^18.6.0",
         "@commitlint/config-conventional": "^18.6.0",
         "@types/jest": "^29.5.12",
-        "@types/node": "^20.11.15",
+        "@types/node": "^20.11.17",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "commitlint": "^18.6.0",
@@ -6317,9 +6317,9 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "20.11.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
-      "integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
+      "version": "20.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
+      "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@commitlint/cli": "^18.6.0",
     "@commitlint/config-conventional": "^18.6.0",
     "@types/jest": "^29.5.12",
-    "@types/node": "^20.11.15",
+    "@types/node": "^20.11.17",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "commitlint": "^18.6.0",

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@types/google-libphonenumber": "^7.4.30",
         "@types/is-url": "^1.2.32",
         "@types/morgan": "^1.9.9",
-        "@types/node": "^20.11.15",
+        "@types/node": "^20.11.17",
         "@types/nunjucks": "^3.2.6",
         "accessible-autocomplete": "^2.0.4",
         "apollo-cache-inmemory": "^1.6.6",
@@ -3040,9 +3040,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.11.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
-      "integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
+      "version": "20.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
+      "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -34,7 +34,7 @@
     "@types/google-libphonenumber": "^7.4.30",
     "@types/is-url": "^1.2.32",
     "@types/morgan": "^1.9.9",
-    "@types/node": "^20.11.15",
+    "@types/node": "^20.11.17",
     "@types/nunjucks": "^3.2.6",
     "accessible-autocomplete": "^2.0.4",
     "apollo-cache-inmemory": "^1.6.6",


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates all instances of "click yes/no radio" in E2E tests to use new, DRY cypress commands, therefore reducing the need to import yes/no radio inputs in individual tests.

## Resolution :heavy_check_mark:
- Create `clickYesRadioInput` command with a default index set to 0.
- Create `clickNoRadioInput` command with a default index set to 0.
- Create `assertYesRadioOptionIsNotChecked` command.
- Create `assertNoRadioOptionIsNotChecked` command.
- Update all E2E tests.

## Miscellaneous :heavy_plus_sign:
- Bump dependencies.
