### PR TITLE
chore(sonarCloud): Simplify UI unit test error handling describe blocks

### DIFF
--- a/src/ui/server/controllers/insurance/account/create/confirm-email-resent/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/confirm-email-resent/index.test.ts
@@ -127,20 +127,18 @@ describe('controllers/insurance/account/create/confirm-email-resent', () => {
       });
     });
 
-    describe('api error handling', () => {
-      describe('when there is an error', () => {
-        beforeEach(() => {
-          req.query.id = mockAccount.id;
+    describe('when there is an error calling the API', () => {
+      beforeAll(() => {
+        req.query.id = mockAccount.id;
 
-          getAccountSpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.account.get = getAccountSpy;
-        });
+        getAccountSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        api.keystone.account.get = getAccountSpy;
+      });
 
-        it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
-          await get(req, res);
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await get(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-        });
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
       });
     });
   });

--- a/src/ui/server/controllers/insurance/account/create/confirm-email/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/confirm-email/index.test.ts
@@ -98,18 +98,16 @@ describe('controllers/insurance/account/create/confirm-email', () => {
       });
     });
 
-    describe('api error handling', () => {
-      describe('when there is an error', () => {
-        beforeAll(() => {
-          getAccountSpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.account.get = getAccountSpy;
-        });
+    describe('when there is an error calling the API', () => {
+      beforeAll(() => {
+        getAccountSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        api.keystone.account.get = getAccountSpy;
+      });
 
-        it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
-          await get(req, res);
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await get(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-        });
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
       });
     });
   });

--- a/src/ui/server/controllers/insurance/account/create/resend-confirm-email/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/resend-confirm-email/index.test.ts
@@ -86,18 +86,16 @@ describe('controllers/insurance/account/create/resend-confirm-email', () => {
       });
     });
 
-    describe('api error handling', () => {
-      describe('when there is an error', () => {
-        beforeEach(() => {
-          sendEmailConfirmEmailAddressSpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.account.sendEmailConfirmEmailAddress = sendEmailConfirmEmailAddressSpy;
-        });
+    describe('when there is an error calling the API', () => {
+      beforeAll(() => {
+        sendEmailConfirmEmailAddressSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        api.keystone.account.sendEmailConfirmEmailAddress = sendEmailConfirmEmailAddressSpy;
+      });
 
-        it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
-          await get(req, res);
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await get(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-        });
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
       });
     });
   });

--- a/src/ui/server/controllers/insurance/account/create/verify-email/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/verify-email/index.test.ts
@@ -152,22 +152,20 @@ describe('controllers/insurance/account/create/verify-email', () => {
       });
     });
 
-    describe('api error handling', () => {
-      describe('when there is an error', () => {
-        beforeEach(() => {
-          req.query.token = mockToken;
-          req.query.id = mockAccount.id;
+    describe('when there is an error calling the API', () => {
+      beforeEach(() => {
+        req.query.token = mockToken;
+        req.query.id = mockAccount.id;
 
-          verifyEmailAddressSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        verifyEmailAddressSpy = jest.fn(() => Promise.reject(new Error('mock')));
 
-          api.keystone.account.verifyEmailAddress = verifyEmailAddressSpy;
-        });
+        api.keystone.account.verifyEmailAddress = verifyEmailAddressSpy;
+      });
 
-        it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
-          await get(req, res);
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await get(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-        });
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
       });
     });
   });

--- a/src/ui/server/controllers/insurance/account/sign-in/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/index.test.ts
@@ -320,20 +320,18 @@ describe('controllers/insurance/account/sign-in', () => {
       });
     });
 
-    describe('api error handling', () => {
-      describe('when there is an error', () => {
-        beforeEach(() => {
-          req.body = validBody;
+    describe('when there is an error calling the API', () => {
+      beforeEach(() => {
+        req.body = validBody;
 
-          accountSignInSpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.account.signIn = accountSignInSpy;
-        });
+        accountSignInSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        api.keystone.account.signIn = accountSignInSpy;
+      });
 
-        it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
-          await post(req, res);
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-        });
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
       });
     });
   });

