### PR TITLE
feat(EMS-3186-3188): No PDF - Export contract - Agent charges - Alternative currency - Prefixes, dynamic label

### DIFF
--- a/e2e-tests/content-strings/fields/insurance/export-contract/index.js
+++ b/e2e-tests/content-strings/fields/insurance/export-contract/index.js
@@ -143,7 +143,7 @@ export const EXPORT_CONTRACT_FIELDS = {
       },
     },
     [FIXED_SUM_AMOUNT]: {
-      LABEL: 'How much are they charging in TODO?',
+      LABEL: 'How much are they charging in',
       SUMMARY: {
         TITLE: 'How much they are charging',
         FORM_TITLE: EXPORT_CONTRACT_FORM_TITLES.AGENT,

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges-change-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges-change-currency.spec.js
@@ -1,0 +1,71 @@
+import FIELD_IDS from '../../../../../../constants/field-ids/insurance/export-contract';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { assertCurrencyFormFields } from '../../../../../../shared-test-assertions';
+
+const {
+  ROOT,
+  EXPORT_CONTRACT: {
+    AGENT_CHARGES,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  AGENT_CHARGES: { FIXED_SUM_AMOUNT },
+} = FIELD_IDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context("Insurance - Export contract - Agent charges page - As an Exporter I want to change the currency of my agent's charges", () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      // go to the page we want to test.
+      cy.startInsuranceExportContractSection({});
+      cy.completeAndSubmitAboutGoodsOrServicesForm({});
+      cy.completeAndSubmitHowYouWillGetPaidForm({});
+      cy.completeAndSubmitAgentForm({ isUsingAgent: true });
+      cy.completeAndSubmitAgentDetailsForm({});
+      cy.completeAndSubmitAgentServiceForm({ agentIsCharging: true });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_CHARGES}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+    cy.navigateToUrl(url);
+
+    cy.completeAgentChargesForm({
+      fixedSumMethod: true,
+      fixedSumAmount: null,
+      payableCountry: null,
+    });
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('prefixes should be displayed based on the chosen currency', () => {
+    before(() => {
+      cy.saveSession();
+      cy.navigateToUrl(url);
+
+      cy.completeAndSubmitAgentChargesForm({
+        fixedSumMethod: true,
+        fixedSumAmount: null,
+        payableCountry: null,
+      });
+    });
+
+    const { prefixAssertions } = assertCurrencyFormFields({ fieldId: FIXED_SUM_AMOUNT });
+
+    prefixAssertions();
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges.spec.js
@@ -7,6 +7,7 @@ import { EXPORT_CONTRACT_FIELDS as FIELDS } from '../../../../../../content-stri
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { assertCountryAutocompleteInput } from '../../../../../../shared-test-assertions';
+import { GBP } from '../../../../../../fixtures/currencies';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.EXPORT_CONTRACT.AGENT_CHARGES;
 
@@ -25,7 +26,7 @@ const {
 
 const baseUrl = Cypress.config('baseUrl');
 
-context("Insurance - Export contract - Agent charges page - As an Exporter, I want to state what my agen's charges are, So that UKEF, the legal team and the British Embassy are aware of expenses incurred in my export contract bid", () => {
+context("Insurance - Export contract - Agent charges page - As an Exporter, I want to state what my agent's charges are, So that UKEF, the legal team and the British Embassy are aware of expenses incurred in my export contract bid", () => {
   let referenceNumber;
   let url;
   let agentChargesAlternativeCurrencyUrl;
@@ -111,7 +112,11 @@ context("Insurance - Export contract - Agent charges page - As an Exporter, I wa
         const field = fieldSelector(fieldId);
 
         field.input().should('be.visible');
-        cy.checkText(field.label(), FIELDS.AGENT_CHARGES[fieldId].LABEL);
+
+        const expectedLabel = `${FIELDS.AGENT_CHARGES[fieldId].LABEL} ${GBP.name}?`;
+
+        cy.checkText(field.label(), expectedLabel);
+
         cy.assertPrefix({ fieldId, value: SYMBOLS.GBP });
 
         cy.checkLink(

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-change-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-change-currency.spec.js
@@ -45,7 +45,7 @@ context('Insurance - Your business - Turnover page - As an Exporter I want to ch
     cy.deleteApplication(referenceNumber);
   });
 
-  describe('prefixes should be displayed based on currency chosen', () => {
+  describe('prefixes should be displayed based on the chosen currency', () => {
     const { prefixAssertions } = assertCurrencyFormFields({ fieldId: ESTIMATED_ANNUAL_TURNOVER });
 
     prefixAssertions();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-change-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-change-currency.spec.js
@@ -43,13 +43,13 @@ context('Insurance - Your Buyer - Trading history page - Currency symbol when ch
     cy.deleteApplication(referenceNumber);
   });
 
-  describe(`prefixes should be displayed based on currency chosen for ${TOTAL_AMOUNT_OVERDUE}`, () => {
+  describe(`prefixes should be displayed based on the chosen currency for ${TOTAL_AMOUNT_OVERDUE}`, () => {
     const { prefixAssertions } = assertCurrencyFormFields({ fieldId: TOTAL_AMOUNT_OVERDUE });
 
     prefixAssertions();
   });
 
-  describe(`prefixes should be displayed based on currency chosen for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
+  describe(`prefixes should be displayed based on the chosen currency for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
     before(() => {
       cy.saveSession();
       cy.navigateToUrl(url);

--- a/src/ui/server/content-strings/fields/insurance/export-contract/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/export-contract/index.ts
@@ -141,7 +141,7 @@ export const EXPORT_CONTRACT_FIELDS = {
       },
     },
     [FIXED_SUM_AMOUNT]: {
-      LABEL: 'How much are they charging in TODO?',
+      LABEL: 'How much are they charging in',
       SUMMARY: {
         TITLE: 'How much they are charging',
         FORM_TITLE: EXPORT_CONTRACT_FORM_TITLES.AGENT,

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.test.ts
@@ -35,8 +35,6 @@ const {
   },
 } = POLICY_FIELD_IDS;
 
-const { PAGE_TITLE } = PAGE_CONTENT_STRINGS;
-
 const {
   policy: { policyCurrencyCode },
   referenceNumber,
@@ -87,7 +85,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
             ...FIELDS.EXPORT_VALUE.MULTIPLE[MAXIMUM_BUYER_WILL_OWE],
           },
         },
-        DYNAMIC_PAGE_TITLE: `${PAGE_TITLE} ${currency.name}`,
+        DYNAMIC_PAGE_TITLE: `${PAGE_CONTENT_STRINGS.PAGE_TITLE} ${currency.name}`,
         CURRENCY_PREFIX_SYMBOL: currency.symbol,
         SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_SAVE_AND_BACK}`,
       };

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.ts
@@ -31,8 +31,6 @@ const {
 
 export const PAGE_CONTENT_STRINGS = PAGES.INSURANCE.POLICY.MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE;
 
-const { PAGE_TITLE } = PAGE_CONTENT_STRINGS;
-
 /**
  * pageVariables
  * Page fields and "save and go back" URL
@@ -55,7 +53,7 @@ export const pageVariables = (referenceNumber: number, currencies: Array<Currenc
         ...FIELDS.EXPORT_VALUE.MULTIPLE[MAXIMUM_BUYER_WILL_OWE],
       },
     },
-    DYNAMIC_PAGE_TITLE: `${PAGE_TITLE} ${currency.name}`,
+    DYNAMIC_PAGE_TITLE: `${PAGE_CONTENT_STRINGS.PAGE_TITLE} ${currency.name}`,
     CURRENCY_PREFIX_SYMBOL: currency.symbol,
     SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE_SAVE_AND_BACK}`,
   };

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
@@ -35,8 +35,6 @@ const {
   },
 } = POLICY_FIELD_IDS;
 
-const { PAGE_TITLE } = PAGE_CONTENT_STRINGS;
-
 const {
   policy: { policyCurrencyCode },
   referenceNumber,
@@ -81,7 +79,7 @@ describe('controllers/insurance/policy/single-contract-policy/total-contract-val
           ID: FIELD_ID,
           ...FIELDS.CONTRACT_POLICY.SINGLE[FIELD_ID],
         },
-        DYNAMIC_PAGE_TITLE: `${PAGE_TITLE} ${currency.name}?`,
+        DYNAMIC_PAGE_TITLE: `${PAGE_CONTENT_STRINGS.PAGE_TITLE} ${currency.name}?`,
         CURRENCY_PREFIX_SYMBOL: currency.symbol,
         SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_SAVE_AND_BACK}`,
       };

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.ts
@@ -33,8 +33,6 @@ export const PAGE_CONTENT_STRINGS = PAGES.INSURANCE.POLICY.SINGLE_CONTRACT_POLIC
 
 export const FIELD_ID = TOTAL_CONTRACT_VALUE;
 
-const { PAGE_TITLE } = PAGE_CONTENT_STRINGS;
-
 /**
  * pageVariables
  * Page fields and "save and go back" URL
@@ -51,7 +49,7 @@ export const pageVariables = (referenceNumber: number, currencies: Array<Currenc
       ID: FIELD_ID,
       ...FIELDS.CONTRACT_POLICY.SINGLE[FIELD_ID],
     },
-    DYNAMIC_PAGE_TITLE: `${PAGE_TITLE} ${currency.name}?`,
+    DYNAMIC_PAGE_TITLE: `${PAGE_CONTENT_STRINGS.PAGE_TITLE} ${currency.name}?`,
     CURRENCY_PREFIX_SYMBOL: currency.symbol,
     SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE_SAVE_AND_BACK}`,
   };

--- a/src/ui/templates/partials/insurance/export-contract-agent-charges-conditional-fixed-sum-html.njk
+++ b/src/ui/templates/partials/insurance/export-contract-agent-charges-conditional-fixed-sum-html.njk
@@ -7,6 +7,7 @@
   {{ textInput.render({
     id: fieldId,
     labelText: field.LABEL,
+    labelClasses: "govuk-!-font-weight-bold govuk-!-font-size-24",
     inputClasses: "govuk-input--width-5",
     prefixText: CURRENCY_PREFIX_SYMBOL,
     errorMessage: validationErrors.errorList[fieldId],


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the "Agent charges - alternative currency" functionality in the "Export contract" section of a No PDF application so that the "Fixed sum amount" label and input renders a dynamic label and prefix, depending on if the selected currency is an "alternative" currency or not.

## Resolution :heavy_check_mark:
- Update field content strings.
- Add and update E2E tests.
- Update the `AGENT_CHARGES` GET and POST controller to render a dynamic `FIXED_SUM_AMOUNT` label.
- Update the `AGENT_CHARGES` GET and POST controller to render a dynamic `FIXED_SUM_AMOUNT` label.
- Add a missing `labelClasses` nunjucks attribute.

## Miscellaneous :heavy_plus_sign:
- Fix some typos.
- Documentation improvements.
- Simplify some `DYNAMIC_PAGE_TITLE` instances.
