### PR TITLE
feat(EMS-2938): No PDF - Export contract - Private market - Form validation

### DIFF
--- a/e2e-tests/commands/insurance/complete-and-submit-private-market-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-private-market-form.js
@@ -1,8 +1,15 @@
 /**
  * completeAndSubmitPrivateMarketForm
- * Complete and submit the "Tried to get private market" form
+ * Complete and submit the "Tried to insure through the private market" form
+ * @param {Boolean} attempted: Has attempted to insure through the private market
  */
-const completeAndSubmitPrivateMarketForm = () => {
+const completeAndSubmitPrivateMarketForm = ({ attempted = false }) => {
+  if (attempted) {
+    cy.clickYesRadioInput();
+  } else {
+    cy.clickNoRadioInput();
+  }
+
   cy.clickSubmitButton();
 };
 

--- a/e2e-tests/commands/insurance/complete-export-contract-section.js
+++ b/e2e-tests/commands/insurance/complete-export-contract-section.js
@@ -16,7 +16,7 @@ const completeExportContractSection = ({
   cy.completeAndSubmitHowYouWillGetPaidForm({});
 
   if (totalContractValueOverThreshold) {
-    cy.completeAndSubmitPrivateMarketForm();
+    cy.completeAndSubmitPrivateMarketForm({});
   }
 
   if (submitCheckYourAnswers) {

--- a/e2e-tests/constants/routes/insurance/export-contract.js
+++ b/e2e-tests/constants/routes/insurance/export-contract.js
@@ -2,6 +2,7 @@ const ROOT = '/export-contract';
 const ABOUT_GOODS_OR_SERVICES_ROOT = `${ROOT}/about-goods-or-services`;
 const HOW_WILL_YOU_GET_PAID_ROOT = `${ROOT}/how-will-you-get-paid`;
 const PRIVATE_MARKET_ROOT = `${ROOT}/private-market`;
+const DECLINED_BY_PRIVATE_MARKET_ROOT = `${ROOT}/declined-by-private-market`;
 
 export const EXPORT_CONTRACT = {
   ROOT,
@@ -17,5 +18,6 @@ export const EXPORT_CONTRACT = {
   PRIVATE_MARKET_SAVE_AND_BACK: `${PRIVATE_MARKET_ROOT}/save-and-go-back`,
   PRIVATE_MARKET_CHANGE: `${PRIVATE_MARKET_ROOT}/change`,
   PRIVATE_MARKET_CHECK_AND_CHANGE: `${PRIVATE_MARKET_ROOT}/check-and-change`,
+  DECLINED_BY_PRIVATE_MARKET: DECLINED_BY_PRIVATE_MARKET_ROOT,
   CHECK_YOUR_ANSWERS: `${ROOT}/check-your-answers`,
 };

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -158,6 +158,11 @@ export const ERROR_MESSAGES = {
           ABOVE_MAXIMUM: `The description of how you will get paid for your export cannot be more than a ${MAXIMUM_CHARACTERS.PAYMENT_TERMS_DESCRIPTION} characters`,
         },
       },
+      PRIVATE_MARKET: {
+        [FIELD_IDS.INSURANCE.EXPORT_CONTRACT.PRIVATE_MARKET.ATTEMPTED]: {
+          IS_EMPTY: 'Select if you have tried to insure this export through the private market',
+        },
+      },
     },
     POLICY: {
       TYPE_OF_POLICY: {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/private-market.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/private-market.spec.js
@@ -1,12 +1,14 @@
 import {
+  field as fieldSelector,
   headingCaption,
   yesNoRadioHint,
   noRadio,
+  noRadioInput,
   yesRadio,
 } from '../../../../../../pages/shared';
 import partials from '../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../constants';
-import { PAGES, PRIVATE_MARKET_WHY_DESCRIPTION } from '../../../../../../content-strings';
+import { ERROR_MESSAGES, PAGES, PRIVATE_MARKET_WHY_DESCRIPTION } from '../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
@@ -15,27 +17,38 @@ const { privateMarketWhyDescription } = partials;
 const CONTENT_STRINGS = PAGES.INSURANCE.EXPORT_CONTRACT.PRIVATE_MARKET;
 
 const {
-  ROOT: INSURANCE_ROOT,
-  EXPORT_CONTRACT: { PRIVATE_MARKET },
+  ROOT,
+  EXPORT_CONTRACT: { PRIVATE_MARKET, CHECK_YOUR_ANSWERS, DECLINED_BY_PRIVATE_MARKET },
 } = INSURANCE_ROUTES;
 
 const {
   EXPORT_CONTRACT: {
-    PRIVATE_MARKET: { ATTEMPTED },
+    PRIVATE_MARKET: { ATTEMPTED: FIELD_ID },
   },
 } = INSURANCE_FIELD_IDS;
+
+const ERROR_MESSAGE = ERROR_MESSAGES.INSURANCE.EXPORT_CONTRACT.PRIVATE_MARKET[FIELD_ID].IS_EMPTY;
+
+const ERROR_ASSERTIONS = {
+  numberOfExpectedErrors: 1,
+  errorIndex: 0,
+};
 
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Export contract - Private market page - As an exporter, I want to state whether I tried to get insurance through the private market previously, So that UKEF can ensure it is complementing rather than competing with the private market', () => {
   let referenceNumber;
   let url;
+  let declinedByPrivateMarketUrl;
+  let checkYourAnswersUrl;
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET}`;
+      url = `${baseUrl}${ROOT}/${referenceNumber}${PRIVATE_MARKET}`;
+      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+      declinedByPrivateMarketUrl = `${baseUrl}${ROOT}/${referenceNumber}${DECLINED_BY_PRIVATE_MARKET}`;
 
       // go to the page we want to test.
       cy.navigateToUrl(url);
@@ -53,8 +66,8 @@ context('Insurance - Export contract - Private market page - As an exporter, I w
   it('renders core page elements', () => {
     cy.corePageChecks({
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
-      currentHref: `${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET}`,
-      backLink: `${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET}#`,
+      currentHref: `${ROOT}/${referenceNumber}${PRIVATE_MARKET}`,
+      backLink: `${ROOT}/${referenceNumber}${PRIVATE_MARKET}#`,
     });
   });
 