--- a/src/ui/server/controllers/insurance/account/sign-in/request-new-code/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/request-new-code/index.test.ts
@@ -123,18 +123,16 @@ describe('controllers/insurance/account/sign-in/request-new-code', () => {
       });
     });
 
-    describe('api error handling', () => {
-      describe('when there is an error', () => {
-        beforeEach(() => {
-          signInSendNewCodeSpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.account.signInSendNewCode = signInSendNewCodeSpy;
-        });
+    describe('when there is an error calling the API', () => {
+      beforeAll(() => {
+        signInSendNewCodeSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        api.keystone.account.signInSendNewCode = signInSendNewCodeSpy;
+      });
 
-        it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
-          await post(req, res);
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-        });
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
       });
     });
   });

--- a/src/ui/server/controllers/insurance/check-your-answers/save-data/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/save-data/index.test.ts
@@ -41,23 +41,19 @@ describe('controllers/insurance/check-your-answers/save-data', () => {
     expect(result).toEqual(mockUpdateApplicationResponse);
   });
 
-  describe('api error handling', () => {
-    describe('update declarations call', () => {
-      describe('when there is an error', () => {
-        beforeEach(() => {
-          updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.application.update.declarations = updateApplicationSpy;
-        });
+  describe('when there is an error calling the API', () => {
+    beforeAll(() => {
+      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      api.keystone.application.update.declarations = updateApplicationSpy;
+    });
 
-        it('should throw an error', async () => {
-          try {
-            await save.sectionReview(mockApplication, mockFormBody);
-          } catch (err) {
-            const expected = new Error("Updating application's section review");
-            expect(err).toEqual(expected);
-          }
-        });
-      });
+    it('should throw an error', async () => {
+      try {
+        await save.sectionReview(mockApplication, mockFormBody);
+      } catch (err) {
+        const expected = new Error("Updating application's section review");
+        expect(err).toEqual(expected);
+      }
     });
   });
 });

--- a/src/ui/server/controllers/insurance/dashboard/index.test.ts
+++ b/src/ui/server/controllers/insurance/dashboard/index.test.ts
@@ -138,20 +138,18 @@ describe('controllers/insurance/dashboard', () => {
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
     });
 
-    describe('api error handling', () => {
-      describe('when there is an error', () => {
-        beforeAll(() => {
-          const mockError = new Error('mock');
-          getApplicationsSpy = jest.fn(() => Promise.reject(mockError));
+    describe('when there is an error calling the API', () => {
+      beforeAll(() => {
+        const mockError = new Error('mock');
+        getApplicationsSpy = jest.fn(() => Promise.reject(mockError));
 
-          api.keystone.applications.getAll = getApplicationsSpy;
-        });
+        api.keystone.applications.getAll = getApplicationsSpy;
+      });
 
-        it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
-          await get(req, res);
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await get(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-        });
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
       });
     });
   });

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/index.test.ts
@@ -107,18 +107,16 @@ describe('controllers/insurance/declarations/anti-bribery', () => {
       });
     });
 
-    describe('api error handling', () => {
-      describe('when there is an error', () => {
-        beforeAll(() => {
-          getLatestAntiBriberySpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.application.declarations.getLatestAntiBribery = getLatestAntiBriberySpy;
-        });
+    describe('when there is an error calling the API', () => {
+      beforeAll(() => {
+        getLatestAntiBriberySpy = jest.fn(() => Promise.reject(new Error('mock')));
+        api.keystone.application.declarations.getLatestAntiBribery = getLatestAntiBriberySpy;
+      });
 
-        it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
-          await get(req, res);
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await get(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-        });
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
       });
     });
   });

--- a/src/ui/server/controllers/insurance/declarations/confirmation-and-acknowledgements/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/confirmation-and-acknowledgements/index.test.ts
@@ -105,19 +105,17 @@ describe('controllers/insurance/declarations/confirmation-and-acknowledgements',
       });
     });
 
