### PR TITLE
feat(EMS-3089-3112): No PDF - Export contract - Check/change answers - Payment terms description

### DIFF
--- a/e2e-tests/commands/insurance/check-export-contract-summary-list.js
+++ b/e2e-tests/commands/insurance/check-export-contract-summary-list.js
@@ -1,5 +1,6 @@
 import { summaryList } from '../../pages/shared';
 import getSummaryListField from './get-summary-list-field';
+import { EXPECTED_SINGLE_LINE_STRING } from '../../constants';
 import FIELD_IDS from '../../constants/field-ids/insurance/export-contract';
 import { EXPORT_CONTRACT_FIELDS as FIELDS } from '../../content-strings/fields/insurance/export-contract';
 import application from '../../fixtures/application';
@@ -38,11 +39,23 @@ const checkExportContractSummaryList = ({
   [PAYMENT_TERMS_DESCRIPTION]: () => {
     const fieldId = PAYMENT_TERMS_DESCRIPTION;
 
-    const { expectedKey, expectedChangeLinkText } = getSummaryListField(fieldId, FIELDS.HOW_WILL_YOU_GET_PAID);
+    const { expectedKey } = getSummaryListField(fieldId, FIELDS.HOW_WILL_YOU_GET_PAID);
 
-    const expectedValue = application.EXPORT_CONTRACT.HOW_WILL_YOU_GET_PAID[fieldId];
+    const row = summaryList.field(fieldId);
 
-    cy.assertSummaryListRow(summaryList, fieldId, expectedKey, expectedValue, expectedChangeLinkText);
+    cy.checkText(
+      row.key(),
+      expectedKey,
+    );
+
+    row.value().contains(EXPECTED_SINGLE_LINE_STRING);
+
+    const expectedLineBreaks = 3;
+
+    cy.assertLength(
+      row.valueHtmlLineBreak(),
+      expectedLineBreaks,
+    );
   },
 });
 

