### PR TITLE
chore(test): Split up "Your buyer" E2E tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,7 +239,16 @@ jobs:
             "your-business/nature-of-business/**/*.spec.js",
             "your-business/turnover/**/*.spec.js",
             "your-business/credit-control/**/*.spec.js",
-            "your-buyer/**/*.spec.js",
+            "your-buyer/alternative-currency/**/*.spec.js",
+            "your-buyer/buyer-financial-information/**/*.spec.js",
+            "your-buyer/change-your-answers/**/*.spec.js",
+            "your-buyer/check-your-answers/**/*.spec.js",
+            "your-buyer/company-or-organisation/**/*.spec.js",
+            "your-buyer/connection-to-the-buyer/**/*.spec.js",
+            "your-buyer/credit-insurance-cover/**/*.spec.js",
+            "your-buyer/root/**/*.spec.js",
+            "your-buyer/traded-with-buyer/**/*.spec.js",
+            "your-buyer/trading-history/**/*.spec.js",
           ]
 
     concurrency:


### PR DESCRIPTION
## Introduction :pencil2:
This buyer splits E2E your-buyer tests on different runners

## Resolution :heavy_check_mark:
* Added different folders to test.yml for your-buyer
