### PR TITLE
chore(EMS-2884): No PDF - DRY "Single/multiple" policy cypress commands

### DIFF
--- a/e2e-tests/commands/insurance/complete-and-submit-policy-type-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-policy-type-form.js
@@ -7,14 +7,25 @@ const {
   },
 } = FIELD_IDS;
 
-export default (policyType) => {
+const {
+  POLICY_TYPE: { SINGLE, MULTIPLE },
+} = FIELD_VALUES;
+
+/**
+ * completeAndSubmitPolicyTypeForm
+ * Complete and submit the "policy type" form.
+ * @param {String} policyType: Single or multiple. Defaults to single.
+ */
+const completeAndSubmitPolicyTypeForm = ({ policyType = SINGLE }) => {
   const fieldId = POLICY_TYPE;
 
-  if (policyType === FIELD_VALUES.POLICY_TYPE.SINGLE) {
+  if (policyType === SINGLE) {
     typeOfPolicyPage[fieldId].single.label().click();
-  } else if (policyType === FIELD_VALUES.POLICY_TYPE.MULTIPLE) {
+  } else if (policyType === MULTIPLE) {
     typeOfPolicyPage[fieldId].multiple.label().click();
   }
 
   cy.clickSubmitButton();
 };
+
+export default completeAndSubmitPolicyTypeForm;

--- a/e2e-tests/commands/insurance/complete-policy-section.js
+++ b/e2e-tests/commands/insurance/complete-policy-section.js
@@ -1,6 +1,6 @@
 import { APPLICATION } from '../../constants';
 
-const { POLICY_TYPE } = APPLICATION;;
+const { POLICY_TYPE } = APPLICATION;
 
 /**
  * completePolicySection

--- a/e2e-tests/commands/insurance/complete-policy-section.js
+++ b/e2e-tests/commands/insurance/complete-policy-section.js
@@ -1,6 +1,6 @@
-import { FIELD_VALUES } from '../../constants';
+import { APPLICATION } from '../../constants';
 
-const { SINGLE } = FIELD_VALUES.POLICY_TYPE;
+const { POLICY_TYPE } = APPLICATION;;
 
 /**
  * completePolicySection
@@ -15,7 +15,7 @@ const { SINGLE } = FIELD_VALUES.POLICY_TYPE;
  */
 const completePolicySection = ({
   viaTaskList,
-  policyType = SINGLE,
+  policyType = POLICY_TYPE.SINGLE,
   policyValueOverMvpMaximum = false,
   sameName = true,
   needPreCreditPeriod = false,
@@ -24,9 +24,9 @@ const completePolicySection = ({
 }) => {
   cy.startInsurancePolicySection({ viaTaskList });
 
-  cy.completeAndSubmitPolicyTypeForm(policyType);
+  cy.completeAndSubmitPolicyTypeForm({ policyType });
 
-  if (policyType === SINGLE) {
+  if (policyType === POLICY_TYPE.SINGLE) {
     cy.completeAndSubmitSingleContractPolicyForm({});
 
     cy.completeAndSubmitTotalContractValueForm({ policyValueOverMvpMaximum });

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
@@ -1,6 +1,6 @@
-import { FIELD_VALUES } from '../../constants';
+import { APPLICATION } from '../../constants';
 
-const { POLICY_TYPE } = FIELD_VALUES;
+const { POLICY_TYPE } = APPLICATION;
 
 /**
  * completePrepareApplicationMultiplePolicyType

--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-populated-application.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-populated-application.spec.js
@@ -104,7 +104,7 @@ context('Insurance - Dashboard - populated application', () => {
       cy.startInsurancePolicySection({});
 
       // complete the first form - single contract policy
-      cy.completeAndSubmitPolicyTypeForm(policyType);
+      cy.completeAndSubmitPolicyTypeForm({ policyType });
 
       // complete and submit the next 2 forms
       cy.completeAndSubmitSingleContractPolicyForm({});
@@ -135,7 +135,7 @@ context('Insurance - Dashboard - populated application', () => {
       cy.startInsurancePolicySection({});
 
       // complete the first form - single contract policy
-      cy.completeAndSubmitPolicyTypeForm(policyType);
+      cy.completeAndSubmitPolicyTypeForm({ policyType });
 
       // complete and submit the next 2 forms
       cy.completeAndSubmitMultipleContractPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/another-company.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/another-company.spec.js
@@ -65,7 +65,7 @@ context(`Insurance - Policy - Another company page - ${story}`, () => {
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: true });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/save-and-back.spec.js
@@ -1,4 +1,3 @@
-import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
 
@@ -30,7 +29,7 @@ context('Insurance - Policy - Another company page - Save and back', () => {
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-confirm-address/broker-confirm-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-confirm-address/broker-confirm-address.spec.js
@@ -2,7 +2,6 @@ import partials from '../../../../../../partials';
 import { insetText } from '../../../../../../pages/shared';
 import { brokerConfirmAddressPage } from '../../../../../../pages/insurance/policy';
 import { BUTTONS, PAGES } from '../../../../../../content-strings';
-import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
 import mockApplication from '../../../../../../fixtures/application';
@@ -39,7 +38,7 @@ context("Insurance - Policy - Broker confirm address - As an exporter, I want to
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: true });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
@@ -1,7 +1,6 @@
 import partials from '../../../../../../partials';
 import { field as fieldSelector } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
-import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
@@ -41,7 +40,7 @@ context("Insurance - Policy - Broker details page - As an exporter, I want to pr
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: true });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/save-and-back.spec.js
@@ -1,5 +1,4 @@
 import { field as fieldSelector } from '../../../../../../pages/shared';
-import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
 import mockApplication from '../../../../../../fixtures/application';
@@ -30,7 +29,7 @@ context('Insurance - Policy - Broker details page - Save and back', () => {
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/validation/broker-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/validation/broker-details-validation.spec.js
@@ -1,6 +1,5 @@
 import { field as fieldSelector } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
 import { POLICY_FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
@@ -42,7 +41,7 @@ context('Insurance - Policy - Broker details page - validation', () => {
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: true });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
@@ -52,7 +52,7 @@ context('Insurance - Policy - Broker page - As an Exporter I want to confirm if 
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: true });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
@@ -1,4 +1,3 @@
-import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
 
@@ -28,7 +27,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-multiple-contract-policy.spec.js
@@ -20,7 +20,7 @@ context('Insurance - Policy - Complete the entire section as a multiple contract
 
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(policyType);
+      cy.completeAndSubmitPolicyTypeForm({ policyType });
       cy.completeAndSubmitMultipleContractPolicyForm({});
       cy.completeAndSubmitExportValueForm({ policyType });
       cy.completeAndSubmitNameOnPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-single-contract-policy.spec.js
@@ -1,11 +1,9 @@
-import { FIELD_VALUES, ROUTES } from '../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
 
 const {
-  INSURANCE: {
-    ROOT: INSURANCE_ROOT,
-    ALL_SECTIONS,
-  },
-} = ROUTES;
+  ROOT: INSURANCE_ROOT,
+  ALL_SECTIONS,
+} = INSURANCE_ROUTES;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -18,7 +16,7 @@ context('Insurance - Policy - Complete the entire section as a single contract p
 
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/changing-from-different-name-to-same-name-then-back-to-different-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/changing-from-different-name-to-same-name-then-back-to-different-name.spec.js
@@ -1,5 +1,4 @@
 import { summaryList } from '../../../../../../pages/shared';
-import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 
@@ -28,7 +27,7 @@ context(`Insurance - Policy - Different name on Policy page - Changing ${OTHER_N
 
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: false });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/changing-from-same-name-to-different-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/changing-from-same-name-to-different-name.spec.js
@@ -1,5 +1,4 @@
 import { summaryList } from '../../../../../../pages/shared';
-import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 
@@ -28,7 +27,7 @@ context(`Insurance - Policy - Different name on Policy page - Changing ${SAME_NA
 
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
@@ -2,7 +2,6 @@ import { headingCaption, field as fieldSelector } from '../../../../../../pages/
 import { PAGES } from '../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
 import { ACCOUNT_FIELDS } from '../../../../../../content-strings/fields/insurance/account';
-import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import mockApplication from '../../../../../../fixtures/application';
@@ -43,7 +42,7 @@ context('Insurance - Policy - Different name on Policy page - I want to enter th
 
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: false });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/entering-details-of-policy-owner.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/entering-details-of-policy-owner.spec.js
@@ -2,7 +2,6 @@ import {
   summaryList,
   field as fieldSelector,
 } from '../../../../../../pages/shared';
-import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import mockApplication from '../../../../../../fixtures/application';
@@ -42,7 +41,7 @@ context(`Insurance - Policy - Different name on Policy page - Entering name of p
 
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: false });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/save-and-back.spec.js
@@ -1,5 +1,4 @@
 import { field } from '../../../../../../pages/shared';
-import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import application from '../../../../../../fixtures/application';
@@ -37,7 +36,7 @@ context('Insurance - Policy - Different name on policy - Save and go back', () =
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: false });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/validation/different-name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/validation/different-name-on-policy-validation.spec.js
@@ -2,7 +2,6 @@ import { field as fieldSelector } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { ACCOUNT_FIELDS } from '../../../../../../../content-strings/fields/insurance/account';
 import { POLICY_FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
-import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { assertEmailFieldValidation } from '../../../../../../../shared-test-assertions';
@@ -53,7 +52,7 @@ context('Insurance - Policy - Different name on Policy page - Validation', () =>
 
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: false });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value-alternative-currency.spec.js
@@ -36,7 +36,7 @@ context('Insurance - Policy - Multiple contract policy - Export value page - Alt
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(policyType);
+      cy.completeAndSubmitPolicyTypeForm({ policyType });
 
       cy.completeAndSubmitMultipleContractPolicyForm({
         isoCode: NON_STANDARD_CURRENCY_CODE,

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value-non-gbp-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value-non-gbp-currency.spec.js
@@ -36,7 +36,7 @@ context('Insurance - Policy - Multiple contract policy - Export value page - Non
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(policyType);
+      cy.completeAndSubmitPolicyTypeForm({ policyType });
 
       cy.completeAndSubmitMultipleContractPolicyForm({
         isoCode: USD.isoCode,

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value.spec.js
@@ -45,7 +45,7 @@ context('Insurance - Policy - Multiple contract policy - Export value page - As 
 
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(policyType);
+      cy.completeAndSubmitPolicyTypeForm({ policyType });
       cy.completeAndSubmitMultipleContractPolicyForm({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/save-and-back.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Policy - Multiple contract policy Export value page - Save 
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(policyType);
+      cy.completeAndSubmitPolicyTypeForm({ policyType });
       cy.completeAndSubmitMultipleContractPolicyForm({});
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/validation/multiple-contract-policy-export-value-validation-maximum-buyer-will-owe.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/validation/multiple-contract-policy-export-value-validation-maximum-buyer-will-owe.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Policy - Multiple contract policy - Export value page - for
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(policyType);
+      cy.completeAndSubmitPolicyTypeForm({ policyType });
       cy.completeAndSubmitMultipleContractPolicyForm({ policyType });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/validation/multiple-contract-policy-export-value-validation-total-sales-to-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/validation/multiple-contract-policy-export-value-validation-total-sales-to-buyer.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Policy - Multiple contract policy - Export value page - for
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(policyType);
+      cy.completeAndSubmitPolicyTypeForm({ policyType });
       cy.completeAndSubmitMultipleContractPolicyForm({ policyType });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -5,7 +5,7 @@ import {
 } from '../../../../../../pages/shared';
 import { ERROR_MESSAGES, PAGES } from '../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
-import { FIELD_VALUES } from '../../../../../../constants';
+import { APPLICATION } from '../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import application from '../../../../../../fixtures/application';
@@ -56,7 +56,7 @@ context('Insurance - Policy - Multiple contract policy page - As an exporter, I 
 
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
+      cy.completeAndSubmitPolicyTypeForm({ policyType: APPLICATION.POLICY_TYPE.MULTIPLE });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/save-and-back.spec.js
@@ -1,4 +1,4 @@
-import { FIELD_VALUES } from '../../../../../../constants';
+import { APPLICATION } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const {
@@ -21,7 +21,7 @@ context('Insurance - Policy - Multiple contract policy page - Save and go back',
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
+      cy.completeAndSubmitPolicyTypeForm({ policyType: APPLICATION.POLICY_TYPE.MULTIPLE });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
       allSectionsUrl = `${baseUrl}${ROOT}/${referenceNumber}${ALL_SECTIONS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-requested-start-date.spec.js
@@ -1,7 +1,7 @@
 import { field as fieldSelector } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
-import { FIELD_VALUES } from '../../../../../../../constants';
+import { APPLICATION } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import dateField from '../../../../../../../commands/insurance/date-field';
 
@@ -54,7 +54,7 @@ context('Insurance - Policy - Multiple contract policy page - form validation - 
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
+      cy.completeAndSubmitPolicyTypeForm({ policyType: APPLICATION.POLICY_TYPE.MULTIPLE });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-total-months-of-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-total-months-of-cover.spec.js
@@ -1,11 +1,12 @@
 import { field as fieldSelector } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import { APPLICATION, FIELD_VALUES } from '../../../../../../../constants';
+import { APPLICATION } from '../../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 
 const {
   POLICY: { TOTAL_MONTHS_OF_COVER: MAXIMUM_MONTHS_OF_COVER },
+  POLICY_TYPE,
 } = APPLICATION;
 
 const {
@@ -45,7 +46,7 @@ context('Insurance - Policy - Multiple contract policy page - form validation - 
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
+      cy.completeAndSubmitPolicyTypeForm({ policyType: POLICY_TYPE.MULTIPLE });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
@@ -1,9 +1,13 @@
 import partials from '../../../../../../../partials';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import { FIELD_VALUES, ROUTES } from '../../../../../../../constants';
+import { APPLICATION } from '../../../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 
-const { INSURANCE } = ROUTES;
+const {
+  ROOT,
+  POLICY: { MULTIPLE_CONTRACT_POLICY },
+} = INSURANCE_ROUTES;
 
 const {
   CURRENCY: { CURRENCY_CODE },
@@ -36,9 +40,9 @@ context('Insurance - Policy - Multiple contract policy page - form validation', 
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
+      cy.completeAndSubmitPolicyTypeForm({ policyType: APPLICATION.POLICY_TYPE.MULTIPLE });
 
-      url = `${baseUrl}${INSURANCE.ROOT}/${referenceNumber}${INSURANCE.POLICY.MULTIPLE_CONTRACT_POLICY}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/name-on-policy-page.spec.js
@@ -1,7 +1,6 @@
 import { headingCaption, field } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
-import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import account from '../../../../../../fixtures/account';
@@ -44,7 +43,7 @@ context('Insurance - Policy - Name on Policy page - I want to enter the details 
 
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/save-and-back.spec.js
@@ -1,5 +1,4 @@
 import { field } from '../../../../../../pages/shared';
-import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import application from '../../../../../../fixtures/application';
@@ -34,7 +33,7 @@ context('Insurance - Policy - Name on policy - Save and go back', () => {
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
@@ -1,7 +1,6 @@
 import { field as fieldSelector } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
@@ -49,7 +48,7 @@ context('Insurance - Policy - Name on policy - Validation', () => {
 
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/changing-another-company-from-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/changing-another-company-from-yes-to-no.spec.js
@@ -1,5 +1,4 @@
 import { field as fieldSelector, countryInput } from '../../../../../../pages/shared';
-import { FIELD_VALUES } from '../../../../../../constants';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
@@ -28,7 +27,7 @@ context(`Insurance - Policy - Other company details page - Changing ${REQUESTED}
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: true });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/other-company-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/other-company-details.spec.js
@@ -1,5 +1,4 @@
 import { field as fieldSelector, headingCaption } from '../../../../../../pages/shared';
-import { FIELD_VALUES } from '../../../../../../constants';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
 import { PAGES } from '../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
@@ -35,7 +34,7 @@ context(`Insurance - Policy - Other company details page - ${story}`, () => {
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: true });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/save-and-back.spec.js
@@ -1,5 +1,4 @@
 import { field } from '../../../../../../pages/shared';
-import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
 import application from '../../../../../../fixtures/application';
@@ -32,7 +31,7 @@ context('Insurance - Policy - Other company details page - Save and back', () =>
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/validation/other-company-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/validation/other-company-details-validation.spec.js
@@ -1,5 +1,4 @@
 import { field as fieldSelector, countryInput } from '../../../../../../../pages/shared';
-import { FIELD_VALUES } from '../../../../../../../constants';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance';
@@ -36,7 +35,7 @@ context('Insurance - Policy - Other company details page - Validation', () => {
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: true });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
@@ -46,7 +46,7 @@ context(`Insurance - Policy - Pre-credit period page - ${story}`, () => {
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/save-and-back.spec.js
@@ -2,7 +2,6 @@ import { field as fieldSelector } from '../../../../../../pages/shared';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
-import { FIELD_VALUES } from '../../../../../../constants';
 import mockApplication from '../../../../../../fixtures/application';
 
 const {
@@ -32,7 +31,7 @@ context('Insurance - Policy - Pre-credit period page - Save and go back', () => 
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
@@ -1,7 +1,6 @@
 import { field as fieldSelector } from '../../../../../../pages/shared';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
-import { FIELD_VALUES } from '../../../../../../constants';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -34,7 +33,7 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
@@ -5,7 +5,6 @@ import {
 } from '../../../../../../pages/shared';
 import { ERROR_MESSAGES, PAGES } from '../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
-import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import application from '../../../../../../fixtures/application';
@@ -57,7 +56,7 @@ context('Insurance - Policy - Single contract policy page - As an exporter, I wa
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/save-and-back.spec.js
@@ -34,7 +34,7 @@ context('Insurance - Policy - Single contract policy - Total contract value page
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(policyType);
+      cy.completeAndSubmitPolicyTypeForm({ policyType });
       cy.completeAndSubmitSingleContractPolicyForm({});
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value-alternative-currency.spec.js
@@ -1,5 +1,4 @@
 import { field } from '../../../../../../../pages/shared';
-import { FIELD_VALUES } from '../../../../../../../constants';
 import { PAGES } from '../../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
@@ -29,7 +28,7 @@ context('Insurance - Policy - Single contract policy - Total contract value page
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({
         isoCode: NON_STANDARD_CURRENCY_CODE,
         alternativeCurrency: true,

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value-non-gbp-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value-non-gbp-currency.spec.js
@@ -1,5 +1,4 @@
 import { field } from '../../../../../../../pages/shared';
-import { FIELD_VALUES } from '../../../../../../../constants';
 import { PAGES } from '../../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
@@ -29,7 +28,7 @@ context('Insurance - Policy - Single contract policy - Total contract value page
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({
         isoCode: USD.isoCode,
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value.spec.js
@@ -1,7 +1,6 @@
 import { field as fieldSelector, headingCaption } from '../../../../../../../pages/shared';
 import { PAGES } from '../../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
-import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import application from '../../../../../../../fixtures/application';
@@ -38,7 +37,7 @@ context('Insurance - Policy - Single contract policy - Total contract value page
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/validation/single-contract-policy-total-contract-value-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/validation/single-contract-policy-total-contract-value-validation.spec.js
@@ -3,7 +3,6 @@ import partials from '../../../../../../../../partials';
 import { ERROR_MESSAGES } from '../../../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
-import { FIELD_VALUES } from '../../../../../../../../constants';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -42,7 +41,7 @@ context('Insurance - Policy - Single contract policy - Total contract value page
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
@@ -1,6 +1,6 @@
 import { field as fieldSelector } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import { FIELD_VALUES, ELIGIBILITY } from '../../../../../../../constants';
+import { ELIGIBILITY } from '../../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import dateField from '../../../../../../../commands/insurance/date-field';
@@ -58,7 +58,7 @@ context('Insurance - Policy - Single contract policy page - form validation - co
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
@@ -1,7 +1,6 @@
 import { field as fieldSelector } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
-import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import dateField from '../../../../../../../commands/insurance/date-field';
 
@@ -54,7 +53,7 @@ context('Insurance - Policy - Single contract policy page - form validation - re
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation.spec.js
@@ -1,9 +1,12 @@
 import partials from '../../../../../../../partials';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import { FIELD_VALUES, ROUTES } from '../../../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 
-const { INSURANCE } = ROUTES;
+const {
+  ROOT,
+  POLICY: { SINGLE_CONTRACT_POLICY },
+} = INSURANCE_ROUTES;
 
 const {
   CURRENCY: { CURRENCY_CODE },
@@ -36,9 +39,9 @@ context('Insurance - Policy - Single contract policy page - form validation', ()
       referenceNumber = refNumber;
 
       cy.startInsurancePolicySection({});
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
 
-      url = `${baseUrl}${INSURANCE.ROOT}/${referenceNumber}${INSURANCE.POLICY.SINGLE_CONTRACT_POLICY}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/type-of-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/type-of-policy.spec.js
@@ -2,7 +2,7 @@ import { field, headingCaption } from '../../../../../../pages/shared';
 import { insurance } from '../../../../../../pages';
 import { ERROR_MESSAGES, PAGES } from '../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
-import { FIELD_IDS, FIELD_VALUES } from '../../../../../../constants';
+import { APPLICATION, FIELD_IDS } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const {
@@ -152,7 +152,7 @@ context('Insurance - Policy - Type of policy page - As an exporter, I want to en
       });
 
       it(`should redirect to ${MULTIPLE_CONTRACT_POLICY}`, () => {
-        cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.MULTIPLE);
+        cy.completeAndSubmitPolicyTypeForm({ policyType: APPLICATION.POLICY_TYPE.MULTIPLE });
 
         const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/submit-textarea-fields-with-special-characters/submit-policy-textarea-fields-with-special-characters.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/submit-textarea-fields-with-special-characters/submit-policy-textarea-fields-with-special-characters.spec.js
@@ -1,6 +1,5 @@
 import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../constants/field-ids/insurance/policy';
-import { FIELD_VALUES } from '../../../../../constants/field-values';
 import { field, backLink } from '../../../../../pages/shared';
 import mockStringWithSpecialCharacters from '../../../../../fixtures/string-with-special-characters';
 
@@ -24,7 +23,7 @@ context('Insurance - Textarea fields - `Policy` textarea fields should render sp
       // go to the page we want to test.
       cy.startInsurancePolicySection({});
 
-      cy.completeAndSubmitPolicyTypeForm(FIELD_VALUES.POLICY_TYPE.SINGLE);
+      cy.completeAndSubmitPolicyTypeForm({});
       cy.completeAndSubmitSingleContractPolicyForm({});
       cy.completeAndSubmitTotalContractValueForm({});
       cy.completeAndSubmitNameOnPolicyForm({ sameName: false });


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the `completeAndSubmitPolicyTypeForm` cypress command so that we do not need to import and pass a "policy type" `FIELD_VALUE` in individual tests.

This command now defaults to "single".

As the Policy section grows, this will save us some time when creating new tests and reduce "import noise".

## Resolution :heavy_check_mark:
- Update `completeAndSubmitPolicyTypeForm` to default to a "single contract policy" type.
- Update all E2E tests.
- Update E2E tests that require a "multiple contract policy" to import the value from `APPLICATION` constants, instead of `FIELD_VALUES`.

## Miscellaneous :heavy_plus_sign:
- Add missing documentation.
- Minor destructuring improvements.