-    describe('api error handling', () => {
-      describe('when there is an error', () => {
-        beforeAll(() => {
-          getLatestConfirmationAndAcknowledgementSpy = jest.fn(() => Promise.reject(new Error('mock')));
+    describe('when there is an error calling the API', () => {
+      beforeAll(() => {
+        getLatestConfirmationAndAcknowledgementSpy = jest.fn(() => Promise.reject(new Error('mock')));
 
-          api.keystone.application.declarations.getLatestConfirmationAndAcknowledgement = getLatestConfirmationAndAcknowledgementSpy;
-        });
+        api.keystone.application.declarations.getLatestConfirmationAndAcknowledgement = getLatestConfirmationAndAcknowledgementSpy;
+      });
 
-        it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
-          await get(req, res);
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await get(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-        });
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
       });
     });
   });

--- a/src/ui/server/controllers/insurance/declarations/how-your-data-will-be-used/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/how-your-data-will-be-used/index.test.ts
@@ -108,19 +108,17 @@ describe('controllers/insurance/declarations/how-your-data-will-be-used', () => 
       });
     });
 
-    describe('api error handling', () => {
-      describe('when there is an error', () => {
-        beforeAll(() => {
-          getLatestHowDataWillBeUsedSpy = jest.fn(() => Promise.reject(new Error('mock')));
+    describe('when there is an error calling the API', () => {
+      beforeAll(() => {
+        getLatestHowDataWillBeUsedSpy = jest.fn(() => Promise.reject(new Error('mock')));
 
-          api.keystone.application.declarations.getLatestHowDataWillBeUsed = getLatestHowDataWillBeUsedSpy;
-        });
+        api.keystone.application.declarations.getLatestHowDataWillBeUsed = getLatestHowDataWillBeUsedSpy;
+      });
 
-        it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
-          await get(req, res);
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await get(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
-        });
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
       });
     });
   });

--- a/src/ui/server/controllers/insurance/declarations/save-data/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/save-data/index.test.ts
@@ -45,23 +45,19 @@ describe('controllers/insurance/declarations/save-data', () => {
     expect(result).toEqual(mockUpdateApplicationResponse);
   });
 
-  describe('api error handling', () => {
-    describe('update declarations call', () => {
-      describe('when there is an error', () => {
-        beforeEach(() => {
-          updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.application.update.declarations = updateApplicationSpy;
-        });
+  describe('when there is an error calling the API', () => {
+    beforeEach(() => {
+      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      api.keystone.application.update.declarations = updateApplicationSpy;
+    });
 
-        it('should throw an error', async () => {
-          try {
-            await save.declaration(mockApplication, mockFormBody);
-          } catch (err) {
-            const expected = new Error("Updating application's declarations");
-            expect(err).toEqual(expected);
-          }
-        });
-      });
+    it('should throw an error', async () => {
+      try {
+        await save.declaration(mockApplication, mockFormBody);
+      } catch (err) {
+        const expected = new Error("Updating application's declarations");
+        expect(err).toEqual(expected);
+      }
     });
   });
 });

--- a/src/ui/server/controllers/insurance/export-contract/save-data/export-contract/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/export-contract/index.test.ts
@@ -67,22 +67,18 @@ describe('controllers/insurance/export-contract/save-data/export-contract', () =
   });
 
   describe('api error handling', () => {
-    describe('update exportContract call', () => {
-      describe('when there is an error', () => {
-        beforeEach(() => {
-          updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.application.update.exportContract = updateApplicationSpy;
-        });
+    beforeEach(() => {
+      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      api.keystone.application.update.exportContract = updateApplicationSpy;
+    });
 
-        it('should throw an error', async () => {
-          try {
-            await save.exportContract(mockApplication, mockFormBody.valid);
-          } catch (err) {
-            const expected = new Error("Updating application's exportContract");
-            expect(err).toEqual(expected);
-          }
-        });
-      });
+    it('should throw an error', async () => {
+      try {
+        await save.exportContract(mockApplication, mockFormBody.valid);
+      } catch (err) {
+        const expected = new Error("Updating application's exportContract");
+        expect(err).toEqual(expected);
+      }
     });
   });
 });

--- a/src/ui/server/controllers/insurance/export-contract/save-data/private-market/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/private-market/index.test.ts
@@ -66,23 +66,19 @@ describe('controllers/insurance/export-contract/save-data/private-market', () =>
     });
   });
 
