### PR TITLE
feat(EMS-2949): No PDF - Export contract - Agent details - Form validation - Name

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-details/validation/agent-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-details/validation/agent-details-validation.spec.js
@@ -10,7 +10,7 @@ const {
 } = INSURANCE_ROUTES;
 
 const {
-  AGENT_DETAILS: { FULL_ADDRESS, COUNTRY_CODE },
+  AGENT_DETAILS: { NAME, FULL_ADDRESS, COUNTRY_CODE },
 } = FIELD_IDS;
 
 const {
@@ -21,7 +21,7 @@ const {
   },
 } = ERROR_MESSAGES;
 
-const expectedErrorsCount = 2;
+const expectedErrorsCount = 3;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -51,6 +51,44 @@ context('Insurance - Export contract - Agent details page - As an Exporter, I wa
     cy.deleteApplication(referenceNumber);
   });
 
+  describe(NAME, () => {
+    const assertions = {
+      field: fieldSelector(NAME),
+      errorIndex: 0,
+      expectedErrorsCount,
+    };
+
+    const ERROR_MESSAGES_OBJECT = AGENT_DETAILS_ERROR_MESSAGES[NAME];
+
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    it(`should render validation errors when ${NAME} is over ${MAXIMUM_CHARACTERS.AGENT_NAME} characters`, () => {
+      const value = 'a'.repeat(MAXIMUM_CHARACTERS.AGENT_NAME + 1);
+
+      cy.submitAndAssertFieldErrors({ ...assertions, value, expectedErrorMessage: ERROR_MESSAGES_OBJECT.ABOVE_MAXIMUM });
+    });
+
+    it(`should render validation errors when ${NAME} contains a special character`, () => {
+      const value = 'a!';
+
+      cy.submitAndAssertFieldErrors({ ...assertions, value, expectedErrorMessage: ERROR_MESSAGES_OBJECT.INCORRECT_FORMAT });
+    });
+
+    it(`should render validation errors when ${NAME} contains a number`, () => {
+      const value = 'a1';
+
+      cy.submitAndAssertFieldErrors({ ...assertions, value, expectedErrorMessage: ERROR_MESSAGES_OBJECT.INCORRECT_FORMAT });
+    });
+
+    it(`should render validation errors when ${NAME} contains a number and special character`, () => {
+      const value = 'a1!';
+
+      cy.submitAndAssertFieldErrors({ ...assertions, value, expectedErrorMessage: ERROR_MESSAGES_OBJECT.INCORRECT_FORMAT });
+    });
+  });
+
   describe(FULL_ADDRESS, () => {
     const field = fieldSelector(FULL_ADDRESS);
 
@@ -59,13 +97,14 @@ context('Insurance - Export contract - Agent details page - As an Exporter, I wa
       input: field.textarea,
     };
 
-    const errorIndex = 0;
-
+    const errorIndex = 1;
     const ERROR_MESSAGES_OBJECT = AGENT_DETAILS_ERROR_MESSAGES[FULL_ADDRESS];
 
-    it(`should render validation errors when ${FULL_ADDRESS} is left empty`, () => {
+    beforeEach(() => {
       cy.navigateToUrl(url);
+    });
 
+    it(`should render validation errors when ${FULL_ADDRESS} is left empty`, () => {
       cy.submitAndAssertFieldErrors({
         field: textareaField,
         errorIndex,
@@ -75,8 +114,6 @@ context('Insurance - Export contract - Agent details page - As an Exporter, I wa
     });
 
     it(`should render validation errors when ${FULL_ADDRESS} is over ${MAXIMUM_CHARACTERS.FULL_ADDRESS} characters`, () => {
-      cy.navigateToUrl(url);
-
       cy.submitAndAssertFieldErrors({
         field: textareaField,
         value: 'a'.repeat(MAXIMUM_CHARACTERS.FULL_ADDRESS + 1),
@@ -93,7 +130,7 @@ context('Insurance - Export contract - Agent details page - As an Exporter, I wa
 
       cy.submitAndAssertFieldErrors({
         field: autoCompleteField(COUNTRY_CODE),
-        errorIndex: 1,
+        errorIndex: 2,
         expectedErrorsCount,
         expectedErrorMessage: AGENT_DETAILS_ERROR_MESSAGES[COUNTRY_CODE].IS_EMPTY,
       });

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
@@ -156,6 +156,7 @@ describe('controllers/insurance/export-contract/agent-details', () => {
 
   describe('post', () => {
     const validBody = {
+      [NAME]: mockApplication.exportContract.agent[NAME],
       [FULL_ADDRESS]: mockApplication.exportContract.agent[FULL_ADDRESS],
       [COUNTRY_CODE]: mockCountries[0].isoCode,
     };

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/validation/rules/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/validation/rules/index.ts
@@ -1,8 +1,9 @@
+import nameRule from './name';
 import fullAddressRule from './full-address';
 import countryCodeRule from './country-code';
 import { ValidationErrors } from '../../../../../../../types';
 
-const rules = [fullAddressRule, countryCodeRule];
+const rules = [nameRule, fullAddressRule, countryCodeRule];
 
 const validationRules = rules as Array<() => ValidationErrors>;
 

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/validation/rules/name/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/validation/rules/name/index.test.ts
@@ -1,0 +1,29 @@
+import name from '.';
+import { MAXIMUM_CHARACTERS } from '../../../../../../../constants';
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import alphaCharactersAndMaxLengthValidation from '../../../../../../../shared-validation/alpha-characters-and-max-length';
+import { RequestBody } from '../../../../../../../../types';
+import { mockErrors } from '../../../../../../../test-mocks';
+
+const {
+  AGENT_DETAILS: { NAME: FIELD_ID },
+} = FIELD_IDS;
+
+const {
+  AGENT_DETAILS: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
+} = ERROR_MESSAGES.INSURANCE.EXPORT_CONTRACT;
+
+describe('controllers/insurance/export-contract/agent-details/validation/rules/name', () => {
+  const mockBody = {
+    [FIELD_ID]: '',
+  } as RequestBody;
+
+  it('should return the result of alphaCharactersAndMaxLengthValidation', () => {
+    const response = name(mockBody, mockErrors);
+
+    const expected = alphaCharactersAndMaxLengthValidation(mockBody, FIELD_ID, ERROR_MESSAGES_OBJECT, mockErrors, MAXIMUM_CHARACTERS.AGENT_NAME);
+
+    expect(response).toEqual(expected);
+  });
+});

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/validation/rules/name/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/validation/rules/name/index.ts
@@ -1,0 +1,24 @@
+import { MAXIMUM_CHARACTERS } from '../../../../../../../constants';
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
+import { ERROR_MESSAGES } from '../../../../../../../content-strings';
+import alphaCharactersAndMaxLengthValidation from '../../../../../../../shared-validation/alpha-characters-and-max-length';
+import { RequestBody } from '../../../../../../../../types';
+
+const {
+  AGENT_DETAILS: { NAME: FIELD_ID },
+} = FIELD_IDS;
+
+const {
+  AGENT_DETAILS: { [FIELD_ID]: ERROR_MESSAGES_OBJECT },
+} = ERROR_MESSAGES.INSURANCE.EXPORT_CONTRACT;
+
+/**
+ * validate the "agent name" field
+ * @param {RequestBody} formBody: Form body
+ * @param {Object} errors: Other validation errors for the same form
+ * @returns {ValidationErrors} alphaCharactersAndMaxLengthValidation
+ */
+const name = (formBody: RequestBody, errors: object) =>
+  alphaCharactersAndMaxLengthValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MAXIMUM_CHARACTERS.AGENT_NAME);
+
+export default name;


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds the last remaining piece of form validation to the "Agent details" form, for the "name" field.

## Resolution :heavy_check_mark:
- Update E2E tests.
- Update UI POST controller so that `validBody` contains a `NAME`.
- Create new `name` validation rule; Simply consuming an existing, DRY shared validation helper, `alphaCharactersAndMaxLengthValidation`.