### PR TITLE
fix(EMS-2969): No PDF - Your Buyer - Check your answers - Trading history fields

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-trading-history-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-trading-history-yes-to-no.spec.js
@@ -1,0 +1,76 @@
+import { FIELD_VALUES } from '../../../../../../constants';
+import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { summaryList } from '../../../../../../pages/shared';
+
+const {
+  YOUR_BUYER: {
+    TRADED_WITH_BUYER,
+    OUTSTANDING_PAYMENTS,
+    TOTAL_AMOUNT_OVERDUE,
+    TOTAL_OUTSTANDING_PAYMENTS,
+    FAILED_PAYMENTS,
+  },
+} = INSURANCE_FIELD_IDS;
+
+const {
+  ROOT,
+  YOUR_BUYER: {
+    CHECK_YOUR_ANSWERS,
+  },
+} = INSURANCE_ROUTES;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Your buyer - Change your answers - Trading history - As an exporter, I want to change my answers to the trading history section from yes to no', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.startInsuranceYourBuyerSection({});
+
+      cy.completeAndSubmitCompanyOrOrganisationForm({});
+      cy.completeAndSubmitConnectionToTheBuyerForm({});
+      cy.completeAndSubmitTradedWithBuyerForm({ exporterHasTradedWithBuyer: true });
+      cy.completeAndSubmitTradingHistoryWithBuyerForm({ outstandingPayments: true, failedToPay: true });
+      cy.completeAndSubmitBuyerFinancialInformationForm({});
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  const fieldId = TRADED_WITH_BUYER;
+
+  describe('form submission with a new answer', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(fieldId).changeLink().click();
+
+      cy.completeAndSubmitTradedWithBuyerForm({});
+    });
+
+    it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId });
+    });
+
+    it('should render the new answer and not render option rows', () => {
+      cy.assertSummaryListRowValue(summaryList, fieldId, FIELD_VALUES.NO);
+      cy.assertSummaryListRowDoesNotExist(summaryList, TOTAL_OUTSTANDING_PAYMENTS);
+      cy.assertSummaryListRowDoesNotExist(summaryList, FAILED_PAYMENTS);
+      cy.assertSummaryListRowDoesNotExist(summaryList, TOTAL_AMOUNT_OVERDUE);
+      cy.assertSummaryListRowDoesNotExist(summaryList, OUTSTANDING_PAYMENTS);
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-trading-history.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-trading-history.spec.js
@@ -206,4 +206,42 @@ context('Insurance - Your buyer - Change your answers - Trading history - As an 
       });
     });
   });
+
+  describe(`changing ${TRADED_WITH_BUYER} from yes to no`, () => {
+    const fieldId = TRADED_WITH_BUYER;
+
+    describe('when clicking the `change` link', () => {
+      it(`should redirect to ${TRADED_WITH_BUYER_CHANGE}`, () => {
+        cy.navigateToUrl(url);
+
+        summaryList.field(OUTSTANDING_PAYMENTS).changeLink().click();
+        cy.completeAndSubmitTradingHistoryWithBuyerForm({ outstandingPayments: true, failedToPay: true });
+
+        summaryList.field(fieldId).changeLink().click();
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: TRADED_WITH_BUYER_CHANGE, fieldId });
+      });
+    });
+
+    describe('form submission with a new answer', () => {
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.completeAndSubmitTradedWithBuyerForm({});
+      });
+
+      it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId });
+      });
+
+      it('should render the new answer and not render option rows', () => {
+        cy.assertSummaryListRowValue(summaryList, fieldId, FIELD_VALUES.NO);
+        cy.assertSummaryListRowDoesNotExist(summaryList, TOTAL_OUTSTANDING_PAYMENTS);
+        cy.assertSummaryListRowDoesNotExist(summaryList, FAILED_PAYMENTS);
+        cy.assertSummaryListRowDoesNotExist(summaryList, TOTAL_AMOUNT_OVERDUE);
+        cy.assertSummaryListRowDoesNotExist(summaryList, OUTSTANDING_PAYMENTS);
+      });
+    });
+  });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-trading-history.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-trading-history.spec.js
@@ -206,42 +206,4 @@ context('Insurance - Your buyer - Change your answers - Trading history - As an 
       });
     });
   });
