### PR TITLE
chore(tech): Upgrade docker syntax to V2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,7 +164,7 @@ jobs:
           MOCK_ACCOUNT_PASSWORD: ${{ secrets.MOCK_ACCOUNT_PASSWORD }}
           JWT_SIGNING_KEY: ${{ secrets.JWT_SIGNING_KEY }}
         run: |
-          docker-compose up --build -d
+          docker compose up --build -d
           npm run ci:all
           npm run test --prefix ./src/api
 
@@ -298,7 +298,7 @@ jobs:
         run: npm run ci:all
 
       - name: Docker
-        run: docker-compose up --build -d
+        run: docker compose up --build -d
 
       - name: Wait
         run: sleep 30s
@@ -361,7 +361,7 @@ jobs:
         run: npm run ci:all
 
       - name: Docker
-        run: docker-compose up --build -d
+        run: docker compose up --build -d
 
       - name: Wait
         run: sleep 30s
@@ -413,7 +413,7 @@ jobs:
         run: npm run ci:all
 
       - name: Docker
-        run: docker-compose up --build -d
+        run: docker compose up --build -d
 
       - name: Wait
         run: sleep 30s

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This project utilizes various technologies and tools, including:
 
 To run the project locally, follow these steps:
 
-1. Execute `docker-compose up` from the root directory. Use `--build` for the first-time usage.
+1. Execute `docker compose up` from the root directory. Use `--build` for the first-time usage.
 2. Visit [https://localhost:5000](https://localhost:5000) in your web browser.
 3. If presented with the certificate not trusted error, then please accept and proceed with certificate is self-signed for domain `localhost`.
 


### PR DESCRIPTION
## Introduction :pencil2:
GitHub Actions has stoped supporting `docker-compose` as per their migration plan https://github.com/actions/runner-images/issues/9557.

## Resolution :heavy_check_mark:
- Upgrade to docker `v2` syntax.
