### PR TITLE
chore(EMS-3156): No PDF - Simplify UI unit test referenceNumber instances

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -298,10 +298,10 @@ var EXPORT_CONTRACT = {
     DECLINED_DESCRIPTION: "declinedDescription"
   },
   USING_AGENT: "isUsingAgent",
-  AGENT: {
-    COUNTRY_CODE: "countryCode",
+  AGENT_DETAILS: {
+    NAME: "name",
     FULL_ADDRESS: "fullAddress",
-    NAME: "name"
+    COUNTRY_CODE: "countryCode"
   },
   AGENT_SERVICE: {
     IS_CHARGING: "agentIsCharging",

--- a/src/ui/server/controllers/insurance/account/create/your-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/index.test.ts
@@ -13,7 +13,7 @@ import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import mapEligibilityAnswers from '../../../../../helpers/map-eligibility-answers';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockAccount, mockApplication, mockSession } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockAccount, mockSession, referenceNumber } from '../../../../../test-mocks';
 
 const { FIRST_NAME, LAST_NAME, EMAIL, PASSWORD } = ACCOUNT_FIELD_IDS;
 
@@ -27,8 +27,6 @@ const {
     PROBLEM_WITH_SERVICE,
   },
 } = ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/account/create/your-details', () => {
   let req: Request;

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
@@ -11,7 +11,7 @@ import generateValidationErrors from './validation';
 import accessCodeValidationErrors from './validation/rules/access-code';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockAccount, mockApplication, mockSession, mockApplications } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockAccount, referenceNumber, mockSession, mockApplications } from '../../../../../test-mocks';
 
 const {
   ACCOUNT: { ACCESS_CODE },
@@ -32,8 +32,6 @@ const {
 describe('controllers/insurance/account/sign-in/enter-code', () => {
   let req: Request;
   let res: Response;
-
-  const { referenceNumber } = mockApplication;
 
   beforeEach(() => {
     req = mockReq();

--- a/src/ui/server/controllers/insurance/application-submitted/index.test.ts
+++ b/src/ui/server/controllers/insurance/application-submitted/index.test.ts
@@ -5,7 +5,7 @@ import insuranceCorePageVariables from '../../../helpers/page-variables/core/ins
 import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
 import mapApplicationToFormFields from '../../../helpers/mappings/map-application-to-form-fields';
 import { Request, Response } from '../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../test-mocks';
 
 const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE },
@@ -70,7 +70,7 @@ describe('controllers/insurance/application-submitted', () => {
       it(`should redirect to ${ALL_SECTIONS}`, () => {
         get(req, res);
 
-        const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALL_SECTIONS}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });

--- a/src/ui/server/controllers/insurance/business/alternative-trading-address/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/alternative-trading-address/index.test.ts
@@ -8,7 +8,7 @@ import { FIELDS } from '../../../../content-strings/fields/insurance/your-busine
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
@@ -75,7 +75,7 @@ describe('controllers/insurance/business/alternative-trading-address', () => {
     it('should render template', () => {
       get(req, res);
 
-      const { company, referenceNumber } = mockApplication;
+      const { company } = mockApplication;
 
       const addressHtml = generateMultipleFieldHtml(company[COMPANY_ADDRESS]);
 
@@ -114,7 +114,7 @@ describe('controllers/insurance/business/alternative-trading-address', () => {
 
         await post(req, res);
 
-        const { company, referenceNumber } = mockApplication;
+        const { company } = mockApplication;
 
         const addressHtml = generateMultipleFieldHtml(company[COMPANY_ADDRESS]);
 
@@ -158,7 +158,7 @@ describe('controllers/insurance/business/alternative-trading-address', () => {
       it('should redirect to next page', async () => {
         await post(req, res);
 
-        const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${NATURE_OF_BUSINESS_ROOT}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${NATURE_OF_BUSINESS_ROOT}`;
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
 
@@ -168,7 +168,7 @@ describe('controllers/insurance/business/alternative-trading-address', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
       });
@@ -179,7 +179,7 @@ describe('controllers/insurance/business/alternative-trading-address', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/business/check-your-answers/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/check-your-answers/index.test.ts
@@ -7,7 +7,7 @@ import getUserNameFromSession from '../../../../helpers/get-user-name-from-sessi
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import { yourBusinessSummaryLists } from '../../../../helpers/summary-lists/your-business';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 import { mockCompany, mockBusiness } from '../../../../test-mocks/mock-application';
 
 const { CHECK_YOUR_ANSWERS } = PAGES.INSURANCE.EXPORTER_BUSINESS;
@@ -18,14 +18,10 @@ const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 describe('controllers/insurance/business/check-your-answers', () => {
   let req: Request;
   let res: Response;
-  let refNumber: number;
 
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-    refNumber = Number(mockApplication.referenceNumber);
   });
 
   describe('TEMPLATE', () => {
@@ -37,7 +33,7 @@ describe('controllers/insurance/business/check-your-answers', () => {
   describe('get', () => {
     it('should render template', async () => {
       await get(req, res);
-      const summaryLists = yourBusinessSummaryLists(mockCompany, mockBusiness, mockApplication.referenceNumber);
+      const summaryLists = yourBusinessSummaryLists(mockCompany, mockBusiness, referenceNumber);
 
       const expectedVariables = {
         ...insuranceCorePageVariables({
@@ -46,7 +42,7 @@ describe('controllers/insurance/business/check-your-answers', () => {
         }),
         userName: getUserNameFromSession(req.session.user),
         application: mapApplicationToFormFields(mockApplication),
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`,
         SUMMARY_LISTS: summaryLists,
       };
 

--- a/src/ui/server/controllers/insurance/business/company-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.test.ts
@@ -10,7 +10,7 @@ import mapAndSave from '../map-and-save/company-details';
 import { companiesHouseSummaryList } from '../../../../helpers/summary-lists/companies-house';
 import { Request, Response } from '../../../../../types';
 import companyDetailsValidation from './validation/company-details';
-import { mockReq, mockRes, mockApplication, mockPhoneNumbers } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockPhoneNumbers, referenceNumber } from '../../../../test-mocks';
 
 const {
   YOUR_COMPANY: { HAS_DIFFERENT_TRADING_NAME, TRADING_ADDRESS, WEBSITE, PHONE_NUMBER, DIFFERENT_TRADING_NAME },
@@ -77,11 +77,11 @@ describe('controllers/insurance/business/companies-details', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${COMPANY_DETAILS_SAVE_AND_BACK}`,
-        DIFFERENT_COMPANIES_HOUSE_NUMBER_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${COMPANY_DETAILS_ROOT}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${COMPANY_DETAILS_SAVE_AND_BACK}`,
+        DIFFERENT_COMPANIES_HOUSE_NUMBER_URL: `${INSURANCE_ROOT}/${referenceNumber}${COMPANY_DETAILS_ROOT}`,
         FIELDS: BUSINESS_FIELD_IDS,
       };
 
@@ -104,7 +104,7 @@ describe('controllers/insurance/business/companies-details', () => {
     describe('when application has populated company data', () => {
       it('should render the company-details template with correct variables', () => {
         get(req, res);
-        const { company, referenceNumber } = mockApplication;
+        const { company } = mockApplication;
 
         const submittedValues = {
           [HAS_DIFFERENT_TRADING_NAME]: company?.[HAS_DIFFERENT_TRADING_NAME],
@@ -176,7 +176,7 @@ describe('controllers/insurance/business/companies-details', () => {
             HTML_FLAGS,
           }),
           userName: getUserNameFromSession(req.session.user),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           validationErrors,
           submittedValues: expectedSubmittedValues,
           SUMMARY_LIST: companiesHouseSummaryList(mockApplication.company, IS_APPLICATION_SUMMARY_LIST),
@@ -187,11 +187,11 @@ describe('controllers/insurance/business/companies-details', () => {
     describe('when there are no validation errors', () => {
       it('should redirect to next page', async () => {
         req.body = validBody;
-        req.originalUrl = `insurance/${mockApplication.referenceNumber}/${COMPANY_DETAILS_ROOT}`;
+        req.originalUrl = `insurance/${referenceNumber}/${COMPANY_DETAILS_ROOT}`;
 
         await post(req, res);
 
-        const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${NATURE_OF_BUSINESS_ROOT}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${NATURE_OF_BUSINESS_ROOT}`;
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
 
@@ -225,7 +225,7 @@ describe('controllers/insurance/business/companies-details', () => {
 
               await post(req, res);
 
-              const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_ROOT}`;
+              const expected = `${INSURANCE_ROOT}/${referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_ROOT}`;
               expect(res.redirect).toHaveBeenCalledWith(expected);
             });
           });
@@ -241,7 +241,7 @@ describe('controllers/insurance/business/companies-details', () => {
 
               await post(req, res);
 
-              const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_CHANGE}`;
+              const expected = `${INSURANCE_ROOT}/${referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_CHANGE}`;
               expect(res.redirect).toHaveBeenCalledWith(expected);
             });
           });
@@ -257,7 +257,7 @@ describe('controllers/insurance/business/companies-details', () => {
 
               await post(req, res);
 
-              const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_CHECK_AND_CHANGE}`;
+              const expected = `${INSURANCE_ROOT}/${referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_CHECK_AND_CHANGE}`;
               expect(res.redirect).toHaveBeenCalledWith(expected);
             });
           });
@@ -275,7 +275,7 @@ describe('controllers/insurance/business/companies-details', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
       });
@@ -291,7 +291,7 @@ describe('controllers/insurance/business/companies-details', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/business/credit-control/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/credit-control/index.test.ts
@@ -10,7 +10,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../map-and-save/business';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const { HAS_CREDIT_CONTROL } = BUSINESS_FIELD_IDS;
 
@@ -20,8 +20,6 @@ const {
   CHECK_YOUR_ANSWERS: { YOUR_BUSINESS: CHECK_AND_CHANGE_ROUTE },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 jest.mock('../map-and-save/business');
 
@@ -159,7 +157,7 @@ describe('controllers/insurance/business/credit-control', () => {
       it('should redirect to next page', async () => {
         await post(req, res);
 
-        const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
 
@@ -171,7 +169,7 @@ describe('controllers/insurance/business/credit-control', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
       });
@@ -183,7 +181,7 @@ describe('controllers/insurance/business/credit-control', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/business/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/index.test.ts
@@ -5,14 +5,12 @@ import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import sectionStartPageVariables from '../../../helpers/page-variables/core/insurance/section-start';
 import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
 import { Request, Response } from '../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../test-mocks';
+import { referenceNumber, mockReq, mockRes } from '../../../test-mocks';
 
 const {
   EXPORTER_BUSINESS: { COMPANY_DETAILS_ROOT },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/business/index', () => {
   let req: Request;

--- a/src/ui/server/controllers/insurance/business/nature-of-business/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/index.test.ts
@@ -10,7 +10,7 @@ import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/business';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const { GOODS_OR_SERVICES, YEARS_EXPORTING, EMPLOYEES_UK } = BUSINESS_FIELD_IDS.NATURE_OF_YOUR_BUSINESS;
 
@@ -66,7 +66,7 @@ describe('controllers/insurance/business/nature-of-business', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELDS: {
@@ -85,8 +85,8 @@ describe('controllers/insurance/business/nature-of-business', () => {
           },
         },
         POST_ROUTES: {
-          NATURE_OF_BUSINESS: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${NATURE_OF_BUSINESS_ROOT}`,
-          SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${NATURE_OF_BUSINESS_SAVE_AND_BACK}`,
+          NATURE_OF_BUSINESS: `${INSURANCE_ROOT}/${referenceNumber}${NATURE_OF_BUSINESS_ROOT}`,
+          SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${NATURE_OF_BUSINESS_SAVE_AND_BACK}`,
         },
       };
 
@@ -105,7 +105,7 @@ describe('controllers/insurance/business/nature-of-business', () => {
         }),
         userName: getUserNameFromSession(req.session.user),
         application: mapApplicationToFormFields(mockApplication),
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
       });
     });
 
@@ -141,7 +141,7 @@ describe('controllers/insurance/business/nature-of-business', () => {
             BACK_LINK: req.headers.referer,
           }),
           userName: getUserNameFromSession(req.session.user),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           validationErrors,
           application: mapApplicationToFormFields(mockApplication),
           submittedValues: payload,
@@ -161,7 +161,7 @@ describe('controllers/insurance/business/nature-of-business', () => {
 
         await post(req, res);
 
-        const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TURNOVER_ROOT}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${TURNOVER_ROOT}`;
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
 
@@ -188,7 +188,7 @@ describe('controllers/insurance/business/nature-of-business', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
       });
@@ -201,7 +201,7 @@ describe('controllers/insurance/business/nature-of-business', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/business/turnover/alternative-currency/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/alternative-currency/index.test.ts
@@ -12,7 +12,7 @@ import getUserNameFromSession from '../../../../../helpers/get-user-name-from-se
 import generateValidationErrors from './validation';
 import mapAndSave from '../../map-and-save/turnover';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockCurrenciesResponse, mockCurrenciesEmptyResponse, mockApplication, GBP } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockCurrenciesResponse, mockCurrenciesEmptyResponse, mockApplication, referenceNumber, GBP } from '../../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -209,7 +209,7 @@ describe('controllers/insurance/business/turnover/alternative-currency', () => {
 
         await post(req, res);
 
-        const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TURNOVER_ROOT}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${TURNOVER_ROOT}`;
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
 
@@ -219,7 +219,7 @@ describe('controllers/insurance/business/turnover/alternative-currency', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TURNOVER_CHANGE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${TURNOVER_CHANGE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -231,7 +231,7 @@ describe('controllers/insurance/business/turnover/alternative-currency', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TURNOVER_CHECK_AND_CHANGE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${TURNOVER_CHECK_AND_CHANGE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/business/turnover/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/index.test.ts
@@ -13,7 +13,15 @@ import mapAndSave from '../map-and-save/turnover';
 import getCurrencyByCode from '../../../../helpers/get-currency-by-code';
 import api from '../../../../api';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockCurrencies, mockCurrenciesResponse, mockCurrenciesEmptyResponse } from '../../../../test-mocks';
+import {
+  mockReq,
+  mockRes,
+  mockApplication,
+  referenceNumber,
+  mockCurrencies,
+  mockCurrenciesResponse,
+  mockCurrenciesEmptyResponse,
+} from '../../../../test-mocks';
 
 const { FINANCIAL_YEAR_END_DATE, ESTIMATED_ANNUAL_TURNOVER, PERCENTAGE_TURNOVER, TURNOVER_CURRENCY_CODE } = BUSINESS_FIELD_IDS.TURNOVER;
 
@@ -75,7 +83,7 @@ describe('controllers/insurance/business/turnover', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber, mockCurrencies, currencyValue);
+      const result = pageVariables(referenceNumber, mockCurrencies, currencyValue);
 
       const currency = getCurrencyByCode(mockCurrencies, String(currencyValue));
 
@@ -94,8 +102,8 @@ describe('controllers/insurance/business/turnover', () => {
             ...TURNOVER_FIELDS[PERCENTAGE_TURNOVER],
           },
         },
-        PROVIDE_ALTERNATIVE_CURRENCY_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TURNOVER_ALTERNATIVE_CURRENCY}`,
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TURNOVER_SAVE_AND_BACK}`,
+        PROVIDE_ALTERNATIVE_CURRENCY_URL: `${INSURANCE_ROOT}/${referenceNumber}${TURNOVER_ALTERNATIVE_CURRENCY}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${TURNOVER_SAVE_AND_BACK}`,
         CURRENCY_PREFIX_SYMBOL: currency.symbol,
       };
 
@@ -106,7 +114,7 @@ describe('controllers/insurance/business/turnover', () => {
       it(`should have correct properties with "PROVIDE_ALTERNATIVE_CURRENCY_URL" set to ${TURNOVER_ALTERNATIVE_CURRENCY_CHANGE}`, () => {
         const isChange = true;
 
-        const result = pageVariables(mockApplication.referenceNumber, mockCurrencies, currencyValue, isChange);
+        const result = pageVariables(referenceNumber, mockCurrencies, currencyValue, isChange);
 
         const currency = getCurrencyByCode(mockCurrencies, String(currencyValue));
 
@@ -125,8 +133,8 @@ describe('controllers/insurance/business/turnover', () => {
               ...TURNOVER_FIELDS[PERCENTAGE_TURNOVER],
             },
           },
-          PROVIDE_ALTERNATIVE_CURRENCY_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TURNOVER_ALTERNATIVE_CURRENCY_CHANGE}`,
-          SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TURNOVER_SAVE_AND_BACK}`,
+          PROVIDE_ALTERNATIVE_CURRENCY_URL: `${INSURANCE_ROOT}/${referenceNumber}${TURNOVER_ALTERNATIVE_CURRENCY_CHANGE}`,
+          SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${TURNOVER_SAVE_AND_BACK}`,
           CURRENCY_PREFIX_SYMBOL: currency.symbol,
         };
 
@@ -139,7 +147,7 @@ describe('controllers/insurance/business/turnover', () => {
         const isChange = undefined;
         const isCheckAndChange = true;
 
-        const result = pageVariables(mockApplication.referenceNumber, mockCurrencies, currencyValue, isChange, isCheckAndChange);
+        const result = pageVariables(referenceNumber, mockCurrencies, currencyValue, isChange, isCheckAndChange);
 
         const currency = getCurrencyByCode(mockCurrencies, String(currencyValue));
 
@@ -158,8 +166,8 @@ describe('controllers/insurance/business/turnover', () => {
               ...TURNOVER_FIELDS[PERCENTAGE_TURNOVER],
             },
           },
-          PROVIDE_ALTERNATIVE_CURRENCY_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TURNOVER_ALTERNATIVE_CURRENCY_CHECK_AND_CHANGE}`,
-          SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TURNOVER_SAVE_AND_BACK}`,
+          PROVIDE_ALTERNATIVE_CURRENCY_URL: `${INSURANCE_ROOT}/${referenceNumber}${TURNOVER_ALTERNATIVE_CURRENCY_CHECK_AND_CHANGE}`,
+          SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${TURNOVER_SAVE_AND_BACK}`,
           CURRENCY_PREFIX_SYMBOL: currency.symbol,
         };
 
@@ -185,7 +193,7 @@ describe('controllers/insurance/business/turnover', () => {
         }),
         userName: getUserNameFromSession(req.session.user),
         application: mapApplicationToFormFields(mockApplication),
-        ...pageVariables(mockApplication.referenceNumber, mockCurrencies, currencyValue),
+        ...pageVariables(referenceNumber, mockCurrencies, currencyValue),
       });
     });
 
@@ -258,7 +266,7 @@ describe('controllers/insurance/business/turnover', () => {
             BACK_LINK: req.headers.referer,
           }),
           userName: getUserNameFromSession(req.session.user),
-          ...pageVariables(mockApplication.referenceNumber, mockCurrencies, currencyValue),
+          ...pageVariables(referenceNumber, mockCurrencies, currencyValue),
           validationErrors,
           application: mapApplicationToFormFields(mockApplication),
           submittedValues: sanitiseData(payload),
@@ -274,7 +282,7 @@ describe('controllers/insurance/business/turnover', () => {
       it('should redirect to next page', async () => {
         await post(req, res);
 
-        const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CREDIT_CONTROL}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${CREDIT_CONTROL}`;
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
 
@@ -294,7 +302,7 @@ describe('controllers/insurance/business/turnover', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
       });
@@ -305,7 +313,7 @@ describe('controllers/insurance/business/turnover', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/check-your-answers/policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/policy/index.test.ts
@@ -12,7 +12,16 @@ import sectionStatus from '../../../../helpers/section-status';
 import constructPayload from '../../../../helpers/construct-payload';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockCurrencies, mockCurrenciesResponse, mockCurrenciesEmptyResponse, mockContact } from '../../../../test-mocks';
+import {
+  mockReq,
+  mockRes,
+  mockApplication,
+  mockCurrencies,
+  mockCurrenciesResponse,
+  mockCurrenciesEmptyResponse,
+  mockContact,
+  referenceNumber,
+} from '../../../../test-mocks';
 import { mockBroker } from '../../../../test-mocks/mock-application';
 
 const CHECK_YOUR_ANSWERS_TEMPLATE = TEMPLATES.INSURANCE.CHECK_YOUR_ANSWERS;
@@ -25,7 +34,7 @@ const {
   },
 } = ROUTES;
 
-const { policy, exportContract, referenceNumber } = mockApplication;
+const { policy, exportContract } = mockApplication;
 
 describe('controllers/insurance/check-your-answers/policy', () => {
   jest.mock('../save-data');
@@ -43,7 +52,6 @@ describe('controllers/insurance/check-your-answers/policy', () => {
     req = mockReq();
     res = mockRes();
 
-    req.params.referenceNumber = String(referenceNumber);
     api.keystone.APIM.getCurrencies = getCurrenciesSpy;
   });
 

--- a/src/ui/server/controllers/insurance/check-your-answers/your-business/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/your-business/index.test.ts
@@ -11,9 +11,9 @@ import sectionStatus from '../../../../helpers/section-status';
 import constructPayload from '../../../../helpers/construct-payload';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
-const { company, business, referenceNumber } = mockApplication;
+const { company, business } = mockApplication;
 
 const CHECK_YOUR_ANSWERS_TEMPLATE = TEMPLATES.INSURANCE.CHECK_YOUR_ANSWERS;
 
@@ -38,8 +38,6 @@ describe('controllers/insurance/check-your-answers/your-business', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
   });
 
   describe('FIELD_ID', () => {
@@ -52,14 +50,14 @@ describe('controllers/insurance/check-your-answers/your-business', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELD: {
           ID: FIELD_ID,
           ...FIELDS[FIELD_ID],
         },
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${YOUR_BUSINESS_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${YOUR_BUSINESS_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -90,7 +88,7 @@ describe('controllers/insurance/check-your-answers/your-business', () => {
         userName: getUserNameFromSession(req.session.user),
         status,
         SUMMARY_LISTS: summaryList,
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);

--- a/src/ui/server/controllers/insurance/check-your-answers/your-buyer/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/your-buyer/index.test.ts
@@ -11,7 +11,7 @@ import sectionStatus from '../../../../helpers/section-status';
 import constructPayload from '../../../../helpers/construct-payload';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const CHECK_YOUR_ANSWERS_TEMPLATE = TEMPLATES.INSURANCE.CHECK_YOUR_ANSWERS;
 
@@ -37,8 +37,6 @@ describe('controllers/insurance/check-your-answers/your-buyer', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
   });
 
   describe('FIELD_ID', () => {
@@ -51,14 +49,14 @@ describe('controllers/insurance/check-your-answers/your-buyer', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELD: {
           ID: FIELD_ID,
           ...FIELDS[FIELD_ID],
         },
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${YOUR_BUYER_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${YOUR_BUYER_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -78,7 +76,7 @@ describe('controllers/insurance/check-your-answers/your-buyer', () => {
       const summaryList = yourBuyerSummaryList(
         mockApplication.buyer,
         mockApplication.eligibility,
-        mockApplication.referenceNumber,
+        referenceNumber,
         mockApplication.totalContractValueOverThreshold,
         checkAndChange,
       );
@@ -95,7 +93,7 @@ describe('controllers/insurance/check-your-answers/your-buyer', () => {
         userName: getUserNameFromSession(req.session.user),
         status,
         SUMMARY_LISTS: summaryList,
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.test.ts
@@ -9,7 +9,7 @@ import mapApplicationToFormFields from '../../../../../helpers/mappings/map-appl
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import save from '../../save-data';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -54,14 +54,14 @@ describe('controllers/insurance/declarations/anti-bribery/code-of-conduct', () =
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELDS: {
           ID: FIELD_ID,
           ...DECLARATIONS_FIELDS[FIELD_ID],
         },
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CODE_OF_CONDUCT_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${CODE_OF_CONDUCT_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -92,7 +92,7 @@ describe('controllers/insurance/declarations/anti-bribery/code-of-conduct', () =
 
       const expectedVariables = {
         ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer, HTML_FLAGS }),
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         application: mapApplicationToFormFields(res.locals.application),
         applicationAnswer: mockApplication.declaration[FIELD_ID],
@@ -170,7 +170,7 @@ describe('controllers/insurance/declarations/anti-bribery/code-of-conduct', () =
 
         const expectedVariables = {
           ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer, HTML_FLAGS }),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           validationErrors: generateValidationErrors(payload, FIELD_ID, ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY),
         };

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/exporting-with-code-of-conduct/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/exporting-with-code-of-conduct/index.test.ts
@@ -8,7 +8,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import save from '../../save-data';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -46,14 +46,14 @@ describe('controllers/insurance/declarations/anti-bribery/exporting-with-a-code-
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELD: {
           ID: FIELD_ID,
           ...DECLARATIONS_FIELDS[FIELD_ID],
         },
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -72,7 +72,7 @@ describe('controllers/insurance/declarations/anti-bribery/exporting-with-a-code-
 
       const expectedVariables = {
         ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer }),
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         applicationAnswer: mockApplication.declaration[FIELD_ID],
       };
@@ -129,7 +129,7 @@ describe('controllers/insurance/declarations/anti-bribery/exporting-with-a-code-
 
         const expectedVariables = {
           ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer }),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           validationErrors: generateValidationErrors(payload, FIELD_ID, ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY),
         };

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/index.test.ts
@@ -11,7 +11,7 @@ import keystoneDocumentRendererConfig from '../../../../helpers/keystone-documen
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockDeclarations } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockDeclarations, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -50,14 +50,14 @@ describe('controllers/insurance/declarations/anti-bribery', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELD: {
           ID: FIELD_ID,
           ...FIELDS[FIELD_ID],
         },
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ANTI_BRIBERY_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${ANTI_BRIBERY_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -85,7 +85,7 @@ describe('controllers/insurance/declarations/anti-bribery', () => {
           PAGE_CONTENT_STRINGS: PAGES.INSURANCE.DECLARATIONS.ANTI_BRIBERY,
           BACK_LINK: req.headers.referer,
         }),
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         documentContent: mockDeclarations.antiBribery.content.document,
         documentConfig: keystoneDocumentRendererConfig(),
@@ -172,7 +172,7 @@ describe('controllers/insurance/declarations/anti-bribery', () => {
             PAGE_CONTENT_STRINGS: PAGES.INSURANCE.DECLARATIONS.ANTI_BRIBERY,
             BACK_LINK: req.headers.referer,
           }),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           documentContent: mockDeclarations.confidentiality.content.document,
           documentConfig: keystoneDocumentRendererConfig(),

--- a/src/ui/server/controllers/insurance/declarations/confidentiality/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/confidentiality/index.test.ts
@@ -9,7 +9,7 @@ import mapApplicationToFormFields from '../../../../helpers/mappings/map-applica
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -47,14 +47,14 @@ describe('controllers/insurance/declarations/confidentiality', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELD: {
           ID: FIELD_ID,
           ...FIELDS[FIELD_ID],
         },
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CONFIDENTIALITY_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${CONFIDENTIALITY_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -76,7 +76,7 @@ describe('controllers/insurance/declarations/confidentiality', () => {
           PAGE_CONTENT_STRINGS: PAGES.INSURANCE.DECLARATIONS.CONFIDENTIALITY,
           BACK_LINK: req.headers.referer,
         }),
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         CONFIDENTIALITY_CONTENT,
         application: mapApplicationToFormFields(res.locals.application),
@@ -137,7 +137,7 @@ describe('controllers/insurance/declarations/confidentiality', () => {
             PAGE_CONTENT_STRINGS: PAGES.INSURANCE.DECLARATIONS.CONFIDENTIALITY,
             BACK_LINK: req.headers.referer,
           }),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           CONFIDENTIALITY_CONTENT,
           validationErrors: generateValidationErrors(payload, FIELD_ID, ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY),

--- a/src/ui/server/controllers/insurance/declarations/confirmation-and-acknowledgements/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/confirmation-and-acknowledgements/index.test.ts
@@ -11,7 +11,7 @@ import keystoneDocumentRendererConfig from '../../../../helpers/keystone-documen
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockDeclarations } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockDeclarations, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -48,14 +48,14 @@ describe('controllers/insurance/declarations/confirmation-and-acknowledgements',
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELD: {
           ID: FIELD_ID,
           ...FIELDS[FIELD_ID],
         },
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CONFIRMATION_AND_ACKNOWLEDGEMENTS_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${CONFIRMATION_AND_ACKNOWLEDGEMENTS_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -83,7 +83,7 @@ describe('controllers/insurance/declarations/confirmation-and-acknowledgements',
           PAGE_CONTENT_STRINGS: PAGES.INSURANCE.DECLARATIONS.CONFIRMATION_AND_ACKNOWLEDGEMENTS,
           BACK_LINK: req.headers.referer,
         }),
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         documentContent: mockDeclarations.confirmationAndAcknowledgement.content.document,
         documentConfig: keystoneDocumentRendererConfig(),
@@ -171,7 +171,7 @@ describe('controllers/insurance/declarations/confirmation-and-acknowledgements',
             PAGE_CONTENT_STRINGS: PAGES.INSURANCE.DECLARATIONS.CONFIRMATION_AND_ACKNOWLEDGEMENTS,
             BACK_LINK: req.headers.referer,
           }),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           documentContent: mockDeclarations.confirmationAndAcknowledgement.content.document,
           documentConfig: keystoneDocumentRendererConfig(),

--- a/src/ui/server/controllers/insurance/declarations/how-your-data-will-be-used/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/how-your-data-will-be-used/index.test.ts
@@ -11,7 +11,7 @@ import keystoneDocumentRendererConfig from '../../../../helpers/keystone-documen
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockDeclarations } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockDeclarations, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -50,7 +50,7 @@ describe('controllers/insurance/declarations/how-your-data-will-be-used', () => 
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELD: {
@@ -58,7 +58,7 @@ describe('controllers/insurance/declarations/how-your-data-will-be-used', () => 
           ...FIELDS[FIELD_ID],
         },
         SUBMIT_BUTTON_COPY: BUTTONS.SUBMIT_APPLICATION,
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${HOW_YOUR_DATA_WILL_BE_USED_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${HOW_YOUR_DATA_WILL_BE_USED_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -86,7 +86,7 @@ describe('controllers/insurance/declarations/how-your-data-will-be-used', () => 
           PAGE_CONTENT_STRINGS: PAGES.INSURANCE.DECLARATIONS.HOW_YOUR_DATA_WILL_BE_USED,
           BACK_LINK: req.headers.referer,
         }),
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         documentContent: mockDeclarations.howDataWillBeUsed.content.document,
         documentConfig: keystoneDocumentRendererConfig(),
@@ -196,7 +196,7 @@ describe('controllers/insurance/declarations/how-your-data-will-be-used', () => 
             PAGE_CONTENT_STRINGS: PAGES.INSURANCE.DECLARATIONS.HOW_YOUR_DATA_WILL_BE_USED,
             BACK_LINK: req.headers.referer,
           }),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           documentContent: mockDeclarations.howDataWillBeUsed.content.document,
           documentConfig: keystoneDocumentRendererConfig(),

--- a/src/ui/server/controllers/insurance/declarations/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/save-and-back/index.test.ts
@@ -4,13 +4,11 @@ import DECLARATIONS_FIELD_IDS from '../../../../constants/field-ids/insurance/de
 import constructPayload from '../../../../helpers/construct-payload';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../../test-mocks';
+import { referenceNumber, mockReq, mockRes } from '../../../../test-mocks';
 
 const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE },
 } = ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/declarations/confidentiality/save-and-back', () => {
   let req: Request;
@@ -29,8 +27,6 @@ describe('controllers/insurance/declarations/confidentiality/save-and-back', () 
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(referenceNumber);
 
     req.body = mockFormBody;
   });

--- a/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.test.ts
@@ -6,7 +6,7 @@ import getUserNameFromSession from '../../../../helpers/get-user-name-from-sessi
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import mapEligibilityAnswers from '../../../../helpers/map-eligibility-answers';
 import api from '../../../../api';
-import { mockAccount, mockApplication, mockSession, mockReq, mockRes } from '../../../../test-mocks';
+import { mockAccount, referenceNumber, mockSession, mockReq, mockRes } from '../../../../test-mocks';
 import { Request, Response } from '../../../../../types';
 
 const {
@@ -22,8 +22,6 @@ const {
 describe('controllers/insurance/eligibility/eligible-to-apply-online', () => {
   let req: Request;
   let res: Response;
-
-  const { referenceNumber } = mockApplication;
 
   const mockCreateApplicationResponse = { referenceNumber };
 

--- a/src/ui/server/controllers/insurance/export-contract/about-goods-or-services/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/about-goods-or-services/index.test.ts
@@ -14,7 +14,7 @@ import mapCountries from '../../../../helpers/mappings/map-countries';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import mapAndSave from '../map-and-save/export-contract';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockCountries } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockCountries, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -38,7 +38,6 @@ const {
 describe('controllers/insurance/export-contract/about-goods-or-services', () => {
   let req: Request;
   let res: Response;
-  let refNumber: number;
 
   jest.mock('../map-and-save/export-contract');
 
@@ -60,8 +59,6 @@ describe('controllers/insurance/export-contract/about-goods-or-services', () => 
     res = mockRes();
 
     res.locals.application = mockApplicationWithoutCountryCode;
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-    refNumber = Number(mockApplication.referenceNumber);
     api.keystone.countries.getAll = getCountriesSpy;
   });
 
@@ -77,7 +74,7 @@ describe('controllers/insurance/export-contract/about-goods-or-services', () => 
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(refNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELDS: {
@@ -144,7 +141,7 @@ describe('controllers/insurance/export-contract/about-goods-or-services', () => 
           BACK_LINK: req.headers.referer,
           HTML_FLAGS,
         }),
-        ...pageVariables(refNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         application: mapApplicationToFormFields(mockApplicationWithoutCountryCode),
         countries: mapCountries(mockCountries),
@@ -175,7 +172,7 @@ describe('controllers/insurance/export-contract/about-goods-or-services', () => 
             BACK_LINK: req.headers.referer,
             HTML_FLAGS,
           }),
-          ...pageVariables(refNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           application: mapApplicationToFormFields(mockApplicationWithCountry),
           countries: mapCountries(mockCountries, countryIsoCode),
@@ -275,7 +272,7 @@ describe('controllers/insurance/export-contract/about-goods-or-services', () => 
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -287,7 +284,7 @@ describe('controllers/insurance/export-contract/about-goods-or-services', () => 
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${refNumber}${ABOUT_GOODS_OR_SERVICES_CHECK_AND_CHANGE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES_CHECK_AND_CHANGE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -306,7 +303,7 @@ describe('controllers/insurance/export-contract/about-goods-or-services', () => 
             BACK_LINK: req.headers.referer,
             HTML_FLAGS,
           }),
-          ...pageVariables(refNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           application: mockApplicationWithoutCountryCode,
           submittedValues: sanitiseData(payload),
@@ -337,7 +334,7 @@ describe('controllers/insurance/export-contract/about-goods-or-services', () => 
               BACK_LINK: req.headers.referer,
               HTML_FLAGS,
             }),
-            ...pageVariables(refNumber),
+            ...pageVariables(referenceNumber),
             userName: getUserNameFromSession(req.session.user),
             application: mockApplicationWithoutCountryCode,
             submittedValues: payload,

--- a/src/ui/server/controllers/insurance/export-contract/about-goods-or-services/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/about-goods-or-services/save-and-back/index.test.ts
@@ -7,15 +7,13 @@ import mapAndSave from '../../map-and-save/export-contract';
 import generateValidationErrors from '../validation';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
-import { mockApplication, mockCountries, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockCountries, mockReq, mockRes, referenceNumber } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
 const {
   ABOUT_GOODS_OR_SERVICES: { DESCRIPTION, FINAL_DESTINATION },
 } = EXPORT_CONTRACT_FIELD_IDS;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/export-contract/about-goods-or-services/save-and-back', () => {
   let req: Request;
@@ -34,8 +32,6 @@ describe('controllers/insurance/export-contract/about-goods-or-services/save-and
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(referenceNumber);
 
     req.body = mockFormBody;
 

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
@@ -10,15 +10,13 @@ import insuranceCorePageVariables from '../../../../helpers/page-variables/core/
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockCountries } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockCountries, referenceNumber } from '../../../../test-mocks';
 
 const { INSURANCE_ROOT, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
 const {
   AGENT_DETAILS: { NAME, FULL_ADDRESS, COUNTRY_CODE },
 } = EXPORT_CONTRACT_FIELD_IDS;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/export-contract/agent-details', () => {
   let req: Request;
@@ -31,7 +29,6 @@ describe('controllers/insurance/export-contract/agent-details', () => {
     res = mockRes();
 
     res.locals.application = mockApplication;
-    req.params.referenceNumber = String(referenceNumber);
     api.keystone.countries.getAll = getCountriesSpy;
   });
 

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
@@ -28,7 +28,6 @@ describe('controllers/insurance/export-contract/agent-details', () => {
     req = mockReq();
     res = mockRes();
 
-    res.locals.application = mockApplication;
     api.keystone.countries.getAll = getCountriesSpy;
   });
 

--- a/src/ui/server/controllers/insurance/export-contract/agent/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent/index.test.ts
@@ -31,8 +31,6 @@ describe('controllers/insurance/export-contract/agent', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    res.locals.application = mockApplication;
   });
 
   afterAll(() => {

--- a/src/ui/server/controllers/insurance/export-contract/agent/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent/index.test.ts
@@ -10,7 +10,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../map-and-save/export-contract-agent';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -19,8 +19,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const { USING_AGENT } = EXPORT_CONTRACT_FIELD_IDS;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/export-contract/agent', () => {
   let req: Request;
@@ -35,7 +33,6 @@ describe('controllers/insurance/export-contract/agent', () => {
     res = mockRes();
 
     res.locals.application = mockApplication;
-    req.params.referenceNumber = String(referenceNumber);
   });
 
   afterAll(() => {

--- a/src/ui/server/controllers/insurance/export-contract/agent/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/export-contract-agent';
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import { Request, Response } from '../../../../../../types';
-import { mockApplication, mockCountries, mockReq, mockRes } from '../../../../../test-mocks';
+import { referenceNumber, mockCountries, mockReq, mockRes } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -17,8 +17,6 @@ describe('controllers/insurance/export-contract/agent/save-and-back', () => {
 
   let mapAndSaveSpy = jest.fn(() => Promise.resolve(true));
 
-  const refNumber = Number(mockApplication.referenceNumber);
-
   const mockFormBody = {
     _csrf: '1234',
     [FIELD_ID]: 'Mock description',
@@ -27,8 +25,6 @@ describe('controllers/insurance/export-contract/agent/save-and-back', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
 
     req.body = mockFormBody;
 
@@ -59,7 +55,7 @@ describe('controllers/insurance/export-contract/agent/save-and-back', () => {
       it(`should redirect to ${ALL_SECTIONS}`, async () => {
         await post(req, res);
 
-        const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
@@ -72,7 +68,7 @@ describe('controllers/insurance/export-contract/agent/save-and-back', () => {
 
       await post(req, res);
 
-      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+      const expected = `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       expect(res.redirect).toHaveBeenCalledWith(expected);
     });

--- a/src/ui/server/controllers/insurance/export-contract/check-your-answers/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/check-your-answers/index.test.ts
@@ -24,8 +24,6 @@ describe('controllers/insurance/export-contract/check-your-answers', () => {
     req = mockReq();
     res = mockRes();
 
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-
     api.keystone.countries.getAll = getCountriesSpy;
   });
 

--- a/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/index.test.ts
@@ -40,8 +40,6 @@ describe('controllers/insurance/export-contract/declined-by-private-market', () 
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    res.locals.application = mockApplication;
   });
 
   afterAll(() => {

--- a/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/index.test.ts
@@ -11,7 +11,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/private-market';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -29,8 +29,6 @@ const {
   },
 } = TEMPLATES;
 
-const { referenceNumber } = mockApplication;
-
 describe('controllers/insurance/export-contract/declined-by-private-market', () => {
   let req: Request;
   let res: Response;
@@ -44,7 +42,6 @@ describe('controllers/insurance/export-contract/declined-by-private-market', () 
     res = mockRes();
 
     res.locals.application = mockApplication;
-    req.params.referenceNumber = String(referenceNumber);
   });
 
   afterAll(() => {

--- a/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/private-market';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockApplication, mockCountries, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockCountries, referenceNumber, mockReq, mockRes } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -17,8 +17,6 @@ describe('controllers/insurance/export-contract/declined-by-private-market/save-
 
   let mapAndSaveSpy = jest.fn(() => Promise.resolve(true));
 
-  const refNumber = Number(mockApplication.referenceNumber);
-
   const mockFormBody = {
     _csrf: '1234',
     [FIELD_ID]: 'Mock description',
@@ -27,8 +25,6 @@ describe('controllers/insurance/export-contract/declined-by-private-market/save-
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
 
     req.body = mockFormBody;
 
@@ -59,7 +55,7 @@ describe('controllers/insurance/export-contract/declined-by-private-market/save-
       it(`should redirect to ${ALL_SECTIONS}`, async () => {
         await post(req, res);
 
-        const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
@@ -72,7 +68,7 @@ describe('controllers/insurance/export-contract/declined-by-private-market/save-
 
       await post(req, res);
 
-      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+      const expected = `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       expect(res.redirect).toHaveBeenCalledWith(expected);
     });

--- a/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/index.test.ts
@@ -17,6 +17,7 @@ import {
   mockApplication,
   mockApplicationTotalContractValueThresholdTrue,
   mockApplicationTotalContractValueThresholdFalse,
+  referenceNumber,
 } from '../../../../test-mocks';
 
 const {
@@ -38,7 +39,6 @@ const {
 describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
   let req: Request;
   let res: Response;
-  let refNumber: number;
 
   jest.mock('../map-and-save/export-contract');
 
@@ -49,8 +49,6 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
     res = mockRes();
 
     res.locals.application = mockApplication;
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-    refNumber = Number(mockApplication.referenceNumber);
   });
 
   afterAll(() => {
@@ -65,7 +63,7 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(refNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELD: {
@@ -97,7 +95,7 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
 
       const expectedVariables = {
         ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer }),
-        ...pageVariables(refNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         application: mapApplicationToFormFields(mockApplication),
       };
@@ -145,7 +143,7 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${PRIVATE_MARKET_CHANGE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET_CHANGE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -158,7 +156,7 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -170,7 +168,7 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${PRIVATE_MARKET}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -197,7 +195,7 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
 
         const expectedVariables = {
           ...singleInputPageVariables({ FIELD_ID, PAGE_CONTENT_STRINGS, BACK_LINK: req.headers.referer }),
-          ...pageVariables(refNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           application: mapApplicationToFormFields(mockApplication),
           submittedValues: payload,

--- a/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/index.test.ts
@@ -47,8 +47,6 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    res.locals.application = mockApplication;
   });
 
   afterAll(() => {

--- a/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/save-and-back/index.test.ts
@@ -5,11 +5,9 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/export-contract';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockApplication, mockCountries, mockReq, mockRes } from '../../../../../test-mocks';
+import { referenceNumber, mockCountries, mockReq, mockRes } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/export-contract/how-will-you-get-paid/save-and-back', () => {
   let req: Request;
@@ -27,8 +25,6 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid/save-and-b
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(referenceNumber);
 
     req.body = mockFormBody;
 

--- a/src/ui/server/controllers/insurance/export-contract/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/index.test.ts
@@ -5,9 +5,7 @@ import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import sectionStartPageVariables from '../../../helpers/page-variables/core/insurance/section-start';
 import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
 import { Request, Response } from '../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../test-mocks';
-
-const { referenceNumber } = mockApplication;
+import { referenceNumber, mockReq, mockRes } from '../../../test-mocks';
 
 const {
   EXPORT_CONTRACT: { ABOUT_GOODS_OR_SERVICES },

--- a/src/ui/server/controllers/insurance/export-contract/private-market/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/private-market/index.test.ts
@@ -9,7 +9,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../map-and-save/private-market';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -26,9 +26,6 @@ const {
     INSURANCE: { EXPORT_CONTRACT },
   },
 } = TEMPLATES;
-
-const { referenceNumber } = mockApplication;
-
 describe('controllers/insurance/export-contract/private-market', () => {
   let req: Request;
   let res: Response;
@@ -42,7 +39,6 @@ describe('controllers/insurance/export-contract/private-market', () => {
     res = mockRes();
 
     res.locals.application = mockApplication;
-    req.params.referenceNumber = String(referenceNumber);
   });
 
   afterAll(() => {

--- a/src/ui/server/controllers/insurance/export-contract/private-market/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/private-market/index.test.ts
@@ -37,8 +37,6 @@ describe('controllers/insurance/export-contract/private-market', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    res.locals.application = mockApplication;
   });
 
   afterAll(() => {

--- a/src/ui/server/controllers/insurance/export-contract/private-market/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/private-market/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/private-market';
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import { Request, Response } from '../../../../../../types';
-import { mockApplication, mockCountries, mockReq, mockRes } from '../../../../../test-mocks';
+import { referenceNumber, mockCountries, mockReq, mockRes } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -17,8 +17,6 @@ describe('controllers/insurance/export-contract/private-market/save-and-back', (
 
   let mapAndSaveSpy = jest.fn(() => Promise.resolve(true));
 
-  const refNumber = Number(mockApplication.referenceNumber);
-
   const mockFormBody = {
     _csrf: '1234',
     [FIELD_ID]: 'Mock description',
@@ -27,8 +25,6 @@ describe('controllers/insurance/export-contract/private-market/save-and-back', (
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
 
     req.body = mockFormBody;
 
@@ -59,7 +55,7 @@ describe('controllers/insurance/export-contract/private-market/save-and-back', (
       it(`should redirect to ${ALL_SECTIONS}`, async () => {
         await post(req, res);
 
-        const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
@@ -72,7 +68,7 @@ describe('controllers/insurance/export-contract/private-market/save-and-back', (
 
       await post(req, res);
 
-      const expected = `${INSURANCE_ROOT}/${refNumber}${ALL_SECTIONS}`;
+      const expected = `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       expect(res.redirect).toHaveBeenCalledWith(expected);
     });

--- a/src/ui/server/controllers/insurance/policy/another-company/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/another-company/index.test.ts
@@ -44,8 +44,6 @@ describe('controllers/insurance/policy/another-company', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    res.locals.application = mockApplication;
   });
 
   afterAll(() => {

--- a/src/ui/server/controllers/insurance/policy/another-company/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/another-company/index.test.ts
@@ -11,7 +11,7 @@ import { sanitiseData } from '../../../../helpers/sanitise-data';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../map-and-save/jointly-insured-party';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -38,7 +38,6 @@ const {
 describe('controllers/insurance/policy/another-company', () => {
   let req: Request;
   let res: Response;
-  let refNumber: number;
 
   jest.mock('../map-and-save/policy');
 
@@ -47,9 +46,6 @@ describe('controllers/insurance/policy/another-company', () => {
     res = mockRes();
 
     res.locals.application = mockApplication;
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-    refNumber = Number(mockApplication.referenceNumber);
   });
 
   afterAll(() => {
@@ -77,7 +73,7 @@ describe('controllers/insurance/policy/another-company', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(refNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELD_ID,
@@ -116,7 +112,7 @@ describe('controllers/insurance/policy/another-company', () => {
           BACK_LINK: req.headers.referer,
           HTML_FLAGS,
         }),
-        ...pageVariables(refNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         submittedValues: mockApplication.policy.jointlyInsuredParty,
       };
@@ -213,7 +209,7 @@ describe('controllers/insurance/policy/another-company', () => {
             BACK_LINK: req.headers.referer,
             HTML_FLAGS,
           }),
-          ...pageVariables(refNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           application: res.locals.application,
           submittedValues: sanitisedData,

--- a/src/ui/server/controllers/insurance/policy/broker-confirm-address/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-confirm-address/index.test.ts
@@ -7,7 +7,7 @@ import insuranceCorePageVariables from '../../../../helpers/page-variables/core/
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
 import replaceNewLineWithLineBreak from '../../../../helpers/replace-new-line-with-line-break';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const {
   BROKER_DETAILS: { FULL_ADDRESS: FIELD_ID },
@@ -47,11 +47,11 @@ describe('controllers/insurance/policy/broker-confirm-address', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
-        USE_DIFFERENT_ADDRESS_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${BROKER_DETAILS_ROOT}`,
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALL_SECTIONS}`,
+        USE_DIFFERENT_ADDRESS_URL: `${INSURANCE_ROOT}/${referenceNumber}${BROKER_DETAILS_ROOT}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`,
       };
 
       expect(result).toEqual(expected);
@@ -67,7 +67,7 @@ describe('controllers/insurance/policy/broker-confirm-address', () => {
           PAGE_CONTENT_STRINGS,
           BACK_LINK: req.headers.referer,
         }),
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         submittedAnswer: replaceNewLineWithLineBreak(mockApplication.broker[FIELD_ID]),
       });
@@ -90,7 +90,7 @@ describe('controllers/insurance/policy/broker-confirm-address', () => {
     it(`should redirect to ${LOSS_PAYEE_ROOT}`, () => {
       post(req, res);
 
-      const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${LOSS_PAYEE_ROOT}`;
+      const expected = `${INSURANCE_ROOT}/${referenceNumber}${LOSS_PAYEE_ROOT}`;
 
       expect(res.redirect).toHaveBeenCalledWith(expected);
     });

--- a/src/ui/server/controllers/insurance/policy/broker-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-details/index.test.ts
@@ -176,7 +176,7 @@ describe('controllers/insurance/policy/broker-details', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
       });
@@ -187,7 +187,7 @@ describe('controllers/insurance/policy/broker-details', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/policy/broker/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/broker/index.test.ts
@@ -11,7 +11,7 @@ import mapApplicationToFormFields from '../../../../helpers/mappings/map-applica
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../map-and-save/broker';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const { USING_BROKER } = POLICY_FIELD_IDS;
 
@@ -36,8 +36,6 @@ const {
     INSURANCE: { BROKER: BROKER_PARTIALS },
   },
 } = TEMPLATES;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/broker', () => {
   let req: Request;

--- a/src/ui/server/controllers/insurance/policy/call-map-and-save/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/call-map-and-save/index.test.ts
@@ -32,8 +32,6 @@ describe('controllers/insurance/policy/call-map-and-save', () => {
     req = mockReq();
     res = mockRes();
 
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-
     req.body = mockFormBody;
   });
 

--- a/src/ui/server/controllers/insurance/policy/check-your-answers/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/check-your-answers/index.test.ts
@@ -9,28 +9,33 @@ import getUserNameFromSession from '../../../../helpers/get-user-name-from-sessi
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import { policySummaryLists } from '../../../../helpers/summary-lists/policy';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockCurrencies, mockContact, mockCurrenciesResponse, mockCurrenciesEmptyResponse } from '../../../../test-mocks';
+import {
+  mockReq,
+  mockRes,
+  mockApplication,
+  mockCurrencies,
+  mockContact,
+  mockCurrenciesResponse,
+  mockCurrenciesEmptyResponse,
+  referenceNumber,
+} from '../../../../test-mocks';
 import { mockBroker } from '../../../../test-mocks/mock-application';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, EXPORT_CONTRACT, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
 const { POLICY } = FIELD_IDS.INSURANCE;
 
-const { policy, exportContract, referenceNumber } = mockApplication;
+const { policy, exportContract } = mockApplication;
 
 describe('controllers/insurance/policy/check-your-answers', () => {
   let req: Request;
   let res: Response;
-  let refNumber: number;
 
   let getCurrenciesSpy = jest.fn(() => Promise.resolve(mockCurrenciesResponse));
 
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-    refNumber = Number(mockApplication.referenceNumber);
 
     api.keystone.APIM.getCurrencies = getCurrenciesSpy;
   });
@@ -41,7 +46,7 @@ describe('controllers/insurance/policy/check-your-answers', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(refNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELD: FIELDS[POLICY.POLICY_TYPE],
@@ -80,7 +85,7 @@ describe('controllers/insurance/policy/check-your-answers', () => {
           PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.CHECK_YOUR_ANSWERS,
           BACK_LINK: req.headers.referer,
         }),
-        ...pageVariables(refNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         application: mapApplicationToFormFields(res.locals.application),
         SUMMARY_LISTS: summaryLists,

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/index.test.ts
@@ -12,7 +12,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/policy-contact';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockContact } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockContact, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -35,7 +35,6 @@ const { FIRST_NAME, LAST_NAME, EMAIL } = ACCOUNT_FIELD_IDS;
 describe('controllers/insurance/policy/different-name-on-policy', () => {
   let req: Request;
   let res: Response;
-  let refNumber: number;
 
   jest.mock('../map-and-save/policy-contact');
 
@@ -44,9 +43,6 @@ describe('controllers/insurance/policy/different-name-on-policy', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-    refNumber = Number(mockApplication.referenceNumber);
   });
 
   afterAll(() => {
@@ -55,7 +51,7 @@ describe('controllers/insurance/policy/different-name-on-policy', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(refNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELDS: {
@@ -79,7 +75,7 @@ describe('controllers/insurance/policy/different-name-on-policy', () => {
             ID: POLICY_CONTACT_DETAIL,
           },
         },
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${DIFFERENT_NAME_ON_POLICY_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${DIFFERENT_NAME_ON_POLICY_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -109,7 +105,7 @@ describe('controllers/insurance/policy/different-name-on-policy', () => {
           PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.DIFFERENT_NAME_ON_POLICY,
           BACK_LINK: req.headers.referer,
         }),
-        ...pageVariables(refNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         application: mockApplication,
         submittedValues: {
@@ -170,7 +166,7 @@ describe('controllers/insurance/policy/different-name-on-policy', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -183,7 +179,7 @@ describe('controllers/insurance/policy/different-name-on-policy', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -201,7 +197,7 @@ describe('controllers/insurance/policy/different-name-on-policy', () => {
             PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.DIFFERENT_NAME_ON_POLICY,
             BACK_LINK: req.headers.referer,
           }),
-          ...pageVariables(refNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           application: mockApplication,
           submittedValues: payload,

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/save-and-back/index.test.ts
@@ -6,15 +6,13 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/policy-contact';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockApplication, mockReq, mockRes, mockContact } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockContact, referenceNumber } from '../../../../../test-mocks';
 
 const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE },
 } = ROUTES;
 
 const { FIRST_NAME } = ACCOUNT_FIELD_IDS;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/different-name-on-policy/save-and-back', () => {
   let req: Request;
@@ -33,8 +31,6 @@ describe('controllers/insurance/policy/different-name-on-policy/save-and-back', 
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(referenceNumber);
 
     req.body = mockFormBody;
   });

--- a/src/ui/server/controllers/insurance/policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/index.test.ts
@@ -5,14 +5,12 @@ import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import sectionStartPageVariables from '../../../helpers/page-variables/core/insurance/section-start';
 import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
 import { Request, Response } from '../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../test-mocks';
+import { referenceNumber, mockReq, mockRes } from '../../../test-mocks';
 
 const {
   POLICY: { TYPE_OF_POLICY },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/index', () => {
   let req: Request;

--- a/src/ui/server/controllers/insurance/policy/loss-payee-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/loss-payee-details/index.test.ts
@@ -11,7 +11,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import mapAndSave from '../map-and-save/nominated-loss-payee';
-import { mockReq, mockRes, mockApplication, mockLossPayeeDetails } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockLossPayeeDetails, referenceNumber } from '../../../../test-mocks';
 
 const { NAME, LOCATION, IS_LOCATED_INTERNATIONALLY, IS_LOCATED_IN_UK } = POLICY_FIELD_IDS.LOSS_PAYEE_DETAILS;
 
@@ -30,8 +30,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const { LOSS_PAYEE_DETAILS } = POLICY_FIELDS;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/loss-payee-details', () => {
   let req: Request;
@@ -142,7 +140,7 @@ describe('controllers/insurance/policy/loss-payee-details', () => {
             PAGE_CONTENT_STRINGS,
             BACK_LINK: req.headers.referer,
           }),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           submittedValues: payload,
           validationErrors: generateValidationErrors(payload),
@@ -175,7 +173,7 @@ describe('controllers/insurance/policy/loss-payee-details', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
       });
@@ -186,7 +184,7 @@ describe('controllers/insurance/policy/loss-payee-details', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/policy/loss-payee-financial-details-international/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/loss-payee-financial-details-international/index.test.ts
@@ -9,7 +9,7 @@ import getUserNameFromSession from '../../../../helpers/get-user-name-from-sessi
 import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockLossPayeeFinancialDetailsInternational } from '../../../../test-mocks';
+import { mockReq, mockRes, mockLossPayeeFinancialDetailsInternational, referenceNumber } from '../../../../test-mocks';
 
 const { BIC_SWIFT_CODE, IBAN } = POLICY_FIELD_IDS.LOSS_PAYEE_FINANCIAL_INTERNATIONAL;
 const { FINANCIAL_ADDRESS } = POLICY_FIELD_IDS;
@@ -21,8 +21,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const { LOSS_PAYEE_FINANCIAL_INTERNATIONAL, FINANCIAL_ADDRESS: FINANCIAL_ADDRESS_FIELD } = POLICY_FIELDS;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/loss-payee-financial-details-international', () => {
   let req: Request;
@@ -124,7 +122,7 @@ describe('controllers/insurance/policy/loss-payee-financial-details-internationa
             PAGE_CONTENT_STRINGS,
             BACK_LINK: req.headers.referer,
           }),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           submittedValues: payload,
           validationErrors: generateValidationErrors(payload),

--- a/src/ui/server/controllers/insurance/policy/loss-payee-financial-details-uk/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/loss-payee-financial-details-uk/index.test.ts
@@ -9,7 +9,7 @@ import getUserNameFromSession from '../../../../helpers/get-user-name-from-sessi
 import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockLossPayeeFinancialDetailsUk } from '../../../../test-mocks';
+import { mockReq, mockRes, mockLossPayeeFinancialDetailsUk, referenceNumber } from '../../../../test-mocks';
 
 const { SORT_CODE, ACCOUNT_NUMBER } = POLICY_FIELD_IDS.LOSS_PAYEE_FINANCIAL_UK;
 const { FINANCIAL_ADDRESS } = POLICY_FIELD_IDS;
@@ -21,8 +21,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const { LOSS_PAYEE_FINANCIAL_UK, FINANCIAL_ADDRESS: FINANCIAL_ADDRESS_FIELD } = POLICY_FIELDS;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/loss-payee-financial-details-uk', () => {
   let req: Request;
@@ -124,7 +122,7 @@ describe('controllers/insurance/policy/loss-payee-financial-details-uk', () => {
             PAGE_CONTENT_STRINGS,
             BACK_LINK: req.headers.referer,
           }),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           submittedValues: payload,
           validationErrors: generateValidationErrors(payload),

--- a/src/ui/server/controllers/insurance/policy/loss-payee/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/loss-payee/index.test.ts
@@ -10,7 +10,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../map-and-save/nominated-loss-payee';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const {
   LOSS_PAYEE: { IS_APPOINTED },
@@ -21,8 +21,6 @@ const {
   POLICY: { LOSS_PAYEE_DETAILS_ROOT, LOSS_PAYEE_SAVE_AND_BACK, CHECK_YOUR_ANSWERS },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/loss-payee', () => {
   let req: Request;

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.test.ts
@@ -39,6 +39,7 @@ const { PAGE_TITLE } = PAGE_CONTENT_STRINGS;
 
 const {
   policy: { policyCurrencyCode },
+  referenceNumber,
 } = mockApplication;
 
 const { allCurrencies } = mockCurrenciesResponse;
@@ -46,7 +47,6 @@ const { allCurrencies } = mockCurrenciesResponse;
 describe('controllers/insurance/policy/multiple-contract-policy/export-value', () => {
   let req: Request;
   let res: Response;
-  let refNumber: number;
 
   jest.mock('../../map-and-save/policy');
 
@@ -58,8 +58,6 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
     res = mockRes();
 
     res.locals.application = mockApplication;
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-    refNumber = Number(mockApplication.referenceNumber);
     api.keystone.APIM.getCurrencies = getCurrenciesSpy;
   });
 
@@ -75,7 +73,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(refNumber, allCurrencies, String(policyCurrencyCode));
+      const result = pageVariables(referenceNumber, allCurrencies, String(policyCurrencyCode));
 
       const currency = getCurrencyByCode(mockCurrencies, String(policyCurrencyCode));
 
@@ -92,7 +90,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
         },
         DYNAMIC_PAGE_TITLE: `${PAGE_TITLE} ${currency.name}`,
         CURRENCY_PREFIX_SYMBOL: currency.symbol,
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${refNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -123,7 +121,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
     it('should render template', async () => {
       await get(req, res);
 
-      const generatedPageVariables = pageVariables(refNumber, allCurrencies, String(policyCurrencyCode));
+      const generatedPageVariables = pageVariables(referenceNumber, allCurrencies, String(policyCurrencyCode));
 
       const { DYNAMIC_PAGE_TITLE } = generatedPageVariables;
 
@@ -224,7 +222,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -236,7 +234,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -255,7 +253,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
 
         const payload = constructPayload(req.body, FIELD_IDS);
 
-        const generatedPageVariables = pageVariables(refNumber, allCurrencies, String(policyCurrencyCode));
+        const generatedPageVariables = pageVariables(referenceNumber, allCurrencies, String(policyCurrencyCode));
 
         const { DYNAMIC_PAGE_TITLE } = generatedPageVariables;
 

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.test.ts
@@ -57,7 +57,6 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
     req = mockReq();
     res = mockRes();
 
-    res.locals.application = mockApplication;
     api.keystone.APIM.getCurrencies = getCurrenciesSpy;
   });
 

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.test.ts
@@ -118,6 +118,8 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
     });
 
     it('should render template', async () => {
+      res.locals.application = mockApplication;
+
       await get(req, res);
 
       const generatedPageVariables = pageVariables(referenceNumber, allCurrencies, String(policyCurrencyCode));
@@ -248,6 +250,8 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
       });
 
       it('should render template with validation errors and submitted values from constructPayload function', async () => {
+        res.locals.application = mockApplication;
+
         await post(req, res);
 
         const payload = constructPayload(req.body, FIELD_IDS);

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/save-and-back/index.test.ts
@@ -5,11 +5,9 @@ import constructPayload from '../../../../../../helpers/construct-payload';
 import mapAndSave from '../../../map-and-save/policy';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../../../../test-mocks';
+import { referenceNumber, mockReq, mockRes } from '../../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/multiple-contract-policy/export-value/save-and-back', () => {
   let req: Request;
@@ -28,8 +26,6 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value/sav
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(referenceNumber);
 
     req.body = mockFormBody;
   });

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.test.ts
@@ -87,7 +87,6 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
     req = mockReq();
     res = mockRes();
 
-    res.locals.application = mockApplication;
     api.keystone.APIM.getCurrencies = getCurrenciesSpy;
   });
 

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.test.ts
@@ -14,7 +14,11 @@ import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/policy';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes, mockCurrenciesResponse, mockCurrenciesEmptyResponse } from '../../../../test-mocks';
-import { mockApplicationMultiplePolicy as mockApplication, mockApplicationMultiplePolicyWithoutCurrencyCode } from '../../../../test-mocks/mock-application';
+import {
+  mockApplicationMultiplePolicy as mockApplication,
+  mockApplicationMultiplePolicyWithoutCurrencyCode,
+  referenceNumber,
+} from '../../../../test-mocks/mock-application';
 
 const {
   INSURANCE_ROOT,
@@ -73,7 +77,6 @@ const applicationCurrencyAnswer = mockApplication.policy[POLICY_CURRENCY_CODE];
 describe('controllers/insurance/policy/multiple-contract-policy', () => {
   let req: Request;
   let res: Response;
-  let refNumber: number;
 
   jest.mock('../map-and-save/policy');
 
@@ -85,8 +88,6 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
     res = mockRes();
 
     res.locals.application = mockApplication;
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-    refNumber = Number(mockApplication.referenceNumber);
     api.keystone.APIM.getCurrencies = getCurrenciesSpy;
   });
 
@@ -96,7 +97,7 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(refNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELDS: {
@@ -168,7 +169,7 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
           PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.MULTIPLE_CONTRACT_POLICY,
           BACK_LINK: req.headers.referer,
         }),
-        ...pageVariables(refNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         application: mapApplicationToFormFields(mockApplication),
         ...mapRadioAndSelectOptions(alternativeCurrencies, supportedCurrencies, applicationCurrencyAnswer),
@@ -266,7 +267,7 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
 
             await post(req, res);
 
-            const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_YOUR_ANSWERS}`;
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
             expect(res.redirect).toHaveBeenCalledWith(expected);
           });
@@ -280,7 +281,7 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
 
             await post(req, res);
 
-            const expected = `${INSURANCE_ROOT}/${refNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE}`;
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHANGE}`;
 
             expect(res.redirect).toHaveBeenCalledWith(expected);
           });
@@ -296,7 +297,7 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
 
             await post(req, res);
 
-            const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_AND_CHANGE_ROUTE}`;
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
             expect(res.redirect).toHaveBeenCalledWith(expected);
           });
@@ -310,7 +311,7 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
 
             await post(req, res);
 
-            const expected = `${INSURANCE_ROOT}/${refNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE}`;
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_CHECK_AND_CHANGE}`;
 
             expect(res.redirect).toHaveBeenCalledWith(expected);
           });
@@ -336,7 +337,7 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
               PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.MULTIPLE_CONTRACT_POLICY,
               BACK_LINK: req.headers.referer,
             }),
-            ...pageVariables(refNumber),
+            ...pageVariables(referenceNumber),
             userName: getUserNameFromSession(req.session.user),
             application: mapApplicationToFormFields(mockApplication),
             submittedValues: payload,
@@ -361,7 +362,7 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
               PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.MULTIPLE_CONTRACT_POLICY,
               BACK_LINK: req.headers.referer,
             }),
-            ...pageVariables(refNumber),
+            ...pageVariables(referenceNumber),
             userName: getUserNameFromSession(req.session.user),
             application: mapApplicationToFormFields(mockApplicationMultiplePolicyWithoutCurrencyCode),
             submittedValues: payload,

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.test.ts
@@ -161,6 +161,8 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
     });
 
     it('should render template', async () => {
+      res.locals.application = mockApplication;
+
       await get(req, res);
 
       const expectedVariables = {
@@ -327,6 +329,8 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
 
       describe(`when the application has a ${POLICY_CURRENCY_CODE} answer`, () => {
         it('should render template with validation errors and submitted values from constructPayload function and application', async () => {
+          res.locals.application = mockApplication;
+
           await post(req, res);
 
           const payload = constructPayload(req.body, FIELD_IDS);

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/save-and-back/index.test.ts
@@ -5,11 +5,9 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/policy';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
+import { referenceNumber, mockReq, mockRes } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/multiple-contract-policy/save-and-back', () => {
   let req: Request;
@@ -28,8 +26,6 @@ describe('controllers/insurance/policy/multiple-contract-policy/save-and-back', 
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(referenceNumber);
 
     req.body = mockFormBody;
   });

--- a/src/ui/server/controllers/insurance/policy/name-on-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/name-on-policy/index.test.ts
@@ -10,7 +10,7 @@ import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/policy-contact';
 import getNameEmailPositionFromOwnerAndPolicy from '../../../../helpers/get-name-email-position-from-owner-and-policy';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE: {
@@ -37,7 +37,6 @@ const {
 describe('controllers/insurance/policy/name-on-policy', () => {
   let req: Request;
   let res: Response;
-  let refNumber: number;
 
   jest.mock('../map-and-save/policy-contact');
 
@@ -46,9 +45,6 @@ describe('controllers/insurance/policy/name-on-policy', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-    refNumber = Number(mockApplication.referenceNumber);
   });
 
   afterAll(() => {
@@ -57,7 +53,7 @@ describe('controllers/insurance/policy/name-on-policy', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(refNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELDS: {
@@ -70,7 +66,7 @@ describe('controllers/insurance/policy/name-on-policy', () => {
             ...FIELDS.NAME_ON_POLICY[POSITION],
           },
         },
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${NAME_ON_POLICY_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${NAME_ON_POLICY_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -102,7 +98,7 @@ describe('controllers/insurance/policy/name-on-policy', () => {
           PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.NAME_ON_POLICY,
           BACK_LINK: req.headers.referer,
         }),
-        ...pageVariables(refNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         application: mockApplication,
         submittedValues,
@@ -202,7 +198,7 @@ describe('controllers/insurance/policy/name-on-policy', () => {
 
             await post(req, res);
 
-            const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_YOUR_ANSWERS}`;
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
             expect(res.redirect).toHaveBeenCalledWith(expected);
           });
@@ -217,7 +213,7 @@ describe('controllers/insurance/policy/name-on-policy', () => {
 
             await post(req, res);
 
-            const expected = `${INSURANCE_ROOT}/${refNumber}${DIFFERENT_NAME_ON_POLICY_CHANGE}`;
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${DIFFERENT_NAME_ON_POLICY_CHANGE}`;
 
             expect(res.redirect).toHaveBeenCalledWith(expected);
           });
@@ -237,7 +233,7 @@ describe('controllers/insurance/policy/name-on-policy', () => {
 
             await post(req, res);
 
-            const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_AND_CHANGE_ROUTE}`;
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
             expect(res.redirect).toHaveBeenCalledWith(expected);
           });
@@ -252,7 +248,7 @@ describe('controllers/insurance/policy/name-on-policy', () => {
 
             await post(req, res);
 
-            const expected = `${INSURANCE_ROOT}/${refNumber}${DIFFERENT_NAME_ON_POLICY_CHECK_AND_CHANGE}`;
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${DIFFERENT_NAME_ON_POLICY_CHECK_AND_CHANGE}`;
 
             expect(res.redirect).toHaveBeenCalledWith(expected);
           });
@@ -277,7 +273,7 @@ describe('controllers/insurance/policy/name-on-policy', () => {
             PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.NAME_ON_POLICY,
             BACK_LINK: req.headers.referer,
           }),
-          ...pageVariables(refNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           application: mockApplication,
           submittedValues,

--- a/src/ui/server/controllers/insurance/policy/name-on-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/name-on-policy/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/policy-contact';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
+import { referenceNumber, mockReq, mockRes } from '../../../../../test-mocks';
 
 const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE },
@@ -15,8 +15,6 @@ const {
 const {
   NAME_ON_POLICY: { NAME, SAME_NAME },
 } = POLICY_FIELD_IDS;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/name-on-policy/save-and-back', () => {
   let req: Request;
@@ -35,8 +33,6 @@ describe('controllers/insurance/policy/name-on-policy/save-and-back', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(referenceNumber);
 
     req.body = mockFormBody;
   });

--- a/src/ui/server/controllers/insurance/policy/other-company-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/index.test.ts
@@ -57,8 +57,6 @@ describe('controllers/insurance/policy/other-company-details', () => {
 
     res.locals.application = mockApplicationWithoutCountryCode;
 
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-
     api.keystone.countries.getAll = getCountriesSpy;
   });
 

--- a/src/ui/server/controllers/insurance/policy/pre-credit-period/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/pre-credit-period/index.test.ts
@@ -41,8 +41,6 @@ describe('controllers/insurance/policy/pre-credit-period', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    res.locals.application = mockApplication;
   });
 
   afterAll(() => {

--- a/src/ui/server/controllers/insurance/policy/pre-credit-period/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/pre-credit-period/index.test.ts
@@ -12,7 +12,7 @@ import { sanitiseData } from '../../../../helpers/sanitise-data';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/policy';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -33,7 +33,6 @@ const {
 describe('controllers/insurance/policy/pre-credit-period', () => {
   let req: Request;
   let res: Response;
-  let refNumber: number;
 
   jest.mock('../map-and-save/policy');
 
@@ -44,9 +43,6 @@ describe('controllers/insurance/policy/pre-credit-period', () => {
     res = mockRes();
 
     res.locals.application = mockApplication;
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-    refNumber = Number(mockApplication.referenceNumber);
   });
 
   afterAll(() => {
@@ -67,7 +63,7 @@ describe('controllers/insurance/policy/pre-credit-period', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(refNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELD_ID: NEED_PRE_CREDIT_PERIOD,
@@ -126,7 +122,7 @@ describe('controllers/insurance/policy/pre-credit-period', () => {
           BACK_LINK: req.headers.referer,
           HTML_FLAGS,
         }),
-        ...pageVariables(refNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         application: mapApplicationToFormFields(mockApplication),
         applicationAnswer: mockApplication.policy[NEED_PRE_CREDIT_PERIOD],
@@ -183,7 +179,7 @@ describe('controllers/insurance/policy/pre-credit-period', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -195,7 +191,7 @@ describe('controllers/insurance/policy/pre-credit-period', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -224,7 +220,7 @@ describe('controllers/insurance/policy/pre-credit-period', () => {
             BACK_LINK: req.headers.referer,
             HTML_FLAGS,
           }),
-          ...pageVariables(refNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           application: res.locals.application,
           submittedValues: sanitisedData,

--- a/src/ui/server/controllers/insurance/policy/pre-credit-period/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/pre-credit-period/save-and-back/index.test.ts
@@ -5,11 +5,9 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/policy';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
+import { referenceNumber, mockReq, mockRes } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/pre-credit-period/save-and-back', () => {
   let req: Request;
@@ -28,8 +26,6 @@ describe('controllers/insurance/policy/pre-credit-period/save-and-back', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(referenceNumber);
 
     req.body = mockFormBody;
   });

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/index.test.ts
@@ -14,7 +14,7 @@ import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/policy';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes, mockCurrencies, mockCurrenciesResponse, mockCurrenciesEmptyResponse } from '../../../../test-mocks';
-import mockApplication, { mockApplicationSinglePolicyWithoutCurrencyCode } from '../../../../test-mocks/mock-application';
+import mockApplication, { referenceNumber, mockApplicationSinglePolicyWithoutCurrencyCode } from '../../../../test-mocks/mock-application';
 
 const {
   INSURANCE_ROOT,
@@ -68,7 +68,6 @@ const applicationCurrencyAnswer = mockApplication.policy[POLICY_CURRENCY_CODE];
 describe('controllers/insurance/policy/single-contract-policy', () => {
   let req: Request;
   let res: Response;
-  let refNumber: number;
 
   jest.mock('../save-data/policy');
 
@@ -81,8 +80,6 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
 
     res.locals.application = mockApplication;
 
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-    refNumber = Number(mockApplication.referenceNumber);
     api.keystone.APIM.getCurrencies = getCurrenciesSpy;
   });
 
@@ -92,7 +89,7 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(refNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELDS: {
@@ -158,7 +155,7 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
           PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.SINGLE_CONTRACT_POLICY,
           BACK_LINK: req.headers.referer,
         }),
-        ...pageVariables(refNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         application: mapApplicationToFormFields(mockApplication),
         ...mapRadioAndSelectOptions(alternativeCurrencies, supportedCurrencies, applicationCurrencyAnswer),
@@ -266,7 +263,7 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
 
             await post(req, res);
 
-            const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_YOUR_ANSWERS}`;
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
             expect(res.redirect).toHaveBeenCalledWith(expected);
           });
@@ -280,7 +277,7 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
 
             await post(req, res);
 
-            const expected = `${INSURANCE_ROOT}/${refNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_CHANGE}`;
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_CHANGE}`;
 
             expect(res.redirect).toHaveBeenCalledWith(expected);
           });
@@ -296,7 +293,7 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
 
             await post(req, res);
 
-            const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_AND_CHANGE_ROUTE}`;
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
             expect(res.redirect).toHaveBeenCalledWith(expected);
           });
@@ -310,7 +307,7 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
 
             await post(req, res);
 
-            const expected = `${INSURANCE_ROOT}/${refNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_CHECK_AND_CHANGE}`;
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_CHECK_AND_CHANGE}`;
 
             expect(res.redirect).toHaveBeenCalledWith(expected);
           });
@@ -336,7 +333,7 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
               PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.SINGLE_CONTRACT_POLICY,
               BACK_LINK: req.headers.referer,
             }),
-            ...pageVariables(refNumber),
+            ...pageVariables(referenceNumber),
             userName: getUserNameFromSession(req.session.user),
             application: mapApplicationToFormFields(mockApplication),
             submittedValues: payload,
@@ -361,7 +358,7 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
               PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.SINGLE_CONTRACT_POLICY,
               BACK_LINK: req.headers.referer,
             }),
-            ...pageVariables(refNumber),
+            ...pageVariables(referenceNumber),
             userName: getUserNameFromSession(req.session.user),
             application: mapApplicationToFormFields(mockApplicationSinglePolicyWithoutCurrencyCode),
             submittedValues: payload,

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/index.test.ts
@@ -78,8 +78,6 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
     req = mockReq();
     res = mockRes();
 
-    res.locals.application = mockApplication;
-
     api.keystone.APIM.getCurrencies = getCurrenciesSpy;
   });
 

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/save-and-back/index.test.ts
@@ -5,13 +5,11 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/policy';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
+import { referenceNumber, mockReq, mockRes } from '../../../../../test-mocks';
 
 const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE },
 } = ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/single-contract-policy/save-and-back', () => {
   let req: Request;
@@ -30,8 +28,6 @@ describe('controllers/insurance/policy/single-contract-policy/save-and-back', ()
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(referenceNumber);
 
     req.body = mockFormBody;
   });

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
@@ -38,8 +38,8 @@ const {
 const { PAGE_TITLE } = PAGE_CONTENT_STRINGS;
 
 const {
-  referenceNumber,
   policy: { policyCurrencyCode },
+  referenceNumber,
 } = mockApplication;
 
 const { allCurrencies } = mockCurrenciesResponse;
@@ -47,7 +47,6 @@ const { allCurrencies } = mockCurrenciesResponse;
 describe('controllers/insurance/policy/single-contract-policy/total-contract-value', () => {
   let req: Request;
   let res: Response;
-  let refNumber: number;
 
   jest.mock('../../map-and-save/policy');
 
@@ -59,8 +58,6 @@ describe('controllers/insurance/policy/single-contract-policy/total-contract-val
     res = mockRes();
 
     res.locals.application = mockApplication;
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
-    refNumber = Number(mockApplication.referenceNumber);
     api.keystone.APIM.getCurrencies = getCurrenciesSpy;
   });
 
@@ -216,7 +213,7 @@ describe('controllers/insurance/policy/single-contract-policy/total-contract-val
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -228,7 +225,7 @@ describe('controllers/insurance/policy/single-contract-policy/total-contract-val
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${refNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
@@ -57,7 +57,6 @@ describe('controllers/insurance/policy/single-contract-policy/total-contract-val
     req = mockReq();
     res = mockRes();
 
-    res.locals.application = mockApplication;
     api.keystone.APIM.getCurrencies = getCurrenciesSpy;
   });
 

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
@@ -110,6 +110,8 @@ describe('controllers/insurance/policy/single-contract-policy/total-contract-val
     });
 
     it('should render template', async () => {
+      res.locals.application = mockApplication;
+
       await get(req, res);
 
       const generatedPageVariables = pageVariables(referenceNumber, allCurrencies, String(policyCurrencyCode));
@@ -239,6 +241,8 @@ describe('controllers/insurance/policy/single-contract-policy/total-contract-val
       });
 
       it('should render template with validation errors and submitted values from constructPayload function', async () => {
+        res.locals.application = mockApplication;
+
         await post(req, res);
 
         const payload = constructPayload(req.body, [FIELD_ID]);

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/save-and-back/index.test.ts
@@ -5,11 +5,9 @@ import constructPayload from '../../../../../../helpers/construct-payload';
 import mapAndSave from '../../../map-and-save/policy';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../../../../test-mocks';
+import { referenceNumber, mockReq, mockRes } from '../../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/single-contract-policy/total-contract-value/save-and-back', () => {
   let req: Request;
@@ -28,8 +26,6 @@ describe('controllers/insurance/policy/single-contract-policy/total-contract-val
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(referenceNumber);
 
     req.body = mockFormBody;
   });

--- a/src/ui/server/controllers/insurance/policy/type-of-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/type-of-policy/index.test.ts
@@ -11,7 +11,7 @@ import generateValidationErrors from './validation';
 import constructPayload from '../../../../helpers/construct-payload';
 import mapAndSave from '../map-and-save/policy';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -29,8 +29,6 @@ const {
   TYPE_OF_POLICY: { POLICY_TYPE: FIELD_ID },
 } = POLICY_FIELD_IDS;
 
-const { referenceNumber } = mockApplication;
-
 const singlePolicyRoute = `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
 const multiplePolicyRoute = `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
 const checkAndChangeRoute = `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_CHECK_AND_CHANGE}`;
@@ -38,7 +36,6 @@ const checkAndChangeRoute = `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRA
 describe('controllers/insurance/policy/type-of-policy', () => {
   let req: Request;
   let res: Response;
-  let refNumber: number;
 
   jest.mock('../save-data/policy');
 
@@ -48,17 +45,15 @@ describe('controllers/insurance/policy/type-of-policy', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(referenceNumber);
-    refNumber = Number(referenceNumber);
   });
+
   afterAll(() => {
     jest.resetAllMocks();
   });
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(refNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELD: FIELDS[FIELD_ID],
@@ -91,7 +86,7 @@ describe('controllers/insurance/policy/type-of-policy', () => {
           PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.TYPE_OF_POLICY,
           BACK_LINK: req.headers.referer,
         }),
-        ...pageVariables(refNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         application: mapApplicationToFormFields(res.locals.application),
       };
@@ -155,7 +150,7 @@ describe('controllers/insurance/policy/type-of-policy', () => {
 
             await post(req, res);
 
-            const expected = `${INSURANCE_ROOT}/${refNumber}${SINGLE_CONTRACT_POLICY_CHECK_AND_CHANGE}`;
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_CHECK_AND_CHANGE}`;
 
             expect(res.redirect).toHaveBeenCalledWith(expected);
           });
@@ -204,7 +199,7 @@ describe('controllers/insurance/policy/type-of-policy', () => {
 
             await post(req, res);
 
-            const expected = `${INSURANCE_ROOT}/${refNumber}${MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE}`;
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE}`;
 
             expect(res.redirect).toHaveBeenCalledWith(expected);
           });
@@ -223,7 +218,7 @@ describe('controllers/insurance/policy/type-of-policy', () => {
             PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.TYPE_OF_POLICY,
             BACK_LINK: req.headers.referer,
           }),
-          ...pageVariables(refNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           validationErrors: generateValidationErrors(payload),
         };
@@ -249,7 +244,7 @@ describe('controllers/insurance/policy/type-of-policy', () => {
             PAGE_CONTENT_STRINGS: PAGES.INSURANCE.POLICY.TYPE_OF_POLICY,
             BACK_LINK: req.headers.referer,
           }),
-          ...pageVariables(refNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           validationErrors: generateValidationErrors(payload),
         };

--- a/src/ui/server/controllers/insurance/policy/type-of-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/type-of-policy/save-and-back/index.test.ts
@@ -5,13 +5,11 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save/policy';
 import { Request, Response } from '../../../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
+import { referenceNumber, mockReq, mockRes } from '../../../../../test-mocks';
 
 const {
   INSURANCE: { INSURANCE_ROOT, PROBLEM_WITH_SERVICE },
 } = ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/policy/type-of-policy/save-and-back', () => {
   let req: Request;
@@ -30,8 +28,6 @@ describe('controllers/insurance/policy/type-of-policy/save-and-back', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(referenceNumber);
 
     req.body = mockFormBody;
   });

--- a/src/ui/server/controllers/insurance/your-buyer/alternative-currency/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/alternative-currency/index.test.ts
@@ -20,6 +20,7 @@ import {
   mockCurrenciesResponse,
   mockCurrenciesEmptyResponse,
   mockBuyerTradingHistory,
+  referenceNumber,
 } from '../../../../test-mocks';
 import mapAndSave from '../map-and-save/buyer-trading-history';
 
@@ -45,7 +46,6 @@ describe('controllers/insurance/your-buyer/alternative-currency', () => {
     req = mockReq();
     res = mockRes();
 
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
     api.keystone.APIM.getCurrencies = getCurrenciesSpy;
   });
 
@@ -174,7 +174,7 @@ describe('controllers/insurance/your-buyer/alternative-currency', () => {
 
       it('should redirect to the next page', async () => {
         await post(req, res);
-        const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TRADING_HISTORY}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${TRADING_HISTORY}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
@@ -195,7 +195,7 @@ describe('controllers/insurance/your-buyer/alternative-currency', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TRADING_HISTORY_CHANGE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${TRADING_HISTORY_CHANGE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -207,7 +207,7 @@ describe('controllers/insurance/your-buyer/alternative-currency', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TRADING_HISTORY_CHECK_AND_CHANGE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${TRADING_HISTORY_CHECK_AND_CHANGE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/your-buyer/buyer-financial-information/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/buyer-financial-information/index.test.ts
@@ -9,7 +9,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import mapAndSave from '../map-and-save/buyer-relationship';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -41,8 +41,6 @@ describe('controllers/insurance/your-buyer/buyer-financial-information', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
   });
 
   afterAll(() => {
@@ -60,10 +58,10 @@ describe('controllers/insurance/your-buyer/buyer-financial-information', () => {
           },
         },
         PAGE_CONTENT_STRINGS,
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${BUYER_FINANCIAL_INFORMATION_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${BUYER_FINANCIAL_INFORMATION_SAVE_AND_BACK}`,
       };
 
-      expect(pageVariables(mockApplication.referenceNumber)).toEqual(expected);
+      expect(pageVariables(referenceNumber)).toEqual(expected);
     });
   });
 
@@ -109,7 +107,7 @@ describe('controllers/insurance/your-buyer/buyer-financial-information', () => {
           BACK_LINK: req.headers.referer,
           HTML_FLAGS,
         }),
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         application: mapApplicationToFormFields(mockApplication),
         FIELD_HINT: PAGE_CONTENT_STRINGS.HINT,
@@ -148,7 +146,7 @@ describe('controllers/insurance/your-buyer/buyer-financial-information', () => {
 
       it(`should redirect to the next page when ${HAS_BUYER_FINANCIAL_ACCOUNTS} is true`, async () => {
         await post(req, res);
-        const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
@@ -169,7 +167,7 @@ describe('controllers/insurance/your-buyer/buyer-financial-information', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -181,7 +179,7 @@ describe('controllers/insurance/your-buyer/buyer-financial-information', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -204,7 +202,7 @@ describe('controllers/insurance/your-buyer/buyer-financial-information', () => {
           }),
           userName: getUserNameFromSession(req.session.user),
           FIELD_HINT: PAGE_CONTENT_STRINGS.HINT,
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           submittedValues: payload,
           validationErrors,
         };

--- a/src/ui/server/controllers/insurance/your-buyer/check-your-answers/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/check-your-answers/index.test.ts
@@ -6,7 +6,7 @@ import getUserNameFromSession from '../../../../helpers/get-user-name-from-sessi
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import { yourBuyerSummaryList } from '../../../../helpers/summary-lists/your-buyer';
 import { Request, Response, ApplicationBuyer } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockBuyer } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockBuyer, referenceNumber } from '../../../../test-mocks';
 
 const { CHECK_YOUR_ANSWERS } = PAGES.INSURANCE.YOUR_BUYER;
 const { CHECK_YOUR_ANSWERS: CHECK_YOUR_ANSWERS_TEMPLATE } = TEMPLATES.INSURANCE.YOUR_BUYER;
@@ -22,8 +22,6 @@ describe('controllers/insurance/your-buyer/check-your-answers', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
   });
 
   describe('TEMPLATE', () => {
@@ -42,7 +40,7 @@ describe('controllers/insurance/your-buyer/check-your-answers', () => {
       const summaryList = yourBuyerSummaryList(
         mockApplicationBuyer,
         mockApplication.eligibility,
-        mockApplication.referenceNumber,
+        referenceNumber,
         mockApplication.totalContractValueOverThreshold,
       );
 

--- a/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/index.test.ts
@@ -10,7 +10,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import mapAndSave from '../map-and-save/buyer';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockBuyer } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockBuyer, referenceNumber } from '../../../../test-mocks';
 
 const { COMPANY_OR_ORGANISATION } = BUYER_FIELD_IDS;
 
@@ -40,8 +40,6 @@ describe('controllers/insurance/your-buyer/company-or-organisation', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
   });
 
   afterAll(() => {
@@ -73,10 +71,10 @@ describe('controllers/insurance/your-buyer/company-or-organisation', () => {
             ...FIELDS.COMPANY_OR_ORGANISATION[WEBSITE],
           },
         },
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${COMPANY_OR_ORGANISATION_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${COMPANY_OR_ORGANISATION_SAVE_AND_BACK}`,
       };
 
-      expect(pageVariables(mockApplication.referenceNumber)).toEqual(expected);
+      expect(pageVariables(referenceNumber)).toEqual(expected);
     });
   });
 
@@ -105,7 +103,7 @@ describe('controllers/insurance/your-buyer/company-or-organisation', () => {
         }),
         application: mapApplicationToFormFields(mockApplication),
         userName: getUserNameFromSession(req.session.user),
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
@@ -138,7 +136,7 @@ describe('controllers/insurance/your-buyer/company-or-organisation', () => {
 
       it('should redirect to the next page', async () => {
         await post(req, res);
-        const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CONNECTION_WITH_BUYER}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${CONNECTION_WITH_BUYER}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
@@ -166,7 +164,7 @@ describe('controllers/insurance/your-buyer/company-or-organisation', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
       });
@@ -178,7 +176,7 @@ describe('controllers/insurance/your-buyer/company-or-organisation', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -199,7 +197,7 @@ describe('controllers/insurance/your-buyer/company-or-organisation', () => {
             BACK_LINK: req.headers.referer,
           }),
           userName: getUserNameFromSession(req.session.user),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           submittedValues: payload,
           validationErrors,
         };

--- a/src/ui/server/controllers/insurance/your-buyer/connection-with-buyer/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/connection-with-buyer/index.test.ts
@@ -10,7 +10,7 @@ import generateValidationErrors from './validation';
 import constructPayload from '../../../../helpers/construct-payload';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockBuyer } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockBuyer, referenceNumber } from '../../../../test-mocks';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import mapAndSave from '../map-and-save/buyer-relationship';
 
@@ -47,8 +47,6 @@ describe('controllers/insurance/your-buyer/connection-with-buyer', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
   });
 
   afterAll(() => {
@@ -77,7 +75,7 @@ describe('controllers/insurance/your-buyer/connection-with-buyer', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELD_ID: CONNECTION_WITH_BUYER,
@@ -93,7 +91,7 @@ describe('controllers/insurance/your-buyer/connection-with-buyer', () => {
           },
         },
         PAGE_CONTENT_STRINGS,
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -122,7 +120,7 @@ describe('controllers/insurance/your-buyer/connection-with-buyer', () => {
           BACK_LINK: req.headers.referer,
           HTML_FLAGS,
         }),
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         application: mapApplicationToFormFields(mockApplication),
         FIELD_HINT: PAGE_CONTENT_STRINGS.HINT,
@@ -161,7 +159,7 @@ describe('controllers/insurance/your-buyer/connection-with-buyer', () => {
 
       it('should redirect to the next page', async () => {
         await post(req, res);
-        const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TRADED_WITH_BUYER}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${TRADED_WITH_BUYER}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
@@ -184,7 +182,7 @@ describe('controllers/insurance/your-buyer/connection-with-buyer', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
       });
@@ -196,7 +194,7 @@ describe('controllers/insurance/your-buyer/connection-with-buyer', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -217,7 +215,7 @@ describe('controllers/insurance/your-buyer/connection-with-buyer', () => {
             BACK_LINK: req.headers.referer,
             HTML_FLAGS,
           }),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           validationErrors,
           submittedValues: sanitiseData(payload),

--- a/src/ui/server/controllers/insurance/your-buyer/credit-insurance-cover/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/credit-insurance-cover/index.test.ts
@@ -6,12 +6,12 @@ import YOUR_BUYER_FIELD_IDS from '../../../../constants/field-ids/insurance/your
 import { YOUR_BUYER_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance';
 import insuranceCorePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
-import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
 import constructPayload from '../../../../helpers/construct-payload';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/buyer-relationship';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
+import { Request, Response } from '../../../../../types';
 
 const { HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER, PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER } = YOUR_BUYER_FIELD_IDS;
 
@@ -42,8 +42,6 @@ describe('controllers/insurance/your-buyer/credit-insurance-cover', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
   });
 
   afterAll(() => {
@@ -74,7 +72,7 @@ describe('controllers/insurance/your-buyer/credit-insurance-cover', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber);
+      const result = pageVariables(referenceNumber);
 
       const expected = {
         FIELD_ID: HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER,
@@ -88,7 +86,7 @@ describe('controllers/insurance/your-buyer/credit-insurance-cover', () => {
             ...FIELDS[PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER],
           },
         },
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CREDIT_INSURANCE_COVER_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${CREDIT_INSURANCE_COVER_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -123,7 +121,7 @@ describe('controllers/insurance/your-buyer/credit-insurance-cover', () => {
           BACK_LINK: req.headers.referer,
           HTML_FLAGS,
         }),
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         applicationAnswer: mockApplication.buyer.relationship[HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER],
       };
@@ -160,7 +158,7 @@ describe('controllers/insurance/your-buyer/credit-insurance-cover', () => {
 
       it('should redirect to the next page', async () => {
         await post(req, res);
-        const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
@@ -183,7 +181,7 @@ describe('controllers/insurance/your-buyer/credit-insurance-cover', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
       });
@@ -195,7 +193,7 @@ describe('controllers/insurance/your-buyer/credit-insurance-cover', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -216,7 +214,7 @@ describe('controllers/insurance/your-buyer/credit-insurance-cover', () => {
             BACK_LINK: req.headers.referer,
             HTML_FLAGS,
           }),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           userName: getUserNameFromSession(req.session.user),
           submittedValues: sanitiseData(payload),
           validationErrors,

--- a/src/ui/server/controllers/insurance/your-buyer/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/index.test.ts
@@ -5,14 +5,12 @@ import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import sectionStartPageVariables from '../../../helpers/page-variables/core/insurance/section-start';
 import getUserNameFromSession from '../../../helpers/get-user-name-from-session';
 import { Request, Response } from '../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../test-mocks';
+import { referenceNumber, mockReq, mockRes } from '../../../test-mocks';
 
 const {
   YOUR_BUYER: { COMPANY_OR_ORGANISATION },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('controllers/insurance/your-buyer/index', () => {
   let req: Request;

--- a/src/ui/server/controllers/insurance/your-buyer/traded-with-buyer/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/traded-with-buyer/index.test.ts
@@ -9,7 +9,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import mapAndSave from '../map-and-save/buyer-trading-history';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -35,8 +35,6 @@ describe('controllers/insurance/your-buyer/traded-with-buyer', () => {
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
   });
 
   afterAll(() => {
@@ -47,10 +45,10 @@ describe('controllers/insurance/your-buyer/traded-with-buyer', () => {
     it('should have correct properties', () => {
       const expected = {
         FIELD_ID: TRADED_WITH_BUYER,
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TRADED_WITH_BUYER_SAVE_AND_BACK}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${TRADED_WITH_BUYER_SAVE_AND_BACK}`,
       };
 
-      expect(pageVariables(mockApplication.referenceNumber)).toEqual(expected);
+      expect(pageVariables(referenceNumber)).toEqual(expected);
     });
   });
 
@@ -96,7 +94,7 @@ describe('controllers/insurance/your-buyer/traded-with-buyer', () => {
           HTML_FLAGS,
         }),
         userName: getUserNameFromSession(req.session.user),
-        ...pageVariables(mockApplication.referenceNumber),
+        ...pageVariables(referenceNumber),
         submittedValues: mockApplication.buyer.buyerTradingHistory,
       };
 
@@ -132,7 +130,7 @@ describe('controllers/insurance/your-buyer/traded-with-buyer', () => {
 
       it(`should redirect to the next page when ${TRADED_WITH_BUYER} is true`, async () => {
         await post(req, res);
-        const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TRADING_HISTORY}`;
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${TRADING_HISTORY}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });
@@ -167,7 +165,7 @@ describe('controllers/insurance/your-buyer/traded-with-buyer', () => {
           };
 
           await post(req, res);
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -183,7 +181,7 @@ describe('controllers/insurance/your-buyer/traded-with-buyer', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -199,7 +197,7 @@ describe('controllers/insurance/your-buyer/traded-with-buyer', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -218,7 +216,7 @@ describe('controllers/insurance/your-buyer/traded-with-buyer', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CREDIT_INSURANCE_COVER}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CREDIT_INSURANCE_COVER}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -240,7 +238,7 @@ describe('controllers/insurance/your-buyer/traded-with-buyer', () => {
             HTML_FLAGS,
           }),
           userName: getUserNameFromSession(req.session.user),
-          ...pageVariables(mockApplication.referenceNumber),
+          ...pageVariables(referenceNumber),
           submittedValues: payload,
           application: mapApplicationToFormFields(mockApplication),
           validationErrors,

--- a/src/ui/server/controllers/insurance/your-buyer/trading-history/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/trading-history/index.test.ts
@@ -11,6 +11,8 @@ import tradingHistoryValidation from './validation';
 import constructPayload from '../../../../helpers/construct-payload';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import mapAndSave from '../map-and-save/buyer-trading-history';
+import getCurrencyByCode from '../../../../helpers/get-currency-by-code';
+import api from '../../../../api';
 import { Request, Response } from '../../../../../types';
 import {
   mockReq,
@@ -20,9 +22,8 @@ import {
   mockApplicationTotalContractValueThresholdFalse,
   mockCurrencies,
   mockCurrenciesResponse,
+  referenceNumber,
 } from '../../../../test-mocks';
-import getCurrencyByCode from '../../../../helpers/get-currency-by-code';
-import api from '../../../../api';
 
 const {
   INSURANCE_ROOT,
@@ -69,7 +70,6 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
     req = mockReq();
     res = mockRes();
 
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
     api.keystone.APIM.getCurrencies = getCurrenciesSpy;
   });
 
@@ -79,7 +79,7 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
 
   describe('pageVariables', () => {
     it('should have correct properties', () => {
-      const result = pageVariables(mockApplication.referenceNumber, mockCurrencies, currencyValue);
+      const result = pageVariables(referenceNumber, mockCurrencies, currencyValue);
 
       const currency = getCurrencyByCode(mockCurrencies, String(currencyValue));
 
@@ -103,8 +103,8 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
           },
         },
         PAGE_CONTENT_STRINGS,
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${SAVE_AND_BACK}`,
-        PROVIDE_ALTERNATIVE_CURRENCY_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALTERNATIVE_CURRENCY}`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${SAVE_AND_BACK}`,
+        PROVIDE_ALTERNATIVE_CURRENCY_URL: `${INSURANCE_ROOT}/${referenceNumber}${ALTERNATIVE_CURRENCY}`,
         CURRENCY_PREFIX_SYMBOL: currency.symbol,
       };
 
@@ -115,7 +115,7 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
       it(`should have correct properties with "PROVIDE_ALTERNATIVE_CURRENCY_URL" set to ${ALTERNATIVE_CURRENCY_CHANGE}`, () => {
         const isChange = true;
 
-        const result = pageVariables(mockApplication.referenceNumber, mockCurrencies, currencyValue, isChange);
+        const result = pageVariables(referenceNumber, mockCurrencies, currencyValue, isChange);
 
         const currency = getCurrencyByCode(mockCurrencies, String(currencyValue));
 
@@ -139,8 +139,8 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
             },
           },
           PAGE_CONTENT_STRINGS,
-          SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${SAVE_AND_BACK}`,
-          PROVIDE_ALTERNATIVE_CURRENCY_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALTERNATIVE_CURRENCY_CHANGE}`,
+          SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${SAVE_AND_BACK}`,
+          PROVIDE_ALTERNATIVE_CURRENCY_URL: `${INSURANCE_ROOT}/${referenceNumber}${ALTERNATIVE_CURRENCY_CHANGE}`,
           CURRENCY_PREFIX_SYMBOL: currency.symbol,
         };
 
@@ -153,7 +153,7 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
         const isChange = undefined;
         const isCheckAndChange = true;
 
-        const result = pageVariables(mockApplication.referenceNumber, mockCurrencies, currencyValue, isChange, isCheckAndChange);
+        const result = pageVariables(referenceNumber, mockCurrencies, currencyValue, isChange, isCheckAndChange);
 
         const currency = getCurrencyByCode(mockCurrencies, String(currencyValue));
 
@@ -177,8 +177,8 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
             },
           },
           PAGE_CONTENT_STRINGS,
-          SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${SAVE_AND_BACK}`,
-          PROVIDE_ALTERNATIVE_CURRENCY_URL: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALTERNATIVE_CURRENCY_CHECK_AND_CHANGE}`,
+          SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${SAVE_AND_BACK}`,
+          PROVIDE_ALTERNATIVE_CURRENCY_URL: `${INSURANCE_ROOT}/${referenceNumber}${ALTERNATIVE_CURRENCY_CHECK_AND_CHANGE}`,
           CURRENCY_PREFIX_SYMBOL: currency.symbol,
         };
 
@@ -235,7 +235,7 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
           HTML_FLAGS,
         }),
         userName: getUserNameFromSession(req.session.user),
-        ...pageVariables(mockApplication.referenceNumber, mockCurrencies, currencyValue),
+        ...pageVariables(referenceNumber, mockCurrencies, currencyValue),
         application: mapApplicationToFormFields(mockApplication),
       };
 
@@ -288,7 +288,7 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CREDIT_INSURANCE_COVER}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CREDIT_INSURANCE_COVER}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -299,7 +299,7 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
           res.locals.application = mockApplicationTotalContractValueThresholdFalse;
 
           await post(req, res);
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -311,7 +311,7 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -323,7 +323,7 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
@@ -345,7 +345,7 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
             HTML_FLAGS,
           }),
           userName: getUserNameFromSession(req.session.user),
-          ...pageVariables(mockApplication.referenceNumber, mockCurrencies, currencyValue),
+          ...pageVariables(referenceNumber, mockCurrencies, currencyValue),
           submittedValues: payload,
           validationErrors,
         };

--- a/src/ui/server/helpers/flatten-application-data/index.test.ts
+++ b/src/ui/server/helpers/flatten-application-data/index.test.ts
@@ -1,7 +1,7 @@
 import flattenApplicationData, { mapPolicyContact, mapBroker } from '.';
 import INSURANCE_FIELD_IDS from '../../constants/field-ids/insurance';
 import getTrueAndFalseAnswers from '../get-true-and-false-answers';
-import { mockApplication } from '../../test-mocks';
+import { mockApplication, referenceNumber } from '../../test-mocks';
 
 const {
   POLICY: {
@@ -56,7 +56,7 @@ describe('server/helpers/flatten-application-data', () => {
       const expected = {
         ...mockApplication.eligibility,
         version: mockApplication.version,
-        referenceNumber: mockApplication.referenceNumber,
+        referenceNumber,
         createdAt: mockApplication.createdAt,
         updatedAt: mockApplication.updatedAt,
         dealType: mockApplication.dealType,

--- a/src/ui/server/helpers/get-application/index.test.ts
+++ b/src/ui/server/helpers/get-application/index.test.ts
@@ -1,6 +1,6 @@
 import getApplication from '.';
 import api from '../../api';
-import { mockApplication } from '../../test-mocks';
+import { mockApplication, referenceNumber } from '../../test-mocks';
 
 describe('helpers/get-application', () => {
   let getApplicationSpy;
@@ -9,10 +9,10 @@ describe('helpers/get-application', () => {
     getApplicationSpy = jest.fn(() => Promise.resolve());
     api.keystone.application.get = getApplicationSpy;
 
-    await getApplication(mockApplication.referenceNumber);
+    await getApplication(referenceNumber);
 
     expect(getApplicationSpy).toHaveBeenCalledTimes(1);
-    expect(getApplicationSpy).toHaveBeenCalledWith(mockApplication.referenceNumber);
+    expect(getApplicationSpy).toHaveBeenCalledWith(referenceNumber);
   });
 
   describe('when there is no application', () => {
@@ -20,7 +20,7 @@ describe('helpers/get-application', () => {
       getApplicationSpy = jest.fn(() => Promise.resolve());
       api.keystone.application.get = getApplicationSpy;
 
-      const result = await getApplication(mockApplication.referenceNumber);
+      const result = await getApplication(referenceNumber);
 
       expect(result).toEqual(false);
     });
@@ -31,7 +31,7 @@ describe('helpers/get-application', () => {
       getApplicationSpy = jest.fn(() => Promise.resolve({}));
       api.keystone.application.get = getApplicationSpy;
 
-      const result = await getApplication(mockApplication.referenceNumber);
+      const result = await getApplication(referenceNumber);
 
       expect(result).toEqual(false);
     });
@@ -42,7 +42,7 @@ describe('helpers/get-application', () => {
       getApplicationSpy = jest.fn(() => Promise.resolve({}));
       api.keystone.application.get = getApplicationSpy;
 
-      const result = await getApplication(mockApplication.referenceNumber);
+      const result = await getApplication(referenceNumber);
 
       expect(result).toEqual(false);
     });
@@ -55,7 +55,7 @@ describe('helpers/get-application', () => {
       api.keystone.application.get = getApplicationSpy;
 
       try {
-        await getApplication(mockApplication.referenceNumber);
+        await getApplication(referenceNumber);
       } catch (err) {
         expect(err).toEqual(new Error(`Getting application ${mockErrorMessage}`));
       }
@@ -66,7 +66,7 @@ describe('helpers/get-application', () => {
     getApplicationSpy = jest.fn(() => Promise.resolve(mockApplication));
     api.keystone.application.get = getApplicationSpy;
 
-    const result = await getApplication(mockApplication.referenceNumber);
+    const result = await getApplication(referenceNumber);
 
     expect(result).toEqual(mockApplication);
   });

--- a/src/ui/server/helpers/page-variables/core/insurance/section-start/index.test.ts
+++ b/src/ui/server/helpers/page-variables/core/insurance/section-start/index.test.ts
@@ -1,13 +1,13 @@
 import sectionStartPageVariables from '.';
 import insuranceCorePageVariables from '..';
 import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
-import { mockApplication } from '../../../../../test-mocks';
+import { referenceNumber } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT } = INSURANCE_ROUTES;
 
 describe('server/helpers/page-variables/core/insurance/section-start', () => {
   const mock = {
-    REFERENCE_NUMBER: mockApplication.referenceNumber,
+    REFERENCE_NUMBER: referenceNumber,
     START_NOW_ROUTE: '/mock-route',
     PAGE_CONTENT_STRINGS: {
       PAGE_TITLE: 'Mock title',

--- a/src/ui/server/helpers/summary-lists/export-contract/about-the-export-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/export-contract/about-the-export-fields/index.test.ts
@@ -8,7 +8,7 @@ import getFieldById from '../../../get-field-by-id';
 import getCountryByIsoCode from '../../../get-country-by-iso-code';
 import generateChangeLink from '../../../generate-change-link';
 import replaceNewLineWithLineBreak from '../../../replace-new-line-with-line-break';
-import { mockApplication, mockCountries } from '../../../../test-mocks';
+import { mockApplication, mockCountries, referenceNumber } from '../../../../test-mocks';
 
 const {
   ABOUT_GOODS_OR_SERVICES: { DESCRIPTION, FINAL_DESTINATION },
@@ -31,7 +31,6 @@ const {
 
 describe('server/helpers/summary-lists/export-contract/about-goods-or-services-fields', () => {
   const mockAnswers = mockApplication.exportContract;
-  const { referenceNumber } = mockApplication;
   const checkAndChange = false;
 
   it('should return fields and values from the submitted data/answers', () => {

--- a/src/ui/server/helpers/summary-lists/export-contract/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/export-contract/index.test.ts
@@ -2,11 +2,9 @@ import { generateFields, exportContractSummaryLists } from '.';
 import generateAboutTheExportFields from './about-the-export-fields';
 import generateGroupsOfSummaryLists from '../generate-groups-of-summary-lists';
 import { mockCountries } from '../../../test-mocks';
-import mockApplication, { mockExportContract } from '../../../test-mocks/mock-application';
+import { referenceNumber, mockExportContract } from '../../../test-mocks/mock-application';
 
 describe('server/helpers/summary-lists/export-contract', () => {
-  const { referenceNumber } = mockApplication;
-
   const mockAnswers = mockExportContract;
   const checkAndChange = true;
 

--- a/src/ui/server/helpers/summary-lists/policy/broker-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/policy/broker-fields/index.test.ts
@@ -9,7 +9,7 @@ import getFieldById from '../../../get-field-by-id';
 import mapYesNoField from '../../../mappings/map-yes-no-field';
 import generateChangeLink from '../../../generate-change-link';
 import replaceNewLineWithLineBreak from '../../../replace-new-line-with-line-break';
-import mockApplication, { mockBroker } from '../../../../test-mocks/mock-application';
+import { mockBroker, referenceNumber } from '../../../../test-mocks/mock-application';
 
 const {
   POLICY: { BROKER: FORM_TITLE },
@@ -28,7 +28,6 @@ const {
 
 describe('server/helpers/summary-lists/policy/broker-fields', () => {
   describe('optionalBrokerFields', () => {
-    const { referenceNumber } = mockApplication;
     const checkAndChange = false;
 
     describe(`${USING_BROKER} is Yes`, () => {
@@ -77,7 +76,6 @@ describe('server/helpers/summary-lists/policy/broker-fields', () => {
   });
 
   describe('generateBrokerFields', () => {
-    const { referenceNumber } = mockApplication;
     const checkAndChange = false;
 
     it('should return a title and fields from the submitted data/answers', () => {

--- a/src/ui/server/helpers/summary-lists/policy/change-link/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/policy/change-link/index.test.ts
@@ -1,6 +1,6 @@
 import changeLink from '.';
 import { FIELD_VALUES, ROUTES } from '../../../../constants';
-import { mockApplication } from '../../../../test-mocks';
+import { referenceNumber } from '../../../../test-mocks';
 import generateChangeLink from '../../../generate-change-link';
 
 const {
@@ -15,8 +15,6 @@ const {
 } = ROUTES;
 
 describe('server/helpers/summary-lists/policy/change-link', () => {
-  const { referenceNumber } = mockApplication;
-
   const mockFieldId = 'mockField';
   const checkAndChange = false;
 

--- a/src/ui/server/helpers/summary-lists/policy/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/policy/index.test.ts
@@ -4,11 +4,9 @@ import generatePolicyContactFields from './policy-contact-fields';
 import { generateBrokerFields } from './broker-fields';
 import generateGroupsOfSummaryLists from '../generate-groups-of-summary-lists';
 import { mockCurrencies, mockContact } from '../../../test-mocks';
-import mockApplication, { mockBroker } from '../../../test-mocks/mock-application';
+import mockApplication, { mockBroker, referenceNumber } from '../../../test-mocks/mock-application';
 
 describe('server/helpers/summary-lists/policy', () => {
-  const { referenceNumber } = mockApplication;
-
   const mockAnswers = mockApplication.policy;
   const checkAndChange = false;
 

--- a/src/ui/server/helpers/summary-lists/policy/policy-and-date-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/policy/policy-and-date-fields/index.test.ts
@@ -11,7 +11,7 @@ import generatePreCreditPeriodFields from './pre-credit-period-fields';
 import generateSingleContractPolicyFields from './single-contract-policy-fields';
 import generateMultipleContractPolicyFields from './multiple-contract-policy-fields';
 import getCurrencyByCode from '../../../get-currency-by-code';
-import { mockApplication, mockApplicationMultiplePolicy, mockCurrencies } from '../../../../test-mocks';
+import { mockApplication, mockApplicationMultiplePolicy, mockCurrencies, referenceNumber } from '../../../../test-mocks';
 import { ApplicationPolicy } from '../../../../../types';
 
 const {
@@ -32,8 +32,6 @@ const {
 } = INSURANCE_ROUTES;
 
 describe('server/helpers/summary-lists/policy/policy-and-date-fields', () => {
-  const { referenceNumber } = mockApplication;
-
   const mockAnswers = mockApplication.policy;
   const checkAndChange = false;
 

--- a/src/ui/server/helpers/summary-lists/policy/policy-and-date-fields/multiple-contract-policy-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/policy/policy-and-date-fields/multiple-contract-policy-fields/index.test.ts
@@ -7,7 +7,7 @@ import fieldGroupItem from '../../../generate-field-group-item';
 import getFieldById from '../../../../get-field-by-id';
 import formatCurrency from '../../../../format-currency';
 import mapMonthString from '../../../../data-content-mappings/map-month-string';
-import mockApplication, { mockMultiplePolicy } from '../../../../../test-mocks/mock-application';
+import { mockMultiplePolicy, referenceNumber } from '../../../../../test-mocks/mock-application';
 import generateChangeLink from '../../../../generate-change-link';
 
 const {
@@ -30,7 +30,6 @@ const {
 
 describe('server/helpers/summary-lists/policy/policy-and-date-fields/multiple-contract-policy-fields', () => {
   const mockAnswers = mockMultiplePolicy;
-  const { referenceNumber } = mockApplication;
   const checkAndChange = false;
 
   const expectedBase = {

--- a/src/ui/server/helpers/summary-lists/policy/policy-and-date-fields/pre-credit-period-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/policy/policy-and-date-fields/pre-credit-period-fields/index.test.ts
@@ -6,7 +6,7 @@ import fieldGroupItem from '../../../generate-field-group-item';
 import getFieldById from '../../../../get-field-by-id';
 import generateChangeLink from '../../../../generate-change-link';
 import mapYesNoField from '../../../../mappings/map-yes-no-field';
-import mockApplication, { mockSinglePolicy } from '../../../../../test-mocks/mock-application';
+import { referenceNumber, mockSinglePolicy } from '../../../../../test-mocks/mock-application';
 import { ApplicationPolicy } from '../../../../../../types';
 
 const { NEED_PRE_CREDIT_PERIOD, CREDIT_PERIOD_WITH_BUYER } = POLICY_FIELD_IDS;
@@ -15,7 +15,6 @@ const {
   POLICY: { PRE_CREDIT_PERIOD_CHANGE, PRE_CREDIT_PERIOD_CHECK_AND_CHANGE },
 } = INSURANCE_ROUTES;
 
-const { referenceNumber } = mockApplication;
 const checkAndChange = true;
 
 const expectedNeedPreCreditPeriodField = (answers: ApplicationPolicy) =>

--- a/src/ui/server/helpers/summary-lists/policy/policy-and-date-fields/single-contract-policy-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/policy/policy-and-date-fields/single-contract-policy-fields/index.test.ts
@@ -7,7 +7,7 @@ import fieldGroupItem from '../../../generate-field-group-item';
 import getFieldById from '../../../../get-field-by-id';
 import formatDate from '../../../../date/format-date';
 import formatCurrency from '../../../../format-currency';
-import mockApplication, { mockSinglePolicy } from '../../../../../test-mocks/mock-application';
+import { referenceNumber, mockSinglePolicy } from '../../../../../test-mocks/mock-application';
 
 const {
   CONTRACT_POLICY: {
@@ -22,7 +22,6 @@ const {
 
 describe('server/helpers/summary-lists/policy/policy-and-date-fields/single-contract-policy-fields', () => {
   const mockAnswers = mockSinglePolicy;
-  const { referenceNumber } = mockApplication;
   const checkAndChange = false;
 
   const expectedBase = {

--- a/src/ui/server/helpers/summary-lists/policy/policy-contact-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/policy/policy-contact-fields/index.test.ts
@@ -7,7 +7,7 @@ import { POLICY_FIELDS as FIELDS } from '../../../../content-strings/fields/insu
 import fieldGroupItem from '../../generate-field-group-item';
 import getFieldById from '../../../get-field-by-id';
 import generateChangeLink from '../../../generate-change-link';
-import { mockApplication, mockContact } from '../../../../test-mocks';
+import { referenceNumber, mockContact } from '../../../../test-mocks';
 
 const {
   POLICY: { NAME_ON_POLICY: FORM_TITLE },
@@ -27,7 +27,6 @@ const {
 
 describe('server/helpers/summary-lists/policy/policy-contact-fields', () => {
   const mockAnswers = mockContact;
-  const { referenceNumber } = mockApplication;
   const checkAndChange = false;
 
   it(`should return relevant fields and values including ${EMAIL} field without a change link when ${IS_SAME_AS_OWNER} is true`, () => {

--- a/src/ui/server/helpers/summary-lists/your-business/credit-control-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-business/credit-control-fields/index.test.ts
@@ -7,7 +7,7 @@ import getFieldById from '../../../get-field-by-id';
 import generateTurnoverFields from '.';
 import mapYesNoField from '../../../mappings/map-yes-no-field';
 import generateChangeLink from '../../../generate-change-link';
-import mockApplication, { mockBusiness } from '../../../../test-mocks/mock-application';
+import { mockBusiness, referenceNumber } from '../../../../test-mocks/mock-application';
 
 const {
   YOUR_BUSINESS: { CREDIT_CONTROL: FORM_TITLE },
@@ -23,7 +23,6 @@ const {
 
 describe('server/helpers/summary-lists/your-business/credit-control-fields', () => {
   const mockAnswers = mockBusiness;
-  const { referenceNumber } = mockApplication;
   const checkAndChange = false;
 
   const expectedFields = [

--- a/src/ui/server/helpers/summary-lists/your-business/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-business/index.test.ts
@@ -4,10 +4,9 @@ import generateYourCompanyFields from './your-company-fields';
 import generateTurnoverFields from './turnover-fields';
 import generateCreditControlFields from './credit-control-fields';
 import generateGroupsOfSummaryLists from '../generate-groups-of-summary-lists';
-import mockApplication, { mockCompany, mockBusiness } from '../../../test-mocks/mock-application';
+import { mockCompany, mockBusiness, referenceNumber } from '../../../test-mocks/mock-application';
 
 describe('server/helpers/summary-lists/your-business', () => {
-  const { referenceNumber } = mockApplication;
   const checkAndChange = false;
 
   describe('generateFields', () => {

--- a/src/ui/server/helpers/summary-lists/your-business/nature-of-your-business-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-business/nature-of-your-business-fields/index.test.ts
@@ -5,7 +5,7 @@ import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
 import fieldGroupItem from '../../generate-field-group-item';
 import getFieldById from '../../../get-field-by-id';
 import generateNatureOfYourBusinessFields from '.';
-import mockApplication, { mockBusiness } from '../../../../test-mocks/mock-application';
+import { mockBusiness, referenceNumber } from '../../../../test-mocks/mock-application';
 import generateChangeLink from '../../../generate-change-link';
 
 const {
@@ -24,7 +24,6 @@ const {
 
 describe('server/helpers/summary-lists/your-business/nature-of-your-business-fields', () => {
   const mockAnswers = mockBusiness;
-  const { referenceNumber } = mockApplication;
   const checkAndChange = false;
 
   const expectedFields = [

--- a/src/ui/server/helpers/summary-lists/your-business/turnover-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-business/turnover-fields/index.test.ts
@@ -8,7 +8,7 @@ import formatCurrency from '../../../format-currency';
 import generateTurnoverFields from '.';
 import mapPercentage from '../../../map-percentage';
 import generateChangeLink from '../../../generate-change-link';
-import mockApplication, { mockBusiness } from '../../../../test-mocks/mock-application';
+import { mockBusiness, referenceNumber } from '../../../../test-mocks/mock-application';
 
 const {
   YOUR_BUSINESS: { TURNOVER: FORM_TITLE },
@@ -26,7 +26,6 @@ const {
 
 describe('server/helpers/summary-lists/your-business/turnover-fields', () => {
   const mockAnswers = mockBusiness;
-  const { referenceNumber } = mockApplication;
   const checkAndChange = false;
 
   const expectedFields = [

--- a/src/ui/server/helpers/summary-lists/your-business/your-company-fields/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-business/your-company-fields/index.test.ts
@@ -7,7 +7,7 @@ import getFieldById from '../../../get-field-by-id';
 import formatDate from '../../../date/format-date';
 import generateYourCompanyFields from '.';
 import generateChangeLink from '../../../generate-change-link';
-import mockApplication, { mockCompany } from '../../../../test-mocks/mock-application';
+import { mockCompany, referenceNumber } from '../../../../test-mocks/mock-application';
 import { DEFAULT } from '../../../../content-strings';
 import { ApplicationCompany } from '../../../../../types';
 import generateMultipleFieldHtml from '../../../generate-multiple-field-html';
@@ -39,18 +39,12 @@ const {
 const addressObject = generateAddressObject(mockCompany[DIFFERENT_TRADING_ADDRESS][FULL_ADDRESS]);
 const address = generateMultipleFieldHtml(addressObject);
 
-const summaryList = (mockAnswers: ApplicationCompany, referenceNumber: number, financialYearEndDateValue: string, checkAndChange = false) => [
+const summaryList = (mockAnswers: ApplicationCompany, refNumber: number, financialYearEndDateValue: string, checkAndChange = false) => [
   fieldGroupItem(
     {
       field: getFieldById(FIELDS.COMPANY_DETAILS, HAS_DIFFERENT_TRADING_NAME),
       data: mockAnswers,
-      href: generateChangeLink(
-        COMPANY_DETAILS_CHANGE,
-        COMPANY_DETAILS_CHECK_AND_CHANGE,
-        `#${HAS_DIFFERENT_TRADING_NAME}-label`,
-        referenceNumber,
-        checkAndChange,
-      ),
+      href: generateChangeLink(COMPANY_DETAILS_CHANGE, COMPANY_DETAILS_CHECK_AND_CHANGE, `#${HAS_DIFFERENT_TRADING_NAME}-label`, refNumber, checkAndChange),
       renderChangeLink: true,
     },
     mapYesAlternateField(mockAnswers[HAS_DIFFERENT_TRADING_NAME], mockAnswers[DIFFERENT_TRADING_NAME]),
@@ -59,7 +53,7 @@ const summaryList = (mockAnswers: ApplicationCompany, referenceNumber: number, f
     {
       field: getFieldById(FIELDS.COMPANY_DETAILS, TRADING_ADDRESS),
       data: mockAnswers,
-      href: generateChangeLink(COMPANY_DETAILS_CHANGE, COMPANY_DETAILS_CHECK_AND_CHANGE, `#${TRADING_ADDRESS}-label`, referenceNumber, checkAndChange),
+      href: generateChangeLink(COMPANY_DETAILS_CHANGE, COMPANY_DETAILS_CHECK_AND_CHANGE, `#${TRADING_ADDRESS}-label`, refNumber, checkAndChange),
       renderChangeLink: true,
     },
     mapYesAlternateField(mockAnswers[TRADING_ADDRESS], address),
@@ -67,13 +61,13 @@ const summaryList = (mockAnswers: ApplicationCompany, referenceNumber: number, f
   fieldGroupItem({
     field: getFieldById(FIELDS.COMPANY_DETAILS, WEBSITE),
     data: mockAnswers,
-    href: generateChangeLink(COMPANY_DETAILS_CHANGE, COMPANY_DETAILS_CHECK_AND_CHANGE, `#${WEBSITE}-label`, referenceNumber, checkAndChange),
+    href: generateChangeLink(COMPANY_DETAILS_CHANGE, COMPANY_DETAILS_CHECK_AND_CHANGE, `#${WEBSITE}-label`, refNumber, checkAndChange),
     renderChangeLink: true,
   }),
   fieldGroupItem({
     field: getFieldById(FIELDS.COMPANY_DETAILS, PHONE_NUMBER),
     data: mockAnswers,
-    href: generateChangeLink(COMPANY_DETAILS_CHANGE, COMPANY_DETAILS_CHECK_AND_CHANGE, `#${PHONE_NUMBER}-label`, referenceNumber, checkAndChange),
+    href: generateChangeLink(COMPANY_DETAILS_CHANGE, COMPANY_DETAILS_CHECK_AND_CHANGE, `#${PHONE_NUMBER}-label`, refNumber, checkAndChange),
     renderChangeLink: true,
   }),
 ];
@@ -82,7 +76,6 @@ describe('server/helpers/summary-lists/your-business/your-company-fields', () =>
   describe('generateYourCompanyFields', () => {
     describe('when a company has a financial year end date', () => {
       const mockAnswers = mockCompany;
-      const { referenceNumber } = mockApplication;
       const checkAndChange = false;
       const financialYearEndDateValue = formatDate(mockAnswers[FINANCIAL_YEAR_END_DATE], DATE_FORMAT);
 
@@ -102,7 +95,6 @@ describe('server/helpers/summary-lists/your-business/your-company-fields', () =>
 
     describe('when a company does not have a financial year end date', () => {
       const mockAnswers = mockCompany;
-      const { referenceNumber } = mockApplication;
       const checkAndChange = false;
       const financialYearEndDateValue = DEFAULT.EMPTY;
 

--- a/src/ui/server/helpers/summary-lists/your-buyer/company-or-organisation/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-buyer/company-or-organisation/index.test.ts
@@ -8,7 +8,7 @@ import fieldGroupItem from '../../generate-field-group-item';
 import getFieldById from '../../../get-field-by-id';
 import generateMultipleFieldHtml from '../../../generate-multiple-field-html';
 import generateChangeLink from '../../../generate-change-link';
-import mockApplication, { mockApplicationBuyer } from '../../../../test-mocks/mock-application';
+import mockApplication, { mockApplicationBuyer, referenceNumber } from '../../../../test-mocks/mock-application';
 
 const {
   YOUR_BUYER: FIELD_IDS,
@@ -35,8 +35,6 @@ describe('server/helpers/summary-lists/your-buyer/company-or-organisation-fields
   describe('generateCompanyOrOrganisationFields', () => {
     const mockAnswers = mockApplicationBuyer;
     const mockAddress = mockAnswers[ADDRESS];
-
-    const { referenceNumber } = mockApplication;
 
     const addressObject = generateAddressObject(mockAddress);
 

--- a/src/ui/server/helpers/summary-lists/your-buyer/connection-with-buyer/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-buyer/connection-with-buyer/index.test.ts
@@ -7,7 +7,7 @@ import fieldGroupItem from '../../generate-field-group-item';
 import getFieldById from '../../../get-field-by-id';
 import mapYesNoField from '../../../mappings/map-yes-no-field';
 import generateChangeLink from '../../../generate-change-link';
-import mockApplication, { mockApplicationBuyer } from '../../../../test-mocks/mock-application';
+import { mockApplicationBuyer, referenceNumber } from '../../../../test-mocks/mock-application';
 
 const { YOUR_BUYER: FIELD_IDS } = INSURANCE_FIELD_IDS;
 
@@ -25,7 +25,6 @@ const { CONNECTION_WITH_BUYER, CONNECTION_WITH_BUYER_DESCRIPTION } = FIELD_IDS;
 
 describe('server/helpers/summary-lists/your-buyer/connection-with-buyer-fields', () => {
   const mockAnswers = mockApplicationBuyer.relationship;
-  const { referenceNumber } = mockApplication;
   const checkAndChange = false;
 
   describe('optionalFields', () => {

--- a/src/ui/server/helpers/summary-lists/your-buyer/credit-insurance-history/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-buyer/credit-insurance-history/index.test.ts
@@ -7,7 +7,7 @@ import fieldGroupItem from '../../generate-field-group-item';
 import getFieldById from '../../../get-field-by-id';
 import mapYesNoField from '../../../mappings/map-yes-no-field';
 import generateChangeLink from '../../../generate-change-link';
-import mockApplication, { mockApplicationBuyer } from '../../../../test-mocks/mock-application';
+import { mockApplicationBuyer, referenceNumber } from '../../../../test-mocks/mock-application';
 
 const {
   YOUR_BUYER: { CREDIT_INSURANCE_HISTORY: FORM_TITLE },
@@ -21,7 +21,6 @@ const { HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER, PREVIOUS_CREDIT_INSURANC
 
 describe('server/helpers/summary-lists/your-buyer/credit-insurance-history-fields', () => {
   const mockAnswers = mockApplicationBuyer.relationship;
-  const { referenceNumber } = mockApplication;
   const checkAndChange = false;
 
   describe('optionalFields', () => {

--- a/src/ui/server/helpers/summary-lists/your-buyer/financial-accounts/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-buyer/financial-accounts/index.test.ts
@@ -7,7 +7,7 @@ import fieldGroupItem from '../../generate-field-group-item';
 import getFieldById from '../../../get-field-by-id';
 import mapYesNoField from '../../../mappings/map-yes-no-field';
 import generateChangeLink from '../../../generate-change-link';
-import mockApplication, { mockApplicationBuyer } from '../../../../test-mocks/mock-application';
+import { mockApplicationBuyer, referenceNumber } from '../../../../test-mocks/mock-application';
 
 const {
   YOUR_BUYER: { FINANCIAL_ACCOUNTS: FORM_TITLE },
@@ -21,7 +21,6 @@ const { HAS_BUYER_FINANCIAL_ACCOUNTS } = YOUR_BUYER_FIELD_IDS;
 
 describe('server/helpers/summary-lists/your-buyer/financial-accounts-fields', () => {
   const mockAnswers = mockApplicationBuyer.relationship;
-  const { referenceNumber } = mockApplication;
   const checkAndChange = false;
 
   describe('creditInsuranceHistoryFields', () => {

--- a/src/ui/server/helpers/summary-lists/your-buyer/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-buyer/index.test.ts
@@ -5,10 +5,10 @@ import tradingHistoryFields from './trading-history';
 import creditInsuranceHistoryFields from './credit-insurance-history';
 import financialAccountsFields from './financial-accounts';
 import generateGroupsOfSummaryLists from '../generate-groups-of-summary-lists';
-import mockApplication, { mockApplicationBuyer } from '../../../test-mocks/mock-application';
+import mockApplication, { mockApplicationBuyer, referenceNumber } from '../../../test-mocks/mock-application';
 
 describe('server/helpers/summary-lists/your-buyer', () => {
-  const { referenceNumber, buyer, totalContractValueOverThreshold } = mockApplication;
+  const { buyer, totalContractValueOverThreshold } = mockApplication;
   const checkAndChange = false;
 
   describe('optionalFields', () => {

--- a/src/ui/server/helpers/summary-lists/your-buyer/trading-history/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-buyer/trading-history/index.test.ts
@@ -9,7 +9,7 @@ import mapYesNoField from '../../../mappings/map-yes-no-field';
 import generateChangeLink from '../../../generate-change-link';
 import optionalTradedWithBuyerFields from './optional-fields/traded-with-buyer';
 import optionalOutstandingPaymentsFields from './optional-fields/outstanding-payments';
-import mockApplication, { mockApplicationBuyer } from '../../../../test-mocks/mock-application';
+import { mockApplicationBuyer, referenceNumber } from '../../../../test-mocks/mock-application';
 
 const {
   YOUR_BUYER: { TRADING_HISTORY: FORM_TITLE },
@@ -21,7 +21,6 @@ const { TRADED_WITH_BUYER, OUTSTANDING_PAYMENTS } = BUYER_FIELD_IDS;
 
 describe('server/helpers/summary-lists/your-buyer/trading-history', () => {
   const mockAnswers = mockApplicationBuyer.buyerTradingHistory;
-  const { referenceNumber } = mockApplication;
   const checkAndChange = false;
 
   const expectedBase = [

--- a/src/ui/server/helpers/summary-lists/your-buyer/trading-history/optional-fields/outstanding-payments/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-buyer/trading-history/optional-fields/outstanding-payments/index.test.ts
@@ -6,7 +6,7 @@ import fieldGroupItem from '../../../../generate-field-group-item';
 import getFieldById from '../../../../../get-field-by-id';
 import generateChangeLink from '../../../../../generate-change-link';
 import formatCurrency from '../../../../../format-currency';
-import mockApplication, { mockApplicationBuyer } from '../../../../../../test-mocks/mock-application';
+import { mockApplicationBuyer, referenceNumber } from '../../../../../../test-mocks/mock-application';
 
 const { TRADING_HISTORY_CHANGE, TRADING_HISTORY_CHECK_AND_CHANGE } = YOUR_BUYER_ROUTES;
 
@@ -17,7 +17,6 @@ const {
 
 describe('server/helpers/summary-lists/your-buyer/trading-history/optional-fields/outstanding-payments', () => {
   const mockAnswers = mockApplicationBuyer.buyerTradingHistory;
-  const { referenceNumber } = mockApplication;
   const checkAndChange = false;
 
   describe(`when ${OUTSTANDING_PAYMENTS} is true`, () => {

--- a/src/ui/server/helpers/summary-lists/your-buyer/trading-history/optional-fields/traded-with-buyer/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-buyer/trading-history/optional-fields/traded-with-buyer/index.test.ts
@@ -6,7 +6,7 @@ import fieldGroupItem from '../../../../generate-field-group-item';
 import getFieldById from '../../../../../get-field-by-id';
 import mapYesNoField from '../../../../../mappings/map-yes-no-field';
 import generateChangeLink from '../../../../../generate-change-link';
-import mockApplication, { mockApplicationBuyer } from '../../../../../../test-mocks/mock-application';
+import { mockApplicationBuyer, referenceNumber } from '../../../../../../test-mocks/mock-application';
 
 const { TRADING_HISTORY_CHANGE, TRADING_HISTORY_CHECK_AND_CHANGE } = YOUR_BUYER_ROUTES;
 
@@ -14,7 +14,6 @@ const { TRADED_WITH_BUYER, OUTSTANDING_PAYMENTS, FAILED_PAYMENTS } = BUYER_FIELD
 
 describe('server/helpers/summary-lists/your-buyer/trading-history/optional-fields/traded-with-buyer', () => {
   const mockAnswers = mockApplicationBuyer.buyerTradingHistory;
-  const { referenceNumber } = mockApplication;
   const checkAndChange = false;
 
   describe(`when ${TRADED_WITH_BUYER} is true`, () => {

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/prepare-application.test.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/prepare-application.test.ts
@@ -69,7 +69,7 @@ describe('server/helpers/task-list/prepare-application', () => {
       const expectedDependencies = getAllTasksFieldsInAGroup(previousGroups[0]);
 
       const EXPORTER_BUSINESS = {
-        href: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${EXPORTER_BUSINESS_ROOT}`,
+        href: `${INSURANCE_ROOT}/${referenceNumber}${EXPORTER_BUSINESS_ROOT}`,
         title: PREPARE_APPLICATION.TASKS.EXPORTER_BUSINESS,
         id: TASK_IDS.PREPARE_APPLICATION.EXPORTER_BUSINESS,
         fields: businessRequiredFields(hasDifferentTradingName),
@@ -77,7 +77,7 @@ describe('server/helpers/task-list/prepare-application', () => {
       };
 
       const YOUR_BUYER = {
-        href: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${YOUR_BUYER_ROOT}`,
+        href: `${INSURANCE_ROOT}/${referenceNumber}${YOUR_BUYER_ROOT}`,
         title: PREPARE_APPLICATION.TASKS.BUYER,
         id: TASK_IDS.PREPARE_APPLICATION.BUYER,
         fields: yourBuyerRequiredFields({
@@ -91,7 +91,7 @@ describe('server/helpers/task-list/prepare-application', () => {
       };
 
       const POLICY = {
-        href: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${POLICY_ROOT}`,
+        href: `${INSURANCE_ROOT}/${referenceNumber}${POLICY_ROOT}`,
         title: TASKS.LIST.PREPARE_APPLICATION.TASKS.POLICY,
         id: TASK_IDS.PREPARE_APPLICATION.POLICY,
         fields: policyRequiredFields({

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/submit-application.test.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/submit-application.test.ts
@@ -41,7 +41,7 @@ describe('server/helpers/task-list/submit-application', () => {
     const expectedDependencies = [...initialChecksFields, ...prepareApplicationFields];
 
     const CHECK_ANSWERS = {
-      href: `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${TYPE_OF_POLICY}`,
+      href: `${INSURANCE_ROOT}/${referenceNumber}${TYPE_OF_POLICY}`,
       title: SUBMIT_APPLICATION.TASKS.CHECK_ANSWERS,
       id: TASK_IDS.SUBMIT_APPLICATION.CHECK_ANSWERS,
       fields: [POLICY, EXPORTER_BUSINESS, BUYER],

--- a/src/ui/server/helpers/task-list/index.test.ts
+++ b/src/ui/server/helpers/task-list/index.test.ts
@@ -2,11 +2,11 @@ import generateTaskList, { mapTask, generateTaskStatusesAndLinks, generateSimpli
 import { taskStatus, taskLink } from './task-helpers';
 import generateGroupsAndTasks from './generate-groups-and-tasks';
 import flattenApplicationData from '../flatten-application-data';
-import { mockApplication } from '../../test-mocks';
+import { mockApplication, referenceNumber } from '../../test-mocks';
 
 describe('server/helpers/task-list', () => {
   const mockApplicationFlat = flattenApplicationData(mockApplication);
-  const mockTaskListData = generateGroupsAndTasks(mockApplication.referenceNumber);
+  const mockTaskListData = generateGroupsAndTasks(referenceNumber);
 
   const { 0: mockTaskGroup } = mockTaskListData;
   const { tasks: group1Tasks } = mockTaskGroup;

--- a/src/ui/server/middleware/insurance/application-access/index.test.ts
+++ b/src/ui/server/middleware/insurance/application-access/index.test.ts
@@ -1,7 +1,7 @@
 import applicationAccessMiddleware, { IRRELEVANT_ROUTES } from '.';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
-import { mockReq, mockRes, mockApplication, mockAccount } from '../../../test-mocks';
 import { Next, Request, Response } from '../../../../types';
+import { mockReq, mockRes, mockApplication, mockAccount, referenceNumber } from '../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -80,7 +80,7 @@ describe('middleware/insurance/application-access', () => {
 
   describe('when the route contains a relevant route', () => {
     beforeEach(() => {
-      req.baseUrl = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALL_SECTIONS}`;
+      req.baseUrl = `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
     });
 
     describe("when req.session.user.id matches the application's owner ID", () => {

--- a/src/ui/server/middleware/insurance/application-status/index.test.ts
+++ b/src/ui/server/middleware/insurance/application-status/index.test.ts
@@ -2,7 +2,7 @@ import applicationStatusMiddleware from '.';
 import { ROUTES } from '../../../constants/routes';
 import { APPLICATION } from '../../../constants';
 import POLICY_FIELD_IDS from '../../../constants/field-ids/insurance/policy';
-import { mockReq, mockRes, mockApplication, mockAccount } from '../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockAccount, referenceNumber } from '../../../test-mocks';
 import { Next, Request, Response } from '../../../../types';
 
 const {
@@ -12,8 +12,6 @@ const {
 const {
   TYPE_OF_POLICY: { POLICY_TYPE },
 } = POLICY_FIELD_IDS;
-
-const { referenceNumber } = mockApplication;
 
 describe('middleware/insurance/application-status', () => {
   let req: Request;

--- a/src/ui/server/middleware/insurance/application-status/is-check-your-answers-route/index.test.ts
+++ b/src/ui/server/middleware/insurance/application-status/is-check-your-answers-route/index.test.ts
@@ -1,10 +1,8 @@
 import isCheckYourAnswersRoute, { mapCheckYourAnswersRoutes } from '.';
 import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
-import { mockApplication } from '../../../../test-mocks';
+import { referenceNumber } from '../../../../test-mocks';
 
 const { CHECK_YOUR_ANSWERS, INSURANCE_ROOT } = INSURANCE_ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('middleware/insurance/application-status/is-check-your-answers-route', () => {
   describe('mapCheckYourAnswersRoutes', () => {

--- a/src/ui/server/middleware/insurance/application-status/is-submit-your-application-route/index.test.ts
+++ b/src/ui/server/middleware/insurance/application-status/is-submit-your-application-route/index.test.ts
@@ -1,6 +1,6 @@
 import isSubmitYourApplicationRoute, { mapSubmitYourApplicationRoutes } from '.';
 import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
-import { mockApplication } from '../../../../test-mocks';
+import { referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -12,8 +12,6 @@ const {
     HOW_YOUR_DATA_WILL_BE_USED,
   },
 } = INSURANCE_ROUTES;
-
-const { referenceNumber } = mockApplication;
 
 describe('middleware/insurance/application-status/is-submit-your-application-route', () => {
   describe('mapSubmitYourApplicationRoutes', () => {

--- a/src/ui/server/middleware/insurance/get-application/index.test.ts
+++ b/src/ui/server/middleware/insurance/get-application/index.test.ts
@@ -1,8 +1,8 @@
 import getApplicationMiddleware, { RELEVANT_ROUTES } from '.';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import api from '../../../api';
-import { mockReq, mockRes, mockApplication } from '../../../test-mocks';
 import mapTotalContractValueOverThreshold from '../map-total-contract-value-over-threshold';
+import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../test-mocks';
 import { Next, Request, Response } from '../../../../types';
 
 const {
@@ -35,8 +35,6 @@ describe('middleware/insurance/get-application', () => {
     req = mockReq();
     res = mockRes();
     next = nextSpy;
-
-    req.params.referenceNumber = String(mockApplication.referenceNumber);
   });
 
   describe('RELEVANT_ROUTES', () => {
@@ -74,7 +72,7 @@ describe('middleware/insurance/get-application', () => {
 
   describe('when the route contains a relevant route', () => {
     beforeEach(() => {
-      req.originalUrl = `${INSURANCE_ROOT}/${mockApplication.referenceNumber}${ALL_SECTIONS}`;
+      req.originalUrl = `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
     });
 
     describe('when an application exists', () => {

--- a/src/ui/server/test-mocks/index.ts
+++ b/src/ui/server/test-mocks/index.ts
@@ -15,6 +15,7 @@ import mockApplication, {
   mockApplicationTotalContractValueThresholdFalse,
   mockBusiness,
   mockCompanyDifferentTradingAddress,
+  referenceNumber,
 } from './mock-application';
 import mockApplications from './mock-applications';
 import mockEligibility from './mock-eligibility';
@@ -57,7 +58,7 @@ const mockReq = () => {
     originalUrl: 'mock?mockQueryParam',
     baseUrl: 'mock',
     params: {
-      referenceNumber: mockApplication.referenceNumber.toString(),
+      referenceNumber: String(referenceNumber),
     },
     query: {},
     redirect: jest.fn(),
@@ -154,4 +155,5 @@ export {
   mockReq,
   mockRes,
   mockValidEmail,
+  referenceNumber,
 };

--- a/src/ui/server/test-mocks/mock-application.ts
+++ b/src/ui/server/test-mocks/mock-application.ts
@@ -15,6 +15,8 @@ import { GBP, EUR } from '../constants/supported-currencies';
 
 dotenv.config();
 
+export const referenceNumber = 10001;
+
 const mockGenericPolicy = {
   id: 'clav8by1i0007kgoqies0dbfc',
   requestedStartDate: add(new Date(), { months: 1 }),
@@ -148,8 +150,8 @@ export const mockApplicationDeclaration = {
 
 const mockApplication = {
   id: 'clacdgc630000kdoqn7wcgrz1',
+  referenceNumber,
   version: APPLICATION.LATEST_VERSION.LATEST_VERSION_NUMBER,
-  referenceNumber: 10001,
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
   dealType: APPLICATION.DEAL_TYPE,


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates all UI unit tests so that:

- There is no need to destructure `const { referenceNumber } = mockApplication;`.
  - Instead, this can be imported.
- There are no unnecessary instances of the following:
```js
req.params.referenceNumber = String(mockApplication.referenceNumber);
res.locals.application = mockApplication;
```

## Resolution :heavy_check_mark:
In all UI unit tests:
- Replace `referenceNumber` destructuring with an import from `test-mocks`.
- Remove `req.params.referenceNumber` instances.
- Remove `res.locals.application = mockApplication` instances.