-  describe('api error handling', () => {
-    describe('update privateMarket call', () => {
-      describe('when there is an error', () => {
-        beforeEach(() => {
-          updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.application.update.privateMarket = updateApplicationSpy;
-        });
+  describe('when there is an error calling the API', () => {
+    beforeAll(() => {
+      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      api.keystone.application.update.privateMarket = updateApplicationSpy;
+    });
 
-        it('should throw an error', async () => {
-          try {
-            await save.privateMarket(mockApplication, mockFormBody.valid);
-          } catch (err) {
-            const expected = new Error("Updating application's privateMarket");
-            expect(err).toEqual(expected);
-          }
-        });
-      });
+    it('should throw an error', async () => {
+      try {
+        await save.privateMarket(mockApplication, mockFormBody.valid);
+      } catch (err) {
+        const expected = new Error("Updating application's privateMarket");
+        expect(err).toEqual(expected);
+      }
     });
   });
 });

--- a/src/ui/server/controllers/insurance/policy/save-data/broker/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/broker/index.api-error.test.ts
@@ -3,27 +3,19 @@ import api from '../../../../../api';
 import { mockApplication, mockBroker } from '../../../../../test-mocks';
 
 describe('controllers/insurance/policy/save-data/broker - API error', () => {
-  const mockUpdateApplicationResponse = mockApplication;
-  let updateApplicationSpy = jest.fn(() => Promise.resolve(mockUpdateApplicationResponse));
   const mockFormBody = mockBroker;
 
   beforeEach(() => {
+    const updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
     api.keystone.application.update.broker = updateApplicationSpy;
   });
 
-  describe('when there is an error', () => {
-    beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
-      api.keystone.application.update.broker = updateApplicationSpy;
-    });
-
-    it('should throw an error', async () => {
-      try {
-        await save.broker(mockApplication, mockFormBody);
-      } catch (err) {
-        const expected = new Error("Updating application's broker");
-        expect(err).toEqual(expected);
-      }
-    });
+  it('should throw an error', async () => {
+    try {
+      await save.broker(mockApplication, mockFormBody);
+    } catch (err) {
+      const expected = new Error("Updating application's broker");
+      expect(err).toEqual(expected);
+    }
   });
 });

--- a/src/ui/server/controllers/insurance/policy/save-data/jointly-insured-party/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/jointly-insured-party/index.api-error.test.ts
@@ -3,27 +3,19 @@ import api from '../../../../../api';
 import { mockApplication, mockJointlyInsuredParty } from '../../../../../test-mocks';
 
 describe('controllers/insurance/policy/save-data/jointly-insured-policy - API error', () => {
-  const mockUpdateApplicationResponse = mockApplication;
-  let updateApplicationSpy = jest.fn(() => Promise.resolve(mockUpdateApplicationResponse));
   const mockFormBody = mockJointlyInsuredParty;
 
   beforeEach(() => {
+    const updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
     api.keystone.application.update.jointlyInsuredParty = updateApplicationSpy;
   });
 
-  describe('when there is an error', () => {
-    beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
-      api.keystone.application.update.jointlyInsuredParty = updateApplicationSpy;
-    });
-
-    it('should throw an error', async () => {
-      try {
-        await save.jointlyInsuredParty(mockApplication, mockFormBody);
-      } catch (err) {
-        const expected = new Error("Updating application's jointly insured party");
-        expect(err).toEqual(expected);
-      }
-    });
+  it('should throw an error', async () => {
+    try {
+      await save.jointlyInsuredParty(mockApplication, mockFormBody);
+    } catch (err) {
+      const expected = new Error("Updating application's jointly insured party");
+      expect(err).toEqual(expected);
+    }
   });
 });

--- a/src/ui/server/controllers/insurance/policy/save-data/nominated-loss-payee/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/nominated-loss-payee/index.api-error.test.ts
@@ -3,27 +3,19 @@ import api from '../../../../../api';
 import { mockApplication, mockNominatedLossPayee } from '../../../../../test-mocks';
 
 describe('controllers/insurance/policy/save-data/nominated-loss-payee - API error', () => {
-  const mockUpdateApplicationResponse = mockApplication;
-  let updateApplicationSpy = jest.fn(() => Promise.resolve(mockUpdateApplicationResponse));
   const mockFormBody = mockNominatedLossPayee;
 
   beforeEach(() => {
+    const updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
     api.keystone.application.update.nominatedLossPayee = updateApplicationSpy;
   });
 
-  describe('when there is an error', () => {
-    beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
-      api.keystone.application.update.nominatedLossPayee = updateApplicationSpy;
-    });
-
-    it('should throw an error', async () => {
-      try {
-        await save.nominatedLossPayee(mockApplication, mockFormBody);
-      } catch (err) {
-        const expected = new Error("Updating application's nominated loss payee");
-        expect(err).toEqual(expected);
-      }
-    });
+  it('should throw an error', async () => {
+    try {
+      await save.nominatedLossPayee(mockApplication, mockFormBody);
+    } catch (err) {
+      const expected = new Error("Updating application's nominated loss payee");
+      expect(err).toEqual(expected);
+    }
   });
 });

--- a/src/ui/server/controllers/insurance/policy/save-data/policy-contact/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/policy-contact/index.test.ts
@@ -64,23 +64,19 @@ describe('controllers/insurance/policy/save-data/policy-contact', () => {
     });
   });
 
