### PR TITLE
chore(EMS-2883): E2E - Declare and use baseUrl

### DIFF
--- a/e2e-tests/commands/core-page-checks.js
+++ b/e2e-tests/commands/core-page-checks.js
@@ -6,6 +6,8 @@ import {
   submitButton,
 } from '../pages/shared';
 
+const baseUrl = Cypress.config('baseUrl');
+
 // const lighthouseAudit = (lightHouseThresholds = {}) => {
 //   cy.lighthouse({
 //     accessibility: 100,
@@ -29,7 +31,7 @@ const checkBackLink = (currentHref, expectedHref) => {
 
   cy.clickBackLink();
 
-  let expectedUrl = `${Cypress.config('baseUrl')}${expectedHref}`;
+  let expectedUrl = `${baseUrl}${expectedHref}`;
 
   /**
    * Some back links (start of the eligibility flow) can have external links.
@@ -42,7 +44,7 @@ const checkBackLink = (currentHref, expectedHref) => {
   cy.url().should('eq', expectedUrl);
 
   // go back to current page
-  cy.visit(`${Cypress.config('baseUrl')}${currentHref}`);
+  cy.visit(`${baseUrl}${currentHref}`);
 };
 
 /**

--- a/e2e-tests/commands/insurance/account/complete-and-submit-password-reset-form.js
+++ b/e2e-tests/commands/insurance/account/complete-and-submit-password-reset-form.js
@@ -13,7 +13,9 @@ const {
   ACCOUNT: { EMAIL },
 } = INSURANCE_FIELD_IDS;
 
-const linkSentUrl = `${Cypress.config('baseUrl')}${LINK_SENT}`;
+const baseUrl = Cypress.config('baseUrl');
+
+const linkSentUrl = `${baseUrl}${LINK_SENT}`;
 
 /**
  * completeAndSubmitPasswordResetForm

--- a/e2e-tests/commands/insurance/account/create-an-account-and-become-blocked.js
+++ b/e2e-tests/commands/insurance/account/create-an-account-and-become-blocked.js
@@ -13,7 +13,9 @@ const {
 
 const { ACCOUNT: { PASSWORD } } = INSURANCE_FIELD_IDS;
 
-const accountSuspendedEmailSentUrl = `${Cypress.config('baseUrl')}${EMAIL_SENT}`;
+const baseUrl = Cypress.config('baseUrl');
+
+const accountSuspendedEmailSentUrl = `${baseUrl}${EMAIL_SENT}`;
 
 const invalidPassword = `${mockAccount[PASSWORD]}-invalid`;
 

--- a/e2e-tests/commands/insurance/assert-all-sections-url.js
+++ b/e2e-tests/commands/insurance/assert-all-sections-url.js
@@ -2,12 +2,14 @@ import { INSURANCE_ROUTES } from '../../constants/routes/insurance';
 
 const { ROOT: INSURANCE_ROOT, ALL_SECTIONS } = INSURANCE_ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 /**
  * assertAllSectionsUrl
  * @param {Number} Application reference number
  */
 const assertAllSectionsUrl = (referenceNumber) => {
-  const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+  const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
   cy.assertUrl(expected);
 };

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/confirm-email/confirm-email-refresh-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/confirm-email/confirm-email-refresh-page.spec.js
@@ -6,6 +6,8 @@ const {
   ACCOUNT: { CREATE: { CONFIRM_EMAIL } },
 } = ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Create - Confirm email page - refreshing the page', () => {
   before(() => {
     cy.deleteAccount();
@@ -15,7 +17,7 @@ context('Insurance - Account - Create - Confirm email page - refreshing the page
     cy.submitEligibilityAndStartAccountCreation();
     cy.completeAndSubmitCreateAccountForm();
 
-    const expected = `${Cypress.config('baseUrl')}${CONFIRM_EMAIL}`;
+    const expected = `${baseUrl}${CONFIRM_EMAIL}`;
 
     cy.assertUrl(expected);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/confirm-email/confirm-email-renders-submitted-email.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/confirm-email/confirm-email-renders-submitted-email.spec.js
@@ -14,6 +14,8 @@ const {
 
 const { ACCOUNT: { EMAIL } } = INSURANCE_FIELD_IDS;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Create - Confirm email page should render the submitted email', () => {
   beforeEach(() => {
     cy.saveSession();
@@ -23,7 +25,7 @@ context('Insurance - Account - Create - Confirm email page should render the sub
     cy.submitEligibilityAndStartAccountCreation();
     cy.completeAndSubmitCreateAccountForm();
 
-    const expected = `${Cypress.config('baseUrl')}${CONFIRM_EMAIL}`;
+    const expected = `${baseUrl}${CONFIRM_EMAIL}`;
 
     cy.assertUrl(expected);
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/confirm-email/confirm-email.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/confirm-email/confirm-email.spec.js
@@ -8,6 +8,8 @@ const {
   ACCOUNT: { CREATE: { YOUR_DETAILS, CONFIRM_EMAIL } },
 } = ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Create - Confirm email page - As an Exporter I want to create an account for UKEF digital service, So that I can readily use it for my Export Insurance Application with UKEF', () => {
   before(() => {
     cy.deleteAccount();
@@ -17,7 +19,7 @@ context('Insurance - Account - Create - Confirm email page - As an Exporter I wa
     cy.submitEligibilityAndStartAccountCreation();
     cy.completeAndSubmitCreateAccountForm();
 
-    const expected = `${Cypress.config('baseUrl')}${CONFIRM_EMAIL}`;
+    const expected = `${baseUrl}${CONFIRM_EMAIL}`;
 
     cy.assertUrl(expected);
   });
@@ -46,7 +48,7 @@ context('Insurance - Account - Create - Confirm email page - As an Exporter I wa
     it(`should redirect to ${CONFIRM_EMAIL} and render core page elements and content`, () => {
       expectedUrl = CONFIRM_EMAIL;
 
-      cy.assertUrl(`${Cypress.config('baseUrl')}${expectedUrl}`);
+      cy.assertUrl(`${baseUrl}${expectedUrl}`);
 
       cy.corePageChecks({
         pageTitle: CONTENT_STRINGS.PAGE_TITLE,

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/resend-confirm-email/resend-confirm-email-go-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/resend-confirm-email/resend-confirm-email-go-back.spec.js
@@ -6,8 +6,10 @@ const {
   ACCOUNT: { CREATE: { CONFIRM_EMAIL, CONFIRM_EMAIL_RESENT } },
 } = ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Create - Resend confirm email page - Go back to confirm email page via back button', () => {
-  const confirmEmailUrl = `${Cypress.config('baseUrl')}${CONFIRM_EMAIL}`;
+  const confirmEmailUrl = `${baseUrl}${CONFIRM_EMAIL}`;
 
   let expectedUrl;
   let account;
@@ -40,7 +42,7 @@ context('Insurance - Account - Create - Resend confirm email page - Go back to c
 
       confirmEmailPage.havingProblems.requestNew.link().click();
 
-      expectedUrl = `${Cypress.config('baseUrl')}${CONFIRM_EMAIL_RESENT}?id=${account.id}`;
+      expectedUrl = `${baseUrl}${CONFIRM_EMAIL_RESENT}?id=${account.id}`;
 
       cy.assertUrl(expectedUrl);
 
@@ -49,7 +51,7 @@ context('Insurance - Account - Create - Resend confirm email page - Go back to c
   });
 
   it('renders the page without error and have the account ID in the URL params', () => {
-    expectedUrl = `${Cypress.config('baseUrl')}${CONFIRM_EMAIL}?id=${account.id}`;
+    expectedUrl = `${baseUrl}${CONFIRM_EMAIL}?id=${account.id}`;
 
     cy.assertUrl(expectedUrl);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/resend-confirm-email/resend-confirm-email.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/resend-confirm-email/resend-confirm-email.spec.js
@@ -9,6 +9,8 @@ const {
   ACCOUNT: { CREATE: { CONFIRM_EMAIL, CONFIRM_EMAIL_RESENT } },
 } = ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Create - Resend confirm email page - As an Exporter I want to request a new link to confirm my email address, So that I can readily use my email address to set up an account that I can use for UKEF digital service such as EXIP digital service', () => {
   before(() => {
     cy.deleteAccount();
@@ -42,7 +44,7 @@ context('Insurance - Account - Create - Resend confirm email page - As an Export
 
         url = `${CONFIRM_EMAIL_RESENT}?id=${account.id}`;
 
-        cy.assertUrl(`${Cypress.config('baseUrl')}${url}`);
+        cy.assertUrl(`${baseUrl}${url}`);
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/your-details/account-create-your-details-already-signed-in.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/your-details/account-create-your-details-already-signed-in.spec.js
@@ -7,6 +7,8 @@ const {
   DASHBOARD,
 } = ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Create - Your details page - Already signed in', () => {
   let referenceNumber;
   let url;
@@ -15,7 +17,7 @@ context('Insurance - Account - Create - Your details page - Already signed in', 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       cy.assertUrl(url);
     });
@@ -32,7 +34,7 @@ context('Insurance - Account - Create - Your details page - Already signed in', 
   it(`should redirect to ${DASHBOARD} when visiting ${YOUR_DETAILS}`, () => {
     cy.navigateToUrl(YOUR_DETAILS);
 
-    const expectedUrl = `${Cypress.config('baseUrl')}${DASHBOARD}`;
+    const expectedUrl = `${baseUrl}${DASHBOARD}`;
 
     cy.assertUrl(expectedUrl);
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/your-details/account-create-your-details-validation-password.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/your-details/account-create-your-details-validation-password.spec.js
@@ -29,6 +29,8 @@ const fieldErrorAssertions = (value) => ({
   errorMessage: YOUR_DETAILS_ERROR_MESSAGES[PASSWORD].INCORRECT_FORMAT,
 });
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Create - Your details page - form validation - password', () => {
   let url;
 
@@ -37,7 +39,7 @@ context('Insurance - Account - Create - Your details page - form validation - pa
 
     cy.submitEligibilityAndStartAccountCreation();
 
-    url = `${Cypress.config('baseUrl')}${YOUR_DETAILS}`;
+    url = `${baseUrl}${YOUR_DETAILS}`;
 
     cy.assertUrl(url);
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/your-details/account-create-your-details.spec.js
@@ -24,6 +24,8 @@ const {
 
 const FIELD_STRINGS = ACCOUNT_FIELDS.CREATE.YOUR_DETAILS;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Create - Your details page - As an exporter, I want to provide my details when creating my UKEF digital service account, So that the details of the UKEF digital service account created can be unique to me', () => {
   let url;
 
@@ -34,7 +36,7 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
 
     cy.submitEligibilityAndStartAccountCreation();
 
-    url = `${Cypress.config('baseUrl')}${YOUR_DETAILS}`;
+    url = `${baseUrl}${YOUR_DETAILS}`;
 
     cy.assertUrl(url);
   });
@@ -137,7 +139,7 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
       it(`should redirect to ${SIGN_IN.ROOT}`, () => {
         yourDetailsPage.signInButtonLink().click();
 
-        const expectedUrl = `${Cypress.config('baseUrl')}${SIGN_IN.ROOT}`;
+        const expectedUrl = `${baseUrl}${SIGN_IN.ROOT}`;
 
         cy.assertUrl(expectedUrl);
       });
@@ -152,7 +154,7 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
       it(`should redirect to ${CONFIRM_EMAIL}`, () => {
         cy.completeAndSubmitCreateAccountForm();
 
-        const expected = `${Cypress.config('baseUrl')}${CONFIRM_EMAIL}`;
+        const expected = `${baseUrl}${CONFIRM_EMAIL}`;
         cy.assertUrl(expected);
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/account-password-reset.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/account-password-reset.spec.js
@@ -21,6 +21,8 @@ const {
 
 const FIELD_STRINGS = ACCOUNT_FIELDS.PASSWORD_RESET;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Password reset page - As an Exporter, I want to reset my password on my UKEF digital service account, So that I can maintain my account security and sign in into my UKEF digital service account', () => {
   let url;
 
@@ -38,7 +40,7 @@ context('Insurance - Account - Password reset page - As an Exporter, I want to r
     // navigate to password reset page
     signInPage.resetPasswordLink().click();
 
-    url = `${Cypress.config('baseUrl')}${PASSWORD_RESET_ROOT}`;
+    url = `${baseUrl}${PASSWORD_RESET_ROOT}`;
 
     cy.assertUrl(url);
   });
@@ -84,7 +86,7 @@ context('Insurance - Account - Password reset page - As an Exporter, I want to r
     });
 
     it(`should redirect to ${LINK_SENT}`, () => {
-      const expected = `${Cypress.config('baseUrl')}${LINK_SENT}`;
+      const expected = `${baseUrl}${LINK_SENT}`;
 
       cy.assertUrl(expected);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/link-sent/account-password-reset-link-sent.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/link-sent/account-password-reset-link-sent.spec.js
@@ -24,7 +24,9 @@ const {
   ACCOUNT: { EMAIL },
 } = INSURANCE_FIELD_IDS;
 
-const passwordResetUrl = `${Cypress.config('baseUrl')}${PASSWORD_RESET_ROOT}`;
+const baseUrl = Cypress.config('baseUrl');
+
+const passwordResetUrl = `${baseUrl}${PASSWORD_RESET_ROOT}`;
 
 const goToPasswordResetLinkSentPage = () => {
   cy.navigateToUrl(passwordResetUrl);

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/new-password/account-password-reset-new-password-no-token.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/new-password/account-password-reset-new-password-no-token.spec.js
@@ -6,9 +6,11 @@ const {
   },
 } = ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Password reset - new password page - Visit without a token query param', () => {
-  const newPasswordUrl = `${Cypress.config('baseUrl')}${NEW_PASSWORD}`;
-  const passwordResetUrl = `${Cypress.config('baseUrl')}${PASSWORD_RESET_ROOT}`;
+  const newPasswordUrl = `${baseUrl}${NEW_PASSWORD}`;
+  const passwordResetUrl = `${baseUrl}${PASSWORD_RESET_ROOT}`;
 
   before(() => {
     cy.navigateToUrl(newPasswordUrl);

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/new-password/account-password-reset-new-password.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/new-password/account-password-reset-new-password.spec.js
@@ -24,6 +24,8 @@ const {
 
 const FIELD_STRINGS = ACCOUNT_FIELDS.NEW_PASSWORD[PASSWORD];
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Password reset - new password page - As an Exporter, I want to reset my password, So that I can securely access my digital service account with UKEF', () => {
   let url;
   let resetPasswordToken;
@@ -38,7 +40,7 @@ context('Insurance - Account - Password reset - new password page - As an Export
 
     cy.completeAndSubmitPasswordResetForm({});
 
-    url = `${Cypress.config('baseUrl')}${LINK_SENT}`;
+    url = `${baseUrl}${LINK_SENT}`;
 
     cy.assertUrl(url);
   });
@@ -52,7 +54,7 @@ context('Insurance - Account - Password reset - new password page - As an Export
       // Get an account's password reset token
       resetPasswordToken = await api.getAccountPasswordResetToken();
 
-      url = `${Cypress.config('baseUrl')}${NEW_PASSWORD}?token=${resetPasswordToken}`;
+      url = `${baseUrl}${NEW_PASSWORD}?token=${resetPasswordToken}`;
     });
 
     describe('page tests', () => {
@@ -95,7 +97,7 @@ context('Insurance - Account - Password reset - new password page - As an Export
 
         cy.completeAndSubmitNewPasswordAccountForm({ password: newPassword });
 
-        const expected = `${Cypress.config('baseUrl')}${SUCCESS}`;
+        const expected = `${baseUrl}${SUCCESS}`;
         cy.assertUrl(expected);
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/new-password/validation/account-password-reset-new-password-valdation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/new-password/validation/account-password-reset-new-password-valdation.spec.js
@@ -39,6 +39,8 @@ const fieldErrorAssertions = (value) => ({
   errorMessage: YOUR_DETAILS_ERROR_MESSAGES[PASSWORD].INCORRECT_FORMAT,
 });
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Password reset - new password page - form validation - password', () => {
   let url;
   let resetPasswordToken;
@@ -53,7 +55,7 @@ context('Insurance - Account - Password reset - new password page - form validat
 
     cy.completeAndSubmitPasswordResetForm({});
 
-    url = `${Cypress.config('baseUrl')}${LINK_SENT}`;
+    url = `${baseUrl}${LINK_SENT}`;
 
     cy.assertUrl(url);
   });
@@ -71,7 +73,7 @@ context('Insurance - Account - Password reset - new password page - form validat
       // Get an account's password reset token
       resetPasswordToken = await api.getAccountPasswordResetToken();
 
-      url = `${Cypress.config('baseUrl')}${NEW_PASSWORD}?token=${resetPasswordToken}`;
+      url = `${baseUrl}${NEW_PASSWORD}?token=${resetPasswordToken}`;
     });
 
     describe('form validation', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/success/account-password-reset-success.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/success/account-password-reset-success.spec.js
@@ -18,8 +18,10 @@ const {
   ACCOUNT: { PASSWORD },
 } = INSURANCE_FIELD_IDS;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Password reset - success page - I want to reset my password, So that I can securely access my digital service account with UKEF', () => {
-  const successUrl = `${Cypress.config('baseUrl')}${SUCCESS}`;
+  const successUrl = `${baseUrl}${SUCCESS}`;
   let newPasswordUrl;
 
   before(() => {
@@ -42,7 +44,7 @@ context('Insurance - Account - Password reset - success page - I want to reset m
       // Get an account's password reset token
       const resetPasswordToken = await api.getAccountPasswordResetToken();
 
-      newPasswordUrl = `${Cypress.config('baseUrl')}${NEW_PASSWORD}?token=${resetPasswordToken}`;
+      newPasswordUrl = `${baseUrl}${NEW_PASSWORD}?token=${resetPasswordToken}`;
     });
 
     describe('when progressing to the password reset success page', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/enter-code/account-sign-in-enter-code-without-completing-eligibility.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/enter-code/account-sign-in-enter-code-without-completing-eligibility.spec.js
@@ -8,8 +8,10 @@ const {
   DASHBOARD,
 } = ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Sign in - Enter code - without completing eligibility', () => {
-  const enterCodeUrl = `${Cypress.config('baseUrl')}${ENTER_CODE}`;
+  const enterCodeUrl = `${baseUrl}${ENTER_CODE}`;
 
   before(() => {
     cy.deleteAccount();
@@ -44,7 +46,7 @@ context('Insurance - Account - Sign in - Enter code - without completing eligibi
     it(`should redirect to ${DASHBOARD}`, () => {
       cy.completeAndSubmitEnterCodeAccountForm(validSecurityCode);
 
-      const expectedUrl = `${Cypress.config('baseUrl')}${DASHBOARD}`;
+      const expectedUrl = `${baseUrl}${DASHBOARD}`;
 
       cy.assertUrl(expectedUrl);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/enter-code/account-sign-in-enter-code.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/enter-code/account-sign-in-enter-code.spec.js
@@ -20,8 +20,10 @@ const {
 
 const FIELD_STRINGS = ACCOUNT_FIELDS[SECURITY_CODE];
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Sign in - I want to sign in into my UKEF digital service account after completing eligibility, So that I can complete my application for a UKEF Export Insurance Policy', () => {
-  const url = `${Cypress.config('baseUrl')}${ENTER_CODE}`;
+  const url = `${baseUrl}${ENTER_CODE}`;
 
   before(() => {
     cy.deleteAccount();
@@ -85,7 +87,7 @@ context('Insurance - Account - Sign in - I want to sign in into my UKEF digital 
         it(`should re-direct to ${REQUEST_NEW_CODE}`, () => {
           enterCodePage.requestNewCodeLink().click();
 
-          const expectedUrl = `${Cypress.config('baseUrl')}${REQUEST_NEW_CODE}`;
+          const expectedUrl = `${baseUrl}${REQUEST_NEW_CODE}`;
 
           cy.assertUrl(expectedUrl);
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/enter-code/validation/account-sign-in-enter-code-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/enter-code/validation/account-sign-in-enter-code-validation.spec.js
@@ -25,8 +25,10 @@ const fieldIndex = 0;
 const TOTAL_REQUIRED_FIELDS = 1;
 const expectedMessage = String(SECURITY_CODE_ERROR_MESSAGE.INCORRECT);
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Sign in - Enter code - validation', () => {
-  const url = `${Cypress.config('baseUrl')}${ENTER_CODE}`;
+  const url = `${baseUrl}${ENTER_CODE}`;
 
   before(() => {
     cy.deleteAccount();
@@ -86,7 +88,7 @@ context('Insurance - Account - Sign in - Enter code - validation', () => {
       cy.completeAndSubmitEnterCodeAccountForm(validSecurityCode);
 
       cy.getReferenceNumber().then((referenceNumber) => {
-        const expectedUrl = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+        const expectedUrl = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
         cy.assertUrl(expectedUrl);
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/request-new-code/account-sign-in-request-new-code.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/request-new-code/account-sign-in-request-new-code.spec.js
@@ -11,8 +11,10 @@ const {
   },
 } = ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Sign in - Request new code page - I want to enter the new security code sent to my email by UK Export Finance, So that I can sign in into my UKEF digital service account', () => {
-  const url = `${Cypress.config('baseUrl')}${REQUEST_NEW_CODE}`;
+  const url = `${baseUrl}${REQUEST_NEW_CODE}`;
   before(() => {
     cy.deleteAccount();
 
@@ -97,7 +99,7 @@ context('Insurance - Account - Sign in - Request new code page - I want to enter
     });
 
     it(`should redirect to ${ENTER_CODE}`, () => {
-      const expected = `${Cypress.config('baseUrl')}${ENTER_CODE}`;
+      const expected = `${baseUrl}${ENTER_CODE}`;
       cy.assertUrl(expected);
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/validation/account-sign-in-validation-unverified-account.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/validation/account-sign-in-validation-unverified-account.spec.js
@@ -14,6 +14,8 @@ const CONTENT_STRINGS = PAGES.INSURANCE.ACCOUNT.CREATE.CONFIRM_EMAIL_RESENT;
 
 const accountEmail = Cypress.env('GOV_NOTIFY_EMAIL_RECIPIENT_1');
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Sign in - Validation - unverified account', () => {
   let account;
 
@@ -30,7 +32,7 @@ context('Insurance - Account - Sign in - Validation - unverified account', () =>
 
     yourDetailsPage.signInButtonLink().click();
 
-    const expectedUrl = `${Cypress.config('baseUrl')}${SIGN_IN_ROOT}`;
+    const expectedUrl = `${baseUrl}${SIGN_IN_ROOT}`;
     cy.assertUrl(expectedUrl);
   });
 
@@ -54,7 +56,7 @@ context('Insurance - Account - Sign in - Validation - unverified account', () =>
     });
 
     it(`should redirect to ${CONFIRM_EMAIL_RESENT} with account ID in the URL params and render submitted email copy`, () => {
-      const expectedUrl = `${Cypress.config('baseUrl')}${CONFIRM_EMAIL_RESENT}?id=${account.id}`;
+      const expectedUrl = `${baseUrl}${CONFIRM_EMAIL_RESENT}?id=${account.id}`;
 
       cy.assertUrl(expectedUrl);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/validation/account-sign-in-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/validation/account-sign-in-validation.spec.js
@@ -27,6 +27,8 @@ const assertAllFieldErrors = () => {
   cy.submitAndAssertFieldErrors(passwordField, null, 1, TOTAL_REQUIRED_FIELDS, SIGN_IN_ERROR_MESSAGES[PASSWORD].INCORRECT);
 };
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Sign in - Validation', () => {
   let url;
 
@@ -35,7 +37,7 @@ context('Insurance - Account - Sign in - Validation', () => {
 
     cy.submitEligibilityAndStartAccountSignIn();
 
-    url = `${Cypress.config('baseUrl')}${SIGN_IN_ROOT}`;
+    url = `${baseUrl}${SIGN_IN_ROOT}`;
 
     cy.assertUrl(url);
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-out/account-sign-out.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-out/account-sign-out.spec.js
@@ -13,6 +13,8 @@ const {
   DASHBOARD,
 } = ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Sign out - As an Exporter, I want to be able to sign out of the service from any of the digital service pages, So that I can readily maintain the security of my digital service account', () => {
   let referenceNumber;
 
@@ -36,7 +38,7 @@ context('Insurance - Account - Sign out - As an Exporter, I want to be able to s
     });
 
     it(`should redirect to ${SIGN_IN_ROOT}, display an 'important' banner with signed out copy and NOT render a back link`, () => {
-      const expectedUrl = `${Cypress.config('baseUrl')}${SIGN_IN_ROOT}`;
+      const expectedUrl = `${baseUrl}${SIGN_IN_ROOT}`;
 
       cy.assertUrl(expectedUrl);
 
@@ -52,7 +54,7 @@ context('Insurance - Account - Sign out - As an Exporter, I want to be able to s
       cy.navigateToUrl(DASHBOARD);
 
       // should be taken to the sign in page
-      const expectedUrl = `${Cypress.config('baseUrl')}${SIGN_IN_ROOT}`;
+      const expectedUrl = `${baseUrl}${SIGN_IN_ROOT}`;
 
       cy.assertUrl(expectedUrl);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-out/account-signed-out.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-out/account-signed-out.spec.js
@@ -12,6 +12,8 @@ const {
   },
 } = ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Account - Signed out -  As an Exporter I want the system to securely manage my UKEF digital service sessions, So that my UKEF digital service account is securely managed and not compromised', () => {
   const url = SIGNED_OUT;
 
@@ -47,7 +49,7 @@ context('Insurance - Account - Signed out -  As an Exporter I want the system to
     it(`should redirect to ${SIGN_IN_ROOT} when clicking 'sign in'`, () => {
       signedOutPage.signIn().click();
 
-      const expectedUrl = `${Cypress.config('baseUrl')}${SIGN_IN_ROOT}`;
+      const expectedUrl = `${baseUrl}${SIGN_IN_ROOT}`;
 
       cy.assertUrl(expectedUrl);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/cannot-skip-flow/check-your-answers/navigate-to-check-your-answers-pages-without-completing-previous-sections.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/cannot-skip-flow/check-your-answers/navigate-to-check-your-answers-pages-without-completing-previous-sections.spec.js
@@ -10,8 +10,10 @@ const {
   },
 } = INSURANCE_ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Check your answers - cannot skip to any Check your answers page without completing other required fields/sections', () => {
-  const insuranceRoute = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}`;
+  const insuranceRoute = `${baseUrl}${INSURANCE_ROOT}`;
 
   let referenceNumber;
   let completeOtherSectionsUrl;

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/change-your-answers-change-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/change-your-answers-change-broker.spec.js
@@ -32,6 +32,8 @@ const { taskList } = partials.insurancePartials;
 
 const task = taskList.submitApplication.tasks.checkAnswers;
 
+const baseUrl = Cypress.config('baseUrl');
+
 const getFieldVariables = (fieldId, referenceNumber) => ({
   route: BROKER_CHECK_AND_CHANGE,
   checkYourAnswersRoute: TYPE_OF_POLICY,
@@ -55,7 +57,7 @@ context.skip('Insurance - Check your answers - Policy - Broker - Summary list', 
 
       task.link().click();
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/check-your-answers-policy-multiple-same-name-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/check-your-answers-policy-multiple-same-name-summary-list.spec.js
@@ -22,6 +22,8 @@ const { taskList } = partials.insurancePartials;
 
 const task = taskList.submitApplication.tasks.checkAnswers;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Check your answers - Policy - Multiple contract policy - Same name - Summary List', () => {
   let url;
   let referenceNumber;
@@ -33,7 +35,7 @@ context('Insurance - Check your answers - Policy - Multiple contract policy - Sa
 
       task.link().click();
 
-      url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;
+      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
@@ -36,6 +36,8 @@ const getFieldVariables = (fieldId, referenceNumber) => ({
   changeLink: summaryList.field(fieldId).changeLink,
 });
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Check your answers - Turnover - Your business - Summary list', () => {
   let referenceNumber;
   let url;
@@ -51,7 +53,7 @@ context('Insurance - Check your answers - Turnover - Your business - Summary lis
       // To get past "Policy" check your answers page
       cy.submitCheckYourAnswersForm();
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/save-and-back.spec.js
@@ -11,6 +11,8 @@ const { taskList } = partials.insurancePartials;
 
 const task = taskList.submitApplication.tasks.checkAnswers;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Check your answers - Your business page - Save and back', () => {
   let referenceNumber;
   let url;
@@ -27,9 +29,9 @@ context('Insurance - Check your answers - Your business page - Save and back', (
       // To get past "Policy" check your answers page
       cy.submitCheckYourAnswersForm();
 
-      url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
+      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
 
-      allSectionsUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+      allSectionsUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/summary-list/check-your-answers-your-business-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/summary-list/check-your-answers-your-business-summary-list.spec.js
@@ -33,6 +33,8 @@ const { taskList } = partials.insurancePartials;
 
 const task = taskList.submitApplication.tasks.checkAnswers;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Check your answers - Your business - Summary list', () => {
   let referenceNumber;
   let url;
@@ -48,7 +50,7 @@ context('Insurance - Check your answers - Your business - Summary list', () => {
       // To get past "Policy" check your answers page
       cy.submitCheckYourAnswersForm();
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-company-or-organisation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-company-or-organisation.spec.js
@@ -42,6 +42,8 @@ const getFieldVariables = (fieldId, referenceNumber) => ({
   changeLink: summaryList.field(fieldId).changeLink,
 });
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Check your answers - Company or organisation - Your buyer page - Summary list', () => {
   let referenceNumber;
   let url;
@@ -60,7 +62,7 @@ context('Insurance - Check your answers - Company or organisation - Your buyer p
       // To get past "Your business" check your answers page
       cy.submitCheckYourAnswersForm();
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${YOUR_BUYER}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUYER}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer.spec.js
@@ -36,6 +36,8 @@ const getFieldVariables = (fieldId, referenceNumber, route) => ({
   changeLink: summaryList.field(fieldId).changeLink,
 });
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Check your answers - Working with buyer - Your buyer page - Summary list', () => {
   let referenceNumber;
   let url;
@@ -54,7 +56,7 @@ context('Insurance - Check your answers - Working with buyer - Your buyer page -
       // To get past "Your business" check your answers page
       cy.submitCheckYourAnswersForm();
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${YOUR_BUYER}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUYER}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/summary-list/check-your-answers-your-buyer-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/summary-list/check-your-answers-your-buyer-summary-list.spec.js
@@ -33,6 +33,8 @@ const { taskList } = partials.insurancePartials;
 
 const task = taskList.submitApplication.tasks.checkAnswers;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Check your answers - Your buyer page - Summary list - application below total contract value threshold', () => {
   let referenceNumber;
   let url;
@@ -51,7 +53,7 @@ context('Insurance - Check your answers - Your buyer page - Summary list - appli
       // To get past "Your business" check your answers page
       cy.submitCheckYourAnswersForm();
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${YOUR_BUYER}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUYER}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/complete-other-sections.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/complete-other-sections.spec.js
@@ -11,8 +11,10 @@ const {
 
 const CONTENT_STRINGS = PAGES.INSURANCE.COMPLETE_OTHER_SECTIONS;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Complete other sections page', () => {
-  const insuranceRoute = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}`;
+  const insuranceRoute = `${baseUrl}${INSURANCE_ROOT}`;
 
   let referenceNumber;
   let completeOtherSectionsUrl;

--- a/e2e-tests/insurance/cypress/e2e/journeys/complete-prepare-application-tasks.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/complete-prepare-application-tasks.spec.js
@@ -5,6 +5,8 @@ const {
   ALL_SECTIONS,
 } = INSURANCE_ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Complete `prepare your application` tasks', () => {
   let referenceNumber;
   let allSectionsUrl;
@@ -15,7 +17,7 @@ context('Insurance - Complete `prepare your application` tasks', () => {
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      allSectionsUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+      allSectionsUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       cy.navigateToUrl(allSectionsUrl);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/contact-us.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/contact-us.spec.js
@@ -7,6 +7,8 @@ const CONTENT_STRINGS = PAGES.CONTACT_US_PAGE;
 
 const { GENERAL_ENQUIRIES, APPLICATION_ENQUIRES } = CONTENT_STRINGS;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Contact us page - Insurance', () => {
   const url = ROUTES.INSURANCE.CONTACT_US;
 
@@ -16,7 +18,7 @@ context('Contact us page - Insurance', () => {
     // click on contact link in footer
     footer.supportLinks.contact().click();
 
-    cy.assertUrl(`${Cypress.config('baseUrl')}${url}`);
+    cy.assertUrl(`${baseUrl}${url}`);
 
     cy.saveSession();
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/feedback/submit-feedback.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/feedback/submit-feedback.spec.js
@@ -16,9 +16,11 @@ const {
   FEEDBACK_SENT,
 } = ROUTES.INSURANCE;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Feedback - Submit feedback form', () => {
-  const startUrl = `${Cypress.config('baseUrl')}${START}`;
-  const feedbackConfirmationUrl = `${Cypress.config('baseUrl')}${FEEDBACK_SENT}`;
+  const startUrl = `${baseUrl}${START}`;
+  const feedbackConfirmationUrl = `${baseUrl}${FEEDBACK_SENT}`;
 
   describe('when submitting an empty form', () => {
     beforeEach(() => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/header-authenticated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/header-authenticated.spec.js
@@ -18,17 +18,19 @@ const {
   },
 } = FIELD_IDS;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - header - authenticated - As an Exporter, I want the system to have a login service header across every page of the digital service once I am signed in, So that I can easily access the header content anywhere on the application', () => {
   let referenceNumber;
   let allSectionsUrl;
 
-  const dashboardUrl = `${Cypress.config('baseUrl')}${DASHBOARD}`;
+  const dashboardUrl = `${baseUrl}${DASHBOARD}`;
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      allSectionsUrl = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+      allSectionsUrl = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
     });
   });
 
@@ -56,7 +58,7 @@ context('Insurance - header - authenticated - As an Exporter, I want the system 
     it(`should redirect to ${MANAGE} when clicking the link`, () => {
       selector().click();
 
-      const expectedUrl = `${Cypress.config('baseUrl')}${MANAGE}`;
+      const expectedUrl = `${baseUrl}${MANAGE}`;
 
       cy.assertUrl(expectedUrl);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/no-access-application-submitted/no-access-application-submitted.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/no-access-application-submitted/no-access-application-submitted.spec.js
@@ -11,6 +11,8 @@ const {
   NO_ACCESS_APPLICATION_SUBMITTED,
 } = INSURANCE_ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - no access to application when application is submitted', () => {
   let referenceNumber;
   let applicationUrl;
@@ -19,8 +21,8 @@ context('Insurance - no access to application when application is submitted', ()
     cy.completeSignInAndSubmitAnApplication({}).then((refNumber) => {
       referenceNumber = refNumber;
 
-      const submittedUrl = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${APPLICATION_SUBMITTED}`;
-      applicationUrl = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+      const submittedUrl = `${baseUrl}${ROOT}/${referenceNumber}${APPLICATION_SUBMITTED}`;
+      applicationUrl = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       cy.assertUrl(submittedUrl);
     });
@@ -35,7 +37,7 @@ context('Insurance - no access to application when application is submitted', ()
   });
 
   describe('when trying to access an application which has already been submitted', () => {
-    const expectedUrl = `${Cypress.config('baseUrl')}${NO_ACCESS_APPLICATION_SUBMITTED}`;
+    const expectedUrl = `${baseUrl}${NO_ACCESS_APPLICATION_SUBMITTED}`;
 
     beforeEach(() => {
       cy.saveSession();

--- a/e2e-tests/insurance/cypress/e2e/journeys/no-access-to-application/no-access-to-application-signed-in.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/no-access-to-application/no-access-to-application-signed-in.spec.js
@@ -10,6 +10,8 @@ const {
 const firstAccountEmail = Cypress.env('GOV_NOTIFY_EMAIL_RECIPIENT_1');
 const secondAccountEmail = Cypress.env('GOV_NOTIFY_EMAIL_RECIPIENT_2');
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - no access to application page - signed in', () => {
   let referenceNumbers;
   let firstApplicationUrl;
@@ -21,7 +23,7 @@ context('Insurance - no access to application page - signed in', () => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumbers = [refNumber];
 
-      firstApplicationUrl = `${Cypress.config('baseUrl')}${ROOT}/${refNumber}${ALL_SECTIONS}`;
+      firstApplicationUrl = `${baseUrl}${ROOT}/${refNumber}${ALL_SECTIONS}`;
     });
   });
 
@@ -48,7 +50,7 @@ context('Insurance - no access to application page - signed in', () => {
     });
 
     it(`should redirect to ${NO_ACCESS_TO_APPLICATION}`, () => {
-      const expectedUrl = `${Cypress.config('baseUrl')}${NO_ACCESS_TO_APPLICATION}`;
+      const expectedUrl = `${baseUrl}${NO_ACCESS_TO_APPLICATION}`;
 
       cy.assertUrl(expectedUrl);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/no-access-to-application/no-access-to-application.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/no-access-to-application/no-access-to-application.spec.js
@@ -11,6 +11,8 @@ const {
   NO_ACCESS_TO_APPLICATION,
 } = INSURANCE_ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - no access to application page - signed out', () => {
   let referenceNumber;
   let applicationUrl;
@@ -22,7 +24,7 @@ context('Insurance - no access to application page - signed out', () => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      applicationUrl = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+      applicationUrl = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       cy.assertUrl(applicationUrl);
     });
@@ -41,7 +43,7 @@ context('Insurance - no access to application page - signed out', () => {
     });
 
     it(`should redirect to ${NO_ACCESS_TO_APPLICATION}`, () => {
-      const expectedUrl = `${Cypress.config('baseUrl')}${NO_ACCESS_TO_APPLICATION}`;
+      const expectedUrl = `${baseUrl}${NO_ACCESS_TO_APPLICATION}`;
 
       cy.assertUrl(expectedUrl);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/change-your-answers-change-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/change-your-answers-change-broker.spec.js
@@ -22,6 +22,8 @@ const {
   },
 } = INSURANCE_ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 // TODO: EMS-2793 - re-enable
 context.skip('Insurance - Policy - Change your answers - Broker - As an exporter, I want to change my answers to the broker section', () => {
   let referenceNumber;
@@ -33,7 +35,7 @@ context.skip('Insurance - Policy - Change your answers - Broker - As an exporter
 
       cy.completePolicySection({ usingBroker: false });
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/problem-with-service.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/problem-with-service.spec.js
@@ -3,13 +3,15 @@ import { ROUTES } from '../../../../constants';
 
 const CONTENT_STRINGS = PAGES.PROBLEM_WITH_SERVICE_PAGE;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Problem with service page - Insurance', () => {
   const url = ROUTES.INSURANCE.PROBLEM_WITH_SERVICE;
 
   beforeEach(() => {
     cy.navigateToUrl(url);
 
-    cy.assertUrl(`${Cypress.config('baseUrl')}${url}`);
+    cy.assertUrl(`${baseUrl}${url}`);
 
     cy.saveSession();
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/start.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/start.spec.js
@@ -16,6 +16,8 @@ const {
 
 const { startPage } = insurance;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance Eligibility - start page', () => {
   const url = START;
 
@@ -125,7 +127,7 @@ context('Insurance Eligibility - start page', () => {
 
       cy.clickSubmitButton();
 
-      const expected = `${Cypress.config('baseUrl')}${CHECK_IF_ELIGIBLE}`;
+      const expected = `${baseUrl}${CHECK_IF_ELIGIBLE}`;
 
       cy.assertUrl(expected);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/task-list/complete-prepare-application-group.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/task-list/complete-prepare-application-group.spec.js
@@ -2,6 +2,8 @@ import { ROUTES } from '../../../../../constants';
 
 const { ROOT, ALL_SECTIONS } = ROUTES.INSURANCE;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Task list - complete `prepare application` group', () => {
   let referenceNumber;
 
@@ -9,7 +11,7 @@ context('Insurance - Task list - complete `prepare application` group', () => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      const url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+      const url = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-nature-of-your-business.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-nature-of-your-business.spec.js
@@ -18,6 +18,8 @@ const {
   },
 } = INSURANCE_ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Your business - Change your answers - Nature of your business- As an exporter, I want to change my answers to the nature of your business section', () => {
   let referenceNumber;
   let url;
@@ -35,7 +37,7 @@ context('Insurance - Your business - Change your answers - Nature of your busine
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitCreditControlForm({});
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
@@ -19,6 +19,8 @@ const {
   },
 } = INSURANCE_ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Your business - Change your answers - Turnover - As an exporter, I want to change my answers to the turnover section', () => {
   let referenceNumber;
   let url;
@@ -34,7 +36,7 @@ context('Insurance - Your business - Change your answers - Turnover - As an expo
       cy.completeAndSubmitTurnoverForm();
       cy.completeAndSubmitCreditControlForm({});
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-address-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-address-validation.spec.js
@@ -12,6 +12,8 @@ const {
 
 const COMPANY_DETAILS_ERRORS = ERROR_MESSAGES.INSURANCE.EXPORTER_BUSINESS;
 
+const baseUrl = Cypress.config('baseUrl');
+
 describe("Insurance - Your business - Company details page - As an Exporter I want to enter details about my business in 'your business' section - trading address validation", () => {
   let referenceNumber;
   let url;
@@ -20,7 +22,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`;
+      url = `${baseUrl}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`;
 
       cy.startYourBusinessSection({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-name-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-name-validation.spec.js
@@ -12,6 +12,8 @@ const {
 
 const COMPANY_DETAILS_ERRORS = ERROR_MESSAGES.INSURANCE.EXPORTER_BUSINESS;
 
+const baseUrl = Cypress.config('baseUrl');
+
 describe("Insurance - Your business - Company details page- As an Exporter I want to enter details about my business in 'your business' section - trading name validation", () => {
   let referenceNumber;
   let url;
@@ -20,7 +22,7 @@ describe("Insurance - Your business - Company details page- As an Exporter I wan
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`;
+      url = `${baseUrl}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.COMPANY_DETAILS}`;
 
       cy.startYourBusinessSection({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
@@ -16,6 +16,8 @@ const field = fieldSelector(fieldId);
 
 const expectedErrorsCount = 3;
 
+const baseUrl = Cypress.config('baseUrl');
+
 describe('Insurance - Your business - Nature of your business page - As an Exporter I want to enter details about the nature of my business - years exporting input validation', () => {
   let referenceNumber;
   let url;
@@ -28,7 +30,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
 
       cy.completeAndSubmitCompanyDetails({});
 
-      url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.NATURE_OF_BUSINESS_ROOT}`;
+      url = `${baseUrl}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.NATURE_OF_BUSINESS_ROOT}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
@@ -20,6 +20,8 @@ const ERROR_ASSERTIONS = {
   errorIndex: 1,
 };
 
+const baseUrl = Cypress.config('baseUrl');
+
 describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_ID}`, () => {
   let referenceNumber;
   let url;
@@ -33,7 +35,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
       cy.completeAndSubmitCompanyDetails({});
       cy.completeAndSubmitNatureOfYourBusiness();
 
-      url = `${Cypress.config('baseUrl')}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.TURNOVER_ROOT}`;
+      url = `${baseUrl}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.TURNOVER_ROOT}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/buyer-financial-information/buyer-financial-information-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/buyer-financial-information/buyer-financial-information-page.spec.js
@@ -25,6 +25,8 @@ const {
 
 const ERROR_MESSAGE = ERRORS[FIELD_ID];
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Your Buyer - Buyer financial information - As an exporter, I want to provide the details on the buyer of my export trade, So that UKEF can gain clarity on the buyer history as part of due diligence', () => {
   let referenceNumber;
   let url;
@@ -34,8 +36,8 @@ context('Insurance - Your Buyer - Buyer financial information - As an exporter, 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;
-      checkYourAnswersUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;
+      checkYourAnswersUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
       cy.startInsuranceYourBuyerSection({});
       cy.completeAndSubmitCompanyOrOrganisationForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-buyer-financial-accounts.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-buyer-financial-accounts.spec.js
@@ -13,6 +13,8 @@ const {
   },
 } = INSURANCE_ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Your buyer - Change your answers - Buyer financial accounts - As an exporter, I want to change my answers to the buyer financial accounts section', () => {
   let referenceNumber;
   let url;
@@ -28,7 +30,7 @@ context('Insurance - Your buyer - Change your answers - Buyer financial accounts
       cy.completeAndSubmitTradedWithBuyerForm({});
       cy.completeAndSubmitBuyerFinancialInformationForm({});
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-company-or-organisation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-company-or-organisation.spec.js
@@ -21,6 +21,8 @@ const {
   },
 } = INSURANCE_ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Your buyer - Change your answers - Company or organisation - As an exporter, I want to change my answers to the company or organisation section', () => {
   let referenceNumber;
   let url;
@@ -36,7 +38,7 @@ context('Insurance - Your buyer - Change your answers - Company or organisation 
       cy.completeAndSubmitTradedWithBuyerForm({});
       cy.completeAndSubmitBuyerFinancialInformationForm({});
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-connection-to-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-connection-to-buyer.spec.js
@@ -19,6 +19,8 @@ const {
 
 const { BUYER } = application;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Your buyer - Change your answers - Connection to the buyer - As an exporter, I want to change my answers to the connection to the buyer section', () => {
   let url;
   let referenceNumber;
@@ -36,7 +38,7 @@ context('Insurance - Your buyer - Change your answers - Connection to the buyer 
       cy.completeAndSubmitTradedWithBuyerForm({});
       cy.completeAndSubmitBuyerFinancialInformationForm({});
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-credit-insurance-history.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-credit-insurance-history.spec.js
@@ -19,6 +19,8 @@ const {
 
 const { BUYER } = application;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Your buyer - Change your answers - Credit insurance history - As an exporter, I want to change my answers to the credit insurance history section', () => {
   let url;
   let referenceNumber;
@@ -35,7 +37,7 @@ context('Insurance - Your buyer - Change your answers - Credit insurance history
       cy.completeAndSubmitCreditInsuranceCoverForm({});
       cy.completeAndSubmitBuyerFinancialInformationForm({});
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-trading-history.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-trading-history.spec.js
@@ -27,6 +27,8 @@ const {
   },
 } = INSURANCE_ROUTES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Your buyer - Change your answers - Trading history - As an exporter, I want to change my answers to the trading history section', () => {
   let referenceNumber;
   let url;
@@ -42,7 +44,7 @@ context('Insurance - Your buyer - Change your answers - Trading history - As an 
       cy.completeAndSubmitTradedWithBuyerForm({});
       cy.completeAndSubmitBuyerFinancialInformationForm({});
 
-      url = `${Cypress.config('baseUrl')}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-website.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-website.spec.js
@@ -21,6 +21,8 @@ const {
 
 const ERROR_MESSAGE = COMPANY_OR_ORG_ERROR_MESSAGES[FIELD_ID];
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Your Buyer - Company or organisation page - form validation - website', () => {
   let referenceNumber;
   let url;
@@ -31,7 +33,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
 
       cy.startInsuranceYourBuyerSection({});
 
-      url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`;
+      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation.spec.js
@@ -19,6 +19,8 @@ const {
   },
 } = ERROR_MESSAGES;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Your Buyer - Company or organisation page - form validation', () => {
   let referenceNumber;
 
@@ -28,7 +30,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
 
       cy.startInsuranceYourBuyerSection({});
 
-      const expected = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`;
+      const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ROUTES.INSURANCE.YOUR_BUYER.COMPANY_OR_ORGANISATION}`;
 
       cy.assertUrl(expected);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/traded-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/traded-with-buyer.spec.js
@@ -24,6 +24,8 @@ const {
 
 const ERROR_MESSAGE = ERRORS[FIELD_ID];
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Insurance - Your Buyer - Traded with buyer page - As an exporter, I want to confirm my buyer details', () => {
   let referenceNumber;
   let url;
@@ -39,9 +41,9 @@ context('Insurance - Your Buyer - Traded with buyer page - As an exporter, I wan
       cy.completeAndSubmitCompanyOrOrganisationForm({});
       cy.completeAndSubmitConnectionToTheBuyerForm({});
 
-      url = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${TRADED_WITH_BUYER}`;
-      tradingHistoryUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${TRADING_HISTORY}`;
-      buyerFinancialInformationUrl = `${Cypress.config('baseUrl')}${INSURANCE_ROOT}/${referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;
+      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${TRADED_WITH_BUYER}`;
+      tradingHistoryUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${TRADING_HISTORY}`;
+      buyerFinancialInformationUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/accessibility-statement.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/accessibility-statement.spec.js
@@ -27,12 +27,14 @@ const {
   PREPERATION_OF_STATEMENT,
 } = CONTENT_STRINGS;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Accessibility statement page - Quote', () => {
   beforeEach(() => {
     cy.login();
 
     partials.footer.supportLinks.accessibilityStatement().click();
-    cy.assertUrl(`${Cypress.config('baseUrl')}${ROUTES.ACCESSIBILITY_STATEMENT}`);
+    cy.assertUrl(`${baseUrl}${ROUTES.ACCESSIBILITY_STATEMENT}`);
 
     cy.saveSession();
   });

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/buyer-country/buyer-country.spec.js
@@ -13,6 +13,7 @@ const {
 } = ROUTES;
 
 const supportedCountryName = COUNTRY_QUOTE_SUPPORT.ONLINE.NAME;
+
 const baseUrl = Cypress.config('baseUrl');
 
 context('Buyer country page - as an exporter, I want to check if UKEF issue credit insurance cover for where my buyer is based', () => {
@@ -56,7 +57,7 @@ context('Buyer country page - as an exporter, I want to check if UKEF issue cred
       });
 
       it('renders a back link with correct url', () => {
-        const expectedHref = `${Cypress.config('baseUrl')}${BUYER_COUNTRY}`;
+        const expectedHref = `${baseUrl}${BUYER_COUNTRY}`;
 
         cy.checkLink(
           backLink(),

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/contact-us.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/contact-us.spec.js
@@ -7,6 +7,8 @@ const CONTENT_STRINGS = PAGES.CONTACT_US_PAGE;
 
 const { GENERAL_ENQUIRIES, APPLICATION_ENQUIRES } = CONTENT_STRINGS;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Contact us page - Quote', () => {
   const url = ROUTES.CONTACT_US;
 
@@ -16,7 +18,7 @@ context('Contact us page - Quote', () => {
     // click on contact link in footer
     footer.supportLinks.contact().click();
 
-    cy.assertUrl(`${Cypress.config('baseUrl')}${url}`);
+    cy.assertUrl(`${baseUrl}${url}`);
 
     cy.saveSession();
   });

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/get-a-quote-via-email.spec.js
@@ -9,6 +9,8 @@ const FIELD_ID = FIELD_IDS.ELIGIBILITY.BUYER_COUNTRY;
 
 const COUNTRY_NAME_QUOTE_BY_EMAIL_ONLY = 'Egypt';
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Get a quote via email exit page', () => {
   beforeEach(() => {
     cy.login();
@@ -20,7 +22,7 @@ context('Get a quote via email exit page', () => {
 
     cy.clickSubmitButton();
 
-    const expectedUrl = `${Cypress.config('baseUrl')}${ROUTES.QUOTE.GET_A_QUOTE_BY_EMAIL}`;
+    const expectedUrl = `${baseUrl}${ROUTES.QUOTE.GET_A_QUOTE_BY_EMAIL}`;
 
     cy.assertUrl(expectedUrl);
   });

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/problem-with-service.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/problem-with-service.spec.js
@@ -3,13 +3,15 @@ import { ROUTES } from '../../../../../constants';
 
 const CONTENT_STRINGS = PAGES.PROBLEM_WITH_SERVICE_PAGE;
 
+const baseUrl = Cypress.config('baseUrl');
+
 context('Problem with service page - Quote', () => {
   const url = ROUTES.PROBLEM_WITH_SERVICE;
 
   beforeEach(() => {
     cy.navigateToUrl(url);
 
-    cy.assertUrl(`${Cypress.config('baseUrl')}${url}`);
+    cy.assertUrl(`${baseUrl}${url}`);
 
     cy.saveSession();
   });


### PR DESCRIPTION
## Introduction :pencil2:
This PR standardises use of baseUrl in E2E tests.

## Resolution :heavy_check_mark:
* Declared `const baseUrl` in all files which did not use it.
* Change to `${baseUrl}` in urls.