-
-  describe(`changing ${TRADED_WITH_BUYER} from yes to no`, () => {
-    const fieldId = TRADED_WITH_BUYER;
-
-    describe('when clicking the `change` link', () => {
-      it(`should redirect to ${TRADED_WITH_BUYER_CHANGE}`, () => {
-        cy.navigateToUrl(url);
-
-        summaryList.field(OUTSTANDING_PAYMENTS).changeLink().click();
-        cy.completeAndSubmitTradingHistoryWithBuyerForm({ outstandingPayments: true, failedToPay: true });
-
-        summaryList.field(fieldId).changeLink().click();
-        cy.assertChangeAnswersPageUrl({ referenceNumber, route: TRADED_WITH_BUYER_CHANGE, fieldId });
-      });
-    });
-
-    describe('form submission with a new answer', () => {
-      beforeEach(() => {
-        cy.navigateToUrl(url);
-
-        summaryList.field(fieldId).changeLink().click();
-
-        cy.completeAndSubmitTradedWithBuyerForm({});
-      });
-
-      it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
-        cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId });
-      });
-
-      it('should render the new answer and not render option rows', () => {
-        cy.assertSummaryListRowValue(summaryList, fieldId, FIELD_VALUES.NO);
-        cy.assertSummaryListRowDoesNotExist(summaryList, TOTAL_OUTSTANDING_PAYMENTS);
-        cy.assertSummaryListRowDoesNotExist(summaryList, FAILED_PAYMENTS);
-        cy.assertSummaryListRowDoesNotExist(summaryList, TOTAL_AMOUNT_OVERDUE);
-        cy.assertSummaryListRowDoesNotExist(summaryList, OUTSTANDING_PAYMENTS);
-      });
-    });
-  });
 });

--- a/src/ui/server/controllers/insurance/your-buyer/map-submitted-data/buyer-trading-history/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/map-submitted-data/buyer-trading-history/index.test.ts
@@ -102,6 +102,40 @@ describe('controllers/insurance/your-buyer/map-submitted-data/buyer-trading-hist
     });
   });
 
