### PR TITLE
feat(EMS-2936): No PDF - Export contract - Private market - Save and back

### DIFF
--- a/e2e-tests/commands/insurance/complete-and-submit-private-market-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-private-market-form.js
@@ -3,12 +3,8 @@
  * Complete and submit the "Tried to insure through the private market" form
  * @param {Boolean} attempted: Has attempted to insure through the private market
  */
-const completeAndSubmitPrivateMarketForm = ({ attempted = false }) => {
-  if (attempted) {
-    cy.clickYesRadioInput();
-  } else {
-    cy.clickNoRadioInput();
-  }
+const completeAndSubmitPrivateMarketForm = ({ attempted }) => {
+  cy.completePrivateMarketForm({ attempted });
 
   cy.clickSubmitButton();
 };

--- a/e2e-tests/commands/insurance/complete-private-market-form.js
+++ b/e2e-tests/commands/insurance/complete-private-market-form.js
@@ -1,0 +1,14 @@
+/**
+ * completePrivateMarketForm
+ * Complete the "Tried to insure through the private market" form
+ * @param {Boolean} attempted: Has attempted to insure through the private market. Defaults to false.
+ */
+const completePrivateMarketForm = ({ attempted = false }) => {
+  if (attempted) {
+    cy.clickYesRadioInput();
+  } else {
+    cy.clickNoRadioInput();
+  }
+};
+
+export default completePrivateMarketForm;

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/private-market.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/private-market.spec.js
@@ -9,7 +9,7 @@ import {
 import partials from '../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { ERROR_MESSAGES, PAGES, PRIVATE_MARKET_WHY_DESCRIPTION } from '../../../../../../content-strings';
-import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
+import FIELD_IDS from '../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const { privateMarketWhyDescription } = partials;
@@ -24,10 +24,8 @@ const {
 } = INSURANCE_ROUTES;
 
 const {
-  EXPORT_CONTRACT: {
-    PRIVATE_MARKET: { ATTEMPTED: FIELD_ID },
-  },
-} = INSURANCE_FIELD_IDS;
+  PRIVATE_MARKET: { ATTEMPTED: FIELD_ID },
+} = FIELD_IDS;
 
 const ERROR_MESSAGE = ERROR_MESSAGES.INSURANCE.EXPORT_CONTRACT.PRIVATE_MARKET[FIELD_ID].IS_EMPTY;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/save-and-back.spec.js
@@ -1,0 +1,106 @@
+import FIELD_IDS from '../../../../../../constants/field-ids/insurance/export-contract';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+
+const {
+  ROOT: INSURANCE_ROOT,
+  ALL_SECTIONS,
+  EXPORT_CONTRACT: { PRIVATE_MARKET },
+} = INSURANCE_ROUTES;
+
+const {
+  PRIVATE_MARKET: { ATTEMPTED: FIELD_ID },
+} = FIELD_IDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Export contract - Private market - Save and go back', () => {
+  let referenceNumber;
+  let url;
+  let allSectionsUrl;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({ totalContractValueOverThreshold: true }).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      // go to the page we want to test.
+      cy.startInsuranceExportContractSection({});
+      cy.completeAndSubmitAboutGoodsOrServicesForm({});
+      cy.completeAndSubmitHowYouWillGetPaidForm({});
+
+      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET}`;
+      allSectionsUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when submitting an empty form via `save and go back` button', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      cy.clickSaveAndBackButton();
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      const expected = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      cy.assertUrl(expected);
+    });
+  });
+
+  describe(`when selecting no for ${FIELD_ID}`, () => {
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      cy.navigateToUrl(url);
+
+      cy.completePrivateMarketForm({ attempted: false });
+      cy.clickSaveAndBackButton();
+
+      cy.assertUrl(allSectionsUrl);
+    });
+
+    describe('when going back to the page', () => {
+      it('should have the submitted value', () => {
+        cy.navigateToUrl(allSectionsUrl);
+
+        cy.startInsuranceExportContractSection({});
+
+        // go through 2 export contract forms.
+        cy.clickSubmitButtonMultipleTimes({ count: 2 });
+
+        cy.assertNoRadioOptionIsChecked();
+      });
+    });
+  });
+
+  describe(`when selecting yes for ${FIELD_ID}`, () => {
+    it(`should redirect to ${ALL_SECTIONS}`, () => {
+      cy.navigateToUrl(url);
+
+      cy.completePrivateMarketForm({ attempted: true });
+      cy.clickSaveAndBackButton();
+
+      cy.assertUrl(allSectionsUrl);
+    });
+
+    describe('when going back to the page', () => {
+      it('should have the submitted value', () => {
+        cy.navigateToUrl(allSectionsUrl);
+
+        cy.startInsuranceExportContractSection({});
+
+        // go through 2 export contract forms.
+        cy.clickSubmitButtonMultipleTimes({ count: 2 });
+
+        cy.assertYesRadioOptionIsChecked();
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/support/application/export-contract/index.js
+++ b/e2e-tests/insurance/cypress/support/application/export-contract/index.js
@@ -2,5 +2,6 @@ Cypress.Commands.add('completeAboutGoodsOrServicesForm', require('../../../../..
 Cypress.Commands.add('completeAndSubmitAboutGoodsOrServicesForm', require('../../../../../commands/insurance/complete-and-submit-about-goods-or-services-form'));
 Cypress.Commands.add('completeHowYouWillGetPaidForm', require('../../../../../commands/insurance/complete-how-you-will-get-paid-form'));
 Cypress.Commands.add('completeAndSubmitHowYouWillGetPaidForm', require('../../../../../commands/insurance/complete-and-submit-how-you-will-get-paid-form'));
+Cypress.Commands.add('completePrivateMarketForm', require('../../../../../commands/insurance/complete-private-market-form'));
 Cypress.Commands.add('completeAndSubmitPrivateMarketForm', require('../../../../../commands/insurance/complete-and-submit-private-market-form'));
 Cypress.Commands.add('completeAndSubmitDeclinedByPrivateMarketForm', require('../../../../../commands/insurance/complete-and-submit-declined-by-private-market-form'));

--- a/src/ui/server/controllers/insurance/export-contract/private-market/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/private-market/index.test.ts
@@ -13,7 +13,7 @@ import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
-  EXPORT_CONTRACT: { CHECK_YOUR_ANSWERS, DECLINED_BY_PRIVATE_MARKET },
+  EXPORT_CONTRACT: { CHECK_YOUR_ANSWERS, DECLINED_BY_PRIVATE_MARKET, PRIVATE_MARKET_SAVE_AND_BACK },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -98,7 +98,7 @@ describe('controllers/insurance/export-contract/private-market', () => {
 
       const expected = {
         FIELD_ID,
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${req.params.referenceNumber}#`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${req.params.referenceNumber}${PRIVATE_MARKET_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);

