### PR TITLE
chore(EMS-3110): No PDF - Update all E2E tests to use new DRY error summary list commands

### DIFF
--- a/e2e-tests/commands/pagination/assert-pagination-does-not-exist.js
+++ b/e2e-tests/commands/pagination/assert-pagination-does-not-exist.js
@@ -5,7 +5,7 @@ import pagination from '../../partials/pagination';
  * Check that there are no pagination elements visible.
  */
 const assertPaginationDoesNotExist = () => {
-  cy.assertLength(pagination.listItems(), 0);
+  pagination.listItems().should('not.exist');
   pagination.previousLink().should('not.exist');
   pagination.nextLink().should('not.exist');
 };

--- a/e2e-tests/commands/pagination/assert-pagination-does-not-exist.js
+++ b/e2e-tests/commands/pagination/assert-pagination-does-not-exist.js
@@ -5,7 +5,7 @@ import pagination from '../../partials/pagination';
  * Check that there are no pagination elements visible.
  */
 const assertPaginationDoesNotExist = () => {
-  pagination.listItems().should('have.length', 0);
+  cy.assertLength(pagination.listItems(), 0);
   pagination.previousLink().should('not.exist');
   pagination.nextLink().should('not.exist');
 };

--- a/e2e-tests/commands/shared-commands/assertions/assert-error-summary-list-does-not-exist.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-error-summary-list-does-not-exist.js
@@ -1,0 +1,11 @@
+import partials from '../../../partials';
+
+/**
+ * assertErrorSummaryListDoesNotExist
+ * Assert the error summary list does not exist
+ */
+const assertErrorSummaryListDoesNotExist = () => {
+  partials.errorSummaryListItems().should('not.exist');
+};
+
+export default assertErrorSummaryListDoesNotExist;

--- a/e2e-tests/commands/shared-commands/assertions/assert-error-summary-list-length.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-error-summary-list-length.js
@@ -1,0 +1,12 @@
+import partials from '../../../partials';
+
+/**
+ * assertErrorSummaryListLength
+ * Assert the length of the error summary list
+ * @param {Integer} expectedLength: Expected amount
+ */
+const assertErrorSummaryListLength = (expectedLength) => {
+  cy.assertLength(partials.errorSummaryListItems(), expectedLength);
+};
+
+export default assertErrorSummaryListLength;

