### PR TITLE
feat(EMS-2748-2749): No PDF - Policy - Broker details - data saving, save and go back

### DIFF
--- a/database/exip.sql
+++ b/database/exip.sql
@@ -764,6 +764,7 @@ CREATE TABLE `Broker` (
   `town` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `county` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `postcode` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `fullAddress` varchar(300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `email` varchar(300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `Broker_application_idx` (`application`),

--- a/e2e-tests/commands/insurance/complete-and-submit-broker-details-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-broker-details-form.js
@@ -1,21 +1,9 @@
-import { field } from '../../pages/shared';
-import { POLICY as POLICY_FIELD_IDS } from '../../constants/field-ids/insurance/policy';
-import mockApplication from '../../fixtures/application';
-
-const { BROKER } = mockApplication;
-
-const {
-  BROKER_DETAILS: { NAME, EMAIL, FULL_ADDRESS },
-} = POLICY_FIELD_IDS;
-
 /**
  * completeAndSubmitBrokerDetailsForm
  * Complete and submit "broker details" form
  */
 const completeAndSubmitBrokerDetailsForm = () => {
-  cy.keyboardInput(field(NAME).input(), BROKER[NAME]);
-  cy.keyboardInput(field(EMAIL).input(), BROKER[EMAIL]);
-  cy.keyboardInput(field(FULL_ADDRESS).textarea(), BROKER[FULL_ADDRESS]);
+  cy.completeBrokerDetailsForm();
 
   cy.clickSubmitButton();
 };

--- a/e2e-tests/commands/insurance/complete-broker-details-form.js
+++ b/e2e-tests/commands/insurance/complete-broker-details-form.js
@@ -1,0 +1,21 @@
+import { field } from '../../pages/shared';
+import { POLICY as POLICY_FIELD_IDS } from '../../constants/field-ids/insurance/policy';
+import mockApplication from '../../fixtures/application';
+
+const { BROKER } = mockApplication;
+
+const {
+  BROKER_DETAILS: { NAME, EMAIL, FULL_ADDRESS },
+} = POLICY_FIELD_IDS;
+
+/**
+ * completeBrokerDetailsForm
+ * Complete and submit "broker details" form
+ */
+const completeBrokerDetailsForm = () => {
+  cy.keyboardInput(field(NAME).input(), BROKER[NAME]);
+  cy.keyboardInput(field(EMAIL).input(), BROKER[EMAIL]);
+  cy.keyboardInput(field(FULL_ADDRESS).textarea(), BROKER[FULL_ADDRESS]);
+};
+
+export default completeBrokerDetailsForm;

--- a/e2e-tests/commands/insurance/complete-policy-section.js
+++ b/e2e-tests/commands/insurance/complete-policy-section.js
@@ -48,6 +48,10 @@ const completePolicySection = ({
 
   cy.completeAndSubmitBrokerForm({ usingBroker });
 
+  if (usingBroker) {
+    cy.completeAndSubmitBrokerDetailsForm({});
+  }
+
   if (submitCheckYourAnswers) {
     cy.clickSubmitButton();
   }

--- a/e2e-tests/commands/shared-commands/assertions/assert-broker-details-field-values.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-broker-details-field-values.js
@@ -1,0 +1,38 @@
+import { field as fieldSelector } from '../../../pages/shared';
+import { POLICY as POLICY_FIELD_IDS } from '../../../constants/field-ids/insurance/policy';
+import mockApplication from '../../../fixtures/application';
+
+const {
+  BROKER_DETAILS: {
+    NAME,
+    EMAIL,
+    FULL_ADDRESS,
+  },
+} = POLICY_FIELD_IDS;
+
+/**
+ * assertBrokerDetailsFieldValues
+ * Assert all field values in the "broker details" form.
+ * @param {String} expectedName: Name
+ * @param {String} expectedEmail: Email
+ * @param {String} expectedFullAddress: Full address
+ */
+const assertBrokerDetailsFieldValues = ({
+  expectedName = mockApplication.BROKER[NAME],
+  expectedEmail = mockApplication.BROKER[EMAIL],
+  expectedFullAddress = mockApplication.BROKER[FULL_ADDRESS],
+}) => {
+  cy.checkValue(fieldSelector(NAME), expectedName);
+  cy.checkValue(fieldSelector(EMAIL), expectedEmail);
+
+  const addressField = fieldSelector(FULL_ADDRESS);
+
+  const textareaField = {
+    ...addressField,
+    input: addressField.textarea,
+  };
+
+  cy.checkValue(textareaField, expectedFullAddress);
+};
+
+export default assertBrokerDetailsFieldValues;

--- a/e2e-tests/commands/shared-commands/assertions/index.js
+++ b/e2e-tests/commands/shared-commands/assertions/index.js
@@ -50,5 +50,6 @@ Cypress.Commands.add('checkRadioInputYesAriaLabel', require('./check-radio-input
 Cypress.Commands.add('checkRadioInputNoAriaLabel', require('./check-radio-input-no-aria-label'));
 
 Cypress.Commands.add('assertDifferentNameOnPolicyFieldValues', require('./assert-different-name-on-policy-field-values'));
+Cypress.Commands.add('assertBrokerDetailsFieldValues', require('./assert-broker-details-field-values'));
 
 Cypress.Commands.add('submitAndAssertChangeAnswersPageUrl', require('./submit-and-assert-change-answers-page-url'));

--- a/e2e-tests/constants/routes/insurance/policy.js
+++ b/e2e-tests/constants/routes/insurance/policy.js
@@ -46,6 +46,7 @@ export const POLICY = {
   BROKER_CHANGE: `${BROKER_ROOT}/change`,
   BROKER_CHECK_AND_CHANGE: `${BROKER_ROOT}/check-and-change`,
   BROKER_DETAILS_ROOT,
+  BROKER_DETAILS_SAVE_AND_BACK: `${BROKER_DETAILS_ROOT}/save-and-back`,
   BROKER_CONFIRM_ADDRESS_ROOT,
   CHECK_YOUR_ANSWERS: `${ROOT}/check-your-answers`,
 };

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-with-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-with-broker.spec.js
@@ -3,8 +3,7 @@ import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const { APPLICATION_SUBMITTED } = INSURANCE_ROUTES;
 
-// TODO: EMS-2749 - re-enable
-context.skip('Insurance - submit an application - Multiple policy type with a broker - As an Exporter, I want to submit my completed credit insurance application, So that UKEF can process and make a decision on my application', () => {
+context('Insurance - submit an application - Multiple policy type with a broker - As an Exporter, I want to submit my completed credit insurance application, So that UKEF can process and make a decision on my application', () => {
   let referenceNumber;
 
   before(() => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-with-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-with-broker.spec.js
@@ -2,8 +2,7 @@ import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const { APPLICATION_SUBMITTED } = INSURANCE_ROUTES;
 
-// TODO: EMS-2749 - re-enable
-context.skip('Insurance - submit an application - Single policy type with a broker - As an Exporter, I want to submit my completed credit insurance application, So that UKEF can process and make a decision on my application', () => {
+context('Insurance - submit an application - Single policy type with a broker - As an Exporter, I want to submit my completed credit insurance application, So that UKEF can process and make a decision on my application', () => {
   let referenceNumber;
 
   before(() => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/save-and-back.spec.js
@@ -52,7 +52,7 @@ context('Insurance - Policy - Another company page - Save and back', () => {
   });
 
   describe('when no fields are provided', () => {
-    it(`should redirect to ${ALL_SECTIONS} retain the "insurance policy" task status as "in progress"`, () => {
+    it(`should redirect to ${ALL_SECTIONS} and retain the "insurance policy" task status as "in progress"`, () => {
       cy.navigateToUrl(url);
 
       cy.clickSaveAndBackButton();

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
@@ -5,6 +5,7 @@ import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
+import application from '../../../../../../fixtures/application';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.POLICY.BROKER_DETAILS;
 
@@ -115,12 +116,32 @@ context("Insurance - Policy - Broker details page - As an exporter, I want to pr
   });
 
   describe('form submission', () => {
-    it(`should redirect to ${BROKER_CONFIRM_ADDRESS_ROOT} page`, () => {
+    beforeEach(() => {
       cy.navigateToUrl(url);
+    });
 
+    it(`should redirect to ${BROKER_CONFIRM_ADDRESS_ROOT} page`, () => {
       cy.completeAndSubmitBrokerDetailsForm();
 
       cy.assertUrl(brokerConfirmAddressUrl);
+    });
+
+    describe('when going back to the page', () => {
+      it('should have the submitted values', () => {
+        cy.navigateToUrl(url);
+
+        cy.checkValue(fieldSelector(NAME), application.BROKER[NAME]);
+        cy.checkValue(fieldSelector(EMAIL), application.BROKER[EMAIL]);
+
+        const addressField = fieldSelector(FULL_ADDRESS);
+
+        const textareaField = {
+          ...addressField,
+          input: addressField.textarea,
+        };
+
+        cy.checkValue(textareaField, application.BROKER[FULL_ADDRESS]);
+      });
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
@@ -21,7 +21,7 @@ const {
   POLICY: {
     BROKER_ROOT,
     BROKER_DETAILS_ROOT,
-    BROKER_CONFIRM_ADDRESS_ROOT,
+    CHECK_YOUR_ANSWERS,
   },
 } = INSURANCE_ROUTES;
 
@@ -32,7 +32,7 @@ const baseUrl = Cypress.config('baseUrl');
 context("Insurance - Policy - Broker details page - As an exporter, I want to provide UKEF with my broker's details, So that UKEF can communicate with the broker as needed whilst processing my application'", () => {
   let referenceNumber;
   let url;
-  let brokerConfirmAddressUrl;
+  let checkYourAnswersUrl;
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
@@ -50,7 +50,7 @@ context("Insurance - Policy - Broker details page - As an exporter, I want to pr
       cy.completeAndSubmitBrokerForm({ usingBroker: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_DETAILS_ROOT}`;
-      brokerConfirmAddressUrl = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_CONFIRM_ADDRESS_ROOT}`;
+      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
       cy.assertUrl(url);
     });
@@ -119,10 +119,10 @@ context("Insurance - Policy - Broker details page - As an exporter, I want to pr
       cy.navigateToUrl(url);
     });
 
-    it(`should redirect to ${BROKER_CONFIRM_ADDRESS_ROOT} page`, () => {
+    it(`should redirect to ${CHECK_YOUR_ANSWERS} page`, () => {
       cy.completeAndSubmitBrokerDetailsForm();
 
-      cy.assertUrl(brokerConfirmAddressUrl);
+      cy.assertUrl(checkYourAnswersUrl);
     });
 
     describe('when going back to the page', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
@@ -5,7 +5,6 @@ import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
-import application from '../../../../../../fixtures/application';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.POLICY.BROKER_DETAILS;
 
@@ -130,17 +129,7 @@ context("Insurance - Policy - Broker details page - As an exporter, I want to pr
       it('should have the submitted values', () => {
         cy.navigateToUrl(url);
 
-        cy.checkValue(fieldSelector(NAME), application.BROKER[NAME]);
-        cy.checkValue(fieldSelector(EMAIL), application.BROKER[EMAIL]);
-
-        const addressField = fieldSelector(FULL_ADDRESS);
-
-        const textareaField = {
-          ...addressField,
-          input: addressField.textarea,
-        };
-
-        cy.checkValue(textareaField, application.BROKER[FULL_ADDRESS]);
+        cy.assertBrokerDetailsFieldValues({});
       });
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/save-and-back.spec.js
@@ -1,22 +1,24 @@
+import { field as fieldSelector } from '../../../../../../pages/shared';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
+import mockApplication from '../../../../../../fixtures/application';
 
 const {
-  USING_BROKER,
+  BROKER_DETAILS: { NAME },
 } = POLICY_FIELD_IDS;
 
 const {
   ROOT,
   ALL_SECTIONS,
   POLICY: {
-    BROKER_ROOT,
+    BROKER_DETAILS_ROOT,
   },
 } = INSURANCE_ROUTES;
 
 const baseUrl = Cypress.config('baseUrl');
 
-context('Insurance - Policy - Broker page - Save and back', () => {
+context('Insurance - Policy - Broker details page - Save and back', () => {
   let referenceNumber;
   let url;
   let allSectionsUrl;
@@ -34,8 +36,9 @@ context('Insurance - Policy - Broker page - Save and back', () => {
       cy.completeAndSubmitNameOnPolicyForm({});
       cy.completeAndSubmitPreCreditPeriodForm({});
       cy.completeAndSubmitAnotherCompanyForm({});
+      cy.completeAndSubmitBrokerForm({ usingBroker: true });
 
-      url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_DETAILS_ROOT}`;
       allSectionsUrl = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       cy.assertUrl(url);
@@ -62,36 +65,31 @@ context('Insurance - Policy - Broker page - Save and back', () => {
     });
   });
 
-  describe(`when selecting yes for ${USING_BROKER}`, () => {
-    it(`should redirect to ${ALL_SECTIONS} and change the "insurance policy" task status to "completed"`, () => {
+  describe('when fields are partially completed', () => {
+    beforeEach(() => {
       cy.navigateToUrl(url);
+    });
 
-      cy.clickYesRadioInput();
+    it(`should redirect to ${ALL_SECTIONS} and retain the "insurance policy" task status as "in progress"`, () => {
+      cy.keyboardInput(fieldSelector(NAME).input(), mockApplication.BROKER[NAME]);
 
       cy.clickSaveAndBackButton();
 
       cy.assertUrl(allSectionsUrl);
 
-      cy.checkTaskPolicyStatusIsComplete();
+      cy.checkTaskPolicyStatusIsInProgress();
     });
 
-    it('should retain all the fields on the page', () => {
-      cy.navigateToUrl(allSectionsUrl);
-
-      cy.startInsurancePolicySection({});
-
-      // go through 6 policy forms.
-      cy.clickSubmitButtonMultipleTimes({ count: 6 });
-
-      cy.assertYesRadioOptionIsChecked();
+    it('should retain all the relevant fields on the page', () => {
+      cy.checkValue(fieldSelector(NAME), mockApplication.BROKER[NAME]);
     });
   });
 
-  describe(`when selecting no for ${USING_BROKER}`, () => {
+  describe('when all fields are provided', () => {
     it(`should redirect to ${ALL_SECTIONS} and change the "insurance policy" task status to "Completed"`, () => {
       cy.navigateToUrl(url);
 
-      cy.clickNoRadioInput();
+      cy.completeBrokerDetailsForm();
 
       cy.clickSaveAndBackButton();
 
@@ -105,10 +103,10 @@ context('Insurance - Policy - Broker page - Save and back', () => {
 
       cy.startInsurancePolicySection({});
 
-      // go through 6 policy forms.
-      cy.clickSubmitButtonMultipleTimes({ count: 6 });
+      // go through 7 policy forms.
+      cy.clickSubmitButtonMultipleTimes({ count: 7 });
 
-      cy.assertNoRadioOptionIsChecked();
+      cy.assertBrokerDetailsFieldValues({});
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
@@ -63,7 +63,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
   });
 
   describe(`when selecting yes for ${USING_BROKER}`, () => {
-    it(`should redirect to ${ALL_SECTIONS} and change the "insurance policy" task status to "completed"`, () => {
+    it(`should redirect to ${ALL_SECTIONS} and change the "insurance policy" task status to "in progress"`, () => {
       cy.navigateToUrl(url);
 
       cy.clickYesRadioInput();
@@ -72,7 +72,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
 
       cy.assertUrl(allSectionsUrl);
 
-      cy.checkTaskPolicyStatusIsComplete();
+      cy.checkTaskPolicyStatusIsInProgress();
     });
 
     it('should retain all the fields on the page', () => {

--- a/e2e-tests/insurance/cypress/support/application/policy/index.js
+++ b/e2e-tests/insurance/cypress/support/application/policy/index.js
@@ -23,6 +23,7 @@ Cypress.Commands.add('completeAndSubmitPreCreditPeriodForm', require('../../../.
 Cypress.Commands.add('completeAndSubmitAnotherCompanyForm', require('../../../../../commands/insurance/complete-and-submit-another-company-form'));
 Cypress.Commands.add('completeAndSubmitOtherCompanyDetailsForm', require('../../../../../commands/insurance/complete-and-submit-other-company-details-form'));
 Cypress.Commands.add('completeAndSubmitBrokerForm', require('../../../../../commands/insurance/complete-and-submit-broker-form'));
+Cypress.Commands.add('completeBrokerDetailsForm', require('../../../../../commands/insurance/complete-broker-details-form'));
 Cypress.Commands.add('completeAndSubmitBrokerDetailsForm', require('../../../../../commands/insurance/complete-and-submit-broker-details-form'));
 
 Cypress.Commands.add('completeBusinessSection', require('../../../../../commands/insurance/complete-business-section'));

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -1308,6 +1308,9 @@ var lists = {
       town: (0, import_fields.text)(),
       county: (0, import_fields.text)(),
       postcode: (0, import_fields.text)(),
+      fullAddress: (0, import_fields.text)({
+        db: { nativeType: "VarChar(300)" }
+      }),
       email: (0, import_fields.text)({
         db: { nativeType: "VarChar(300)" }
       })

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -1116,6 +1116,7 @@ type Broker {
   town: String
   county: String
   postcode: String
+  fullAddress: String
   email: String
 }
 
@@ -1135,6 +1136,7 @@ input BrokerWhereInput {
   town: StringFilter
   county: StringFilter
   postcode: StringFilter
+  fullAddress: StringFilter
   email: StringFilter
 }
 
@@ -1146,6 +1148,7 @@ input BrokerOrderByInput {
   town: OrderDirection
   county: OrderDirection
   postcode: OrderDirection
+  fullAddress: OrderDirection
   email: OrderDirection
 }
 
@@ -1158,6 +1161,7 @@ input BrokerUpdateInput {
   town: String
   county: String
   postcode: String
+  fullAddress: String
   email: String
 }
 
@@ -1175,6 +1179,7 @@ input BrokerCreateInput {
   town: String
   county: String
   postcode: String
+  fullAddress: String
   email: String
 }
 

--- a/src/api/schema.prisma
+++ b/src/api/schema.prisma
@@ -235,6 +235,7 @@ model Broker {
   town                    String        @default("")
   county                  String        @default("")
   postcode                String        @default("")
+  fullAddress             String        @default("") @mysql.VarChar(300)
   email                   String        @default("") @mysql.VarChar(300)
   from_Application_broker Application[] @relation("Application_broker")
 

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -477,6 +477,9 @@ export const lists = {
       town: text(),
       county: text(),
       postcode: text(),
+      fullAddress: text({
+        db: { nativeType: 'VarChar(300)' },
+      }),
       email: text({
         db: { nativeType: 'VarChar(300)' },
       }),

--- a/src/ui/server/constants/routes/insurance/policy.ts
+++ b/src/ui/server/constants/routes/insurance/policy.ts
@@ -46,6 +46,7 @@ export const POLICY = {
   BROKER_CHANGE: `${BROKER_ROOT}/change`,
   BROKER_CHECK_AND_CHANGE: `${BROKER_ROOT}/check-and-change`,
   BROKER_DETAILS_ROOT,
+  BROKER_DETAILS_SAVE_AND_BACK: `${BROKER_DETAILS_ROOT}/save-and-back`,
   BROKER_CONFIRM_ADDRESS_ROOT,
   CHECK_YOUR_ANSWERS: `${ROOT}/check-your-answers`,
 };

--- a/src/ui/server/controllers/insurance/policy/broker-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-details/index.test.ts
@@ -10,6 +10,7 @@ import mapApplicationToFormFields from '../../../../helpers/mappings/map-applica
 import constructPayload from '../../../../helpers/construct-payload';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import generateValidationErrors from './validation';
+import mapAndSave from '../map-and-save/broker';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
 
@@ -113,11 +114,19 @@ describe('controllers/insurance/policy/broker-details', () => {
   });
 
   describe('post', () => {
+    const validBody = {
+      [NAME]: broker[NAME],
+      [EMAIL]: broker[EMAIL],
+      [FULL_ADDRESS]: broker[FULL_ADDRESS],
+    };
+
+    mapAndSave.broker = jest.fn(() => Promise.resolve(true));
+
     describe('when there are validation errors', () => {
-      it('should render template with validation errors and submitted values', () => {
+      it('should render template with validation errors and submitted values', async () => {
         req.body = {};
 
-        post(req, res);
+        await post(req, res);
 
         const sanitisedData = sanitiseData(req.body);
 
@@ -140,20 +149,26 @@ describe('controllers/insurance/policy/broker-details', () => {
     });
 
     describe('when there are no validation errors', () => {
-      const validBody = {
-        [NAME]: broker[NAME],
-        [EMAIL]: broker[EMAIL],
-        [FULL_ADDRESS]: broker[FULL_ADDRESS],
-      };
-
-      it(`should redirect to ${BROKER_CONFIRM_ADDRESS_ROOT}`, () => {
+      it(`should redirect to ${BROKER_CONFIRM_ADDRESS_ROOT}`, async () => {
         req.body = validBody;
 
-        post(req, res);
+        await post(req, res);
 
         const expected = `${INSURANCE_ROOT}/${req.params.referenceNumber}${BROKER_CONFIRM_ADDRESS_ROOT}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
+      });
+
+      it('should call mapAndSave.broker once with data from constructPayload function', async () => {
+        req.body = validBody;
+
+        await post(req, res);
+
+        const payload = constructPayload(req.body, FIELD_IDS);
+
+        expect(mapAndSave.broker).toHaveBeenCalledTimes(1);
+
+        expect(mapAndSave.broker).toHaveBeenCalledWith(payload, mockApplication);
       });
     });
 
@@ -162,10 +177,46 @@ describe('controllers/insurance/policy/broker-details', () => {
         delete res.locals.application;
       });
 
-      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, () => {
-        post(req, res);
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
 
         expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+      });
+    });
+
+    describe('api error handling', () => {
+      describe('mapAndSave.broker call', () => {
+        beforeEach(() => {
+          req.body = validBody;
+        });
+
+        describe('when no application is returned', () => {
+          beforeEach(() => {
+            const mapAndSaveSpy = jest.fn(() => Promise.resolve(false));
+
+            mapAndSave.broker = mapAndSaveSpy;
+          });
+
+          it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+            await post(req, res);
+
+            expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+          });
+        });
+
+        describe('when there is an error', () => {
+          beforeEach(() => {
+            const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+
+            mapAndSave.broker = mapAndSaveSpy;
+          });
+
+          it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+            await post(req, res);
+
+            expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+          });
+        });
       });
     });
   });

--- a/src/ui/server/controllers/insurance/policy/broker-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-details/index.test.ts
@@ -18,7 +18,7 @@ const { NAME, EMAIL, FULL_ADDRESS } = POLICY_FIELD_IDS.BROKER_DETAILS;
 
 const {
   INSURANCE_ROOT,
-  POLICY: { BROKER_CONFIRM_ADDRESS_ROOT },
+  POLICY: { BROKER_CONFIRM_ADDRESS_ROOT, BROKER_DETAILS_SAVE_AND_BACK },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -78,7 +78,7 @@ describe('controllers/insurance/policy/broker-details', () => {
             ...BROKER_DETAILS[FULL_ADDRESS],
           },
         },
-        SAVE_AND_BACK_URL: `#${referenceNumber}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${BROKER_DETAILS_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);

--- a/src/ui/server/controllers/insurance/policy/broker-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-details/index.test.ts
@@ -18,7 +18,7 @@ const { NAME, EMAIL, FULL_ADDRESS } = POLICY_FIELD_IDS.BROKER_DETAILS;
 
 const {
   INSURANCE_ROOT,
-  POLICY: { BROKER_CONFIRM_ADDRESS_ROOT, BROKER_DETAILS_SAVE_AND_BACK },
+  POLICY: { BROKER_DETAILS_SAVE_AND_BACK, CHECK_YOUR_ANSWERS },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -149,12 +149,12 @@ describe('controllers/insurance/policy/broker-details', () => {
     });
 
     describe('when there are no validation errors', () => {
-      it(`should redirect to ${BROKER_CONFIRM_ADDRESS_ROOT}`, async () => {
+      it(`should redirect to ${CHECK_YOUR_ANSWERS}`, async () => {
         req.body = validBody;
 
         await post(req, res);
 
-        const expected = `${INSURANCE_ROOT}/${req.params.referenceNumber}${BROKER_CONFIRM_ADDRESS_ROOT}`;
+        const expected = `${INSURANCE_ROOT}/${req.params.referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });

--- a/src/ui/server/controllers/insurance/policy/broker-details/index.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-details/index.ts
@@ -16,7 +16,7 @@ const { NAME, EMAIL, FULL_ADDRESS } = POLICY_FIELD_IDS.BROKER_DETAILS;
 
 const {
   INSURANCE_ROOT,
-  POLICY: { BROKER_CONFIRM_ADDRESS_ROOT },
+  POLICY: { BROKER_CONFIRM_ADDRESS_ROOT, BROKER_DETAILS_SAVE_AND_BACK },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -49,7 +49,7 @@ export const pageVariables = (referenceNumber: number) => ({
       ...BROKER_DETAILS[FULL_ADDRESS],
     },
   },
-  SAVE_AND_BACK_URL: `#${referenceNumber}`,
+  SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${BROKER_DETAILS_SAVE_AND_BACK}`,
 });
 
 /**

--- a/src/ui/server/controllers/insurance/policy/broker-details/index.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-details/index.ts
@@ -16,7 +16,7 @@ const { NAME, EMAIL, FULL_ADDRESS } = POLICY_FIELD_IDS.BROKER_DETAILS;
 
 const {
   INSURANCE_ROOT,
-  POLICY: { BROKER_CONFIRM_ADDRESS_ROOT, BROKER_DETAILS_SAVE_AND_BACK },
+  POLICY: { BROKER_DETAILS_SAVE_AND_BACK, CHECK_YOUR_ANSWERS },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -124,7 +124,7 @@ export const post = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${BROKER_CONFIRM_ADDRESS_ROOT}`);
+    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`);
   } catch (err) {
     console.error('Error updating application - policy - broker details %O', err);
     return res.redirect(PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/policy/broker-details/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-details/save-and-back/index.test.ts
@@ -1,10 +1,10 @@
 import { post } from '.';
-import { FIELD_ID, ERROR_MESSAGE } from '..';
 import { ROUTES } from '../../../../../constants';
 import POLICY_FIELD_IDS from '../../../../../constants/field-ids/insurance/policy';
 import constructPayload from '../../../../../helpers/construct-payload';
-import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
+import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save/broker';
+import { FIELD_IDS } from '..';
 import { Request, Response } from '../../../../../../types';
 import { mockReq, mockRes, mockApplication } from '../../../../../test-mocks';
 
@@ -12,7 +12,7 @@ const { USING_BROKER } = POLICY_FIELD_IDS;
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
 
-describe('controllers/insurance/policy/broker/save-and-back', () => {
+describe('controllers/insurance/policy/broker-details/save-and-back', () => {
   let req: Request;
   let res: Response;
 
@@ -47,8 +47,8 @@ describe('controllers/insurance/policy/broker/save-and-back', () => {
 
       await post(req, res);
 
-      const payload = constructPayload(req.body, [FIELD_ID]);
-      const validationErrors = generateValidationErrors(payload, FIELD_ID, ERROR_MESSAGE);
+      const payload = constructPayload(req.body, FIELD_IDS);
+      const validationErrors = generateValidationErrors(payload);
 
       expect(updateMapAndSave).toHaveBeenCalledTimes(1);
 
@@ -72,8 +72,8 @@ describe('controllers/insurance/policy/broker/save-and-back', () => {
 
       await post(req, res);
 
-      const payload = constructPayload(req.body, [FIELD_ID]);
-      const validationErrors = generateValidationErrors(payload, FIELD_ID, ERROR_MESSAGE);
+      const payload = constructPayload(req.body, FIELD_IDS);
+      const validationErrors = generateValidationErrors(payload);
 
       expect(updateMapAndSave).toHaveBeenCalledTimes(1);
 

--- a/src/ui/server/controllers/insurance/policy/broker-details/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-details/save-and-back/index.ts
@@ -1,14 +1,14 @@
+import { Request, Response } from '../../../../../../types';
 import { ROUTES } from '../../../../../constants';
 import constructPayload from '../../../../../helpers/construct-payload';
-import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
+import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save/broker';
-import { FIELD_ID, ERROR_MESSAGE } from '..';
-import { Request, Response } from '../../../../../../types';
+import { FIELD_IDS } from '..';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
 
 /**
- * saves and goes back to all sections from broker page unless there are API errors
+ * saves and goes back to all sections from broker details page unless there are API errors
  * @param {Express.Request} Express request
  * @param {Express.Response} Express response
  * @returns {Express.Response.redirect} redirects to all sections page on success
@@ -25,10 +25,10 @@ const post = async (req: Request, res: Response) => {
 
     const { body } = req;
 
-    const payload = constructPayload(body, [FIELD_ID]);
+    const payload = constructPayload(body, FIELD_IDS);
 
     // run validation on inputs
-    const validationErrors = generateValidationErrors(payload, FIELD_ID, ERROR_MESSAGE);
+    const validationErrors = generateValidationErrors(payload);
 
     // runs save and go back command
     const saveResponse = await mapAndSave.broker(payload, application, validationErrors);
@@ -40,7 +40,7 @@ const post = async (req: Request, res: Response) => {
     // redirect to all sections page
     return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`);
   } catch (err) {
-    console.error('Error updating application - policy - broker (save and back) %O', err);
+    console.error('Error updating application - policy - broker details (save and back) %O', err);
 
     return res.redirect(PROBLEM_WITH_SERVICE);
   }

--- a/src/ui/server/controllers/insurance/policy/broker/index.ts
+++ b/src/ui/server/controllers/insurance/policy/broker/index.ts
@@ -103,10 +103,8 @@ export const post = async (req: Request, res: Response) => {
 
   const payload = constructPayload(req.body, [FIELD_ID]);
 
-  // run validation on inputs
   const validationErrors = generateValidationErrors(payload, FIELD_ID, ERROR_MESSAGE);
 
-  // if any errors then render template with errors
   if (validationErrors) {
     return res.render(TEMPLATE, {
       ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer, HTML_FLAGS }),
@@ -119,7 +117,6 @@ export const post = async (req: Request, res: Response) => {
   }
 
   try {
-    // if no errors, then runs save api call to db
     const saveResponse = await mapAndSave.broker(payload, application);
 
     if (!saveResponse) {
@@ -138,7 +135,7 @@ export const post = async (req: Request, res: Response) => {
 
     return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`);
   } catch (err) {
-    console.error('Error updating application - your business - broker %O', err);
+    console.error('Error updating application - policy - broker %O', err);
     return res.redirect(PROBLEM_WITH_SERVICE);
   }
 };

--- a/src/ui/server/graphql/queries/application.ts
+++ b/src/ui/server/graphql/queries/application.ts
@@ -128,6 +128,7 @@ const applicationQuery = gql`
           isUsingBroker
           name
           email
+          fullAddress
         }
         buyer {
           id

--- a/src/ui/server/helpers/required-fields/policy/index.test.ts
+++ b/src/ui/server/helpers/required-fields/policy/index.test.ts
@@ -16,6 +16,7 @@ const {
   TYPE_OF_POLICY,
   NAME_ON_POLICY,
   USING_BROKER,
+  BROKER_DETAILS: { NAME, EMAIL, FULL_ADDRESS },
 } = POLICY_FIELD_IDS;
 
 const { IS_SAME_AS_OWNER, POSITION, POLICY_CONTACT_EMAIL } = NAME_ON_POLICY;
@@ -70,10 +71,9 @@ describe('server/helpers/required-fields/policy', () => {
 
         const result = getBrokerTasks(isUsingBrokerFlag);
 
-        // TODO: EMS-2749
-        // const expected = [NAME, EMAIL, FULL_ADDRESS];
+        const expected = [NAME, EMAIL, FULL_ADDRESS];
 
-        expect(result).toEqual([]);
+        expect(result).toEqual(expected);
       });
     });
 

--- a/src/ui/server/helpers/required-fields/policy/index.ts
+++ b/src/ui/server/helpers/required-fields/policy/index.ts
@@ -12,6 +12,7 @@ const {
   TYPE_OF_POLICY,
   NAME_ON_POLICY,
   USING_BROKER,
+  BROKER_DETAILS: { NAME, EMAIL, FULL_ADDRESS },
 } = POLICY_FIELD_IDS;
 
 const { IS_SAME_AS_OWNER, POSITION, POLICY_CONTACT_EMAIL } = NAME_ON_POLICY;
@@ -47,10 +48,7 @@ export const getContractPolicyTasks = (policyType?: string): object => {
  */
 export const getBrokerTasks = (isUsingBroker?: boolean) => {
   if (isUsingBroker) {
-    return [];
-
-    // TODO: EMS-2749
-    // return [NAME, EMAIL, FULL_ADDRESS];
+    return [NAME, EMAIL, FULL_ADDRESS];
   }
 
   return [];

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -22,7 +22,7 @@ describe('routes/insurance', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(146);
-    expect(post).toHaveBeenCalledTimes(140);
+    expect(post).toHaveBeenCalledTimes(141);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);

--- a/src/ui/server/routes/insurance/policy/index.test.ts
+++ b/src/ui/server/routes/insurance/policy/index.test.ts
@@ -29,6 +29,7 @@ import { post as differentNameOnPolicySaveAndBackPost } from '../../../controlle
 import { get as getBroker, post as postBroker } from '../../../controllers/insurance/policy/broker';
 import { post as postBrokerSaveAndBack } from '../../../controllers/insurance/policy/broker/save-and-back';
 import { get as getBrokerDetails, post as postBrokerDetails } from '../../../controllers/insurance/policy/broker-details';
+import { post as postBrokerDetailsSaveAndBack } from '../../../controllers/insurance/policy/broker-details/save-and-back';
 import { get as checkYourAnswersGet, post as checkYourAnswersPost } from '../../../controllers/insurance/policy/check-your-answers';
 
 describe('routes/insurance/policy', () => {
@@ -42,7 +43,7 @@ describe('routes/insurance/policy', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(32);
-    expect(post).toHaveBeenCalledTimes(41);
+    expect(post).toHaveBeenCalledTimes(42);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.ROOT}`, policyRootGet);
 
@@ -175,6 +176,7 @@ describe('routes/insurance/policy', () => {
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_DETAILS_ROOT}`, getBrokerDetails);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_DETAILS_ROOT}`, postBrokerDetails);
+    expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_DETAILS_SAVE_AND_BACK}`, postBrokerDetailsSaveAndBack);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.CHECK_YOUR_ANSWERS}`, checkYourAnswersGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.POLICY.CHECK_YOUR_ANSWERS}`, checkYourAnswersPost);

--- a/src/ui/server/routes/insurance/policy/index.ts
+++ b/src/ui/server/routes/insurance/policy/index.ts
@@ -29,6 +29,7 @@ import { post as differentNameOnPolicySaveAndBackPost } from '../../../controlle
 import { get as getBroker, post as postBroker } from '../../../controllers/insurance/policy/broker';
 import { post as postBrokerSaveAndBack } from '../../../controllers/insurance/policy/broker/save-and-back';
 import { get as getBrokerDetails, post as postBrokerDetails } from '../../../controllers/insurance/policy/broker-details';
+import { post as postBrokerDetailsSaveAndBack } from '../../../controllers/insurance/policy/broker-details/save-and-back';
 import { get as checkYourAnswersGet, post as checkYourAnswersPost } from '../../../controllers/insurance/policy/check-your-answers';
 
 // @ts-ignore
@@ -147,6 +148,7 @@ insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_CH
 
 insurancePolicyRouter.get(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_DETAILS_ROOT}`, getBrokerDetails);
 insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_DETAILS_ROOT}`, postBrokerDetails);
+insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.BROKER_DETAILS_SAVE_AND_BACK}`, postBrokerDetailsSaveAndBack);
 
 insurancePolicyRouter.get(`/:referenceNumber${INSURANCE_ROUTES.POLICY.CHECK_YOUR_ANSWERS}`, checkYourAnswersGet);
 insurancePolicyRouter.post(`/:referenceNumber${INSURANCE_ROUTES.POLICY.CHECK_YOUR_ANSWERS}`, checkYourAnswersPost);

--- a/src/ui/templates/insurance/policy/broker-details.njk
+++ b/src/ui/templates/insurance/policy/broker-details.njk
@@ -91,7 +91,7 @@
           name: FIELDS.FULL_ADDRESS.ID,
           id: FIELDS.FULL_ADDRESS.ID,
           maxlength: FIELDS.FULL_ADDRESS.MAXIMUM,
-          value: submittedValues[FIELDS.FULL_ADDRESS.ID],
+          value: submittedValues[FIELDS.FULL_ADDRESS.ID] or application.broker[FIELDS.FULL_ADDRESS.ID],
           label: {
             text: FIELDS.FULL_ADDRESS.LABEL,
             classes: "govuk-body govuk-!-font-weight-bold govuk-!-font-size-24",

--- a/src/ui/types/application.ts
+++ b/src/ui/types/application.ts
@@ -215,7 +215,7 @@ interface ApplicationFlatCore extends ApplicationCore, InsuranceEligibilityCore,
   buyerCountry: string;
 }
 
-type ApplicationFlat = ApplicationFlatCore & ApplicationPolicy & ApplicationCompany & ApplicationDeclaration;
+type ApplicationFlat = ApplicationFlatCore & ApplicationPolicy & ApplicationBroker & ApplicationCompany & ApplicationDeclaration;
 
 interface ApplicationVersion {
   VERSION_NUMBER: string;


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds data saving and "save and go back" functionality to the "Broker details" form of a no PDF application.

## Resolution :heavy_check_mark:
- Add `fullAddress` field to the DB.
- Create new cypress commands:
  - `completeBrokerDetailsForm`
  - `assertBrokerDetailsFieldValues`
- Add "save and back" E2E tests, update existing "Broker details" E2E test.
- Add "save and back" UI route and POST controller.

## Miscellaneous :heavy_plus_sign:
- Re-enable some E2E tests.
- Fix some typos.
