### PR TITLE
chore(EMS-3158): No PDF - Simplify previously submitted country mappings

### DIFF
--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
@@ -12,7 +12,7 @@ import getCountryByIsoCode from '../../../../helpers/get-country-by-iso-code';
 import mapSubmittedEligibilityCountry from '../../../../helpers/mappings/map-submitted-eligibility-country';
 import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { Country, Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockSession, mockCountries } from '../../../../test-mocks';
+import { mockReq, mockRes, mockCountries } from '../../../../test-mocks';
 
 const {
   PROBLEM_WITH_SERVICE,
@@ -69,7 +69,6 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
     let getCisCountriesSpy = jest.fn(() => Promise.resolve(mockCountriesResponse));
 
     beforeEach(() => {
-      delete req.session.submittedData.quoteEligibility[FIELD_IDS.ELIGIBILITY.BUYER_COUNTRY];
       api.keystone.APIM.getCisCountries = getCisCountriesSpy;
     });
 
@@ -86,34 +85,11 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
         ...singleInputPageVariables(PAGE_VARIABLES),
         BACK_LINK: req.headers.referer,
         userName: getUserNameFromSession(req.session.user),
-        countries: mapCountries(mockCountriesResponse),
+        countries: mapCountries(mockCountriesResponse, req.session.submittedData.insuranceEligibility[FIELD_ID]?.isoCode),
         submittedValues: req.session.submittedData.insuranceEligibility,
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
-    });
-
-    describe('when a country has been submitted', () => {
-      it('should render template with countries mapped to submitted country', async () => {
-        req.session.submittedData = mockSession.submittedData;
-
-        await get(req, res);
-
-        const expectedCountries = mapCountries(
-          mockCountriesResponse,
-          req.session.submittedData.insuranceEligibility[FIELD_IDS.ELIGIBILITY.BUYER_COUNTRY].isoCode,
-        );
-
-        const expectedVariables = {
-          ...singleInputPageVariables(PAGE_VARIABLES),
-          BACK_LINK: req.headers.referer,
-          userName: getUserNameFromSession(req.session.user),
-          countries: expectedCountries,
-          submittedValues: req.session.submittedData.insuranceEligibility,
-        };
-
-        expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
-      });
     });
 
     describe('when the get CIS countries API call fails', () => {

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.ts
@@ -2,7 +2,6 @@ import { PAGES } from '../../../../content-strings';
 import { FIELD_IDS, TEMPLATES } from '../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
 import api from '../../../../api';
-import { objectHasProperty } from '../../../../helpers/object';
 import { isPopulatedArray } from '../../../../helpers/array';
 import mapCountries from '../../../../helpers/mappings/map-countries';
 import singleInputPageVariables from '../../../../helpers/page-variables/single-input/insurance';
@@ -38,20 +37,9 @@ export const get = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    let countryValue;
     const { insuranceEligibility } = req.session.submittedData;
 
-    if (objectHasProperty(insuranceEligibility, FIELD_ID)) {
-      countryValue = insuranceEligibility[FIELD_ID];
-    }
-
-    let mappedCountries;
-
-    if (countryValue) {
-      mappedCountries = mapCountries(countries, countryValue.isoCode);
-    } else {
-      mappedCountries = mapCountries(countries);
-    }
+    const mappedCountries = mapCountries(countries, insuranceEligibility[FIELD_ID]?.isoCode);
 
     return res.render(TEMPLATE, {
       ...singleInputPageVariables({

--- a/src/ui/server/controllers/insurance/export-contract/about-goods-or-services/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/about-goods-or-services/index.ts
@@ -9,7 +9,6 @@ import insuranceCorePageVariables from '../../../../helpers/page-variables/core/
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import constructPayload from '../../../../helpers/construct-payload';
-import { objectHasProperty } from '../../../../helpers/object';
 import generateValidationErrors from './validation';
 import getCountryByIsoCode from '../../../../helpers/get-country-by-iso-code';
 import mapCountries from '../../../../helpers/mappings/map-countries';
@@ -100,13 +99,7 @@ export const get = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    let mappedCountries;
-
-    if (objectHasProperty(application.exportContract, FINAL_DESTINATION)) {
-      mappedCountries = mapCountries(countries, application.exportContract[FINAL_DESTINATION]);
-    } else {
-      mappedCountries = mapCountries(countries);
-    }
+    const mappedCountries = mapCountries(countries, application.exportContract[FINAL_DESTINATION]);
 
     return res.render(TEMPLATE, {
       ...insuranceCorePageVariables({
@@ -156,17 +149,9 @@ export const post = async (req: Request, res: Response) => {
         return res.redirect(PROBLEM_WITH_SERVICE);
       }
 
-      let mappedCountries;
+      const submittedCountry = getCountryByIsoCode(countries, payload[FINAL_DESTINATION]);
 
-      if (objectHasProperty(payload, FINAL_DESTINATION)) {
-        const submittedCountry = payload[FINAL_DESTINATION];
-
-        const country = getCountryByIsoCode(countries, submittedCountry);
-
-        mappedCountries = mapCountries(countries, country?.isoCode);
-      } else {
-        mappedCountries = mapCountries(countries);
-      }
+      const mappedCountries = mapCountries(countries, submittedCountry?.isoCode);
 
       return res.render(TEMPLATE, {
         ...insuranceCorePageVariables({

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/index.ts
@@ -10,7 +10,6 @@ import insuranceCorePageVariables from '../../../../helpers/page-variables/core/
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import constructPayload from '../../../../helpers/construct-payload';
-import { objectHasProperty } from '../../../../helpers/object';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/export-contract-agent';
 import { Request, Response } from '../../../../../types';
@@ -72,13 +71,7 @@ export const get = async (req: Request, res: Response) => {
   try {
     const countries = await api.keystone.countries.getAll();
 
-    let mappedCountries;
-
-    if (objectHasProperty(application.exportContract.agent, COUNTRY_CODE)) {
-      mappedCountries = mapCountries(countries, application.exportContract.agent[COUNTRY_CODE]);
-    } else {
-      mappedCountries = mapCountries(countries);
-    }
+    const mappedCountries = mapCountries(countries, application.exportContract.agent[COUNTRY_CODE]);
 
     if (!isPopulatedArray(countries)) {
       return res.redirect(PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/policy/other-company-details/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/index.ts
@@ -12,7 +12,6 @@ import constructPayload from '../../../../helpers/construct-payload';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/jointly-insured-party';
-import { objectHasProperty } from '../../../../helpers/object';
 import { Request, Response } from '../../../../../types';
 
 const {
@@ -76,15 +75,9 @@ export const get = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    let mappedCountries;
-
     const { jointlyInsuredParty } = application.policy;
 
-    if (objectHasProperty(jointlyInsuredParty, COUNTRY_CODE)) {
-      mappedCountries = mapCountries(countries, jointlyInsuredParty[COUNTRY_CODE]);
-    } else {
-      mappedCountries = mapCountries(countries);
-    }
+    const mappedCountries = mapCountries(countries, jointlyInsuredParty[COUNTRY_CODE]);
 
     return res.render(TEMPLATE, {
       ...insuranceCorePageVariables({
@@ -132,15 +125,7 @@ export const post = async (req: Request, res: Response) => {
         return res.redirect(PROBLEM_WITH_SERVICE);
       }
 
-      let mappedCountries;
-
-      if (objectHasProperty(payload, COUNTRY_CODE)) {
-        const submittedCountryCode = payload[COUNTRY_CODE];
-
-        mappedCountries = mapCountries(countries, submittedCountryCode);
-      } else {
-        mappedCountries = mapCountries(countries);
-      }
+      const mappedCountries = mapCountries(countries, payload[COUNTRY_CODE]);
 
       return res.render(TEMPLATE, {
         ...insuranceCorePageVariables({

--- a/src/ui/server/controllers/quote/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.test.ts
@@ -11,7 +11,7 @@ import mapSubmittedEligibilityCountry from '../../../helpers/mappings/map-submit
 import api from '../../../api';
 import mapCountries from '../../../helpers/mappings/map-countries';
 import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
-import { mockReq, mockRes, mockSession, mockCountries } from '../../../test-mocks';
+import { mockReq, mockRes, mockCountries } from '../../../test-mocks';
 import { Country, Request, Response } from '../../../../types';
 
 describe('controllers/quote/buyer-country', () => {
@@ -109,7 +109,6 @@ describe('controllers/quote/buyer-country', () => {
     let getCisCountriesSpy = jest.fn(() => Promise.resolve(mockCountriesResponse));
 
     beforeEach(() => {
-      delete req.session.submittedData.quoteEligibility[FIELD_ID];
       api.keystone.APIM.getCisCountries = getCisCountriesSpy;
     });
 
@@ -125,7 +124,7 @@ describe('controllers/quote/buyer-country', () => {
       const expectedVariables = {
         ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: getBackLink(req.headers.referer), ORIGINAL_URL: req.originalUrl }),
         userName: getUserNameFromSession(req.session.user),
-        countries: mapCountries(mockCountriesResponse),
+        countries: mapCountries(mockCountriesResponse, req.session.submittedData.quoteEligibility[FIELD_ID]?.isoCode),
         submittedValues: req.session.submittedData.quoteEligibility,
         isChangeRoute: isChangeRoute(req.originalUrl),
       };
@@ -166,26 +165,6 @@ describe('controllers/quote/buyer-country', () => {
         };
 
         expect(req.session.submittedData).toEqual(expected);
-      });
-    });
-
-    describe('when a country has been submitted', () => {
-      it('should render template with countries mapped to submitted country', async () => {
-        req.session.submittedData = mockSession.submittedData;
-
-        await get(req, res);
-
-        const expectedCountries = mapCountries(mockCountriesResponse, req.session.submittedData.quoteEligibility[FIELD_ID].isoCode);
-
-        const expectedVariables = {
-          ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: getBackLink(req.headers.referer), ORIGINAL_URL: req.originalUrl }),
-          userName: getUserNameFromSession(req.session.user),
-          countries: expectedCountries,
-          submittedValues: req.session.submittedData.quoteEligibility,
-          isChangeRoute: isChangeRoute(req.originalUrl),
-        };
-
-        expect(res.render).toHaveBeenCalledWith(TEMPLATES.SHARED_PAGES.BUYER_COUNTRY, expectedVariables);
       });
     });
 

--- a/src/ui/server/controllers/quote/buyer-country/index.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.ts
@@ -71,20 +71,9 @@ export const get = async (req: Request, res: Response) => {
       return res.redirect(ROUTES.PROBLEM_WITH_SERVICE);
     }
 
-    let countryValue;
     const { quoteEligibility } = req.session.submittedData;
 
-    if (objectHasProperty(quoteEligibility, FIELD_ID)) {
-      countryValue = quoteEligibility[FIELD_ID];
-    }
-
-    let mappedCountries;
-
-    if (countryValue) {
-      mappedCountries = mapCountries(countries, countryValue.isoCode);
-    } else {
-      mappedCountries = mapCountries(countries);
-    }
+    const mappedCountries = mapCountries(countries, quoteEligibility[FIELD_ID]?.isoCode);
 
     return res.render(TEMPLATE, {
       ...singleInputPageVariables({ ...PAGE_VARIABLES, BACK_LINK: getBackLink(req.headers.referer), ORIGINAL_URL: req.originalUrl }),


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates all UI controllers mapping of previously submitted countries.

Instead of this (simplified example):
```js
if (objectHasProperty(obj[FIELD_ID])) {

let mappedCountries;

if (countryValue) {
  mappedCountries = mapCountries(countries, countryValue.isoCode);
} else {
  mappedCountries = mapCountries(countries);
}
```

We can just do this instead, because `mapCountries` handles an undefined param:

```js
const mappedCountries = mapCountries(countries, obj[FIELD_ID]?.isoCode);
```

## Resolution :heavy_check_mark:
- Update all UI controllers with country mappings, to use the simplified example above.
- Simplify all UI controller unit tests.