+  describe(`when ${OUTSTANDING_PAYMENTS} is set to an empty string`, () => {
+    it(`should return mockFormBody without _csrf and ${OUTSTANDING_PAYMENTS} set to "null"`, () => {
+      mockFormBody[OUTSTANDING_PAYMENTS] = '';
+
+      const result = mapSubmittedData(mockFormBody);
+
+      const { _csrf, alternativeCurrencyCode, ...expectedBody } = mockFormBody;
+
+      const expected = {
+        ...expectedBody,
+        [OUTSTANDING_PAYMENTS]: null,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when ${FAILED_PAYMENTS} is set to an empty string`, () => {
+    it(`should return mockFormBody without _csrf and ${FAILED_PAYMENTS} set to "null"`, () => {
+      mockFormBody[FAILED_PAYMENTS] = '';
+
+      const result = mapSubmittedData(mockFormBody);
+
+      const { _csrf, alternativeCurrencyCode, ...expectedBody } = mockFormBody;
+
+      const expected = {
+        ...expectedBody,
+        [FAILED_PAYMENTS]: null,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
   describe(`when ${TRADED_WITH_BUYER} is set to false`, () => {
     it('should return mockFormBody without _csrf and relevant fields set to "null"', () => {
       mockFormBody[TRADED_WITH_BUYER] = 'false';

--- a/src/ui/server/controllers/insurance/your-buyer/map-submitted-data/buyer-trading-history/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/map-submitted-data/buyer-trading-history/index.test.ts
@@ -8,7 +8,7 @@ const {
   CURRENCY: { CURRENCY_CODE, ALTERNATIVE_CURRENCY_CODE },
 } = INSURANCE_FIELD_IDS;
 
-const { OUTSTANDING_PAYMENTS, TOTAL_OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE } = YOUR_BUYER_FIELD_IDS;
+const { OUTSTANDING_PAYMENTS, TOTAL_OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE, TRADED_WITH_BUYER, FAILED_PAYMENTS } = YOUR_BUYER_FIELD_IDS;
 
 describe('controllers/insurance/your-buyer/map-submitted-data/buyer-trading-history', () => {
   let mockFormBody: RequestBody;
@@ -95,6 +95,26 @@ describe('controllers/insurance/your-buyer/map-submitted-data/buyer-trading-hist
 
       const expected = {
         ...expectedBody,
+        [TOTAL_AMOUNT_OVERDUE]: null,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when ${TRADED_WITH_BUYER} is set to false`, () => {
+    it('should return mockFormBody without _csrf and relevant fields set to "null"', () => {
+      mockFormBody[TRADED_WITH_BUYER] = 'false';
+
+      const result = mapSubmittedData(mockFormBody);
+
+      const { _csrf, alternativeCurrencyCode, ...expectedBody } = mockFormBody;
+
+      const expected = {
+        ...expectedBody,
+        [OUTSTANDING_PAYMENTS]: null,
+        [FAILED_PAYMENTS]: null,
+        [TOTAL_OUTSTANDING_PAYMENTS]: null,
         [TOTAL_AMOUNT_OVERDUE]: null,
       };
 

--- a/src/ui/server/controllers/insurance/your-buyer/map-submitted-data/buyer-trading-history/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/map-submitted-data/buyer-trading-history/index.test.ts
@@ -69,7 +69,7 @@ describe('controllers/insurance/your-buyer/map-submitted-data/buyer-trading-hist
   });
 
   describe(`when ${TOTAL_OUTSTANDING_PAYMENTS} is set to an empty string`, () => {
-    it(`should return mockFormBody without _csrf and ${TOTAL_OUTSTANDING_PAYMENTS} set to "null"`, () => {
+    it(`should return the body with ${TOTAL_OUTSTANDING_PAYMENTS} set to null`, () => {
       mockFormBody[TOTAL_OUTSTANDING_PAYMENTS] = '';
 
       const result = mapSubmittedData(mockFormBody);
@@ -86,7 +86,7 @@ describe('controllers/insurance/your-buyer/map-submitted-data/buyer-trading-hist
   });
 
   describe(`when ${TOTAL_AMOUNT_OVERDUE} is set to an empty string`, () => {
-    it(`should return mockFormBody without _csrf and ${TOTAL_AMOUNT_OVERDUE} set to "null"`, () => {
+    it(`should return the body with ${TOTAL_AMOUNT_OVERDUE} set to null`, () => {
       mockFormBody[TOTAL_AMOUNT_OVERDUE] = '';
 
       const result = mapSubmittedData(mockFormBody);
@@ -103,7 +103,7 @@ describe('controllers/insurance/your-buyer/map-submitted-data/buyer-trading-hist
   });
 
   describe(`when ${OUTSTANDING_PAYMENTS} is set to an empty string`, () => {
-    it(`should return mockFormBody without _csrf and ${OUTSTANDING_PAYMENTS} set to "null"`, () => {
+    it(`should return the body with ${OUTSTANDING_PAYMENTS} set to null`, () => {
       mockFormBody[OUTSTANDING_PAYMENTS] = '';
 
       const result = mapSubmittedData(mockFormBody);
@@ -120,7 +120,7 @@ describe('controllers/insurance/your-buyer/map-submitted-data/buyer-trading-hist
   });
 
   describe(`when ${FAILED_PAYMENTS} is set to an empty string`, () => {
-    it(`should return mockFormBody without _csrf and ${FAILED_PAYMENTS} set to "null"`, () => {
+    it(`should return the body with ${FAILED_PAYMENTS} set to null`, () => {
       mockFormBody[FAILED_PAYMENTS] = '';
 
       const result = mapSubmittedData(mockFormBody);
@@ -137,7 +137,7 @@ describe('controllers/insurance/your-buyer/map-submitted-data/buyer-trading-hist
   });
 
   describe(`when ${TRADED_WITH_BUYER} is set to false`, () => {
-    it('should return mockFormBody without _csrf and relevant fields set to "null"', () => {
+    it('should return the relevant TRADED_WITH_BUYER fields set to null', () => {
       mockFormBody[TRADED_WITH_BUYER] = 'false';
 
       const result = mapSubmittedData(mockFormBody);

--- a/src/ui/server/controllers/insurance/your-buyer/map-submitted-data/buyer-trading-history/index.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/map-submitted-data/buyer-trading-history/index.ts
@@ -8,7 +8,7 @@ const {
   CURRENCY: { CURRENCY_CODE, ALTERNATIVE_CURRENCY_CODE },
 } = INSURANCE_FIELD_IDS;
 
-const { OUTSTANDING_PAYMENTS, TOTAL_OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE } = YOUR_BUYER_FIELD_IDS;
+const { OUTSTANDING_PAYMENTS, TOTAL_OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE, TRADED_WITH_BUYER, FAILED_PAYMENTS } = YOUR_BUYER_FIELD_IDS;
 
 /**
  * maps buyer trading history fields in correct format
@@ -20,6 +20,19 @@ const { OUTSTANDING_PAYMENTS, TOTAL_OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE }
  */
 const mapSubmittedData = (formBody: RequestBody): object => {
   const { _csrf, ...populatedData } = formBody;
+
+  /**
+   * if TRADED_WITH_BUYER is false
+   * all trading history fields should be wiped/set to null
+   */
+  if (objectHasProperty(populatedData, TRADED_WITH_BUYER)) {
+    if (populatedData[TRADED_WITH_BUYER] === 'false') {
+      populatedData[OUTSTANDING_PAYMENTS] = null;
+      populatedData[FAILED_PAYMENTS] = null;
+      populatedData[TOTAL_OUTSTANDING_PAYMENTS] = null;
+      populatedData[TOTAL_AMOUNT_OVERDUE] = null;
+    }
+  }
 
   if (objectHasProperty(populatedData, CURRENCY_CODE)) {
     /**

--- a/src/ui/server/controllers/insurance/your-buyer/map-submitted-data/buyer-trading-history/index.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/map-submitted-data/buyer-trading-history/index.ts
@@ -59,12 +59,24 @@ const mapSubmittedData = (formBody: RequestBody): object => {
     }
   }
 
+  /**
+   * if the following radio inputs are empty strings
+   * they should be set to null
+   */
   if (isEmptyString(populatedData[TOTAL_OUTSTANDING_PAYMENTS])) {
     populatedData[TOTAL_OUTSTANDING_PAYMENTS] = null;
   }
 
   if (isEmptyString(populatedData[TOTAL_AMOUNT_OVERDUE])) {
     populatedData[TOTAL_AMOUNT_OVERDUE] = null;
+  }
+
+  if (isEmptyString(populatedData[OUTSTANDING_PAYMENTS])) {
+    populatedData[OUTSTANDING_PAYMENTS] = null;
+  }
+
+  if (isEmptyString(populatedData[FAILED_PAYMENTS])) {
+    populatedData[FAILED_PAYMENTS] = null;
   }
 
   return populatedData;

--- a/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-trading-history/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-trading-history/index.test.ts
@@ -8,7 +8,7 @@ import { mockApplication, mockBuyerTradingHistory } from '../../../../../test-mo
 import generateValidationErrors from '../../../../../helpers/validation';
 import YOUR_BUYER_FIELD_IDS from '../../../../../constants/field-ids/insurance/your-buyer';
 
-const { TOTAL_OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE } = YOUR_BUYER_FIELD_IDS;
+const { TOTAL_OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE, FAILED_PAYMENTS, OUTSTANDING_PAYMENTS } = YOUR_BUYER_FIELD_IDS;
 
 const {
   CURRENCY: { CURRENCY_CODE },
@@ -17,7 +17,7 @@ const {
 describe('controllers/insurance/your-buyer/save-data/buyer-trading-history', () => {
   describe('NULL_OR_EMPTY_STRING_FIELDS', () => {
     it('should have the relevant fieldIds', () => {
-      expect(NULL_OR_EMPTY_STRING_FIELDS).toEqual([TOTAL_OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE]);
+      expect(NULL_OR_EMPTY_STRING_FIELDS).toEqual([FAILED_PAYMENTS, OUTSTANDING_PAYMENTS, TOTAL_OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE]);
     });
   });
 

--- a/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-trading-history/index.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-trading-history/index.ts
@@ -5,13 +5,13 @@ import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import { Application, RequestBody } from '../../../../../../types';
 import YOUR_BUYER_FIELD_IDS from '../../../../../constants/field-ids/insurance/your-buyer';
 
-const { TOTAL_OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE } = YOUR_BUYER_FIELD_IDS;
+const { TOTAL_OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE, FAILED_PAYMENTS, OUTSTANDING_PAYMENTS } = YOUR_BUYER_FIELD_IDS;
 
 /**
  * string fields which are exempt from being stripped by stripEmptyFormFields
  * for example when a string field needs to be set to an empty string or null
  */
-export const NULL_OR_EMPTY_STRING_FIELDS = [TOTAL_OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE];
+export const NULL_OR_EMPTY_STRING_FIELDS = [FAILED_PAYMENTS, OUTSTANDING_PAYMENTS, TOTAL_OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE];
 
 /**
  * gets fields to add to the database and sanitises them


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where `TRADING_HISTORY` fields were not wiped if an answer is changed from yes to no.

## Resolution :heavy_check_mark:
* Added to `mapSubmittedData` to wipe all trading history fields if `TRADED_WITH_BUYER` is false
* Added fields to `NULL_OR_EMPTY_STRING_FIELDS`
* Updated tests
