### PR TITLE
fix(EMS-3129-3184-3187-3242): No PDF - Visual design issues - Email fields, content, unnecessary button, styling

### DIFF
--- a/e2e-tests/commands/keyboard-input.js
+++ b/e2e-tests/commands/keyboard-input.js
@@ -3,9 +3,21 @@
  * Clear and type text into an input.
  * @param {Function} selector: Cypress selector
  * @param {String} text: Text to enter
+ * @param {Boolean} viaValue: Flag for whether to input the text via the input's value attribute, instead of .type().
  */
-const keyboardInput = (selector, text) => {
-  selector.clear().type(text, { delay: 0 });
+const keyboardInput = (selector, text, viaValue = false) => {
+  /**
+   * If viaValue is provided, invoke the input's value, instead of using .type().
+   * Otherwise, if the text contains empty spaces,
+   * and the input is has a "type" attribute of "email",
+   * cypress will automatically strip the empty spaces.
+   * More information here: https://github.com/cypress-io/cypress/issues/1327
+   */
+  if (viaValue) {
+    selector.clear().invoke('val', text); 
+  } else {
+    selector.clear().type(text, { delay: 0 }); 
+  }
 };
 
 export default keyboardInput;

--- a/e2e-tests/commands/keyboard-input.js
+++ b/e2e-tests/commands/keyboard-input.js
@@ -14,9 +14,9 @@ const keyboardInput = (selector, text, viaValue = false) => {
    * More information here: https://github.com/cypress-io/cypress/issues/1327
    */
   if (viaValue) {
-    selector.clear().invoke('val', text); 
+    selector.clear().invoke('val', text);
   } else {
-    selector.clear().type(text, { delay: 0 }); 
+    selector.clear().type(text, { delay: 0 });
   }
 };
 

--- a/e2e-tests/commands/shared-commands/assertions/assert-section-start-content.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-section-start-content.js
@@ -52,7 +52,7 @@ const assertSectionStartContent = {
     linkRedirection: ({ currentUrl, expectedUrl }) => {
       cy.navigateToUrl(currentUrl);
 
-      allSectionsLink().click();
+      cy.clickAllSectionsLink();
 
       cy.assertUrl(expectedUrl);
     },

--- a/e2e-tests/commands/shared-commands/assertions/check-email-field-rendering.js
+++ b/e2e-tests/commands/shared-commands/assertions/check-email-field-rendering.js
@@ -1,0 +1,19 @@
+import { field as fieldSelector } from '../../../pages/shared';
+
+/**
+ * checkEmailFieldRendering
+ * Check the rendering of an email field
+ * @param {String} fieldId: Field ID
+ * @param {Object} contentStrings: field content strings
+ */
+const checkEmailFieldRendering = ({ fieldId, contentStrings }) => {
+  const field = fieldSelector(fieldId);
+
+  cy.checkText(field.label(), contentStrings.LABEL);
+
+  field.input().should('exist');
+
+  cy.checkTypeAttribute(field.input(), 'email');
+};
+
+export default checkEmailFieldRendering;

--- a/e2e-tests/commands/shared-commands/assertions/check-type-attribute.js
+++ b/e2e-tests/commands/shared-commands/assertions/check-type-attribute.js
@@ -1,0 +1,11 @@
+/**
+ * checkTypeAttribute
+ * Check an element's "type" attribute
+ * @param {Object} selector: Cypress selector
+ * @param {String} expectedType: Expected type
+ */
+const checkTypeAttribute = (selector, expectedType) => {
+  selector.should('have.attr', 'type', expectedType);
+};
+
+export default checkTypeAttribute;

--- a/e2e-tests/commands/shared-commands/assertions/index.js
+++ b/e2e-tests/commands/shared-commands/assertions/index.js
@@ -28,12 +28,14 @@ Cypress.Commands.add('assertTextareaRendering', require('./assert-textarea-rende
 Cypress.Commands.add('assertDynamicCharacterCount', require('./assert-dynamic-character-count'));
 
 Cypress.Commands.add('checkAriaLabel', require('./check-aria-label'));
+Cypress.Commands.add('checkClassName', require('./check-class-name'));
+Cypress.Commands.add('checkEmailFieldRendering', require('./check-email-field-rendering'));
+Cypress.Commands.add('checkIntroText', require('./check-intro-text'));
 Cypress.Commands.add('checkLink', require('./check-link'));
 Cypress.Commands.add('checkText', require('./check-text'));
-Cypress.Commands.add('checkIntroText', require('./check-intro-text'));
-Cypress.Commands.add('checkValue', require('./check-value'));
 Cypress.Commands.add('checkTextareaValue', require('./check-textarea-value'));
-Cypress.Commands.add('checkClassName', require('./check-class-name'));
+Cypress.Commands.add('checkTypeAttribute', require('./check-type-attribute'));
+Cypress.Commands.add('checkValue', require('./check-value'));
 
 Cypress.Commands.add('checkAuthenticatedHeader', require('./check-authenticated-header'));
 

--- a/e2e-tests/commands/shared-commands/form/click-all-sections-link.js
+++ b/e2e-tests/commands/shared-commands/form/click-all-sections-link.js
@@ -1,0 +1,11 @@
+import { allSectionsLink } from '../../../pages/shared';
+
+/**
+ * clickAllSectionsLink
+ * Click an "all sections" link.
+ */
+const clickAllSectionsLink = () => {
+  allSectionsLink().click();
+};
+
+export default clickAllSectionsLink;

--- a/e2e-tests/commands/shared-commands/form/index.js
+++ b/e2e-tests/commands/shared-commands/form/index.js
@@ -4,6 +4,7 @@ Cypress.Commands.add('changeAnswerRadioField', require('./change-answer-radio-fi
 Cypress.Commands.add('clickSubmitButton', require('./click-submit-button'));
 Cypress.Commands.add('clickSubmitButtonMultipleTimes', require('./click-submit-button-multiple-times'));
 Cypress.Commands.add('clickSaveAndBackButton', require('./click-save-and-back-button'));
+Cypress.Commands.add('clickAllSectionsLink', require('./click-all-sections-link'));
 
 Cypress.Commands.add('submitAndAssertFieldErrors', require('./submit-and-assert-field-errors'));
 Cypress.Commands.add('assertFieldErrors', require('./assert-field-errors'));

--- a/e2e-tests/commands/shared-commands/form/submit-and-assert-field-errors.js
+++ b/e2e-tests/commands/shared-commands/form/submit-and-assert-field-errors.js
@@ -19,13 +19,14 @@ const submitAndAssertFieldErrors = ({
   expectedValue,
   assertExpectedValue = true,
   clearInput = true,
+  keyboardInputViaValueAttribute = false,
 }) => {
   /**
    * If a value is provided,
    * Enter the value into the field's input.
    */
   if (value) {
-    cy.keyboardInput(field.input(), value);
+    cy.keyboardInput(field.input(), value, keyboardInputViaValueAttribute);
   } else if (clearInput) {
     field.input().clear();
   }

--- a/e2e-tests/commands/shared-commands/form/submit-and-assert-field-errors.js
+++ b/e2e-tests/commands/shared-commands/form/submit-and-assert-field-errors.js
@@ -9,6 +9,7 @@
  * @param {Number} expectedValue: Expected value after submission.
  * @param {Boolean} assertExpectedValue: Assert an expected value. Defaults to true.
  * @param {Boolean} clearInput: Clear the input before text entry. Defaults to true.
+ * @param {Boolean} keyboardInputViaValueAttribute: Flag for whether to input the text via the input's value attribute, instead of .type().
  */
 const submitAndAssertFieldErrors = ({
   field,

--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -187,7 +187,7 @@ export const ERROR_MESSAGES = {
       AGENT_SERVICE: {
         [FIELD_IDS.INSURANCE.EXPORT_CONTRACT.AGENT_SERVICE.SERVICE_DESCRIPTION]: {
           IS_EMPTY: 'Enter the details of the service the agent is providing',
-          ABOVE_MAXIMUM: `The details of the service the agent is providing cannot be more than ${MAXIMUM_CHARACTERS.FULL_ADDRESS} characters`,
+          ABOVE_MAXIMUM: `The details of the service the agent is providing cannot be more than ${MAXIMUM_CHARACTERS.AGENT_SERVICE_DESCRIPTION} characters`,
         },
         [FIELD_IDS.INSURANCE.EXPORT_CONTRACT.AGENT_SERVICE.IS_CHARGING]: {
           IS_EMPTY: 'Select if the agent is charging for their support',

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/your-details/account-create-your-details.spec.js
@@ -86,11 +86,11 @@ context('Insurance - Account - Create - Your details page - As an exporter, I wa
 
     it('renders `email` label and input', () => {
       const fieldId = EMAIL;
-      const field = fieldSelector(fieldId);
 
-      cy.checkText(field.label(), ACCOUNT_FIELDS[fieldId].LABEL);
-
-      field.input().should('exist');
+      cy.checkEmailFieldRendering({
+        fieldId,
+        contentStrings: ACCOUNT_FIELDS[fieldId],
+      });
     });
 
     describe('password', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/account-password-reset.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/account-password-reset.spec.js
@@ -1,4 +1,3 @@
-import { field as fieldSelector } from '../../../../../../pages/shared';
 import { signInPage } from '../../../../../../pages/insurance/account/sign-in';
 import { yourDetailsPage } from '../../../../../../pages/insurance/account/create';
 import { BUTTONS, PAGES } from '../../../../../../content-strings';
@@ -70,11 +69,11 @@ context('Insurance - Account - Password reset page - As an Exporter, I want to r
 
     it('renders `email` label, hint and input', () => {
       const fieldId = EMAIL;
-      const field = fieldSelector(fieldId);
 
-      cy.checkText(field.label(), FIELD_STRINGS[fieldId].LABEL);
-
-      field.input().should('exist');
+      cy.checkEmailFieldRendering({
+        fieldId,
+        contentStrings: FIELD_STRINGS[fieldId],
+      });
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/account-sign-in.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/account-sign-in.spec.js
@@ -1,7 +1,6 @@
 import { signInPage } from '../../../../../../pages/insurance/account/sign-in';
 import { yourDetailsPage } from '../../../../../../pages/insurance/account/create';
 import passwordField from '../../../../../../partials/insurance/passwordField';
-import { field as fieldSelector } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
 import { ACCOUNT_FIELDS } from '../../../../../../content-strings/fields/insurance/account';
@@ -70,11 +69,11 @@ context('Insurance - Account - Sign in - As an Exporter, I want to sign in into 
 
     it('renders `email` label and input', () => {
       const fieldId = EMAIL;
-      const field = fieldSelector(fieldId);
 
-      cy.checkText(field.label(), FIELD_STRINGS[fieldId].LABEL);
-
-      field.input().should('exist');
+      cy.checkEmailFieldRendering({
+        fieldId,
+        contentStrings: FIELD_STRINGS[fieldId],
+      });
     });
 
     describe('password', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-fixed-sum-amount.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-fixed-sum-amount.spec.js
@@ -19,7 +19,7 @@ const fieldId = FIXED_SUM_AMOUNT;
 
 const baseUrl = Cypress.config('baseUrl');
 
-context(`Insurance - Export contract - Change your answers - Agent charges - ${FIXED_SUM_AMOUNT} As an Exporter, I want to be able to review my input regarding the amount an agent is charging for helping me win my export contract, So that I can be assured I am providing UKEF with the right information`, () => {
+context(`Insurance - Export contract - Change your answers - Agent charges - ${FIXED_SUM_AMOUNT} - As an Exporter, I want to be able to review my input regarding the amount an agent is charging for helping me win my export contract, So that I can be assured I am providing UKEF with the right information`, () => {
   let referenceNumber;
   let checkYourAnswersUrl;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
@@ -94,10 +94,11 @@ context("Insurance - Policy - Broker details page - As an exporter, I want to pr
 
     it(`renders ${EMAIL} label and input`, () => {
       const fieldId = EMAIL;
-      const field = fieldSelector(fieldId);
 
-      cy.checkText(field.label(), FIELD_STRINGS[fieldId].LABEL);
-      field.input().should('exist');
+      cy.checkEmailFieldRendering({
+        fieldId,
+        contentStrings: FIELD_STRINGS[fieldId],
+      });
     });
 
     it(`renders ${FULL_ADDRESS} textarea`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/check-your-answers/check-your-answers.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/check-your-answers/check-your-answers.spec.js
@@ -1,7 +1,4 @@
-import {
-  headingCaption,
-  saveAndBackButton,
-} from '../../../../../../pages/shared';
+import { headingCaption } from '../../../../../../pages/shared';
 import {
   BUTTONS,
   PAGES,
@@ -10,7 +7,6 @@ import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const {
   ROOT,
-  ALL_SECTIONS,
   POLICY: {
     CHECK_YOUR_ANSWERS,
     LOSS_PAYEE_ROOT,
@@ -25,7 +21,6 @@ const baseUrl = Cypress.config('baseUrl');
 context('Insurance - Policy - Check your answers - As an exporter, I want to check my answers to the type of policy section', () => {
   let referenceNumber;
   let url;
-  let allSectionsUrl;
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
@@ -34,7 +29,6 @@ context('Insurance - Policy - Check your answers - As an exporter, I want to che
       cy.completePolicySection({});
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
-      allSectionsUrl = `${ROOT}/${referenceNumber}${ALL_SECTIONS}`;
 
       cy.assertUrl(url);
     });
@@ -53,7 +47,8 @@ context('Insurance - Policy - Check your answers - As an exporter, I want to che
       pageTitle: CONTENT_STRINGS.PAGE_TITLE,
       currentHref: `${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`,
       backLink: `${ROOT}/${referenceNumber}${LOSS_PAYEE_ROOT}`,
-      submitButtonCopy: BUTTONS.CONTINUE_NEXT_SECTION,
+      submitButtonCopy: BUTTONS.SAVE_AND_BACK,
+      assertSaveAndBackButtonDoesNotExist: true,
     });
   });
 
@@ -64,14 +59,6 @@ context('Insurance - Policy - Check your answers - As an exporter, I want to che
 
     it('renders a heading caption', () => {
       cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
-    });
-
-    it('renders a `save and back` button/link', () => {
-      cy.checkLink(
-        saveAndBackButton(),
-        allSectionsUrl,
-        BUTTONS.SAVE_AND_BACK,
-      );
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-multiple-contract-policy.spec.js
@@ -29,8 +29,13 @@ context('Insurance - Policy - Complete the entire section as a multiple contract
       cy.completeAndSubmitBrokerForm({});
       cy.completeAndSubmitLossPayeeForm({});
 
-      // go back to the all sections page
-      cy.clickSaveAndBackButton();
+      /**
+       * Submit the "Policy - check your answers" form,
+       * This proceeds to the next part of the flow - "Export contract - start"
+       * From here, we can get back to the "All sections" page.
+       */
+      cy.clickSubmitButton();
+      cy.clickAllSectionsLink();
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-single-contract-policy.spec.js
@@ -25,8 +25,13 @@ context('Insurance - Policy - Complete the entire section as a single contract p
       cy.completeAndSubmitBrokerForm({});
       cy.completeAndSubmitLossPayeeForm({});
 
-      // go back to the all sections page
-      cy.clickSaveAndBackButton();
+      /**
+       * Submit the "Policy - check your answers" form,
+       * This proceeds to the next part of the flow - "Export contract - start"
+       * From here, we can get back to the "All sections" page.
+       */
+      cy.clickSubmitButton();
+      cy.clickAllSectionsLink();
     });
   });
 

--- a/e2e-tests/shared-test-assertions/email-field-validation/index.js
+++ b/e2e-tests/shared-test-assertions/email-field-validation/index.js
@@ -58,6 +58,7 @@ export const assertEmailFieldValidation = ({
         ...assertions,
         value: INVALID_EMAILS.WITH_SPACE,
         expectedErrorMessage: expectedIncorrectErrorMessage,
+        keyboardInputViaValueAttribute: true,
       });
     });
 

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -184,7 +184,7 @@ export const ERROR_MESSAGES = {
       AGENT_SERVICE: {
         [FIELD_IDS.INSURANCE.EXPORT_CONTRACT.AGENT_SERVICE.SERVICE_DESCRIPTION]: {
           IS_EMPTY: 'Enter the details of the service the agent is providing',
-          ABOVE_MAXIMUM: `The details of the service the agent is providing cannot be more than ${MAXIMUM_CHARACTERS.FULL_ADDRESS} characters`,
+          ABOVE_MAXIMUM: `The details of the service the agent is providing cannot be more than ${MAXIMUM_CHARACTERS.AGENT_SERVICE_DESCRIPTION} characters`,
         },
         [FIELD_IDS.INSURANCE.EXPORT_CONTRACT.AGENT_SERVICE.IS_CHARGING]: {
           IS_EMPTY: 'Select if the agent is charging for their support',

--- a/src/ui/templates/insurance/account/create/your-details.njk
+++ b/src/ui/templates/insurance/account/create/your-details.njk
@@ -58,6 +58,8 @@
           labelText: FIELDS.EMAIL.LABEL,
           labelClasses: "govuk-!-font-weight-bold govuk-!-font-size-24",
           type: "email",
+          autocomplete: true,
+          spellcheck: false,
           value: submittedValues[FIELDS.EMAIL.ID],
           errorMessage: validationErrors.errorList[FIELDS.EMAIL.ID]
         }) }}

--- a/src/ui/templates/insurance/account/create/your-details.njk
+++ b/src/ui/templates/insurance/account/create/your-details.njk
@@ -57,6 +57,7 @@
           id: FIELDS.EMAIL.ID,
           labelText: FIELDS.EMAIL.LABEL,
           labelClasses: "govuk-!-font-weight-bold govuk-!-font-size-24",
+          type: "email",
           value: submittedValues[FIELDS.EMAIL.ID],
           errorMessage: validationErrors.errorList[FIELDS.EMAIL.ID]
         }) }}

--- a/src/ui/templates/insurance/account/password-reset/password-reset.njk
+++ b/src/ui/templates/insurance/account/password-reset/password-reset.njk
@@ -1,7 +1,7 @@
 {% extends 'index.njk' %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
-{% import '../../../components/password-input.njk' as passwordInput %}
+{% import '../../../components/text-input.njk' as textInput %}
 {% import '../../../components/submit-button.njk' as submitButton %}
 
 {% block pageTitle %}
@@ -38,10 +38,12 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half-from-desktop">
 
-        {{ passwordInput.render({
+        {{ textInput.render({
           id: FIELD.ID,
           labelText: FIELD.LABEL,
+          labelClasses: "govuk-!-font-weight-bold govuk-!-font-size-24",
           hintHtml: FIELD.HINT,
+          type: "email",
           value: submittedValues[FIELD.ID],
           errorMessage: validationErrors.errorList[FIELD.ID]
         }) }}

--- a/src/ui/templates/insurance/account/password-reset/password-reset.njk
+++ b/src/ui/templates/insurance/account/password-reset/password-reset.njk
@@ -44,6 +44,8 @@
           labelClasses: "govuk-!-font-weight-bold govuk-!-font-size-24",
           hintHtml: FIELD.HINT,
           type: "email",
+          autocomplete: true,
+          spellcheck: false,
           value: submittedValues[FIELD.ID],
           errorMessage: validationErrors.errorList[FIELD.ID]
         }) }}

--- a/src/ui/templates/insurance/account/sign-in/sign-in.njk
+++ b/src/ui/templates/insurance/account/sign-in/sign-in.njk
@@ -86,6 +86,8 @@
           labelText: FIELDS.EMAIL.LABEL,
           labelClasses: "govuk-!-font-weight-bold govuk-!-font-size-24",
           type: "email",
+          autocomplete: true,
+          spellcheck: false,
           value: submittedValues[FIELDS.EMAIL.ID],
           errorMessage: validationErrors.errorList[FIELDS.EMAIL.ID]
         }) }}

--- a/src/ui/templates/insurance/account/sign-in/sign-in.njk
+++ b/src/ui/templates/insurance/account/sign-in/sign-in.njk
@@ -85,6 +85,7 @@
           id: FIELDS.EMAIL.ID,
           labelText: FIELDS.EMAIL.LABEL,
           labelClasses: "govuk-!-font-weight-bold govuk-!-font-size-24",
+          type: "email",
           value: submittedValues[FIELDS.EMAIL.ID],
           errorMessage: validationErrors.errorList[FIELDS.EMAIL.ID]
         }) }}

--- a/src/ui/templates/insurance/export-contract/agent-details.njk
+++ b/src/ui/templates/insurance/export-contract/agent-details.njk
@@ -84,22 +84,33 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop govuk-!-margin-bottom-8">
-        {{ govukLabel({
-          for: FIELDS.COUNTRY_CODE.ID,
-          classes: "govuk-!-font-weight-bold",
-          text: FIELDS.COUNTRY_CODE.LABEL,
-          attributes: {
-            id: FIELDS.COUNTRY_CODE.ID + "-label",
-            "data-cy": FIELDS.COUNTRY_CODE.ID + "-label"
-          }
-        }) }}
 
-        {{ accessibleAutoCompleteSelect.render({
-          errorMessage: validationErrors.errorList[FIELDS.COUNTRY_CODE.ID].text,
-          fieldId: FIELDS.COUNTRY_CODE.ID,
-          integrity: SRI.ACCESSIBILITY,
-          options: countries
-        }) }}
+        {% set containerClassName = "govuk-form-group" %}
+
+        {% set errorMessage = validationErrors.errorList[FIELDS.COUNTRY_CODE.ID].text %}
+
+        {% if errorMessage %}
+          {% set containerClassName = "govuk-form-group govuk-form-group--error" %}
+        {% endif %}
+
+        <div class="{{ containerClassName }}">
+          {{ govukLabel({
+            for: FIELDS.COUNTRY_CODE.ID,
+            classes: "govuk-!-font-weight-bold",
+            text: FIELDS.COUNTRY_CODE.LABEL,
+            attributes: {
+              id: FIELDS.COUNTRY_CODE.ID + "-label",
+              "data-cy": FIELDS.COUNTRY_CODE.ID + "-label"
+            }
+          }) }}
+
+          {{ accessibleAutoCompleteSelect.render({
+            errorMessage: validationErrors.errorList[FIELDS.COUNTRY_CODE.ID].text,
+            fieldId: FIELDS.COUNTRY_CODE.ID,
+            integrity: SRI.ACCESSIBILITY,
+            options: countries
+          }) }}
+        </div>
       </div>
     </div>
 

--- a/src/ui/templates/insurance/policy/broker-details.njk
+++ b/src/ui/templates/insurance/policy/broker-details.njk
@@ -54,6 +54,7 @@
           labelText: FIELDS.EMAIL.LABEL,
           labelClasses: "govuk-body govuk-!-font-weight-bold govuk-!-font-size-24",
           inputClasses: "govuk-input--width-20",
+          type: "email",
           value: submittedValues[FIELDS.EMAIL.ID] or application.broker[FIELDS.EMAIL.ID],
           errorMessage: validationErrors.errorList[FIELDS.EMAIL.ID]
         }) }}

--- a/src/ui/templates/insurance/policy/broker-details.njk
+++ b/src/ui/templates/insurance/policy/broker-details.njk
@@ -55,6 +55,8 @@
           labelClasses: "govuk-body govuk-!-font-weight-bold govuk-!-font-size-24",
           inputClasses: "govuk-input--width-20",
           type: "email",
+          autocomplete: true,
+          spellcheck: false,
           value: submittedValues[FIELDS.EMAIL.ID] or application.broker[FIELDS.EMAIL.ID],
           errorMessage: validationErrors.errorList[FIELDS.EMAIL.ID]
         }) }}

--- a/src/ui/templates/insurance/policy/check-your-answers.njk
+++ b/src/ui/templates/insurance/policy/check-your-answers.njk
@@ -34,9 +34,7 @@
 
     {{ formButtons.render({
       contentStrings: CONTENT_STRINGS.BUTTONS,
-      submitText: CONTENT_STRINGS.BUTTONS.CONTINUE_NEXT_SECTION,
-      saveAndBackUrl: SAVE_AND_BACK_URL,
-      saveAndBackAsALink: true
+      submitText: CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK
     }) }}
 
   </form>

--- a/src/ui/templates/insurance/policy/different-name-on-policy.njk
+++ b/src/ui/templates/insurance/policy/different-name-on-policy.njk
@@ -76,6 +76,7 @@
             id: FIELDS.EMAIL_ADDRESS.ID,
             labelText: FIELDS.EMAIL_ADDRESS.LABEL,
             labelClasses: "govuk-label--s",
+            type: "email",
             errorMessage: validationErrors.errorList[FIELDS.EMAIL_ADDRESS.ID],
             value: submittedValues[FIELDS.EMAIL_ADDRESS.ID]
           }) }}

--- a/src/ui/templates/insurance/policy/different-name-on-policy.njk
+++ b/src/ui/templates/insurance/policy/different-name-on-policy.njk
@@ -77,6 +77,8 @@
             labelText: FIELDS.EMAIL_ADDRESS.LABEL,
             labelClasses: "govuk-label--s",
             type: "email",
+            autocomplete: true,
+            spellcheck: false,
             errorMessage: validationErrors.errorList[FIELDS.EMAIL_ADDRESS.ID],
             value: submittedValues[FIELDS.EMAIL_ADDRESS.ID]
           }) }}

