### PR TITLE
feat(EMS-2854): No PDF - Policy - Confirm broker address - Multi line support

### DIFF
--- a/e2e-tests/commands/insurance/complete-and-submit-broker-details-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-broker-details-form.js
@@ -1,9 +1,12 @@
 /**
  * completeAndSubmitBrokerDetailsForm
  * Complete and submit "broker details" form
+ * @param {String} name: Broker name
+ * @param {String} email: Broker email
+ * @param {String} fullAddress: Broker's full address
  */
-const completeAndSubmitBrokerDetailsForm = () => {
-  cy.completeBrokerDetailsForm();
+const completeAndSubmitBrokerDetailsForm = ({ name, email, fullAddress }) => {
+  cy.completeBrokerDetailsForm({ name, email, fullAddress });
 
   cy.clickSubmitButton();
 };

--- a/e2e-tests/commands/insurance/complete-broker-details-form.js
+++ b/e2e-tests/commands/insurance/complete-broker-details-form.js
@@ -11,11 +11,18 @@ const {
 /**
  * completeBrokerDetailsForm
  * Complete and submit "broker details" form
+ * @param {String} name: Broker name
+ * @param {String} email: Broker email
+ * @param {String} fullAddress: Broker's full address
  */
-const completeBrokerDetailsForm = () => {
-  cy.keyboardInput(field(NAME).input(), BROKER[NAME]);
-  cy.keyboardInput(field(EMAIL).input(), BROKER[EMAIL]);
-  cy.keyboardInput(field(FULL_ADDRESS).textarea(), BROKER[FULL_ADDRESS]);
+const completeBrokerDetailsForm = ({
+  name = BROKER[NAME],
+  email = BROKER[EMAIL],
+  fullAddress = BROKER[FULL_ADDRESS],
+}) => {
+  cy.keyboardInput(field(NAME).input(), name);
+  cy.keyboardInput(field(EMAIL).input(), email);
+  cy.keyboardInput(field(FULL_ADDRESS).textarea(), fullAddress);
 };
 
 export default completeBrokerDetailsForm;

--- a/e2e-tests/constants/examples/full-address-examples.js
+++ b/e2e-tests/constants/examples/full-address-examples.js
@@ -1,0 +1,7 @@
+export const LINE_1 = 'Line 1';
+export const LINE_2 = 'Line 2';
+export const LINE_3 = 'Line 3';
+export const LINE_4 = 'Line 4';
+
+export const FULL_ADDRESS_MULTI_LINE_STRING = `${LINE_1}\n${LINE_2}\n${LINE_3}\r${LINE_4}`;
+export const FULL_ADDRESS_EXPECTED_MULTI_LINE_STRING = `${LINE_1}${LINE_2}${LINE_3}${LINE_4}`;

--- a/e2e-tests/constants/examples/index.js
+++ b/e2e-tests/constants/examples/index.js
@@ -1,6 +1,7 @@
 export * from './company-details-examples';
 export * from './companies-house-number-examples';
 export * from './email-examples';
+export * from './full-address-examples';
 export * from './password-examples';
 export * from './phone-number-examples';
 export * from './postcode-examples';

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-confirm-address/broker-confirm-address-multiple-lines.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-confirm-address/broker-confirm-address-multiple-lines.spec.js
@@ -1,0 +1,59 @@
+import { insetTextHtml } from '../../../../../../pages/shared';
+import {
+  FIELD_VALUES,
+  FULL_ADDRESS_MULTI_LINE_STRING,
+  FULL_ADDRESS_EXPECTED_MULTI_LINE_STRING,
+} from '../../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
+
+const {
+  BROKER_DETAILS: { FULL_ADDRESS },
+} = POLICY_FIELD_IDS;
+
+const {
+  ROOT,
+  POLICY: { BROKER_CONFIRM_ADDRESS_ROOT },
+} = INSURANCE_ROUTES;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Policy - Broker confirm address - Address with multiple lines', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      // go to the page we want to test.
+      cy.startInsurancePolicySection({});
+
+      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitSingleContractPolicyForm({});
+      cy.completeAndSubmitTotalContractValueForm({});
+      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitPreCreditPeriodForm({});
+      cy.completeAndSubmitAnotherCompanyForm({});
+      cy.completeAndSubmitBrokerForm({ usingBroker: true });
+      cy.completeAndSubmitBrokerDetailsForm({
+        fullAddress: FULL_ADDRESS_MULTI_LINE_STRING,
+      });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_CONFIRM_ADDRESS_ROOT}`;
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  it(`renders ${FULL_ADDRESS}`, () => {
+    cy.checkText(insetTextHtml(), FULL_ADDRESS_EXPECTED_MULTI_LINE_STRING);
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-confirm-address/broker-confirm-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-confirm-address/broker-confirm-address.spec.js
@@ -46,7 +46,7 @@ context("Insurance - Policy - Broker confirm address - As an exporter, I want to
       cy.completeAndSubmitPreCreditPeriodForm({});
       cy.completeAndSubmitAnotherCompanyForm({});
       cy.completeAndSubmitBrokerForm({ usingBroker: true });
-      cy.completeAndSubmitBrokerDetailsForm();
+      cy.completeAndSubmitBrokerDetailsForm({});
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_CONFIRM_ADDRESS_ROOT}`;
       checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
@@ -120,7 +120,7 @@ context("Insurance - Policy - Broker details page - As an exporter, I want to pr
     });
 
     it(`should redirect to ${BROKER_CONFIRM_ADDRESS_ROOT} page`, () => {
-      cy.completeAndSubmitBrokerDetailsForm();
+      cy.completeAndSubmitBrokerDetailsForm({});
 
       cy.assertUrl(brokerConfirmAddressUrl);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/save-and-back.spec.js
@@ -89,7 +89,7 @@ context('Insurance - Policy - Broker details page - Save and back', () => {
     it(`should redirect to ${ALL_SECTIONS} and change the "insurance policy" task status to "Completed"`, () => {
       cy.navigateToUrl(url);
 
-      cy.completeBrokerDetailsForm();
+      cy.completeBrokerDetailsForm({});
 
       cy.clickSaveAndBackButton();
 

--- a/e2e-tests/pages/shared/index.js
+++ b/e2e-tests/pages/shared/index.js
@@ -15,6 +15,7 @@ const form = () => cy.get('[data-cy="form"]');
 const heading = () => cy.get('[data-cy="heading"]');
 const headingCaption = () => cy.get('[data-cy="heading-caption"]');
 const insetText = () => cy.get('[data-cy="inset-text"]');
+const insetTextHtml = () => cy.get('[data-cy="inset-text-html"]');
 const intro = () => cy.get('[data-cy="intro"]');
 const listIntro = () => cy.get('[data-cy="list-intro"]');
 const listItem = (index) => cy.get(`[data-cy="list-item-${index}"]`);
@@ -58,6 +59,7 @@ export {
   headingCaption,
   intro,
   insetText,
+  insetTextHtml,
   listIntro,
   listItem,
   listOutro,

--- a/src/ui/server/controllers/insurance/policy/broker-confirm-address/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-confirm-address/index.test.ts
@@ -5,6 +5,7 @@ import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
 import POLICY_FIELD_IDS from '../../../../constants/field-ids/insurance/policy';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
 
@@ -49,6 +50,7 @@ describe('controllers/insurance/policy/broker-confirm-address', () => {
       const result = pageVariables(mockApplication.referenceNumber);
 
       const expected = {
+        FIELD_ID: FULL_ADDRESS,
         USE_DIFFERENT_ADDRESS_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${BROKER_DETAILS_ROOT}`,
         SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALL_SECTIONS}`,
       };
@@ -68,7 +70,7 @@ describe('controllers/insurance/policy/broker-confirm-address', () => {
         }),
         ...pageVariables(mockApplication.referenceNumber),
         userName: getUserNameFromSession(req.session.user),
-        address: mockApplication.broker[FULL_ADDRESS],
+        application: mapApplicationToFormFields(mockApplication),
       });
     });
 

--- a/src/ui/server/controllers/insurance/policy/broker-confirm-address/index.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-confirm-address/index.ts
@@ -4,6 +4,7 @@ import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
 import POLICY_FIELD_IDS from '../../../../constants/field-ids/insurance/policy';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
+import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import { Request, Response } from '../../../../../types';
 
 const {
@@ -28,6 +29,7 @@ export const TEMPLATE = TEMPLATES.INSURANCE.POLICY.BROKER_CONFIRM_ADDRESS;
  * @returns {Object} Page variables
  */
 export const pageVariables = (referenceNumber: number) => ({
+  FIELD_ID: FULL_ADDRESS,
   USE_DIFFERENT_ADDRESS_URL: `${INSURANCE_ROOT}/${referenceNumber}${BROKER_DETAILS_ROOT}`,
   SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`,
 });
@@ -52,7 +54,7 @@ export const get = (req: Request, res: Response) => {
     }),
     ...pageVariables(application.referenceNumber),
     userName: getUserNameFromSession(req.session.user),
-    address: application.broker[FULL_ADDRESS],
+    application: mapApplicationToFormFields(application),
   });
 };
 

--- a/src/ui/server/helpers/mappings/map-textarea-fields/index.test.ts
+++ b/src/ui/server/helpers/mappings/map-textarea-fields/index.test.ts
@@ -1,6 +1,7 @@
 import mapTextareaFields from '.';
 import INSURANCE_FIELD_IDS from '../../../constants/field-ids/insurance';
 import replaceCharacterCodesWithCharacters from '../../replace-character-codes-with-characters';
+import replaceNewLineWithLineBreak from '../../replace-new-line-with-line-break';
 import { mockApplication } from '../../../test-mocks';
 
 const {
@@ -11,7 +12,10 @@ const {
   EXPORT_CONTRACT: {
     ABOUT_GOODS_OR_SERVICES: { DESCRIPTION },
   },
-  POLICY: { CREDIT_PERIOD_WITH_BUYER },
+  POLICY: {
+    BROKER_DETAILS: { FULL_ADDRESS: BROKER_ADDRESS },
+    CREDIT_PERIOD_WITH_BUYER,
+  },
   YOUR_BUYER: {
     COMPANY_OR_ORGANISATION: { ADDRESS },
     CONNECTION_WITH_BUYER_DESCRIPTION,
@@ -19,7 +23,7 @@ const {
   },
 } = INSURANCE_FIELD_IDS;
 
-const { business, buyer, company, exportContract, policy } = mockApplication;
+const { broker, business, buyer, company, exportContract, policy } = mockApplication;
 
 describe('server/helpers/mappings/map-textarea-fields', () => {
   it('should return textarea fields with replaceCharacterCodesWithCharacters function', () => {
@@ -27,6 +31,10 @@ describe('server/helpers/mappings/map-textarea-fields', () => {
 
     const expected = {
       ...mockApplication,
+      broker: {
+        ...broker,
+        [BROKER_ADDRESS]: replaceNewLineWithLineBreak(broker[BROKER_ADDRESS]),
+      },
       business: {
         ...business,
         [GOODS_OR_SERVICES]: replaceCharacterCodesWithCharacters(business[GOODS_OR_SERVICES]),

--- a/src/ui/server/helpers/mappings/map-textarea-fields/index.ts
+++ b/src/ui/server/helpers/mappings/map-textarea-fields/index.ts
@@ -1,5 +1,6 @@
 import INSURANCE_FIELD_IDS from '../../../constants/field-ids/insurance';
 import replaceCharacterCodesWithCharacters from '../../replace-character-codes-with-characters';
+import replaceNewLineWithLineBreak from '../../replace-new-line-with-line-break';
 import { Application } from '../../../../types';
 
 const {
@@ -10,7 +11,10 @@ const {
   EXPORT_CONTRACT: {
     ABOUT_GOODS_OR_SERVICES: { DESCRIPTION },
   },
-  POLICY: { CREDIT_PERIOD_WITH_BUYER },
+  POLICY: {
+    BROKER_DETAILS: { FULL_ADDRESS: BROKER_ADDRESS },
+    CREDIT_PERIOD_WITH_BUYER,
+  },
   YOUR_BUYER: {
     COMPANY_OR_ORGANISATION: { ADDRESS },
     CONNECTION_WITH_BUYER_DESCRIPTION,
@@ -20,12 +24,14 @@ const {
 
 /**
  * mapTextareaFields
- * Replace character codes in textarea fields with characters
+ * Replace line breaks and character codes in textarea fields
  * @param {Application}
  * @returns {Object} Application with mapped textarea field characters
  */
 const mapTextareaFields = (application: Application): Application => {
-  const { business, buyer, company, exportContract, policy } = application;
+  const { broker, business, buyer, company, exportContract, policy } = application;
+
+  broker[BROKER_ADDRESS] = replaceNewLineWithLineBreak(broker[BROKER_ADDRESS]);
 
   business[GOODS_OR_SERVICES] = replaceCharacterCodesWithCharacters(business[GOODS_OR_SERVICES]);
 

--- a/src/ui/server/helpers/summary-lists/generate-address-object/index.ts
+++ b/src/ui/server/helpers/summary-lists/generate-address-object/index.ts
@@ -8,4 +8,5 @@ import { DEFAULT } from '../../../content-strings';
  * @returns {Object}
  */
 const generateAddressObject = (rawAddress?: string) => (rawAddress ? { address: replaceNewLineWithLineBreak(rawAddress) } : { address: DEFAULT.EMPTY });
+
 export default generateAddressObject;

--- a/src/ui/templates/insurance/policy/broker-confirm-address.njk
+++ b/src/ui/templates/insurance/policy/broker-confirm-address.njk
@@ -28,8 +28,12 @@
 
         <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 
+        {% set addressHtml %}
+          <span data-cy="inset-text-html">{{ application.broker[FIELD_ID] | safe }}</span>
+        {% endset %}
+
         {{ govukInsetText({
-          text: address,
+          html: addressHtml,
           attributes: {
             'data-cy': 'inset-text'
           }


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the "Confirm broker address" functionality of a no PDF application so that if a "full broker address" (textarea) is submitted with line breaks, it will be played back to the user exactly as it was entered.

## Resolution :heavy_check_mark:
- Update `completeBrokerDetailsForm` and `completeAndSubmitBrokerDetailsForm` cypress commands to accept custom values.
- Create `FULL_ADDRESS` E2E constants/examples.
- Add E2E test for submitting and playing back an address with line breaks in the "Confirm broker address" page.
- Update `mapApplicationToFormFields` to map `FULL_ADDRESS`.
- Update "Confirm broker address" GET controller to consume/pass `mapApplicationToFormFields`.
- Update "Confirm broker address" nunjucks component to render the inset text value as raw (safe) HTML.
