### PR TITLE
fix(EMS-3045-3046): No PDF - Policy/Your Buyer - Content and route bugs

### DIFF
--- a/e2e-tests/commands/shared-commands/assertions/assert-section-start-content.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-section-start-content.js
@@ -1,5 +1,4 @@
 import {
-  listIntro,
   listItem,
   listOutro,
   outro,
@@ -15,7 +14,6 @@ import { BUTTONS } from '../../../content-strings';
 const assertSectionStartContent = {
   intro: (expectedText) => cy.checkIntroText(expectedText),
   list: {
-    intro: (expectedText) => cy.checkText(listIntro(), expectedText),
     items: (expectedItems) => {
       expectedItems.forEach((expectedText, index) => {
         cy.checkText(listItem(index + 1), expectedText);

--- a/e2e-tests/constants/routes/insurance/policy.js
+++ b/e2e-tests/constants/routes/insurance/policy.js
@@ -2,6 +2,8 @@ const ROOT = '/policy';
 const BROKER_ROOT = `${ROOT}/broker`;
 const BROKER_DETAILS_ROOT = `${ROOT}/broker-details`;
 const BROKER_CONFIRM_ADDRESS_ROOT = `${ROOT}/broker-confirm-address`;
+const NAME_ON_POLICY_ROOT = `${ROOT}/contact`;
+const DIFFERENT_NAME_ON_POLICY_ROOT = `${ROOT}/contact-details`;
 const LOSS_PAYEE_ROOT = `${ROOT}/loss-payee`;
 const LOSS_PAYEE_DETAILS_ROOT = `${ROOT}/loss-payee-details`;
 
@@ -27,14 +29,14 @@ export const POLICY = {
   MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_SAVE_AND_BACK: `${ROOT}/multiple-contract-policy/export-value/save-and-go-back`,
   MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE: `${ROOT}/multiple-contract-policy/export-value/change`,
   MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE: `${ROOT}/multiple-contract-policy/export-value/check-and-change`,
-  NAME_ON_POLICY: `${ROOT}/name-on-policy`,
-  NAME_ON_POLICY_SAVE_AND_BACK: `${ROOT}/name-on-policy/save-and-go-back`,
-  NAME_ON_POLICY_CHANGE: `${ROOT}/name-on-policy/change`,
-  NAME_ON_POLICY_CHECK_AND_CHANGE: `${ROOT}/name-on-policy/check-and-change`,
-  DIFFERENT_NAME_ON_POLICY: `${ROOT}/different-name-on-policy`,
-  DIFFERENT_NAME_ON_POLICY_SAVE_AND_BACK: `${ROOT}/different-name-on-policy/save-and-go-back`,
-  DIFFERENT_NAME_ON_POLICY_CHANGE: `${ROOT}/different-name-on-policy/change`,
-  DIFFERENT_NAME_ON_POLICY_CHECK_AND_CHANGE: `${ROOT}/different-name-on-policy/check-and-change`,
+  NAME_ON_POLICY: `${ROOT}/${NAME_ON_POLICY_ROOT}`,
+  NAME_ON_POLICY_SAVE_AND_BACK: `${ROOT}/${NAME_ON_POLICY_ROOT}/save-and-go-back`,
+  NAME_ON_POLICY_CHANGE: `${ROOT}/${NAME_ON_POLICY_ROOT}/change`,
+  NAME_ON_POLICY_CHECK_AND_CHANGE: `${ROOT}/${NAME_ON_POLICY_ROOT}/check-and-change`,
+  DIFFERENT_NAME_ON_POLICY: `${ROOT}/${DIFFERENT_NAME_ON_POLICY_ROOT}`,
+  DIFFERENT_NAME_ON_POLICY_SAVE_AND_BACK: `${ROOT}/${DIFFERENT_NAME_ON_POLICY_ROOT}/save-and-go-back`,
+  DIFFERENT_NAME_ON_POLICY_CHANGE: `${ROOT}/${DIFFERENT_NAME_ON_POLICY_ROOT}/change`,
+  DIFFERENT_NAME_ON_POLICY_CHECK_AND_CHANGE: `${ROOT}/${DIFFERENT_NAME_ON_POLICY_ROOT}/check-and-change`,
   PRE_CREDIT_PERIOD: `${ROOT}/pre-credit-period`,
   PRE_CREDIT_PERIOD_SAVE_AND_BACK: `${ROOT}/pre-credit-period/save-and-go-back`,
   PRE_CREDIT_PERIOD_CHANGE: `${ROOT}/pre-credit-period/change`,

--- a/e2e-tests/content-strings/pages/insurance/your-buyer/index.js
+++ b/e2e-tests/content-strings/pages/insurance/your-buyer/index.js
@@ -5,15 +5,14 @@ const SHARED = {
 export const ROOT = {
   ...SHARED,
   PAGE_TITLE: 'Who is your buyer?',
-  INTRO: "Next we'll ask you questions about your buyer and whether you've worked with them in the past.",
+  INTRO: "Next we'll ask you questions about your buyer. This includes:",
   LIST: {
-    INTRO: 'We may also ask you to upload some documents. These are:',
     ITEMS: [
-      'your trading history (for example, transactions with them over the last 12 months)',
-      "any credit insurance you've previously held with them",
-      "records of your buyer's financial accounts (for example, management reports)",
+      "if you're connected to them in any way",
+      "whether you've worked with them in the past",
+      "if you've held credit insurance for them previously ",
     ],
-    OUTRO: "You don't have to provide these if you don't have them, or you would prefer not to share them.",
+    OUTRO: "We'll also ask if you have access to their financial accounts. You don't have to provide them if you don't have them, or you would prefer not to share them.",
   },
   OUTRO: 'However, they will make it easier for us to process your application and we may ask you to provide them later on.',
 };

--- a/e2e-tests/content-strings/pages/insurance/your-buyer/index.js
+++ b/e2e-tests/content-strings/pages/insurance/your-buyer/index.js
@@ -10,7 +10,7 @@ export const ROOT = {
     ITEMS: [
       "if you're connected to them in any way",
       "whether you've worked with them in the past",
-      "if you've held credit insurance for them previously ",
+      "if you've held credit insurance for them previously",
     ],
     OUTRO: "We'll also ask if you have access to their financial accounts. You don't have to provide them if you don't have them, or you would prefer not to share them.",
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/root/your-buyer-root.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/root/your-buyer-root.spec.js
@@ -66,10 +66,6 @@ context('Insurance - Your buyer - Start page - As an exporter, I want to provide
       assertSectionStartContent.intro(CONTENT_STRINGS.INTRO);
     });
 
-    it('renders a list intro', () => {
-      assertSectionStartContent.list.intro(CONTENT_STRINGS.LIST.INTRO);
-    });
-
     it('renders list items', () => {
       assertSectionStartContent.list.items(CONTENT_STRINGS.LIST.ITEMS);
     });

--- a/src/ui/server/constants/routes/insurance/policy.ts
+++ b/src/ui/server/constants/routes/insurance/policy.ts
@@ -2,6 +2,8 @@ const ROOT = '/policy';
 const BROKER_ROOT = `${ROOT}/broker`;
 const BROKER_DETAILS_ROOT = `${ROOT}/broker-details`;
 const BROKER_CONFIRM_ADDRESS_ROOT = `${ROOT}/broker-confirm-address`;
+const NAME_ON_POLICY_ROOT = `${ROOT}/contact`;
+const DIFFERENT_NAME_ON_POLICY_ROOT = `${ROOT}/contact-details`;
 const LOSS_PAYEE_ROOT = `${ROOT}/loss-payee`;
 const LOSS_PAYEE_DETAILS_ROOT = `${ROOT}/loss-payee-details`;
 
@@ -27,14 +29,14 @@ export const POLICY = {
   MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_SAVE_AND_BACK: `${ROOT}/multiple-contract-policy/export-value/save-and-go-back`,
   MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE: `${ROOT}/multiple-contract-policy/export-value/change`,
   MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE: `${ROOT}/multiple-contract-policy/export-value/check-and-change`,
-  NAME_ON_POLICY: `${ROOT}/name-on-policy`,
-  NAME_ON_POLICY_SAVE_AND_BACK: `${ROOT}/name-on-policy/save-and-go-back`,
-  NAME_ON_POLICY_CHANGE: `${ROOT}/name-on-policy/change`,
-  NAME_ON_POLICY_CHECK_AND_CHANGE: `${ROOT}/name-on-policy/check-and-change`,
-  DIFFERENT_NAME_ON_POLICY: `${ROOT}/different-name-on-policy`,
-  DIFFERENT_NAME_ON_POLICY_SAVE_AND_BACK: `${ROOT}/different-name-on-policy/save-and-go-back`,
-  DIFFERENT_NAME_ON_POLICY_CHANGE: `${ROOT}/different-name-on-policy/change`,
-  DIFFERENT_NAME_ON_POLICY_CHECK_AND_CHANGE: `${ROOT}/different-name-on-policy/check-and-change`,
+  NAME_ON_POLICY: `${ROOT}/${NAME_ON_POLICY_ROOT}`,
+  NAME_ON_POLICY_SAVE_AND_BACK: `${ROOT}/${NAME_ON_POLICY_ROOT}/save-and-go-back`,
+  NAME_ON_POLICY_CHANGE: `${ROOT}/${NAME_ON_POLICY_ROOT}/change`,
+  NAME_ON_POLICY_CHECK_AND_CHANGE: `${ROOT}/${NAME_ON_POLICY_ROOT}/check-and-change`,
+  DIFFERENT_NAME_ON_POLICY: `${ROOT}/${DIFFERENT_NAME_ON_POLICY_ROOT}`,
+  DIFFERENT_NAME_ON_POLICY_SAVE_AND_BACK: `${ROOT}/${DIFFERENT_NAME_ON_POLICY_ROOT}/save-and-go-back`,
+  DIFFERENT_NAME_ON_POLICY_CHANGE: `${ROOT}/${DIFFERENT_NAME_ON_POLICY_ROOT}/change`,
+  DIFFERENT_NAME_ON_POLICY_CHECK_AND_CHANGE: `${ROOT}/${DIFFERENT_NAME_ON_POLICY_ROOT}/check-and-change`,
   PRE_CREDIT_PERIOD: `${ROOT}/pre-credit-period`,
   PRE_CREDIT_PERIOD_SAVE_AND_BACK: `${ROOT}/pre-credit-period/save-and-go-back`,
   PRE_CREDIT_PERIOD_CHANGE: `${ROOT}/pre-credit-period/change`,

--- a/src/ui/server/content-strings/pages/insurance/your-buyer/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/your-buyer/index.ts
@@ -5,15 +5,11 @@ const SHARED = {
 const ROOT = {
   ...SHARED,
   PAGE_TITLE: 'Who is your buyer?',
-  INTRO: "Next we'll ask you questions about your buyer and whether you've worked with them in the past.",
+  INTRO: "Next we'll ask you questions about your buyer. This includes:",
   LIST: {
-    INTRO: 'We may also ask you to upload some documents. These are:',
-    ITEMS: [
-      'your trading history (for example, transactions with them over the last 12 months)',
-      "any credit insurance you've previously held with them",
-      "records of your buyer's financial accounts (for example, management reports)",
-    ],
-    OUTRO: "You don't have to provide these if you don't have them, or you would prefer not to share them.",
+    ITEMS: ["if you're connected to them in any way", "whether you've worked with them in the past", "if you've held credit insurance for them previously "],
+    OUTRO:
+      "We'll also ask if you have access to their financial accounts. You don't have to provide them if you don't have them, or you would prefer not to share them.",
   },
   OUTRO: 'However, they will make it easier for us to process your application and we may ask you to provide them later on.',
 };

--- a/src/ui/server/content-strings/pages/insurance/your-buyer/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/your-buyer/index.ts
@@ -7,7 +7,7 @@ const ROOT = {
   PAGE_TITLE: 'Who is your buyer?',
   INTRO: "Next we'll ask you questions about your buyer. This includes:",
   LIST: {
-    ITEMS: ["if you're connected to them in any way", "whether you've worked with them in the past", "if you've held credit insurance for them previously "],
+    ITEMS: ["if you're connected to them in any way", "whether you've worked with them in the past", "if you've held credit insurance for them previously"],
     OUTRO:
       "We'll also ask if you have access to their financial accounts. You don't have to provide them if you don't have them, or you would prefer not to share them.",
   },


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes the wrong content on the Your Buyer start page and the incorrect routes for policy

## Resolution :heavy_check_mark:
* FIxed start page content for your buyer
* Fixed Policy - `Name on policy` and `different name on policy` routes - to `contact` and `contact-details`