### PR TITLE
fix(EMS-3081): No PDF - Policy - Loss payee details URL

### DIFF
--- a/e2e-tests/constants/routes/insurance/policy/loss-payee.js
+++ b/e2e-tests/constants/routes/insurance/policy/loss-payee.js
@@ -3,7 +3,7 @@ import POLICY_ROOT from './root';
 const ROOT = `${POLICY_ROOT}/loss-payee`;
 const LOSS_PAYEE_DETAILS_ROOT = `${POLICY_ROOT}/loss-payee-details`;
 const LOSS_PAYEE_FINANCIAL_DETAILS_UK_ROOT = `${POLICY_ROOT}/loss-payee-bank-details`;
-const LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT = `${ROOT}/loss-payee-international-bank-details`;
+const LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT = `${POLICY_ROOT}/loss-payee-international-bank-details`;
 
 const LOSS_PAYEE_ROUTES = {
   LOSS_PAYEE_ROOT: ROOT,

--- a/src/ui/server/constants/routes/insurance/policy/loss-payee.ts
+++ b/src/ui/server/constants/routes/insurance/policy/loss-payee.ts
@@ -3,7 +3,7 @@ import POLICY_ROOT from './root';
 const ROOT = `${POLICY_ROOT}/loss-payee`;
 const LOSS_PAYEE_DETAILS_ROOT = `${POLICY_ROOT}/loss-payee-details`;
 const LOSS_PAYEE_FINANCIAL_DETAILS_UK_ROOT = `${POLICY_ROOT}/loss-payee-bank-details`;
-const LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT = `${ROOT}/loss-payee-international-bank-details`;
+const LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT = `${POLICY_ROOT}/loss-payee-international-bank-details`;
 
 const LOSS_PAYEE_ROUTES = {
   LOSS_PAYEE_ROOT: ROOT,


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an incorrect URL for the "loss payee - international financial details"  route in a No PDF application.

- Before: `/policy/loss-payee/loss-payee/international-bank-details`
- After: `/policy/loss-payee-international-bank-details`

## Resolution :heavy_check_mark:
- Update route constants.