--- a/e2e-tests/commands/shared-commands/assertions/index.js
+++ b/e2e-tests/commands/shared-commands/assertions/index.js
@@ -18,6 +18,8 @@ Cypress.Commands.add('assertYesRadioOptionIsNotChecked', require('./assert-yes-r
 Cypress.Commands.add('assertNoRadioOptionIsChecked', require('./assert-no-radio-option-is-checked'));
 Cypress.Commands.add('assertNoRadioOptionIsNotChecked', require('./assert-no-radio-option-is-not-checked'));
 Cypress.Commands.add('assertLength', require('./assert-length'));
+Cypress.Commands.add('assertErrorSummaryListLength', require('./assert-error-summary-list-length'));
+Cypress.Commands.add('assertErrorSummaryListDoesNotExist', require('./assert-error-summary-list-does-not-exist'));
 
 Cypress.Commands.add('assertHeadingWithCurrencyName', require('./assert-heading-with-currency-name'));
 Cypress.Commands.add('assertPrefix', require('./assert-prefix'));

--- a/e2e-tests/commands/shared-commands/form/assert-field-errors.js
+++ b/e2e-tests/commands/shared-commands/form/assert-field-errors.js
@@ -18,7 +18,7 @@ const assertFieldErrors = ({
 }) => {
   cy.checkErrorSummaryListHeading();
 
-  cy.assertLength(partials.errorSummaryListItems(), errorSummaryLength);
+  cy.assertErrorSummaryListLength(errorSummaryLength);
 
   cy.checkText(
     partials.errorSummaryListItems().eq(errorIndex),

--- a/e2e-tests/commands/shared-commands/form/assert-field-errors.js
+++ b/e2e-tests/commands/shared-commands/form/assert-field-errors.js
@@ -18,7 +18,7 @@ const assertFieldErrors = ({
 }) => {
   cy.checkErrorSummaryListHeading();
 
-  partials.errorSummaryListItems().should('have.length', errorSummaryLength);
+  cy.assertLength(partials.errorSummaryListItems(), errorSummaryLength);
 
   cy.checkText(
     partials.errorSummaryListItems().eq(errorIndex),

--- a/e2e-tests/commands/shared-commands/form/submit-and-assert-radio-errors.js
+++ b/e2e-tests/commands/shared-commands/form/submit-and-assert-radio-errors.js
@@ -12,7 +12,7 @@ const submitAndAssertRadioErrors = (field, errorIndex, errorSummaryLength, error
 
   cy.checkErrorSummaryListHeading();
 
-  partials.errorSummaryListItems().should('have.length', errorSummaryLength);
+  cy.assertLength(partials.errorSummaryListItems(), errorSummaryLength);
 
   cy.checkText(
     partials.errorSummaryListItems().eq(errorIndex),

--- a/e2e-tests/commands/shared-commands/form/submit-and-assert-radio-errors.js
+++ b/e2e-tests/commands/shared-commands/form/submit-and-assert-radio-errors.js
@@ -12,7 +12,7 @@ const submitAndAssertRadioErrors = (field, errorIndex, errorSummaryLength, error
 
   cy.checkErrorSummaryListHeading();
 
-  cy.assertLength(partials.errorSummaryListItems(), errorSummaryLength);
+  cy.assertErrorSummaryListLength(errorSummaryLength);
 
   cy.checkText(
     partials.errorSummaryListItems().eq(errorIndex),

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/account-creation-and-sign-in-with-eligibility-answers.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/account-creation-and-sign-in-with-eligibility-answers.spec.js
@@ -71,7 +71,7 @@ context('Insurance - Account - When answering eligibility answers, creating an a
 
       cy.assertUrl(dashboardUrl);
 
-      table.body.rows().should('have.length', 1);
+      cy.assertLength(table.body.rows(), 1);
 
       table.body.firstRow.submittedLink().invoke('text').then((refNumber) => {
         referenceNumber = refNumber;

--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-invalid-page-number-param.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-invalid-page-number-param.spec.js
@@ -29,6 +29,6 @@ context('Insurance - Dashboard - visit with 1 existing application and an invali
   });
 
   it('should ignore the invalid page number and have one application in the table', () => {
-    table.body.rows().should('have.length', 1);
+    cy.assertLength(table.body.rows(), 1);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-multiple-applications.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-multiple-applications.spec.js
@@ -21,7 +21,7 @@ context('Insurance - Dashboard - new application', () => {
 
       cy.assertUrl(url);
 
-      table.body.rows().should('have.length', 1);
+      cy.assertLength(table.body.rows(), 1);
     });
   });
 
@@ -62,7 +62,7 @@ context('Insurance - Dashboard - new application', () => {
     });
 
     it('should render the newly created application and the previously created application', () => {
-      table.body.rows().should('have.length', 2);
+      cy.assertLength(table.body.rows(), 2);
     });
 
     it('should order the applications in descending order', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-no-applications.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-no-applications.spec.js
@@ -88,7 +88,7 @@ context('Insurance - Dashboard - no applications', () => {
       header.navigation.applications().click();
 
       // check that the dashboard is now populated
-      dashboardPage.table.body.rows().should('have.length', 1);
+      cy.assertLength(dashboardPage.table.body.rows(), 1);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-only-my-applications.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-only-my-applications.spec.js
@@ -47,7 +47,7 @@ context("Insurance - Dashboard - As an Exporter, I want to access only my UKEF c
   });
 
   it('should have only one application', () => {
-    table.body.rows().should('have.length', 1);
+    cy.assertLength(table.body.rows(), 1);
   });
 
   it('should have the correct reference number', () => {
@@ -86,7 +86,7 @@ context("Insurance - Dashboard - As an Exporter, I want to access only my UKEF c
       });
 
       it('should have only one application', () => {
-        table.body.rows().should('have.length', 1);
+        cy.assertLength(table.body.rows(), 1);
       });
 
       it('should NOT have a reference number that equals the first application/reference number, created by a different exporter', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-135-applications.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-135-applications.spec.js
@@ -38,7 +38,7 @@ context(`Insurance - Dashboard - pagination - ${totalApplications} applications`
     });
 
     it('should render 4 pagination list items - 3 links, 1 ellipsis item', () => {
-      pagination.listItems().should('have.length', 4);
+      cy.assertLength(pagination.listItems(), 4);
 
       cy.assertPaginationItemLink({ index: 0 });
       cy.assertPaginationItemLink({ index: 1 });
@@ -67,7 +67,7 @@ context(`Insurance - Dashboard - pagination - ${totalApplications} applications`
     });
 
     it('should render 7 pagination list items - 6 links, 1 ellipsis item', () => {
-      pagination.listItems().should('have.length', 7);
+      cy.assertLength(pagination.listItems(), 7);
 
       cy.assertPaginationItemLink({ index: 1, pageNumber: 1 });
       cy.assertPaginationItemLink({ index: 2, pageNumber: 2 });
@@ -98,7 +98,7 @@ context(`Insurance - Dashboard - pagination - ${totalApplications} applications`
     });
 
     it('should render 7 pagination list items - 5 links, 2 ellipsis items', () => {
-      pagination.listItems().should('have.length', 7);
+      cy.assertLength(pagination.listItems(), 7);
 
       cy.assertPaginationItemLink({ index: 1, pageNumber: 1 });
       cy.assertPaginationItemEllipsis({ index: 1 });
@@ -132,7 +132,7 @@ context(`Insurance - Dashboard - pagination - ${totalApplications} applications`
     });
 
     it('should render 7 pagination list items - 6 links, 1 ellipsis items', () => {
-      pagination.listItems().should('have.length', 7);
+      cy.assertLength(pagination.listItems(), 7);
 
       cy.assertPaginationItemLink({ index: 1, pageNumber: 1 });
       cy.assertPaginationItemEllipsis({ index: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-16-applications.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-16-applications.spec.js
@@ -38,7 +38,7 @@ context(`Insurance - Dashboard - pagination - ${totalApplications} applications`
     });
 
     it('should render 2 pagination list items with links', () => {
-      pagination.listItems().should('have.length', totalPages);
+      cy.assertLength(pagination.listItems(), totalPages);
 
       cy.assertPaginationItemLink({ index: 0 });
       cy.assertPaginationItemLink({ index: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-30-applications.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-30-applications.spec.js
@@ -37,7 +37,7 @@ context(`Insurance - Dashboard - pagination - ${totalApplications} applications`
     });
 
     it('should render 2 pagination list items with links', () => {
-      pagination.listItems().should('have.length', totalPages);
+      cy.assertLength(pagination.listItems(), totalPages);
 
       cy.assertPaginationItemLink({ index: 0 });
       cy.assertPaginationItemLink({ index: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-45-applications.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-45-applications.spec.js
@@ -38,7 +38,7 @@ context(`Insurance - Dashboard - pagination - ${totalApplications} applications`
     });
 
     it('should render 3 pagination list items with links', () => {
-      pagination.listItems().should('have.length', 3);
+      cy.assertLength(pagination.listItems(), 3);
 
       cy.assertPaginationItemLink({ index: 0 });
       cy.assertPaginationItemLink({ index: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-60-applications.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-60-applications.spec.js
@@ -38,7 +38,7 @@ context(`Insurance - Dashboard - pagination - ${totalApplications} applications`
     });
 
     it('should render 3 pagination list items with links', () => {
-      pagination.listItems().should('have.length', 4);
+      cy.assertLength(pagination.listItems(), 4);
 
       cy.assertPaginationItemLink({ index: 0 });
       cy.assertPaginationItemLink({ index: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-75-applications.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-75-applications.spec.js
@@ -12,7 +12,7 @@ const totalPages = totalApplications / MAX_APPLICATIONS_PER_PAGE;
 const dashboardUrl = `${baseUrl}${DASHBOARD}`;
 
 const assertFullyPopulatedPageLinks = () => {
-  pagination.listItems().should('have.length', 5);
+  cy.assertLength(pagination.listItems(), 5);
 
   cy.assertPaginationItemLink({ index: 1, pageNumber: 1 });
   cy.assertPaginationItemLink({ index: 2, pageNumber: 2 });
@@ -48,7 +48,7 @@ context(`Insurance - Dashboard - pagination - ${totalApplications} applications`
     });
 
     it('should render 4 pagination list items - 3 links, 1 ellipsis item', () => {
-      pagination.listItems().should('have.length', 4);
+      cy.assertLength(pagination.listItems(), 4);
 
       cy.assertPaginationItemLink({ index: 0 });
       cy.assertPaginationItemLink({ index: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-90-applications.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/dashboard/dashboard-pagination/dashboard-pagination-90-applications.spec.js
@@ -38,7 +38,7 @@ context(`Insurance - Dashboard - pagination - ${totalApplications} applications`
     });
 
     it('should render 4 pagination list items - 3 links, 1 ellipsis item', () => {
-      pagination.listItems().should('have.length', 4);
+      cy.assertLength(pagination.listItems(), 4);
 
       cy.assertPaginationItemLink({ index: 0 });
       cy.assertPaginationItemLink({ index: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/validation/loss-payee-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/validation/loss-payee-details-validation.spec.js
@@ -96,7 +96,7 @@ context('Insurance - Policy - Loss Payee Details - Validation', () => {
 
       cy.clickSubmitButton();
 
-      partials.errorSummaryListItems().should('have.length', 1);
+      cy.assertLength(partials.errorSummaryListItems(), 1);
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/validation/loss-payee-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/validation/loss-payee-details-validation.spec.js
@@ -3,7 +3,6 @@ import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { ACCOUNT_FIELDS } from '../../../../../../../content-strings/fields/insurance/account';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
-import partials from '../../../../../../../partials';
 import mockNameWithSpecialCharacters from '../../../../../../../fixtures/name-with-special-characters';
 
 const ERRORS = ERROR_MESSAGES.INSURANCE.POLICY;
@@ -96,7 +95,7 @@ context('Insurance - Policy - Loss Payee Details - Validation', () => {
 
       cy.clickSubmitButton();
 
-      cy.assertLength(partials.errorSummaryListItems(), 1);
+      cy.assertErrorSummaryListLength(1);
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/account-number-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/account-number-validation.spec.js
@@ -1,6 +1,5 @@
 import { field as fieldSelector } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
 import { MAXIMUM_CHARACTERS, MINIMUM_CHARACTERS } from '../../../../../../../constants';
@@ -107,7 +106,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Account number -
 
       cy.clickSubmitButton();
 
-      cy.assertLength(partials.errorSummaryListItems(), 2);
+      cy.assertErrorSummaryListLength(2);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/account-number-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/account-number-validation.spec.js
@@ -107,7 +107,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Account number -
 
       cy.clickSubmitButton();
 
-      partials.errorSummaryListItems().should('have.length', 2);
+      cy.assertLength(partials.errorSummaryListItems(), 2);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/sort-code-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/sort-code-validation.spec.js
@@ -113,7 +113,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Sort code - Vali
 
       cy.clickSubmitButton();
 
-      partials.errorSummaryListItems().should('have.length', 2);
+      cy.assertLength(partials.errorSummaryListItems(), 2);
     });
 
     it(`should not render validation errors when ${FIELD_ID} is only numbers and dashes`, () => {
@@ -121,7 +121,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Sort code - Vali
 
       cy.clickSubmitButton();
 
-      partials.errorSummaryListItems().should('have.length', 2);
+      cy.assertLength(partials.errorSummaryListItems(), 2);
     });
 
     it(`should not render validation errors when ${FIELD_ID} is only numbers and spaces`, () => {
@@ -129,7 +129,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Sort code - Vali
 
       cy.clickSubmitButton();
 
-      partials.errorSummaryListItems().should('have.length', 2);
+      cy.assertLength(partials.errorSummaryListItems(), 2);
     });
 
     it(`should not render validation errors when ${FIELD_ID} is only numbers and spaces and dashes`, () => {
@@ -137,7 +137,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Sort code - Vali
 
       cy.clickSubmitButton();
 
-      partials.errorSummaryListItems().should('have.length', 2);
+      cy.assertLength(partials.errorSummaryListItems(), 2);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/sort-code-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/sort-code-validation.spec.js
@@ -1,6 +1,5 @@
 import { field as fieldSelector } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
 import { MAXIMUM_CHARACTERS, MINIMUM_CHARACTERS } from '../../../../../../../constants';
@@ -113,7 +112,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Sort code - Vali
 
       cy.clickSubmitButton();
 
-      cy.assertLength(partials.errorSummaryListItems(), 2);
+      cy.assertErrorSummaryListLength(2);
     });
 
     it(`should not render validation errors when ${FIELD_ID} is only numbers and dashes`, () => {
@@ -121,7 +120,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Sort code - Vali
 
       cy.clickSubmitButton();
 
-      cy.assertLength(partials.errorSummaryListItems(), 2);
+      cy.assertErrorSummaryListLength(2);
     });
 
     it(`should not render validation errors when ${FIELD_ID} is only numbers and spaces`, () => {
@@ -129,7 +128,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Sort code - Vali
 
       cy.clickSubmitButton();
 
-      cy.assertLength(partials.errorSummaryListItems(), 2);
+      cy.assertErrorSummaryListLength(2);
     });
 
     it(`should not render validation errors when ${FIELD_ID} is only numbers and spaces and dashes`, () => {
@@ -137,7 +136,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Sort code - Vali
 
       cy.clickSubmitButton();
 
-      cy.assertLength(partials.errorSummaryListItems(), 2);
+      cy.assertErrorSummaryListLength(2);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
@@ -64,7 +64,7 @@ context('Insurance - Policy - Multiple contract policy page - form validation', 
     cy.checkErrorSummaryListHeading();
 
     const TOTAL_REQUIRED_FIELDS = 3;
-    partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);
+    cy.assertLength(partials.errorSummaryListItems(), TOTAL_REQUIRED_FIELDS);
 
     cy.checkText(
       partials.errorSummaryListItems().eq(0),

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
@@ -64,7 +64,7 @@ context('Insurance - Policy - Multiple contract policy page - form validation', 
     cy.checkErrorSummaryListHeading();
 
     const TOTAL_REQUIRED_FIELDS = 3;
-    cy.assertLength(partials.errorSummaryListItems(), TOTAL_REQUIRED_FIELDS);
+    cy.assertErrorSummaryListLength(TOTAL_REQUIRED_FIELDS);
 
     cy.checkText(
       partials.errorSummaryListItems().eq(0),

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
@@ -1,5 +1,4 @@
 import { field as fieldSelector } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
@@ -149,7 +148,7 @@ context('Insurance - Policy - Name on policy - Validation', () => {
     it('should NOT display validation error, but redirect to the next page', () => {
       cy.completeAndSubmitNameOnPolicyForm({ sameName: false });
 
-      partials.errorSummaryListItems().should('not.exist');
+      cy.assertErrorSummaryListDoesNotExist();
 
       const expectedUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${DIFFERENT_NAME_ON_POLICY}`;
       cy.assertUrl(expectedUrl);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/validation/pre-credit-period-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/validation/pre-credit-period-validation.spec.js
@@ -1,5 +1,4 @@
 import { noRadio, field as fieldSelector } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
@@ -71,7 +70,7 @@ context('Insurance - Policy - Pre-credit period page - validation', () => {
       cy.navigateToUrl(url);
       cy.clickNoRadioInput();
 
-      partials.errorSummaryListItems().should('not.exist');
+      cy.assertErrorSummaryListDoesNotExist();
     });
   });
 
@@ -119,7 +118,7 @@ context('Insurance - Policy - Pre-credit period page - validation', () => {
     it(`should not render any validation errors when ${CREDIT_PERIOD_WITH_BUYER} is below the minimum`, () => {
       cy.completeAndSubmitPreCreditPeriodForm({ needPreCreditPeriod: true });
 
-      partials.errorSummaryListItems().should('not.exist');
+      cy.assertErrorSummaryListDoesNotExist();
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation.spec.js
@@ -61,7 +61,7 @@ context('Insurance - Policy - Single contract policy page - form validation', ()
     cy.checkErrorSummaryListHeading();
 
     const TOTAL_REQUIRED_FIELDS = 3;
-    cy.assertLength(partials.errorSummaryListItems(), TOTAL_REQUIRED_FIELDS);
+    cy.assertErrorSummaryListLength(TOTAL_REQUIRED_FIELDS);
 
     cy.checkText(
       partials.errorSummaryListItems().eq(0),

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation.spec.js
@@ -61,7 +61,7 @@ context('Insurance - Policy - Single contract policy page - form validation', ()
     cy.checkErrorSummaryListHeading();
 
     const TOTAL_REQUIRED_FIELDS = 3;
-    partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);
+    cy.assertLength(partials.errorSummaryListItems(), TOTAL_REQUIRED_FIELDS);
 
     cy.checkText(
       partials.errorSummaryListItems().eq(0),

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-company-website-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-company-website-validation.spec.js
@@ -99,7 +99,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     });
 
     it('should not display validation errors', () => {
-      partials.errorSummaryListItems().should('have.length', 0);
+      cy.assertLength(partials.errorSummaryListItems(), 0);
     });
 
     it(`should redirect to ${natureOfBusinessUrl}`, () => {
@@ -118,7 +118,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     });
 
     it('should not display validation errors', () => {
-      partials.errorSummaryListItems().should('have.length', 0);
+      cy.assertLength(partials.errorSummaryListItems(), 0);
     });
 
     it(`should redirect to ${natureOfBusinessUrl}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-company-website-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-company-website-validation.spec.js
@@ -99,7 +99,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     });
 
     it('should not display validation errors', () => {
-      cy.assertLength(partials.errorSummaryListItems(), 0);
+      partials.errorSummaryListItems().should('not.exist');
     });
 
     it(`should redirect to ${natureOfBusinessUrl}`, () => {
@@ -118,7 +118,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     });
 
     it('should not display validation errors', () => {
-      cy.assertLength(partials.errorSummaryListItems(), 0);
+      partials.errorSummaryListItems().should('not.exist');
     });
 
     it(`should redirect to ${natureOfBusinessUrl}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-company-website-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-company-website-validation.spec.js
@@ -1,6 +1,5 @@
 import { field } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
-import partials from '../../../../../../../partials';
 import {
   ROUTES, FIELD_IDS, WEBSITE_EXAMPLES,
 } from '../../../../../../../constants';
@@ -99,7 +98,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     });
 
     it('should not display validation errors', () => {
-      partials.errorSummaryListItems().should('not.exist');
+      cy.assertErrorSummaryListDoesNotExist();
     });
 
     it(`should redirect to ${natureOfBusinessUrl}`, () => {
@@ -118,7 +117,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     });
 
     it('should not display validation errors', () => {
-      partials.errorSummaryListItems().should('not.exist');
+      cy.assertErrorSummaryListDoesNotExist();
     });
 
     it(`should redirect to ${natureOfBusinessUrl}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-valid-phone-number-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-valid-phone-number-validation.spec.js
@@ -2,7 +2,6 @@ import { field } from '../../../../../../../pages/shared';
 import {
   ROUTES, FIELD_IDS, VALID_PHONE_NUMBERS, WEBSITE_EXAMPLES,
 } from '../../../../../../../constants';
-import partials from '../../../../../../../partials';
 
 const {
   EXPORTER_BUSINESS: {
@@ -70,7 +69,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     });
 
     it('should not display validation errors', () => {
-      cy.assertLength(partials.errorSummaryListItems(), 0);
+      cy.assertErrorSummaryListDoesNotExist();
     });
 
     it('should redirect to next page', () => {
@@ -87,7 +86,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        cy.assertLength(partials.errorSummaryListItems(), 0);
+        cy.assertErrorSummaryListDoesNotExist();
       });
 
       it('should redirect to next page', () => {
@@ -103,7 +102,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        cy.assertLength(partials.errorSummaryListItems(), 0);
+        cy.assertErrorSummaryListDoesNotExist();
       });
 
       it('should redirect to next page', () => {
@@ -119,7 +118,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        cy.assertLength(partials.errorSummaryListItems(), 0);
+        cy.assertErrorSummaryListDoesNotExist();
       });
 
       it('should redirect to next page', () => {
@@ -135,7 +134,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        cy.assertLength(partials.errorSummaryListItems(), 0);
+        cy.assertErrorSummaryListDoesNotExist();
       });
 
       it('should redirect to next page', () => {
@@ -151,7 +150,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        cy.assertLength(partials.errorSummaryListItems(), 0);
+        cy.assertErrorSummaryListDoesNotExist();
       });
 
       it('should redirect to next page', () => {
@@ -167,7 +166,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        cy.assertLength(partials.errorSummaryListItems(), 0);
+        cy.assertErrorSummaryListDoesNotExist();
       });
 
       it('should redirect to next page', () => {
@@ -183,7 +182,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        cy.assertLength(partials.errorSummaryListItems(), 0);
+        cy.assertErrorSummaryListDoesNotExist();
       });
 
       it('should redirect to next page', () => {
@@ -199,7 +198,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        cy.assertLength(partials.errorSummaryListItems(), 0);
+        cy.assertErrorSummaryListDoesNotExist();
       });
 
       it('should redirect to next page', () => {
@@ -215,7 +214,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        cy.assertLength(partials.errorSummaryListItems(), 0);
+        cy.assertErrorSummaryListDoesNotExist();
       });
 
       it('should redirect to next page', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-valid-phone-number-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-valid-phone-number-validation.spec.js
@@ -70,7 +70,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     });
 
     it('should not display validation errors', () => {
-      partials.errorSummaryListItems().should('have.length', 0);
+      cy.assertLength(partials.errorSummaryListItems(), 0);
     });
 
     it('should redirect to next page', () => {
@@ -87,7 +87,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        partials.errorSummaryListItems().should('have.length', 0);
+        cy.assertLength(partials.errorSummaryListItems(), 0);
       });
 
       it('should redirect to next page', () => {
@@ -103,7 +103,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        partials.errorSummaryListItems().should('have.length', 0);
+        cy.assertLength(partials.errorSummaryListItems(), 0);
       });
 
       it('should redirect to next page', () => {
@@ -119,7 +119,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        partials.errorSummaryListItems().should('have.length', 0);
+        cy.assertLength(partials.errorSummaryListItems(), 0);
       });
 
       it('should redirect to next page', () => {
@@ -135,7 +135,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        partials.errorSummaryListItems().should('have.length', 0);
+        cy.assertLength(partials.errorSummaryListItems(), 0);
       });
 
       it('should redirect to next page', () => {
@@ -151,7 +151,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        partials.errorSummaryListItems().should('have.length', 0);
+        cy.assertLength(partials.errorSummaryListItems(), 0);
       });
 
       it('should redirect to next page', () => {
@@ -167,7 +167,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        partials.errorSummaryListItems().should('have.length', 0);
+        cy.assertLength(partials.errorSummaryListItems(), 0);
       });
 
       it('should redirect to next page', () => {
@@ -183,7 +183,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        partials.errorSummaryListItems().should('have.length', 0);
+        cy.assertLength(partials.errorSummaryListItems(), 0);
       });
 
       it('should redirect to next page', () => {
@@ -199,7 +199,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        partials.errorSummaryListItems().should('have.length', 0);
+        cy.assertLength(partials.errorSummaryListItems(), 0);
       });
 
       it('should redirect to next page', () => {
@@ -215,7 +215,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
 
       it('should not display validation errors', () => {
-        partials.errorSummaryListItems().should('have.length', 0);
+        cy.assertLength(partials.errorSummaryListItems(), 0);
       });
 
       it('should redirect to next page', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { field as fieldSelector } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
@@ -141,7 +140,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
 
         cy.keyboardInput(field.input(), '5');
         cy.clickSubmitButton();
-        cy.assertLength(partials.errorSummaryListItems(), 2);
+        cy.assertErrorSummaryListLength(2);
       });
     });
 
@@ -154,7 +153,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
 
         cy.keyboardInput(field.input(), '5,000');
         cy.clickSubmitButton();
-        cy.assertLength(partials.errorSummaryListItems(), 2);
+        cy.assertErrorSummaryListLength(2);
       });
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
@@ -141,7 +141,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
 
         cy.keyboardInput(field.input(), '5');
         cy.clickSubmitButton();
-        partials.errorSummaryListItems().should('have.length', 2);
+        cy.assertLength(partials.errorSummaryListItems(), 2);
       });
     });
 
@@ -154,7 +154,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
 
         cy.keyboardInput(field.input(), '5,000');
         cy.clickSubmitButton();
-        partials.errorSummaryListItems().should('have.length', 2);
+        cy.assertLength(partials.errorSummaryListItems(), 2);
       });
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
@@ -112,7 +112,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       cy.clickSubmitButton();
 
       cy.checkErrorSummaryListHeading();
-      partials.errorSummaryListItems().should('have.length', 2);
+      cy.assertLength(partials.errorSummaryListItems(), 2);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
@@ -112,7 +112,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       cy.clickSubmitButton();
 
       cy.checkErrorSummaryListHeading();
-      cy.assertLength(partials.errorSummaryListItems(), 2);
+      cy.assertErrorSummaryListLength(2);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
@@ -122,7 +122,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       cy.clickSubmitButton();
 
       cy.checkErrorSummaryListHeading();
-      cy.assertLength(partials.errorSummaryListItems(), 2);
+      cy.assertErrorSummaryListLength(2);
     });
   });
 
@@ -134,7 +134,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       cy.clickSubmitButton();
 
       cy.checkErrorSummaryListHeading();
-      cy.assertLength(partials.errorSummaryListItems(), 2);
+      cy.assertErrorSummaryListLength(2);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
@@ -122,7 +122,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       cy.clickSubmitButton();
 
       cy.checkErrorSummaryListHeading();
-      partials.errorSummaryListItems().should('have.length', 2);
+      cy.assertLength(partials.errorSummaryListItems(), 2);
     });
   });
 
@@ -134,7 +134,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       cy.clickSubmitButton();
 
       cy.checkErrorSummaryListHeading();
-      partials.errorSummaryListItems().should('have.length', 2);
+      cy.assertLength(partials.errorSummaryListItems(), 2);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
@@ -91,7 +91,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
 
     cy.keyboardInput(field.input(), '5');
     cy.clickSubmitButton();
-    partials.errorSummaryListItems().should('have.length', 1);
+    cy.assertLength(partials.errorSummaryListItems(), 1);
   });
 
   it(`should NOT display validation errors when ${FIELD_ID} is correctly entered with a comma`, () => {
@@ -100,7 +100,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
 
     cy.keyboardInput(field.input(), '5,00');
     cy.clickSubmitButton();
-    partials.errorSummaryListItems().should('have.length', 1);
+    cy.assertLength(partials.errorSummaryListItems(), 1);
   });
 
   it(`should NOT display validation errors when ${FIELD_ID} is correctly entered as 0`, () => {
@@ -109,7 +109,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
 
     cy.keyboardInput(field.input(), '0');
     cy.clickSubmitButton();
-    partials.errorSummaryListItems().should('have.length', 1);
+    cy.assertLength(partials.errorSummaryListItems(), 1);
   });
 
   it(`should NOT display validation errors when ${FIELD_ID} is correctly entered as a negative number`, () => {
@@ -118,6 +118,6 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
 
     cy.keyboardInput(field.input(), '-256');
     cy.clickSubmitButton();
-    partials.errorSummaryListItems().should('have.length', 1);
+    cy.assertLength(partials.errorSummaryListItems(), 1);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { field as fieldSelector } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { ROUTES } from '../../../../../../../constants';
@@ -91,7 +90,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
 
     cy.keyboardInput(field.input(), '5');
     cy.clickSubmitButton();
-    cy.assertLength(partials.errorSummaryListItems(), 1);
+    cy.assertErrorSummaryListLength(1);
   });
 
   it(`should NOT display validation errors when ${FIELD_ID} is correctly entered with a comma`, () => {
@@ -100,7 +99,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
 
     cy.keyboardInput(field.input(), '5,00');
     cy.clickSubmitButton();
-    cy.assertLength(partials.errorSummaryListItems(), 1);
+    cy.assertErrorSummaryListLength(1);
   });
 
   it(`should NOT display validation errors when ${FIELD_ID} is correctly entered as 0`, () => {
@@ -109,7 +108,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
 
     cy.keyboardInput(field.input(), '0');
     cy.clickSubmitButton();
-    cy.assertLength(partials.errorSummaryListItems(), 1);
+    cy.assertErrorSummaryListLength(1);
   });
 
   it(`should NOT display validation errors when ${FIELD_ID} is correctly entered as a negative number`, () => {
@@ -118,6 +117,6 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
 
     cy.keyboardInput(field.input(), '-256');
     cy.clickSubmitButton();
-    cy.assertLength(partials.errorSummaryListItems(), 1);
+    cy.assertErrorSummaryListLength(1);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { field as fieldSelector } from '../../../../../../../pages/shared';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { ROUTES } from '../../../../../../../constants';
@@ -112,7 +111,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
 
     cy.clickSubmitButton();
 
-    cy.assertLength(partials.errorSummaryListItems(), 1);
+    cy.assertErrorSummaryListLength(1);
   });
 
   it(`should NOT display validation errors when ${FIELD_ID} is correctly entered as 0`, () => {
@@ -122,6 +121,6 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
 
     cy.clickSubmitButton();
 
-    cy.assertLength(partials.errorSummaryListItems(), 1);
+    cy.assertErrorSummaryListLength(1);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
@@ -112,7 +112,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
 
     cy.clickSubmitButton();
 
-    partials.errorSummaryListItems().should('have.length', 1);
+    cy.assertLength(partials.errorSummaryListItems(), 1);
   });
 
   it(`should NOT display validation errors when ${FIELD_ID} is correctly entered as 0`, () => {
@@ -122,6 +122,6 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
 
     cy.clickSubmitButton();
 
-    partials.errorSummaryListItems().should('have.length', 1);
+    cy.assertLength(partials.errorSummaryListItems(), 1);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-website.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-website.spec.js
@@ -80,7 +80,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
 
       cy.clickSubmitButton();
 
-      partials.errorSummaryListItems().should('have.length', 2);
+      cy.assertLength(partials.errorSummaryListItems(), 2);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-website.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-website.spec.js
@@ -1,5 +1,4 @@
 import { field as fieldSelector } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { ERROR_MESSAGES } from '../../../../../../../content-strings';
 import { ROUTES, WEBSITE_EXAMPLES } from '../../../../../../../constants';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
@@ -80,7 +79,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
 
       cy.clickSubmitButton();
 
-      cy.assertLength(partials.errorSummaryListItems(), 2);
+      cy.assertErrorSummaryListLength(2);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation.spec.js
@@ -50,7 +50,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
     cy.checkErrorSummaryListHeading();
 
     const TOTAL_REQUIRED_FIELDS = 2;
-    cy.assertLength(partials.errorSummaryListItems(), TOTAL_REQUIRED_FIELDS);
+    cy.assertErrorSummaryListLength(TOTAL_REQUIRED_FIELDS);
 
     cy.checkText(
       partials.errorSummaryListItems().eq(0),

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation.spec.js
@@ -50,7 +50,7 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
     cy.checkErrorSummaryListHeading();
 
     const TOTAL_REQUIRED_FIELDS = 2;
-    partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);
+    cy.assertLength(partials.errorSummaryListItems(), TOTAL_REQUIRED_FIELDS);
 
     cy.checkText(
       partials.errorSummaryListItems().eq(0),

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/policy-type/policy-type-validation.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/policy-type/policy-type-validation.spec.js
@@ -40,7 +40,7 @@ context('Policy type page - policy type & length validation - single policy type
       cy.clickSubmitButton();
 
       cy.checkErrorSummaryListHeading();
-      cy.assertLength(partials.errorSummaryListItems(), 1);
+      cy.assertErrorSummaryListLength(1);
 
       const expectedErrorMessage = ERROR_MESSAGES.ELIGIBILITY[POLICY_TYPE];
 

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/policy-type/policy-type-validation.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/policy-type/policy-type-validation.spec.js
@@ -40,7 +40,7 @@ context('Policy type page - policy type & length validation - single policy type
       cy.clickSubmitButton();
 
       cy.checkErrorSummaryListHeading();
-      partials.errorSummaryListItems().should('have.length', 1);
+      cy.assertLength(partials.errorSummaryListItems(), 1);
 
       const expectedErrorMessage = ERROR_MESSAGES.ELIGIBILITY[POLICY_TYPE];
 

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy-validation.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy-validation.spec.js
@@ -49,7 +49,7 @@ context('Tell us about the multiple policy you need - form validation', () => {
       cy.checkErrorSummaryListHeading();
 
       const TOTAL_REQUIRED_FIELDS = 4;
-      cy.assertLength(partials.errorSummaryListItems(), TOTAL_REQUIRED_FIELDS);
+      cy.assertErrorSummaryListLength(TOTAL_REQUIRED_FIELDS);
 
       // currency
       cy.checkText(

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy-validation.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy-validation.spec.js
@@ -49,7 +49,7 @@ context('Tell us about the multiple policy you need - form validation', () => {
       cy.checkErrorSummaryListHeading();
 
       const TOTAL_REQUIRED_FIELDS = 4;
-      partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);
+      cy.assertLength(partials.errorSummaryListItems(), TOTAL_REQUIRED_FIELDS);
 
       // currency
       cy.checkText(

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy-validation.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy-validation.spec.js
@@ -48,7 +48,7 @@ context('Tell us about the policy you need page - form validation', () => {
       cy.checkErrorSummaryListHeading();
 
       const TOTAL_REQUIRED_FIELDS = 4;
-      partials.errorSummaryListItems().should('have.length', TOTAL_REQUIRED_FIELDS);
+      cy.assertLength(partials.errorSummaryListItems(), TOTAL_REQUIRED_FIELDS);
 
       // policy length
       cy.checkText(

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy-validation.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy-validation.spec.js
@@ -48,7 +48,7 @@ context('Tell us about the policy you need page - form validation', () => {
       cy.checkErrorSummaryListHeading();
 
       const TOTAL_REQUIRED_FIELDS = 4;
-      cy.assertLength(partials.errorSummaryListItems(), TOTAL_REQUIRED_FIELDS);
+      cy.assertErrorSummaryListLength(TOTAL_REQUIRED_FIELDS);
 
       // policy length
       cy.checkText(

--- a/e2e-tests/shared-test-assertions/autocomplete-assertions/index.js
+++ b/e2e-tests/shared-test-assertions/autocomplete-assertions/index.js
@@ -34,7 +34,7 @@ export const checkAutocompleteInput = {
 
     const results = field.results();
 
-    results.should('have.length', 1);
+    cy.assertLength(results, 1);
   },
   rendersMultipleResults: (field) => {
     cy.keyboardInput(field.input(), 'A');

--- a/e2e-tests/shared-test-assertions/email-field-validation/index.js
+++ b/e2e-tests/shared-test-assertions/email-field-validation/index.js
@@ -1,6 +1,5 @@
 import { INVALID_EMAILS, VALID_EMAIL } from '../../constants';
 import { field as fieldSelector } from '../../pages/shared';
-import partials from '../../partials';
 
 /**
  * assertEmailFieldValidation
@@ -71,9 +70,9 @@ export const assertEmailFieldValidation = ({
         cy.clickSubmitButton();
 
         if (totalExpectedOtherErrorsWithValidEmail) {
-          cy.assertLength(partials.errorSummaryListItems(), totalExpectedOtherErrorsWithValidEmail);
+          cy.assertErrorSummaryListLength(totalExpectedOtherErrorsWithValidEmail);
         } else {
-          partials.errorSummaryListItems().should('not.exist');
+          cy.assertErrorSummaryListDoesNotExist();
         }
       });
     }

--- a/e2e-tests/shared-test-assertions/email-field-validation/index.js
+++ b/e2e-tests/shared-test-assertions/email-field-validation/index.js
@@ -70,7 +70,11 @@ export const assertEmailFieldValidation = ({
 
         cy.clickSubmitButton();
 
-        cy.assertLength(partials.errorSummaryListItems(), totalExpectedOtherErrorsWithValidEmail);
+        if (totalExpectedOtherErrorsWithValidEmail) {
+          cy.assertLength(partials.errorSummaryListItems(), totalExpectedOtherErrorsWithValidEmail);
+        } else {
+          partials.errorSummaryListItems().should('not.exist');
+        }
       });
     }
   });

--- a/e2e-tests/shared-test-assertions/email-field-validation/index.js
+++ b/e2e-tests/shared-test-assertions/email-field-validation/index.js
@@ -70,7 +70,7 @@ export const assertEmailFieldValidation = ({
 
         cy.clickSubmitButton();
 
-        partials.errorSummaryListItems().should('have.length', totalExpectedOtherErrorsWithValidEmail);
+        cy.assertLength(partials.errorSummaryListItems(), totalExpectedOtherErrorsWithValidEmail);
       });
     }
   });


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates all E2E tests to consume the recently created `assertLength` command via new commands:
- `assertErrorSummaryListLength`
- `assertErrorSummaryListDoesNotExist`

Instead of having to import and use `.should('have.length', X)` or `should('not.exist`) in individual tests.

## Resolution :heavy_check_mark:
- Create new cypress commands.
-  Update all E2E tests.