--- a/src/ui/server/controllers/insurance/export-contract/private-market/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/private-market/index.ts
@@ -11,7 +11,7 @@ import { Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
-  EXPORT_CONTRACT: { CHECK_YOUR_ANSWERS, DECLINED_BY_PRIVATE_MARKET },
+  EXPORT_CONTRACT: { CHECK_YOUR_ANSWERS, DECLINED_BY_PRIVATE_MARKET, PRIVATE_MARKET_SAVE_AND_BACK },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -54,7 +54,7 @@ export const HTML_FLAGS = {
  */
 export const pageVariables = (referenceNumber: number) => ({
   FIELD_ID,
-  SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}#`,
+  SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET_SAVE_AND_BACK}`,
 });
 
 /**

--- a/src/ui/server/controllers/insurance/export-contract/private-market/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/private-market/save-and-back/index.test.ts
@@ -1,0 +1,108 @@
+import { post } from '.';
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+import { ERROR_MESSAGE, FIELD_ID } from '..';
+import constructPayload from '../../../../../helpers/construct-payload';
+import mapAndSave from '../../map-and-save/private-market';
+import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
+import { Request, Response } from '../../../../../../types';
+import { mockApplication, mockCountries, mockReq, mockRes } from '../../../../../test-mocks';
+
+const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
+
+describe('controllers/insurance/export-contract/private-market/save-and-back', () => {
+  let req: Request;
+  let res: Response;
+
+  jest.mock('../../map-and-save/export-contract');
+
+  let mapAndSaveSpy = jest.fn(() => Promise.resolve(true));
+
+  const refNumber = Number(mockApplication.referenceNumber);
+
+  const mockFormBody = {
+    _csrf: '1234',
+    [FIELD_ID]: 'Mock description',
+  };
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+
+    req.params.referenceNumber = String(mockApplication.referenceNumber);
+
+    req.body = mockFormBody;
+
+    mapAndSave.privateMarket = mapAndSaveSpy;
+  });
+
+  describe('when the form has data', () => {
+    beforeEach(() => {
+      mapAndSave.privateMarket = mapAndSaveSpy;
+    });
+
+    describe(`when the form has ${FIELD_ID}`, () => {
+      beforeEach(() => {
+        req.body[FIELD_ID] = mockCountries[0].isoCode;
+      });
+
+      it('should call mapAndSave.privateMarket with data from constructPayload function, application and validationErrors', async () => {
+        await post(req, res);
+
+        const payload = constructPayload(req.body, [FIELD_ID]);
+
+        const validationErrors = generateValidationErrors(payload, FIELD_ID, ERROR_MESSAGE);
+
+        expect(mapAndSave.privateMarket).toHaveBeenCalledTimes(1);
+        expect(mapAndSave.privateMarket).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
+      });
+
+      it(`should redirect to ${ALL_SECTIONS}`, async () => {
+        await post(req, res);
+
+        const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+
+        expect(res.redirect).toHaveBeenCalledWith(expected);
+      });
+    });
+  });
+
+  describe('when the form does not have any data', () => {
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
+      req.body = { _csrf: '1234' };
+
+      await post(req, res);
+
+      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+
+      expect(res.redirect).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('when there is no application', () => {
+    beforeEach(() => {
+      delete res.locals.application;
+    });
+
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+      await post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+    });
+  });
+
+  describe('api error handling', () => {
+    describe('when the mapAndSave call fails', () => {
+      beforeEach(() => {
+        mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+
+        mapAndSave.privateMarket = mapAndSaveSpy;
+      });
+
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/export-contract/private-market/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/private-market/save-and-back/index.ts
@@ -1,0 +1,52 @@
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+import hasFormData from '../../../../../helpers/has-form-data';
+import { ERROR_MESSAGE, FIELD_ID } from '..';
+import constructPayload from '../../../../../helpers/construct-payload';
+import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
+import mapAndSave from '../../map-and-save/private-market';
+import { Request, Response } from '../../../../../../types';
+
+const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
+/**
+ * post
+ * Save any valid "How will you get paid" form fields and if successful, redirect to the all sections page
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.redirect} All sections page or error page
+ */
+export const post = async (req: Request, res: Response) => {
+  try {
+    const { application } = res.locals;
+
+    if (!application) {
+      return res.redirect(PROBLEM_WITH_SERVICE);
+    }
+
+    const { referenceNumber } = req.params;
+
+    /**
+     * If form data is populated:
+     * 1) generate a payload.
+     * 2) generate validation errors.
+     * 3) call mapAndSave
+     * 4) redirect
+     */
+    if (hasFormData(req.body)) {
+      const payload = constructPayload(req.body, [FIELD_ID]);
+
+      const validationErrors = generateValidationErrors(payload, FIELD_ID, ERROR_MESSAGE);
+
+      const saveResponse = await mapAndSave.privateMarket(payload, application, validationErrors);
+
+      if (!saveResponse) {
+        return res.redirect(PROBLEM_WITH_SERVICE);
+      }
+    }
+
+    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`);
+  } catch (err) {
+    console.error('Error updating application - export contract - how will you get paid (save and back) %O', err);
+
+    return res.redirect(PROBLEM_WITH_SERVICE);
+  }
+};