--- a/e2e-tests/fixtures/application.js
+++ b/e2e-tests/fixtures/application.js
@@ -168,7 +168,7 @@ const application = {
     [DESCRIPTION]: 'Mock description',
     [FINAL_DESTINATION]: COUNTRY_APPLICATION_SUPPORT.ONLINE.ISO_CODE,
     HOW_WILL_YOU_GET_PAID: {
-      [PAYMENT_TERMS_DESCRIPTION]: 'Mock payment terms description',
+      [PAYMENT_TERMS_DESCRIPTION]: MULTI_LINE_STRING,
     },
     PRIVATE_MARKET: {
       [ATTEMPTED]: true,

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-about-goods-or-services.spec.js
@@ -61,7 +61,7 @@ context('Insurance - Export contract - Change your answers - About goods or serv
     });
 
     describe('form submission with a new answer', () => {
-      const newAnswer = `${application.EXPORT_CONTRACT.ABOUT_GOODS_OR_SERVICES[fieldId]} additional text`;
+      const newAnswer = `${application.EXPORT_CONTRACT[fieldId]} additional text`;
 
       beforeEach(() => {
         cy.navigateToUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-about-goods-or-services.spec.js
@@ -61,7 +61,7 @@ context('Insurance - Export contract - Change your answers - About goods or serv
     });
 
     describe('form submission with a new answer', () => {
-      const newAnswer = `${application.POLICY[fieldId]} additional text`;
+      const newAnswer = `${application.EXPORT_CONTRACT.ABOUT_GOODS_OR_SERVICES[fieldId]} additional text`;
 
       beforeEach(() => {
         cy.navigateToUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-how-will-you-get-paid-total-contract-value-over-threshold.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-how-will-you-get-paid-total-contract-value-over-threshold.spec.js
@@ -1,0 +1,73 @@
+import { summaryList } from '../../../../../../pages/shared';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import FIELD_IDS from '../../../../../../constants/field-ids/insurance/export-contract';
+import application from '../../../../../../fixtures/application';
+
+const {
+  ROOT,
+  EXPORT_CONTRACT: {
+    CHECK_YOUR_ANSWERS,
+    PRIVATE_MARKET_CHANGE,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  HOW_WILL_YOU_GET_PAID: { PAYMENT_TERMS_DESCRIPTION: FIELD_ID },
+} = FIELD_IDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Export contract - Change your answers - How you will get paid - With total contract value over threshold', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({ totalContractValueOverThreshold: true }).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completeExportContractSection({ totalContractValueOverThreshold: true });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe(FIELD_ID, () => {
+    describe('form submission with a new answer', () => {
+      const newAnswer = `${application.EXPORT_CONTRACT.HOW_WILL_YOU_GET_PAID[FIELD_ID]} additional text`;
+
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+
+        summaryList.field(FIELD_ID).changeLink().click();
+
+        cy.completeAndSubmitHowYouWillGetPaidForm({
+          paymentTermsDescription: newAnswer,
+        });
+      });
+
+      it(`should redirect to ${PRIVATE_MARKET_CHANGE}`, () => {
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: PRIVATE_MARKET_CHANGE, fieldId: FIELD_ID });
+      });
+
+      it('should render the new answer', () => {
+        /**
+         * Submit the PRIVATE_MARKET form,
+         * to get back to CHECK_YOUR_ANSWERS.
+         */
+        cy.clickSubmitButton();
+
+        cy.assertSummaryListRowValue(summaryList, FIELD_ID, newAnswer);
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-how-will-you-get-paid-total-contract-value-over-threshold.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-how-will-you-get-paid-total-contract-value-over-threshold.spec.js
@@ -1,7 +1,6 @@
 import { summaryList } from '../../../../../../pages/shared';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/export-contract';
-import application from '../../../../../../fixtures/application';
 
 const {
   ROOT,
@@ -43,7 +42,7 @@ context('Insurance - Export contract - Change your answers - How you will get pa
 
   describe(FIELD_ID, () => {
     describe('form submission with a new answer', () => {
-      const newAnswer = `${application.EXPORT_CONTRACT.HOW_WILL_YOU_GET_PAID[FIELD_ID]} additional text`;
+      const newAnswer = 'Mock new description';
 
       beforeEach(() => {
         cy.navigateToUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-how-will-you-get-paid.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/change-your-answers-how-will-you-get-paid.spec.js
@@ -1,0 +1,76 @@
+import { summaryList } from '../../../../../../pages/shared';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import FIELD_IDS from '../../../../../../constants/field-ids/insurance/export-contract';
+
+const {
+  ROOT,
+  EXPORT_CONTRACT: {
+    CHECK_YOUR_ANSWERS,
+    HOW_WILL_YOU_GET_PAID_CHANGE,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  HOW_WILL_YOU_GET_PAID: { PAYMENT_TERMS_DESCRIPTION: FIELD_ID },
+} = FIELD_IDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Export contract - Change your answers - How you will get paid - As an exporter, I want to check my answers for the questions concerning how I will get paid for my export', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completeExportContractSection({ totalContractValueOverThreshold: false });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe(FIELD_ID, () => {
+    describe('when clicking the `change` link', () => {
+      it(`should redirect to ${HOW_WILL_YOU_GET_PAID_CHANGE}`, () => {
+        cy.navigateToUrl(url);
+
+        summaryList.field(FIELD_ID).changeLink().click();
+
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: HOW_WILL_YOU_GET_PAID_CHANGE, fieldId: FIELD_ID });
+      });
+    });
+
+    describe('form submission with a new answer', () => {
+      const newAnswer = 'Mock new description';
+
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+
+        summaryList.field(FIELD_ID).changeLink().click();
+
+        cy.completeAndSubmitHowYouWillGetPaidForm({
+          paymentTermsDescription: newAnswer,
+        });
+      });
+
+      it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId: FIELD_ID });
+      });
+
+      it('should render the new answer', () => {
+        cy.assertSummaryListRowValue(summaryList, FIELD_ID, newAnswer);
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/how-will-you-get-paid.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/how-will-you-get-paid.spec.js
@@ -1,11 +1,10 @@
 import { headingCaption } from '../../../../../../pages/shared';
 import { howWillYouGetPaidPage } from '../../../../../../pages/insurance/export-contract';
-import { MAXIMUM_CHARACTERS } from '../../../../../../constants';
+import { EXPECTED_MULTI_LINE_STRING, MAXIMUM_CHARACTERS } from '../../../../../../constants';
 import { ERROR_MESSAGES, PAGES } from '../../../../../../content-strings';
 import { EXPORT_CONTRACT_FIELDS as FIELD_STRINGS } from '../../../../../../content-strings/fields/insurance/export-contract';
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
-import application from '../../../../../../fixtures/application';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.EXPORT_CONTRACT.HOW_WILL_YOU_GET_PAID;
 
@@ -146,11 +145,9 @@ context('Insurance - Export contract - How will you get paid page - As an export
       it('should have the submitted values', () => {
         cy.navigateToUrl(url);
 
-        const expectedValue = application.EXPORT_CONTRACT.HOW_WILL_YOU_GET_PAID[FIELD_ID];
-
         cy.checkTextareaValue({
           fieldId: FIELD_ID,
-          expectedValue,
+          expectedValue: EXPECTED_MULTI_LINE_STRING,
         });
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/save-and-back.spec.js
@@ -1,4 +1,5 @@
 import { howWillYouGetPaidPage } from '../../../../../../pages/insurance/export-contract';
+import { EXPECTED_MULTI_LINE_STRING } from '../../../../../../constants';
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import application from '../../../../../../fixtures/application';
@@ -90,7 +91,7 @@ context('Insurance - Export contract - How will you get paid page - Save and go 
 
       cy.checkTextareaValue({
         fieldId: FIELD_ID,
-        expectedValue: value,
+        expectedValue: EXPECTED_MULTI_LINE_STRING,
       });
     });
   });

--- a/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/index.ts
@@ -9,12 +9,13 @@ import mapApplicationToFormFields from '../../../../helpers/mappings/map-applica
 import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/export-contract';
+import isChangeRoute from '../../../../helpers/is-change-route';
 import { Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
   PROBLEM_WITH_SERVICE,
-  EXPORT_CONTRACT: { HOW_WILL_YOU_GET_PAID_SAVE_AND_BACK, PRIVATE_MARKET, AGENT },
+  EXPORT_CONTRACT: { HOW_WILL_YOU_GET_PAID_SAVE_AND_BACK, PRIVATE_MARKET, PRIVATE_MARKET_CHANGE, AGENT, CHECK_YOUR_ANSWERS },
 } = INSURANCE_ROUTES;
 
 const {
@@ -108,12 +109,29 @@ export const post = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
+    const { totalContractValueOverThreshold } = application;
+
+    if (isChangeRoute(req.originalUrl)) {
+      /**
+       * If the URL is a "change" route
+       * and totalContractValue is over the threshold,
+       * redirect to PRIVATE_MARKET with /change in URL.
+       * This ensures that the next page can consume /change in the URL
+       * and therefore correctly redirect on submission.
+       */
+      if (totalContractValueOverThreshold) {
+        return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET_CHANGE}`);
+      }
+
+      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`);
+    }
+
     /**
      * if totalContractValue is over the threshold
      * redirect to PRIVATE_MARKET
      * otherwise it should redirect to the AGENT page
      */
-    if (application.totalContractValueOverThreshold) {
+    if (totalContractValueOverThreshold) {
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET}`);
     }
 

--- a/src/ui/server/controllers/insurance/export-contract/private-market/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/private-market/index.test.ts
@@ -13,7 +13,7 @@ import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
-  EXPORT_CONTRACT: { DECLINED_BY_PRIVATE_MARKET, PRIVATE_MARKET_SAVE_AND_BACK, AGENT },
+  EXPORT_CONTRACT: { CHECK_YOUR_ANSWERS, DECLINED_BY_PRIVATE_MARKET, PRIVATE_MARKET_SAVE_AND_BACK, PRIVATE_MARKET_CHANGE, AGENT },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -98,7 +98,7 @@ describe('controllers/insurance/export-contract/private-market', () => {
 
       const expected = {
         FIELD_ID,
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${req.params.referenceNumber}${PRIVATE_MARKET_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -178,7 +178,19 @@ describe('controllers/insurance/export-contract/private-market', () => {
         it(`should redirect to ${AGENT}`, async () => {
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${req.params.referenceNumber}${AGENT}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${AGENT}`;
+          expect(res.redirect).toHaveBeenCalledWith(expected);
+        });
+      });
+
+      describe("when the answer is false and the url's last substring is `change` and application.totalContractValueOverThreshold is true", () => {
+        it(`should redirect to ${CHECK_YOUR_ANSWERS}`, async () => {
+          req.originalUrl = PRIVATE_MARKET_CHANGE;
+
+          await post(req, res);
+
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
       });

--- a/src/ui/server/controllers/insurance/export-contract/private-market/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/private-market/index.ts
@@ -7,11 +7,12 @@ import getUserNameFromSession from '../../../../helpers/get-user-name-from-sessi
 import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../map-and-save/private-market';
+import isChangeRoute from '../../../../helpers/is-change-route';
 import { Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
-  EXPORT_CONTRACT: { DECLINED_BY_PRIVATE_MARKET, PRIVATE_MARKET_SAVE_AND_BACK, AGENT },
+  EXPORT_CONTRACT: { DECLINED_BY_PRIVATE_MARKET, PRIVATE_MARKET_SAVE_AND_BACK, AGENT, CHECK_YOUR_ANSWERS },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -122,6 +123,10 @@ export const post = async (req: Request, res: Response) => {
 
     if (answer === 'true') {
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${DECLINED_BY_PRIVATE_MARKET}`);
+    }
+
+    if (isChangeRoute(req.originalUrl)) {
+      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`);
     }
 
     return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${AGENT}`);

--- a/src/ui/server/controllers/insurance/your-buyer/trading-history/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/trading-history/index.test.ts
@@ -12,7 +12,15 @@ import constructPayload from '../../../../helpers/construct-payload';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import mapAndSave from '../map-and-save/buyer-trading-history';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockCurrencies, mockCurrenciesResponse } from '../../../../test-mocks';
+import {
+  mockReq,
+  mockRes,
+  mockApplication,
+  mockApplicationTotalContractValueThresholdTrue,
+  mockApplicationTotalContractValueThresholdFalse,
+  mockCurrencies,
+  mockCurrenciesResponse,
+} from '../../../../test-mocks';
 import getCurrencyByCode from '../../../../helpers/get-currency-by-code';
 import api from '../../../../api';
 
@@ -276,10 +284,7 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
 
       describe('when application.totalContractValueOverThreshold is true', () => {
         it(`should redirect to ${CREDIT_INSURANCE_COVER}`, async () => {
-          res.locals.application = {
-            ...mockApplication,
-            totalContractValueOverThreshold: true,
-          };
+          res.locals.application = mockApplicationTotalContractValueThresholdTrue;
 
           await post(req, res);
 
@@ -291,10 +296,7 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
 
       describe('when application.totalContractValueOverThreshold is NOT true', () => {
         it('should redirect to the next page', async () => {
-          res.locals.application = {
-            ...mockApplication,
-            totalContractValueOverThreshold: false,
-          };
+          res.locals.application = mockApplicationTotalContractValueThresholdFalse;
 
           await post(req, res);
           const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;

--- a/src/ui/server/helpers/summary-lists/export-contract/about-the-export-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/export-contract/about-the-export-fields/index.test.ts
@@ -6,8 +6,9 @@ import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
 import fieldGroupItem from '../../generate-field-group-item';
 import getFieldById from '../../../get-field-by-id';
 import getCountryByIsoCode from '../../../get-country-by-iso-code';
-import { mockApplication, mockCountries } from '../../../../test-mocks';
 import generateChangeLink from '../../../generate-change-link';
+import replaceNewLineWithLineBreak from '../../../replace-new-line-with-line-break';
+import { mockApplication, mockCountries } from '../../../../test-mocks';
 
 const {
   ABOUT_GOODS_OR_SERVICES: { DESCRIPTION, FINAL_DESTINATION },
@@ -20,7 +21,12 @@ const {
 
 const {
   INSURANCE_ROOT,
-  EXPORT_CONTRACT: { ABOUT_GOODS_OR_SERVICES_CHANGE, ABOUT_GOODS_OR_SERVICES_CHECK_AND_CHANGE },
+  EXPORT_CONTRACT: {
+    ABOUT_GOODS_OR_SERVICES_CHANGE,
+    ABOUT_GOODS_OR_SERVICES_CHECK_AND_CHANGE,
+    HOW_WILL_YOU_GET_PAID_CHANGE,
+    HOW_WILL_YOU_GET_PAID_CHECK_AND_CHANGE,
+  },
 } = INSURANCE_ROUTES;
 
 describe('server/helpers/summary-lists/export-contract/about-goods-or-services-fields', () => {
@@ -57,10 +63,16 @@ describe('server/helpers/summary-lists/export-contract/about-goods-or-services-f
         fieldGroupItem(
           {
             field: getFieldById(FIELDS.HOW_WILL_YOU_GET_PAID, PAYMENT_TERMS_DESCRIPTION),
-            href: generateChangeLink('#', '#', `#${PAYMENT_TERMS_DESCRIPTION}-label`, referenceNumber, checkAndChange),
+            href: generateChangeLink(
+              HOW_WILL_YOU_GET_PAID_CHANGE,
+              HOW_WILL_YOU_GET_PAID_CHECK_AND_CHANGE,
+              `#${PAYMENT_TERMS_DESCRIPTION}-label`,
+              referenceNumber,
+              checkAndChange,
+            ),
             renderChangeLink: true,
           },
-          mockAnswers[PAYMENT_TERMS_DESCRIPTION],
+          replaceNewLineWithLineBreak(mockAnswers[PAYMENT_TERMS_DESCRIPTION]),
         ),
       ],
     };

--- a/src/ui/server/helpers/summary-lists/export-contract/about-the-export-fields/index.ts
+++ b/src/ui/server/helpers/summary-lists/export-contract/about-the-export-fields/index.ts
@@ -5,8 +5,9 @@ import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
 import fieldGroupItem from '../../generate-field-group-item';
 import getFieldById from '../../../get-field-by-id';
 import getCountryByIsoCode from '../../../get-country-by-iso-code';
-import { ApplicationExportContract, Country, SummaryListItemData } from '../../../../../types';
 import generateChangeLink from '../../../generate-change-link';
+import replaceNewLineWithLineBreak from '../../../replace-new-line-with-line-break';
+import { ApplicationExportContract, Country, SummaryListItemData } from '../../../../../types';
 
 const {
   EXPORT_CONTRACT: { ABOUT_THE_EXPORT: FORM_TITLE },
@@ -18,7 +19,12 @@ const {
 } = FIELD_IDS;
 
 const {
-  EXPORT_CONTRACT: { ABOUT_GOODS_OR_SERVICES_CHANGE, ABOUT_GOODS_OR_SERVICES_CHECK_AND_CHANGE },
+  EXPORT_CONTRACT: {
+    ABOUT_GOODS_OR_SERVICES_CHANGE,
+    ABOUT_GOODS_OR_SERVICES_CHECK_AND_CHANGE,
+    HOW_WILL_YOU_GET_PAID_CHANGE,
+    HOW_WILL_YOU_GET_PAID_CHECK_AND_CHANGE,
+  },
 } = INSURANCE_ROUTES;
 
 /**
@@ -61,10 +67,16 @@ const generateAboutTheExportFields = (answers: ApplicationExportContract, refere
     fieldGroupItem(
       {
         field: getFieldById(FIELDS.HOW_WILL_YOU_GET_PAID, PAYMENT_TERMS_DESCRIPTION),
-        href: generateChangeLink('#', '#', `#${PAYMENT_TERMS_DESCRIPTION}-label`, referenceNumber, checkAndChange),
+        href: generateChangeLink(
+          HOW_WILL_YOU_GET_PAID_CHANGE,
+          HOW_WILL_YOU_GET_PAID_CHECK_AND_CHANGE,
+          `#${PAYMENT_TERMS_DESCRIPTION}-label`,
+          referenceNumber,
+          checkAndChange,
+        ),
         renderChangeLink: true,
       },
-      answers[PAYMENT_TERMS_DESCRIPTION],
+      replaceNewLineWithLineBreak(answers[PAYMENT_TERMS_DESCRIPTION]),
     ),
   ] as Array<SummaryListItemData>;
 

--- a/src/ui/server/routes/insurance/export-contract/index.test.ts
+++ b/src/ui/server/routes/insurance/export-contract/index.test.ts
@@ -22,8 +22,10 @@ const {
   ABOUT_GOODS_OR_SERVICES_CHANGE,
   ABOUT_GOODS_OR_SERVICES_CHECK_AND_CHANGE,
   HOW_WILL_YOU_GET_PAID,
+  HOW_WILL_YOU_GET_PAID_CHANGE,
   HOW_WILL_YOU_GET_PAID_SAVE_AND_BACK,
   PRIVATE_MARKET,
+  PRIVATE_MARKET_CHANGE,
   PRIVATE_MARKET_SAVE_AND_BACK,
   DECLINED_BY_PRIVATE_MARKET,
   DECLINED_BY_PRIVATE_MARKET_SAVE_AND_BACK,
@@ -41,8 +43,8 @@ describe('routes/insurance/export-contract', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(9);
-    expect(post).toHaveBeenCalledTimes(12);
+    expect(get).toHaveBeenCalledTimes(11);
+    expect(post).toHaveBeenCalledTimes(14);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${ROOT}`, exportContractRootGet);
 
@@ -57,10 +59,14 @@ describe('routes/insurance/export-contract', () => {
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${HOW_WILL_YOU_GET_PAID}`, howWillYouGetPaidGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${HOW_WILL_YOU_GET_PAID}`, howWillYouGetPaidPost);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${HOW_WILL_YOU_GET_PAID_SAVE_AND_BACK}`, howWillYouGetPaidSaveAndBackPost);
+    expect(get).toHaveBeenCalledWith(`/:referenceNumber${HOW_WILL_YOU_GET_PAID_CHANGE}`, howWillYouGetPaidGet);
+    expect(post).toHaveBeenCalledWith(`/:referenceNumber${HOW_WILL_YOU_GET_PAID_CHANGE}`, howWillYouGetPaidPost);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${PRIVATE_MARKET}`, privateMarketGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${PRIVATE_MARKET}`, privateMarketPost);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${PRIVATE_MARKET_SAVE_AND_BACK}`, privateMarketSaveAndBackPost);
+    expect(get).toHaveBeenCalledWith(`/:referenceNumber${PRIVATE_MARKET_CHANGE}`, privateMarketGet);
+    expect(post).toHaveBeenCalledWith(`/:referenceNumber${PRIVATE_MARKET_CHANGE}`, privateMarketPost);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${DECLINED_BY_PRIVATE_MARKET}`, declinedByPrivateMarketGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${DECLINED_BY_PRIVATE_MARKET}`, declinedByPrivateMarketPost);

--- a/src/ui/server/routes/insurance/export-contract/index.ts
+++ b/src/ui/server/routes/insurance/export-contract/index.ts
@@ -22,8 +22,10 @@ const {
   ABOUT_GOODS_OR_SERVICES_CHANGE,
   ABOUT_GOODS_OR_SERVICES_CHECK_AND_CHANGE,
   HOW_WILL_YOU_GET_PAID,
+  HOW_WILL_YOU_GET_PAID_CHANGE,
   HOW_WILL_YOU_GET_PAID_SAVE_AND_BACK,
   PRIVATE_MARKET,
+  PRIVATE_MARKET_CHANGE,
   PRIVATE_MARKET_SAVE_AND_BACK,
   DECLINED_BY_PRIVATE_MARKET,
   DECLINED_BY_PRIVATE_MARKET_SAVE_AND_BACK,
@@ -47,10 +49,14 @@ exportContractRoute.post(`/:referenceNumber${ABOUT_GOODS_OR_SERVICES_CHECK_AND_C
 exportContractRoute.get(`/:referenceNumber${HOW_WILL_YOU_GET_PAID}`, howWillYouGetPaidGet);
 exportContractRoute.post(`/:referenceNumber${HOW_WILL_YOU_GET_PAID}`, howWillYouGetPaidPost);
 exportContractRoute.post(`/:referenceNumber${HOW_WILL_YOU_GET_PAID_SAVE_AND_BACK}`, howWillYouGetPaidSaveAndBackPost);
+exportContractRoute.get(`/:referenceNumber${HOW_WILL_YOU_GET_PAID_CHANGE}`, howWillYouGetPaidGet);
+exportContractRoute.post(`/:referenceNumber${HOW_WILL_YOU_GET_PAID_CHANGE}`, howWillYouGetPaidPost);
 
 exportContractRoute.get(`/:referenceNumber${PRIVATE_MARKET}`, privateMarketGet);
 exportContractRoute.post(`/:referenceNumber${PRIVATE_MARKET}`, privateMarketPost);
 exportContractRoute.post(`/:referenceNumber${PRIVATE_MARKET_SAVE_AND_BACK}`, privateMarketSaveAndBackPost);
+exportContractRoute.get(`/:referenceNumber${PRIVATE_MARKET_CHANGE}`, privateMarketGet);
+exportContractRoute.post(`/:referenceNumber${PRIVATE_MARKET_CHANGE}`, privateMarketPost);
 
 exportContractRoute.get(`/:referenceNumber${DECLINED_BY_PRIVATE_MARKET}`, declinedByPrivateMarketGet);
 exportContractRoute.post(`/:referenceNumber${DECLINED_BY_PRIVATE_MARKET}`, declinedByPrivateMarketPost);

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -21,8 +21,8 @@ describe('routes/insurance', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(171);
-    expect(post).toHaveBeenCalledTimes(172);
+    expect(get).toHaveBeenCalledTimes(173);
+    expect(post).toHaveBeenCalledTimes(174);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);

--- a/src/ui/server/test-mocks/index.ts
+++ b/src/ui/server/test-mocks/index.ts
@@ -9,7 +9,13 @@ import mockCountries from './mock-countries';
 import mockCurrencies, { EUR, HKD, JPY, GBP, USD, mockCurrenciesResponse, mockCurrenciesEmptyResponse } from './mock-currencies';
 import mockCompaniesHouseResponse from './mock-companies-house-response';
 import mockCompany from './mock-company';
-import mockApplication, { mockApplicationMultiplePolicy, mockBusiness, mockCompanyDifferentTradingAddress } from './mock-application';
+import mockApplication, {
+  mockApplicationMultiplePolicy,
+  mockApplicationTotalContractValueThresholdTrue,
+  mockApplicationTotalContractValueThresholdFalse,
+  mockBusiness,
+  mockCompanyDifferentTradingAddress,
+} from './mock-application';
 import mockApplications from './mock-applications';
 import mockEligibility from './mock-eligibility';
 import mockErrorMessagesObject from './mock-error-messages-object';
@@ -111,6 +117,8 @@ export {
   mockApplication,
   mockApplicationMultiplePolicy,
   mockApplications,
+  mockApplicationTotalContractValueThresholdTrue,
+  mockApplicationTotalContractValueThresholdFalse,
   mockBroker,
   mockBusiness,
   mockContact,

--- a/src/ui/server/test-mocks/mock-application.ts
+++ b/src/ui/server/test-mocks/mock-application.ts
@@ -181,4 +181,19 @@ export const mockApplicationMultiplePolicyWithoutCurrencyCode = {
   },
 } as Application;
 
+// export const mockApplicationTotalContractValueThresholdFalse = {
+//   ...mockApplication,
+//   totalContractValueOverThreshold: false,
+// } as Application;
+
+export const mockApplicationTotalContractValueThresholdTrue = {
+  ...mockApplication,
+  totalContractValueOverThreshold: true,
+} as Application;
+
+export const mockApplicationTotalContractValueThresholdFalse = {
+  ...mockApplication,
+  totalContractValueOverThreshold: false,
+} as Application;
+
 export default mockApplication;

--- a/src/ui/server/test-mocks/mock-application.ts
+++ b/src/ui/server/test-mocks/mock-application.ts
@@ -181,11 +181,6 @@ export const mockApplicationMultiplePolicyWithoutCurrencyCode = {
   },
 } as Application;
 
-// export const mockApplicationTotalContractValueThresholdFalse = {
-//   ...mockApplication,
-//   totalContractValueOverThreshold: false,
-// } as Application;
-
 export const mockApplicationTotalContractValueThresholdTrue = {
   ...mockApplication,
   totalContractValueOverThreshold: true,


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds the ability to change a previously provided answer for the `PAYMENT_TERMS_DESCRIPTION` field, via the "check your answers" summary list.

## Resolution :heavy_check_mark:
- Update E2E mock `PAYMENT_TERMS_DESCRIPTION` to use `MULTI_LINE_STRING`.
- Update `checkExportContractSummaryList` and all "How will you get paid" E2E tests to assert the `PAYMENT_TERMS_DESCRIPTION` as a multi line string.
- Add E2E test coverage for changing the `PAYMENT_TERMS_DESCRIPTION` when:
  - The application's total contract value is below the threshold.
  - The application's total contract value is above the threshold (the user journey differes if so).
- Update "How will you get paid" POST controller to redirect to `PRIVATE_MARKET_CHANGE` or `CHECK_YOUR_ANSWERS`, if the application's total contract value is over the threshold.
- Update "Private market" POST controller to redirect to `CHECK_YOUR_ANSWERS` if the route is a "change" route.
- Update the export contract summary list to generate the `PAYMENT_TERMS_DESCRIPTION` field value via `replaceNewLineWithLineBreak` helper function.
- Add new UI routes:
  - GET `HOW_WILL_YOU_GET_PAID_CHANGE`
  - POST `HOW_WILL_YOU_GET_PAID_CHANGE`
  - GET `PRIVATE_MARKET_CHANGE`
  - POST `PRIVATE_MARKET_CHANGE`

## Miscellaneous :heavy_plus_sign:
- Update an "About goods ot services" E2E test to use the correct mock/fixture.
- Create new DRY UI test mocks, update all relevant unit tests:
  - `mockApplicationTotalContractValueThresholdTrue`
  - `mockApplicationTotalContractValueThresholdFalse`