-  describe('api error handling', () => {
-    describe('update policyContact call', () => {
-      describe('when there is an error', () => {
-        beforeEach(() => {
-          updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.application.update.policyContact = updateApplicationSpy;
-        });
+  describe('when there is an error calling the API', () => {
+    beforeEach(() => {
+      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      api.keystone.application.update.policyContact = updateApplicationSpy;
+    });
 
-        it('should throw an error', async () => {
-          try {
-            await save.policyContact(mockApplication, mockFormBody.valid);
-          } catch (err) {
-            const expected = new Error("Updating application's policy contact");
-            expect(err).toEqual(expected);
-          }
-        });
-      });
+    it('should throw an error', async () => {
+      try {
+        await save.policyContact(mockApplication, mockFormBody.valid);
+      } catch (err) {
+        const expected = new Error("Updating application's policy contact");
+        expect(err).toEqual(expected);
+      }
     });
   });
 });

--- a/src/ui/server/controllers/insurance/policy/save-data/policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/policy/index.test.ts
@@ -74,23 +74,19 @@ describe('controllers/insurance/policy/save-data/policy', () => {
     });
   });
 
-  describe('api error handling', () => {
-    describe('update policy call', () => {
-      describe('when there is an error', () => {
-        beforeEach(() => {
-          updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.application.update.policy = updateApplicationSpy;
-        });
+  describe('when there is an error calling the API', () => {
+    beforeEach(() => {
+      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      api.keystone.application.update.policy = updateApplicationSpy;
+    });
 
-        it('should throw an error', async () => {
-          try {
-            await save.policy(mockApplication, mockFormBody.valid);
-          } catch (err) {
-            const expected = new Error("Updating application's policy");
-            expect(err).toEqual(expected);
-          }
-        });
-      });
+    it('should throw an error', async () => {
+      try {
+        await save.policy(mockApplication, mockFormBody.valid);
+      } catch (err) {
+        const expected = new Error("Updating application's policy");
+        expect(err).toEqual(expected);
+      }
     });
   });
 });

--- a/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-relationship/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-relationship/index.test.ts
@@ -65,25 +65,19 @@ describe('controllers/insurance/your-buyer/save-data/buyer-relationship', () => 
     });
   });
 
