### PR TITLE
fix(EMS-3079): No PDF - Policy - Loss Payee details - Wrong name validation

### DIFF
--- a/e2e-tests/commands/insurance/complete-and-submit-loss-payee-details-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-loss-payee-details-form.js
@@ -6,12 +6,12 @@ const { LOSS_PAYEE_DETAILS: { NAME } } = POLICY_FIELD_IDS;
 const { POLICY } = application;
 
 /**
- * completeAndSubmitLossPayeeFormDetailsForm
+ * completeAndSubmitLossPayeeDetailsForm
  * Complete and submit "loss payee details" form
  * @param {Boolean} name: loss payee name
  * @param {Boolean} locatedInUK: if located in UK radio should be selected
  */
-const completeAndSubmitLossPayeeFormDetailsForm = ({
+const completeAndSubmitLossPayeeDetailsForm = ({
   name = POLICY[NAME],
   locatedInUK = true,
 }) => {
@@ -20,4 +20,4 @@ const completeAndSubmitLossPayeeFormDetailsForm = ({
   cy.clickSubmitButton();
 };
 
-export default completeAndSubmitLossPayeeFormDetailsForm;
+export default completeAndSubmitLossPayeeDetailsForm;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/validation/loss-payee-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/validation/loss-payee-details-validation.spec.js
@@ -4,6 +4,7 @@ import { ACCOUNT_FIELDS } from '../../../../../../../content-strings/fields/insu
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import partials from '../../../../../../../partials';
+import mockNameWithSpecialCharacters from '../../../../../../../fixtures/name-with-special-characters';
 
 const ERRORS = ERROR_MESSAGES.INSURANCE.POLICY;
 
@@ -90,7 +91,8 @@ context('Insurance - Policy - Loss Payee Details - Validation', () => {
     });
 
     it(`should not render validation errors when ${FIELD_ID} contains numbers and special characters`, () => {
-      cy.keyboardInput(fieldSelector(FIELD_ID).input(), 'Name 123!');
+      const nameValue = mockNameWithSpecialCharacters('name');
+      cy.keyboardInput(fieldSelector(FIELD_ID).input(), nameValue);
 
       cy.clickSubmitButton();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/validation/loss-payee-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/validation/loss-payee-details-validation.spec.js
@@ -3,6 +3,7 @@ import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { ACCOUNT_FIELDS } from '../../../../../../../content-strings/fields/insurance/account';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
+import partials from '../../../../../../../partials';
 
 const ERRORS = ERROR_MESSAGES.INSURANCE.POLICY;
 
@@ -86,6 +87,14 @@ context('Insurance - Policy - Loss Payee Details - Validation', () => {
       const value = 'a'.repeat(MAX_NAME_CHARACTERS + 1);
 
       cy.submitAndAssertFieldErrors(field, value, errorIndex, numberOfExpectedErrors, ERROR.ABOVE_MAXIMUM);
+    });
+
+    it(`should not render validation errors when ${FIELD_ID} contains numbers and special characters`, () => {
+      cy.keyboardInput(fieldSelector(FIELD_ID).input(), 'Name 123!');
+
+      cy.clickSubmitButton();
+
+      partials.errorSummaryListItems().should('have.length', 1);
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-policy-loss-payee-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-policy-loss-payee-details.spec.js
@@ -1,0 +1,82 @@
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+import { INSURANCE_FIELD_IDS } from '../../../../../constants/field-ids/insurance';
+import { field, backLink } from '../../../../../pages/shared';
+import mockNameWithSpecialCharacters from '../../../../../fixtures/name-with-special-characters';
+import application from '../../../../../fixtures/application';
+
+const {
+  ROOT: INSURANCE_ROOT,
+  POLICY: {
+    LOSS_PAYEE_DETAILS_ROOT,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  POLICY: {
+    LOSS_PAYEE_DETAILS: {
+      NAME,
+    },
+  },
+} = INSURANCE_FIELD_IDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+const { POLICY } = application;
+
+const nameValue = mockNameWithSpecialCharacters(POLICY[NAME]);
+
+context('Insurance - Name fields - Loss payee details - Name field should render special characters without character codes after submission', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      // go to the page we want to test.
+      cy.startInsurancePolicySection({});
+      cy.completeAndSubmitPolicyTypeForm({});
+      cy.completeAndSubmitSingleContractPolicyForm({});
+      cy.completeAndSubmitTotalContractValueForm({});
+      cy.completeAndSubmitNameOnPolicyForm({ sameName: true });
+      cy.completeAndSubmitPreCreditPeriodForm({});
+      cy.completeAndSubmitAnotherCompanyForm({});
+      cy.completeAndSubmitBrokerForm({ usingBroker: false });
+      cy.completeAndSubmitLossPayeeForm({ appointingLossPayee: true });
+
+      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${LOSS_PAYEE_DETAILS_ROOT}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe(NAME, () => {
+    describe('when submitting the name field with special characters and going back to the page', () => {
+      beforeEach(() => {
+        cy.saveSession();
+
+        cy.navigateToUrl(url);
+
+        cy.completeAndSubmitLossPayeeDetailsForm({ name: nameValue });
+
+        backLink().click();
+
+        cy.assertUrl(url);
+      });
+
+      it('should render special characters exactly as they were submitted', () => {
+        cy.checkValue(field(NAME), nameValue);
+      });
+    });
+  });
+});

--- a/src/ui/server/content-strings/fields/insurance/policy/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy/index.ts
@@ -251,6 +251,7 @@ export const POLICY_FIELDS = {
   LOSS_PAYEE_DETAILS: {
     [LOSS_PAYEE_NAME]: {
       LABEL: 'Name of the loss payee',
+      MAXIMUM: 100,
     },
     [LOCATION]: {
       LABEL: 'Where is the loss payee located?',

--- a/src/ui/server/controllers/insurance/policy/loss-payee-details/validation/rules/name.test.ts
+++ b/src/ui/server/controllers/insurance/policy/loss-payee-details/validation/rules/name.test.ts
@@ -1,7 +1,7 @@
-import firstName from './name';
+import name, { MAXIMUM } from './name';
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/policy';
-import nameValidation from '../../../../../../shared-validation/name';
+import providedAndMaxLength from '../../../../../../shared-validation/provided-and-max-length';
 import { RequestBody } from '../../../../../../../types';
 import { mockErrors } from '../../../../../../test-mocks';
 
@@ -16,10 +16,10 @@ describe('controllers/insurance/policy/loss-payee-details/validation/rules/name'
     [FIELD_ID]: '',
   } as RequestBody;
 
-  it('should return the result of nameValidation', () => {
-    const result = firstName(mockBody, mockErrors);
+  it('should return the result of providedAndMaxLength', () => {
+    const result = name(mockBody, mockErrors);
 
-    const expected = nameValidation(mockBody, FIELD_ID, ERROR_MESSAGES_OBJECT, mockErrors);
+    const expected = providedAndMaxLength(mockBody, FIELD_ID, ERROR_MESSAGES_OBJECT, mockErrors, MAXIMUM);
 
     expect(result).toEqual(expected);
   });

--- a/src/ui/server/controllers/insurance/policy/loss-payee-details/validation/rules/name.ts
+++ b/src/ui/server/controllers/insurance/policy/loss-payee-details/validation/rules/name.ts
@@ -17,7 +17,7 @@ export const MAXIMUM = Number(POLICY_FIELDS.LOSS_PAYEE_DETAILS[FIELD_ID].MAXIMUM
  * checks if response has been provided
  * @param {RequestBody} formBody
  * @param {Object} errors
- * @returns {Object} providedAndMaxLength errors
+ * @returns {Function} providedAndMaxLength
  */
 const name = (formBody: RequestBody, errors: object) => providedAndMaxLength(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MAXIMUM);
 

--- a/src/ui/server/controllers/insurance/policy/loss-payee-details/validation/rules/name.ts
+++ b/src/ui/server/controllers/insurance/policy/loss-payee-details/validation/rules/name.ts
@@ -1,7 +1,8 @@
 import { ERROR_MESSAGES } from '../../../../../../content-strings';
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/policy';
 import { RequestBody } from '../../../../../../../types';
-import nameValidation from '../../../../../../shared-validation/name';
+import providedAndMaxLength from '../../../../../../shared-validation/provided-and-max-length';
+import { POLICY_FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
 
 const {
   LOSS_PAYEE_DETAILS: { NAME: FIELD_ID },
@@ -9,13 +10,15 @@ const {
 
 const { [FIELD_ID]: ERROR_MESSAGES_OBJECT } = ERROR_MESSAGES.INSURANCE.POLICY;
 
+export const MAXIMUM = Number(POLICY_FIELDS.LOSS_PAYEE_DETAILS[FIELD_ID].MAXIMUM);
+
 /**
  * validates name field
  * checks if response has been provided
  * @param {RequestBody} formBody
  * @param {Object} errors
- * @returns {Object} errors
+ * @returns {Object} providedAndMaxLength errors
  */
-const name = (formBody: RequestBody, errors: object) => nameValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
+const name = (formBody: RequestBody, errors: object) => providedAndMaxLength(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MAXIMUM);
 
 export default name;

--- a/src/ui/server/helpers/mappings/map-name-fields/index.test.ts
+++ b/src/ui/server/helpers/mappings/map-name-fields/index.test.ts
@@ -8,6 +8,9 @@ const {
   YOUR_BUYER: {
     COMPANY_OR_ORGANISATION: { NAME: BUYER_NAME },
   },
+  POLICY: {
+    LOSS_PAYEE_DETAILS: { NAME: LOSS_PAYEE_NAME },
+  },
 } = INSURANCE_FIELD_IDS;
 
 const characterCodes = '&lt;&gt;&quot;&#x27;&#x2F;&#42;&amp';
@@ -25,6 +28,10 @@ const mockApplicationWithCharacterCodes = {
     [FIRST_NAME]: mockStringWithCharacterCodes,
     [LAST_NAME]: mockStringWithCharacterCodes,
   },
+  nominatedLossPayee: {
+    ...mockApplication.nominatedLossPayee,
+    [LOSS_PAYEE_NAME]: mockStringWithCharacterCodes,
+  },
 };
 
 describe('server/helpers/mappings/map-name-fields', () => {
@@ -36,5 +43,15 @@ describe('server/helpers/mappings/map-name-fields', () => {
     const expected = replaceCharacterCodesWithCharacters(fieldValue);
 
     expect(result.buyer[BUYER_NAME]).toEqual(expected);
+  });
+
+  it(`should replace character codes in nominatedLossPayee.${LOSS_PAYEE_NAME}`, () => {
+    const result = mapNameFields(mockApplicationWithCharacterCodes);
+
+    const fieldValue = mockApplicationWithCharacterCodes.nominatedLossPayee[LOSS_PAYEE_NAME];
+
+    const expected = replaceCharacterCodesWithCharacters(fieldValue);
+
+    expect(result.nominatedLossPayee[LOSS_PAYEE_NAME]).toEqual(expected);
   });
 });

--- a/src/ui/server/helpers/mappings/map-name-fields/index.ts
+++ b/src/ui/server/helpers/mappings/map-name-fields/index.ts
@@ -7,6 +7,9 @@ const {
   YOUR_BUYER: {
     COMPANY_OR_ORGANISATION: { NAME: BUYER_NAME },
   },
+  POLICY: {
+    LOSS_PAYEE_DETAILS: { NAME: LOSS_PAYEE_NAME },
+  },
 } = INSURANCE_FIELD_IDS;
 
 /**
@@ -16,7 +19,7 @@ const {
  * @returns {Object} Application with mapped name field characters
  */
 const mapNameFields = (application: Application): Application => {
-  const { buyer, policyContact } = application;
+  const { buyer, policyContact, nominatedLossPayee } = application;
 
   if (buyer?.[BUYER_NAME]) {
     const fieldValue = buyer[BUYER_NAME];
@@ -34,6 +37,12 @@ const mapNameFields = (application: Application): Application => {
     const fieldValue = policyContact[LAST_NAME];
 
     policyContact[LAST_NAME] = replaceCharacterCodesWithCharacters(fieldValue);
+  }
+
+  if (nominatedLossPayee?.[LOSS_PAYEE_NAME]) {
+    const fieldValue = nominatedLossPayee[LOSS_PAYEE_NAME];
+
+    nominatedLossPayee[LOSS_PAYEE_NAME] = replaceCharacterCodesWithCharacters(fieldValue);
   }
 
   return application;


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where the wrong validation was used for the name field on loss payee details

## Resolution :heavy_check_mark:
* Used providedAndMaxLength validation for name field
* Updated tests