--- a/src/ui/server/controllers/insurance/export-contract/private-market/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/private-market/save-and-back/index.ts
@@ -9,7 +9,7 @@ import { Request, Response } from '../../../../../../types';
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 /**
  * post
- * Save any valid "How will you get paid" form fields and if successful, redirect to the all sections page
+ * Save any valid "Private market" form fields and if successful, redirect to the all sections page
  * @param {Express.Request} Express request
  * @param {Express.Response} Express response
  * @returns {Express.Response.redirect} All sections page or error page

--- a/src/ui/server/routes/insurance/export-contract/index.test.ts
+++ b/src/ui/server/routes/insurance/export-contract/index.test.ts
@@ -6,6 +6,7 @@ import { post as aboutGoodsOrServicesSaveAndBackPost } from '../../../controller
 import { get as howWillYouGetPaidGet, post as howWillYouGetPaidPost } from '../../../controllers/insurance/export-contract/how-will-you-get-paid';
 import { post as howWillYouGetPaidSaveAndBackPost } from '../../../controllers/insurance/export-contract/how-will-you-get-paid/save-and-back';
 import { get as privateMarketGet, post as privateMarketPost } from '../../../controllers/insurance/export-contract/private-market';
+import { post as privateMarketSaveAndBackPost } from '../../../controllers/insurance/export-contract/private-market/save-and-back';
 import {
   get as declinedByPrivateMarketGet,
   post as declinedByPrivateMarketPost,
@@ -21,6 +22,7 @@ const {
   HOW_WILL_YOU_GET_PAID,
   HOW_WILL_YOU_GET_PAID_SAVE_AND_BACK,
   PRIVATE_MARKET,
+  PRIVATE_MARKET_SAVE_AND_BACK,
   DECLINED_BY_PRIVATE_MARKET,
   CHECK_YOUR_ANSWERS,
 } = EXPORT_CONTRACT;
@@ -36,7 +38,7 @@ describe('routes/insurance/export-contract', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(8);
-    expect(post).toHaveBeenCalledTimes(9);
+    expect(post).toHaveBeenCalledTimes(10);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${ROOT}`, exportContractRootGet);
 
@@ -54,6 +56,7 @@ describe('routes/insurance/export-contract', () => {
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${PRIVATE_MARKET}`, privateMarketGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${PRIVATE_MARKET}`, privateMarketPost);
+    expect(post).toHaveBeenCalledWith(`/:referenceNumber${PRIVATE_MARKET_SAVE_AND_BACK}`, privateMarketSaveAndBackPost);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${DECLINED_BY_PRIVATE_MARKET}`, declinedByPrivateMarketGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${DECLINED_BY_PRIVATE_MARKET}`, declinedByPrivateMarketPost);

--- a/src/ui/server/routes/insurance/export-contract/index.ts
+++ b/src/ui/server/routes/insurance/export-contract/index.ts
@@ -6,6 +6,7 @@ import { post as aboutGoodsOrServicesSaveAndBackPost } from '../../../controller
 import { get as howWillYouGetPaidGet, post as howWillYouGetPaidPost } from '../../../controllers/insurance/export-contract/how-will-you-get-paid';
 import { post as howWillYouGetPaidSaveAndBackPost } from '../../../controllers/insurance/export-contract/how-will-you-get-paid/save-and-back';
 import { get as privateMarketGet, post as privateMarketPost } from '../../../controllers/insurance/export-contract/private-market';
+import { post as privateMarketSaveAndBackPost } from '../../../controllers/insurance/export-contract/private-market/save-and-back';
 import {
   get as declinedByPrivateMarketGet,
   post as declinedByPrivateMarketPost,
@@ -21,6 +22,7 @@ const {
   HOW_WILL_YOU_GET_PAID,
   HOW_WILL_YOU_GET_PAID_SAVE_AND_BACK,
   PRIVATE_MARKET,
+  PRIVATE_MARKET_SAVE_AND_BACK,
   DECLINED_BY_PRIVATE_MARKET,
   CHECK_YOUR_ANSWERS,
 } = EXPORT_CONTRACT;
@@ -44,6 +46,7 @@ exportContractRoute.post(`/:referenceNumber${HOW_WILL_YOU_GET_PAID_SAVE_AND_BACK
 
 exportContractRoute.get(`/:referenceNumber${PRIVATE_MARKET}`, privateMarketGet);
 exportContractRoute.post(`/:referenceNumber${PRIVATE_MARKET}`, privateMarketPost);
+exportContractRoute.post(`/:referenceNumber${PRIVATE_MARKET_SAVE_AND_BACK}`, privateMarketSaveAndBackPost);
 
 exportContractRoute.get(`/:referenceNumber${DECLINED_BY_PRIVATE_MARKET}`, declinedByPrivateMarketGet);
 exportContractRoute.post(`/:referenceNumber${DECLINED_BY_PRIVATE_MARKET}`, declinedByPrivateMarketPost);

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -22,7 +22,7 @@ describe('routes/insurance', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(170);
-    expect(post).toHaveBeenCalledTimes(169);
+    expect(post).toHaveBeenCalledTimes(170);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds "save and back" functionality to the "Private market" form, in the "Export contract" section of a no PDF application.

## Resolution :heavy_check_mark:
- Create new `completePrivateMarketForm` cypress command.
- Add E2E test coverage.
- Update UI GET controller to generate a real `SAVE_AND_BACK_URL`.
- Create a new UI POST route and controller.

## Miscellaneous :heavy_plus_sign:
- Simplify an E2E test's `FIELD_IDS` imports/destructuring.