@@ -67,7 +80,7 @@ context('Insurance - Export contract - Private market page - As an exporter, I w
       cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
     });
 
-    describe(`renders ${ATTEMPTED} label and inputs`, () => {
+    describe(`renders ${FIELD_ID} label and inputs`, () => {
       it('renders a hint', () => {
         cy.checkText(yesNoRadioHint(), CONTENT_STRINGS.HINT);
       });
@@ -116,6 +129,43 @@ context('Insurance - Export contract - Private market page - As an exporter, I w
 
     it('renders a `save and back` button', () => {
       cy.assertSaveAndBackButton();
+    });
+  });
+
+  describe('form submission', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    describe('when submitting an empty form', () => {
+      it(`should display validation errors if ${FIELD_ID} radio is not selected`, () => {
+        // cy.navigateToUrl(url);
+
+        const { numberOfExpectedErrors, errorIndex } = ERROR_ASSERTIONS;
+
+        const radioField = {
+          ...fieldSelector(FIELD_ID),
+          input: noRadioInput,
+        };
+
+        cy.submitAndAssertRadioErrors(radioField, errorIndex, numberOfExpectedErrors, ERROR_MESSAGE);
+      });
+    });
+
+    describe(`when selecting no for ${FIELD_ID}`, () => {
+      it(`should redirect to ${CHECK_YOUR_ANSWERS} page`, () => {
+        cy.completeAndSubmitPrivateMarketForm({ attempted: false });
+
+        cy.assertUrl(checkYourAnswersUrl);
+      });
+    });
+
+    describe(`when selecting yes for ${FIELD_ID}`, () => {
+      it(`should redirect to ${DECLINED_BY_PRIVATE_MARKET} page`, () => {
+        cy.completeAndSubmitPrivateMarketForm({ attempted: true });
+
+        cy.assertUrl(declinedByPrivateMarketUrl);
+      });
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/private-market.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/private-market.spec.js
@@ -139,8 +139,6 @@ context('Insurance - Export contract - Private market page - As an exporter, I w
 
     describe('when submitting an empty form', () => {
       it(`should display validation errors if ${FIELD_ID} radio is not selected`, () => {
-        // cy.navigateToUrl(url);
-
         const { numberOfExpectedErrors, errorIndex } = ERROR_ASSERTIONS;
 
         const radioField = {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee/loss-payee.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee/loss-payee.spec.js
@@ -134,8 +134,6 @@ context('Insurance - Policy - Loss payee page - As an exporter, I want to inform
 
     describe('when submitting an empty form', () => {
       it(`should display validation errors if ${FIELD_ID} radio is not selected`, () => {
-        cy.navigateToUrl(url);
-
         const { numberOfExpectedErrors, errorIndex } = ERROR_ASSERTIONS;
 
         const radioField = {

--- a/src/ui/server/constants/routes/insurance/export-contract.ts
+++ b/src/ui/server/constants/routes/insurance/export-contract.ts
@@ -2,6 +2,7 @@ const ROOT = '/export-contract';
 const ABOUT_GOODS_OR_SERVICES_ROOT = `${ROOT}/about-goods-or-services`;
 const HOW_WILL_YOU_GET_PAID_ROOT = `${ROOT}/how-will-you-get-paid`;
 const PRIVATE_MARKET_ROOT = `${ROOT}/private-market`;
+const DECLINED_BY_PRIVATE_MARKET_ROOT = `${ROOT}/declined-by-private-market`;
 
 export const EXPORT_CONTRACT = {
   ROOT,
@@ -17,5 +18,6 @@ export const EXPORT_CONTRACT = {
   PRIVATE_MARKET_SAVE_AND_BACK: `${PRIVATE_MARKET_ROOT}/save-and-go-back`,
   PRIVATE_MARKET_CHANGE: `${PRIVATE_MARKET_ROOT}/change`,
   PRIVATE_MARKET_CHECK_AND_CHANGE: `${PRIVATE_MARKET_ROOT}/check-and-change`,
+  DECLINED_BY_PRIVATE_MARKET: DECLINED_BY_PRIVATE_MARKET_ROOT,
   CHECK_YOUR_ANSWERS: `${ROOT}/check-your-answers`,
 };

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -155,6 +155,11 @@ export const ERROR_MESSAGES = {
           ABOVE_MAXIMUM: `The description of how you will get paid for your export cannot be more than a ${MAXIMUM_CHARACTERS.PAYMENT_TERMS_DESCRIPTION} characters`,
         },
       },
+      PRIVATE_MARKET: {
+        [FIELD_IDS.INSURANCE.EXPORT_CONTRACT.PRIVATE_MARKET.ATTEMPTED]: {
+          IS_EMPTY: 'Select if you have tried to insure this export through the private market',
+        },
+      },
     },
     POLICY: {
       TYPE_OF_POLICY: {

--- a/src/ui/server/test-mocks/mock-application.ts
+++ b/src/ui/server/test-mocks/mock-application.ts
@@ -47,6 +47,11 @@ export const mockExportContract = {
   paymentTermsDescription: 'Mock payment terms description',
 };
 
+export const mockPrivateMarket = {
+  id: 'clldfm6pt000noqa6fs6cj5xo',
+  attempted: false,
+};
+
 export const mockOwner = {
   id: mockAccount.id,
 };
@@ -144,6 +149,7 @@ const mockApplication = {
   policy: mockSinglePolicy,
   policyContact: mockContact,
   exportContract: mockExportContract,
+  privateMarket: mockPrivateMarket,
   company: mockCompany,
   business: mockBusiness,
   broker: mockBroker,


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the "Private market" POST controller so that the `ATTEMPTED` field must be provided. If not, validation errors are rendered.

## Resolution :heavy_check_mark:
- Update `completeAndSubmitPrivateMarketForm` cypress command to conditionallly submit the form with a yes or no answer.
- Create new `DECLINED_BY_PRIVATE_MARKET` route constant.
- Update error messages content strings.
- Update E2E test coverage.
- Update the "Private market" POST controller to:
  - Check for validation errors.
  - Redirect to `DECLINED_BY_PRIVATE_MARKET` if the provided answer is "yes".
- Update UI test mocks.