-  describe('api error handling', () => {
-    describe('update buyerRelationship call', () => {
-      const mockFormBody = mockBuyerRelationship;
+  describe('when there is an error calling the API', () => {
+    beforeAll(() => {
+      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      api.keystone.application.update.buyerRelationship = updateApplicationSpy;
+    });
 
-      describe('when there is an error', () => {
-        beforeEach(() => {
-          updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.application.update.buyerRelationship = updateApplicationSpy;
-        });
-
-        it('should throw an error', async () => {
-          try {
-            await save.buyerRelationship(mockApplication, mockFormBody);
-          } catch (err) {
-            const expected = new Error('Updating buyer relationship');
-            expect(err).toEqual(expected);
-          }
-        });
-      });
+    it('should throw an error', async () => {
+      try {
+        await save.buyerRelationship(mockApplication, mockBuyerRelationship);
+      } catch (err) {
+        const expected = new Error('Updating buyer relationship');
+        expect(err).toEqual(expected);
+      }
     });
   });
 });

--- a/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-trading-history/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-trading-history/index.test.ts
@@ -70,25 +70,19 @@ describe('controllers/insurance/your-buyer/save-data/buyer-trading-history', () 
     });
   });
 
-  describe('api error handling', () => {
-    describe('update buyer call', () => {
-      const mockFormBody = mockBuyerTradingHistory;
+  describe('when there is an error calling the API', () => {
+    beforeAll(() => {
+      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      api.keystone.application.update.buyerTradingHistory = updateApplicationSpy;
+    });
 
-      describe('when there is an error', () => {
-        beforeEach(() => {
-          updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.application.update.buyerTradingHistory = updateApplicationSpy;
-        });
-
-        it('should throw an error', async () => {
-          try {
-            await save.buyerTradingHistory(mockApplication, mockFormBody);
-          } catch (err) {
-            const expected = new Error('Updating buyer trading history');
-            expect(err).toEqual(expected);
-          }
-        });
-      });
+    it('should throw an error', async () => {
+      try {
+        await save.buyerTradingHistory(mockApplication, mockBuyerTradingHistory);
+      } catch (err) {
+        const expected = new Error('Updating buyer trading history');
+        expect(err).toEqual(expected);
+      }
     });
   });
 });

--- a/src/ui/server/controllers/insurance/your-buyer/save-data/buyer/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/save-data/buyer/index.test.ts
@@ -60,25 +60,19 @@ describe('controllers/insurance/your-buyer/save-data/buyer', () => {
     });
   });
 
-  describe('api error handling', () => {
-    describe('update buyer call', () => {
-      const mockFormBody = mockBuyer;
+  describe('when there is an error calling the API', () => {
+    beforeAll(() => {
+      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      api.keystone.application.update.buyer = updateApplicationSpy;
+    });
 
-      describe('when there is an error', () => {
-        beforeEach(() => {
-          updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
-          api.keystone.application.update.buyer = updateApplicationSpy;
-        });
-
-        it('should throw an error', async () => {
-          try {
-            await save.buyer(mockApplication, mockFormBody);
-          } catch (err) {
-            const expected = new Error("Updating application's buyer");
-            expect(err).toEqual(expected);
-          }
-        });
-      });
+    it('should throw an error', async () => {
+      try {
+        await save.buyer(mockApplication, mockBuyer);
+      } catch (err) {
+        const expected = new Error("Updating application's buyer");
+        expect(err).toEqual(expected);
+      }
     });
   });
 });


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes some issues reported by SonarCloud, where there are too many nested describe/it blocks in some API error handling unit tests.

For example:

**Before**

```js
describe('api error handling', () => {
  describe('update declarations call', () => {
    describe('when there is an error', () => {
      beforeEach(() => {
        // ...
      });

      it('should throw an error', async () => {
        // ...
      });
    });
  });
});
```

**After**
```js
describe('when there is an error calling the API', () => {
  beforeAll(() => {
    // ...
  });

  it('should throw an error', async () => {
    // ...
  });
});
```

## Resolution :heavy_check_mark:
- Simplify all API error handling unit tests in the UI's `save-data` directories.

## Miscellaneous :heavy_plus_sign:
- Ensure the said describe blocks are using `beforeAll` instead of `beforeEach`, since there is only 1 test.
- Remove some unnecessary initial declarations of `updateApplicationSpy`.