--- a/src/ui/templates/insurance/your-business/check-your-answers.njk
+++ b/src/ui/templates/insurance/your-business/check-your-answers.njk
@@ -28,12 +28,6 @@
     summaryLists: SUMMARY_LISTS
   }) }}
 
-  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
-
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-
-    <a class="govuk-button" href="{{ SAVE_AND_BACK_URL }}" data-cy="save-and-back-button">{{ CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK }}</a>
-
-  </form>
+  <a class="govuk-button" href="{{ SAVE_AND_BACK_URL }}" data-cy="save-and-back-button">{{ CONTENT_STRINGS.BUTTONS.SAVE_AND_BACK }}</a>
 
 {% endblock %}

--- a/src/ui/templates/insurance/your-business/contact.njk
+++ b/src/ui/templates/insurance/your-business/contact.njk
@@ -92,6 +92,8 @@
             inputClasses: "govuk-input--width-11",
             id: FIELDS.EMAIL_ADDRESS.ID,
             type: "email",
+            autocomplete: true,
+            spellcheck: false,
             labelText: FIELDS.EMAIL_ADDRESS.LABEL,
             labelClasses: "govuk-label--s",
             errorMessage: validationErrors.errorList[FIELDS.EMAIL_ADDRESS.ID],

--- a/src/ui/templates/insurance/your-business/contact.njk
+++ b/src/ui/templates/insurance/your-business/contact.njk
@@ -91,6 +91,7 @@
           {{ textInput.render({
             inputClasses: "govuk-input--width-11",
             id: FIELDS.EMAIL_ADDRESS.ID,
+            type: "email",
             labelText: FIELDS.EMAIL_ADDRESS.LABEL,
             labelClasses: "govuk-label--s",
             errorMessage: validationErrors.errorList[FIELDS.EMAIL_ADDRESS.ID],


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes various issues where:

- Email fields would not render with an `email` type attribute.
- An error message had an incorrect `MAXIMUM_CHARACTERS` reference.
- The "Policy - Check your answers" was unnecessarily rendering an additional button.
- The Account - password reset "email" field was rendering as a password field.
- The "Export contract - agent details" autocomplete field was missing a container class name and therefore a red border was missing during validation errors.

## Resolution :heavy_check_mark:
- Create new `checkEmailFieldRendering` cypress command.
- Create new `checkTypeAttribute` cypress command.
- Update error messages content strings.
- Update all E2E tests with email assertions to use `checkEmailFieldRendering` cypress command.
- Update `keyboardInput` cypress command to handle email input values with empty spaces.
- Remove unnecessary "Save and back" button from "Policy - Check your answers".
- Update Password reset "email" field.
- Update all email fields to have the following attributes:
  - "email" type.
  - "autocomplete" = true.
  - "spellcheck" = false.

## Miscellaneous :heavy_plus_sign:
- Fix a typo in an E2E test description.
- Remove an unnecessary `<form />` from "Business - Check your answers".
