### PR TITLE
fix(EMS-3078): No PDF - Single/multiple contract policy - Alternative currency validation - Pre-selected radio

### DIFF
--- a/e2e-tests/commands/insurance/assert-currency-form-fields.js
+++ b/e2e-tests/commands/insurance/assert-currency-form-fields.js
@@ -115,6 +115,10 @@ const assertCurrencyFormFields = ({
 
     cy.clickSubmitButton();
 
+    const option = currencyRadio({ fieldId: alternativeCurrencyFieldId });
+
+    cy.assertRadioOptionIsChecked(option.input());
+
     cy.checkText(
       partials.errorSummaryListItems().eq(errorIndex),
       errors[alternativeCurrencyFieldId].IS_EMPTY,

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/change-your-answers-policy-single-policy-type.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/change-your-answers-policy-single-policy-type.spec.js
@@ -71,11 +71,27 @@ context('Insurance - Change your answers - Policy - Single contract policy - Sum
   describe('single policy type answers', () => {
     describe(REQUESTED_START_DATE, () => {
       const fieldId = REQUESTED_START_DATE;
-      let fieldVariables = getFieldVariables(fieldId, referenceNumber);
 
-      const newAnswer = {
+      const newStartDate = {
         ...application.POLICY[fieldId],
         year: application.POLICY[fieldId].year + 1,
+      };
+
+      const newEndDate = {
+        ...application.POLICY[fieldId],
+        year: newStartDate.year + 1,
+      };
+
+      const fieldVariables = {
+        startDate: {
+          ...getFieldVariables(fieldId, referenceNumber),
+          newValueInput: newStartDate.year,
+        },
+        endDate: {
+          ...application.POLICY[CONTRACT_COMPLETION_DATE],
+          ...getFieldVariables(CONTRACT_COMPLETION_DATE, referenceNumber),
+          newValueInput: newEndDate.year,
+        },
       };
 
       describe('when clicking the `change` link', () => {
@@ -85,26 +101,23 @@ context('Insurance - Change your answers - Policy - Single contract policy - Sum
 
         it(`should redirect to ${SINGLE_CONTRACT_POLICY_CHECK_AND_CHANGE}`, () => {
           cy.navigateToUrl(url);
-          fieldVariables = getFieldVariables(fieldId, referenceNumber);
 
-          cy.checkChangeLinkUrl(fieldVariables, referenceNumber);
+          cy.checkChangeLinkUrl(fieldVariables.startDate, referenceNumber);
         });
       });
 
       describe('form submission with a new answer', () => {
-        const contractCompletionDateYearChange = newAnswer.year + 1;
-
         beforeEach(() => {
           cy.navigateToUrl(url);
 
           summaryList.field(fieldId).changeLink().click();
 
-          fieldVariables.newValueInput = newAnswer.year;
+          cy.changeAnswerField(fieldVariables.startDate, field(fieldId).yearInput(), false);
 
-          cy.changeAnswerField(fieldVariables, field(fieldId).yearInput(), false);
-
-          fieldVariables.newValueInput = contractCompletionDateYearChange;
-          cy.changeAnswerField(fieldVariables, field(CONTRACT_COMPLETION_DATE).yearInput());
+          cy.changeAnswerField(
+            fieldVariables.endDate,
+            field(CONTRACT_COMPLETION_DATE).yearInput(),
+          );
         });
 
         it(`should redirect to ${TYPE_OF_POLICY}`, () => {
@@ -112,8 +125,10 @@ context('Insurance - Change your answers - Policy - Single contract policy - Sum
         });
 
         it('should render the new answer', () => {
-          fieldVariables.newValue = formatDate(createTimestampFromNumbers(newAnswer.day, newAnswer.month, contractCompletionDateYearChange));
-          cy.checkChangeAnswerRendered({ fieldVariables });
+          const { day, month, year } = newStartDate;
+
+          fieldVariables.startDate.newValue = formatDate(createTimestampFromNumbers(day, month, year));
+          cy.checkChangeAnswerRendered({ fieldVariables: fieldVariables.startDate });
         });
       });
     });

--- a/e2e-tests/shared-test-assertions/currency-form-fields/form-submission.js
+++ b/e2e-tests/shared-test-assertions/currency-form-fields/form-submission.js
@@ -21,7 +21,7 @@ const formSubmissionAssertions = ({
 }) => {
   const selectAltRadioButNoAltCurrency = ({ errorIndex = 0 }) => {
     describe('when selecting the alternative currency radio and NOT entering an alternative currency via the autocomplete input', () => {
-      it('should render validation errors', () => {
+      it('should pre-select the alternative currency option and render validation errors', () => {
         rendersAlternativeCurrencyValidationError({ errorIndex });
       });
     });

--- a/src/ui/server/controllers/insurance/business/turnover/alternative-currency/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/alternative-currency/index.test.ts
@@ -7,7 +7,6 @@ import { FIELDS } from '../../../../../content-strings/fields/insurance';
 import api from '../../../../../api';
 import mapRadioAndSelectOptions from '../../../../../helpers/mappings/map-currencies/radio-and-select-options';
 import constructPayload from '../../../../../helpers/construct-payload';
-import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import insuranceCorePageVariables from '../../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../../helpers/get-user-name-from-session';
 import generateValidationErrors from './validation';
@@ -186,7 +185,6 @@ describe('controllers/insurance/business/turnover/alternative-currency', () => {
           userName: getUserNameFromSession(req.session.user),
           ...mapRadioAndSelectOptions(alternativeCurrencies, supportedCurrencies, ''),
           validationErrors,
-          submittedValues: sanitiseData(payload),
         });
       });
     });

--- a/src/ui/server/controllers/insurance/business/turnover/alternative-currency/index.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/alternative-currency/index.ts
@@ -7,7 +7,6 @@ import api from '../../../../../api';
 import { isPopulatedArray } from '../../../../../helpers/array';
 import mapRadioAndSelectOptions from '../../../../../helpers/mappings/map-currencies/radio-and-select-options';
 import constructPayload from '../../../../../helpers/construct-payload';
-import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import insuranceCorePageVariables from '../../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../../helpers/get-user-name-from-session';
 import generateValidationErrors from './validation';
@@ -119,7 +118,6 @@ export const post = async (req: Request, res: Response) => {
         userName: getUserNameFromSession(req.session.user),
         ...mapRadioAndSelectOptions(alternativeCurrencies, supportedCurrencies, payload[CURRENCY_CODE]),
         validationErrors,
-        submittedValues: sanitiseData(payload),
       });
     }
 

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.ts
@@ -157,7 +157,7 @@ export const post = async (req: Request, res: Response) => {
         return res.redirect(PROBLEM_WITH_SERVICE);
       }
 
-      const currencyAnswer = application.policy[POLICY_CURRENCY_CODE];
+      const currencyAnswer = application.policy[POLICY_CURRENCY_CODE] || payload[CURRENCY_CODE];
 
       return res.render(TEMPLATE, {
         ...insuranceCorePageVariables({

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/index.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/index.ts
@@ -154,7 +154,7 @@ export const post = async (req: Request, res: Response) => {
         return res.redirect(PROBLEM_WITH_SERVICE);
       }
 
-      const currencyAnswer = application.policy[POLICY_CURRENCY_CODE];
+      const currencyAnswer = application.policy[POLICY_CURRENCY_CODE] || payload[CURRENCY_CODE];
 
       return res.render(TEMPLATE, {
         ...insuranceCorePageVariables({

--- a/src/ui/server/controllers/insurance/your-buyer/alternative-currency/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/alternative-currency/index.test.ts
@@ -235,7 +235,6 @@ describe('controllers/insurance/your-buyer/alternative-currency', () => {
           }),
           userName: getUserNameFromSession(req.session.user),
           ...PAGE_VARIABLES,
-          submittedValues: payload,
           validationErrors,
           ...mapRadioAndSelectOptions(alternativeCurrencies, supportedCurrencies, payload[ALTERNATIVE_CURRENCY_CODE]),
         };

--- a/src/ui/server/controllers/insurance/your-buyer/alternative-currency/index.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/alternative-currency/index.ts
@@ -11,7 +11,6 @@ import api from '../../../../api';
 import { isPopulatedArray } from '../../../../helpers/array';
 import mapRadioAndSelectOptions from '../../../../helpers/mappings/map-currencies/radio-and-select-options';
 import constructPayload from '../../../../helpers/construct-payload';
-import { sanitiseData } from '../../../../helpers/sanitise-data';
 import isChangeRoute from '../../../../helpers/is-change-route';
 import isCheckAndChangeRoute from '../../../../helpers/is-check-and-change-route';
 import { Request, Response } from '../../../../../types';
@@ -118,7 +117,6 @@ export const post = async (req: Request, res: Response) => {
         ...PAGE_VARIABLES,
         userName: getUserNameFromSession(req.session.user),
         validationErrors,
-        submittedValues: sanitiseData(payload),
         ...mapRadioAndSelectOptions(alternativeCurrencies, supportedCurrencies, payload[CURRENCY_CODE]),
       });
     }

--- a/src/ui/server/shared-validation/date/index.test.ts
+++ b/src/ui/server/shared-validation/date/index.test.ts
@@ -77,6 +77,7 @@ describe('shared-validation/date', () => {
     it('should a return validation error', () => {
       const mockSubmittedData = {
         ...mockValidBody,
+        [`${FIELD_ID}-month`]: month,
         [`${FIELD_ID}-day`]: invalidDay,
       };
 

--- a/src/ui/server/test-mocks/mock-application.ts
+++ b/src/ui/server/test-mocks/mock-application.ts
@@ -165,4 +165,20 @@ export const mockApplicationMultiplePolicy = {
   policy: mockMultiplePolicy,
 } as Application;
 
+export const mockApplicationSinglePolicyWithoutCurrencyCode = {
+  ...mockApplication,
+  policy: {
+    ...mockApplication.policy,
+    policyCurrencyCode: '',
+  },
+} as Application;
+
+export const mockApplicationMultiplePolicyWithoutCurrencyCode = {
+  ...mockApplicationMultiplePolicy,
+  policy: {
+    ...mockApplicationMultiplePolicy.policy,
+    policyCurrencyCode: '',
+  },
+} as Application;
+
 export default mockApplication;


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue in the single and multiple contract policy forms where, if the "alternative currency" radio option is selected, but there are other validation errors, the "alternative currency" radio option  would not be pre-selected.

## Resolution :heavy_check_mark:
- Update the DRY, shared E2E currency form field assertions (`assertCurrencyFormFields`), to check that the "alternative currency" radio option is checked when there are validation errors.
- Update single and multiple contract policy POST controllers to conditionally use the `POLICY_CURRENCY_CODE` from the submtited values during validation errors.

## Miscellaneous :heavy_plus_sign:
- Remove some unnecessary `submittedValues` properties  from 2x GET controllers.
- Fix a UI date validation unit test that was failing due to the current time of year.
- Fix an E2E test that was failing due to an end date being generated as before the start date, due to the current time of year.
