### PR TITLE
feat(EMS-3231): No PDF - Change your answers - Export contract - Private market

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-private-market-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-private-market-no-to-yes.spec.js
@@ -1,0 +1,111 @@
+import { status, summaryList } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import checkSummaryList from '../../../../../../../commands/insurance/check-export-contract-summary-list';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    EXPORT_CONTRACT,
+  },
+  EXPORT_CONTRACT: {
+    PRIVATE_MARKET_CHECK_AND_CHANGE,
+    DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  PRIVATE_MARKET: { ATTEMPTED: FIELD_ID, DECLINED_DESCRIPTION },
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Change your answers - Export contract - Summary list - Private market - No to yes', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({ totalContractValueOverThreshold: true }).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({
+        referenceNumber,
+        totalContractValueOverThreshold: true,
+        attemptedPrivateMarketCover: false,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${PRIVATE_MARKET_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: PRIVATE_MARKET_CHECK_AND_CHANGE, fieldId: FIELD_ID });
+    });
+  });
+
+  describe('after changing the answer from no to yes', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.completeAndSubmitPrivateMarketForm({
+        attemptedPrivateMarketCover: true,
+      });
+    });
+
+    it(`should redirect to ${DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE}`, () => {
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE, fieldId: FIELD_ID });
+    });
+
+    it(`should redirect to ${EXPORT_CONTRACT} after completing (now required) ${DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE} fields`, () => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.completeAndSubmitPrivateMarketForm({
+        attemptedPrivateMarketCover: true,
+      });
+
+      cy.completeAndSubmitDeclinedByPrivateMarketForm({});
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId: FIELD_ID });
+    });
+
+    it('should render the new answers', () => {
+      checkSummaryList[FIELD_ID]({ shouldRender: true, isYes: true });
+      checkSummaryList[DECLINED_DESCRIPTION]({ shouldRender: true });
+    });
+
+    it('should retain a `completed` status tag', () => {
+      cy.checkTaskStatusCompleted(status);
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-private-market-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-private-market-yes-to-no.spec.js
@@ -1,0 +1,112 @@
+import { status, summaryList } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import checkSummaryList from '../../../../../../../commands/insurance/check-export-contract-summary-list';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    EXPORT_CONTRACT,
+  },
+  EXPORT_CONTRACT: {
+    PRIVATE_MARKET_CHECK_AND_CHANGE,
+    DECLINED_BY_PRIVATE_MARKET,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  PRIVATE_MARKET: { ATTEMPTED: FIELD_ID, DECLINED_DESCRIPTION },
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Change your answers - Export contract - Summary list - Private market - Yes to no', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({ totalContractValueOverThreshold: true }).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({
+        referenceNumber,
+        totalContractValueOverThreshold: true,
+        attemptedPrivateMarketCover: true,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${PRIVATE_MARKET_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: PRIVATE_MARKET_CHECK_AND_CHANGE, fieldId: FIELD_ID });
+    });
+  });
+
+  describe('after changing the answer from yes to no', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.completeAndSubmitPrivateMarketForm({
+        attemptedPrivateMarketCover: false,
+      });
+    });
+
+    it(`should redirect to ${EXPORT_CONTRACT}`, () => {
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId: FIELD_ID });
+    });
+
+    it(`should render the new answer no ${DECLINED_DESCRIPTION} row`, () => {
+      checkSummaryList[FIELD_ID]({ shouldRender: true, isYes: false });
+      checkSummaryList[DECLINED_DESCRIPTION]({ shouldRender: false });
+    });
+
+    it('should retain a `completed` status tag', () => {
+      cy.checkTaskStatusCompleted(status);
+    });
+
+    describe(`when changing the answer again from no to yes and going back to ${DECLINED_BY_PRIVATE_MARKET}`, () => {
+      it(`should have an empty ${DECLINED_DESCRIPTION} value`, () => {
+        summaryList.field(FIELD_ID).changeLink().click();
+
+        cy.completeAndSubmitPrivateMarketForm({
+          attemptedPrivateMarketCover: true,
+        });
+
+        cy.checkTextareaValue({
+          fieldId: DECLINED_DESCRIPTION,
+          expectedValue: '',
+        });
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/index.test.ts
@@ -15,7 +15,14 @@ import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../
 
 const {
   INSURANCE_ROOT,
-  EXPORT_CONTRACT: { AGENT, DECLINED_BY_PRIVATE_MARKET_SAVE_AND_BACK, DECLINED_BY_PRIVATE_MARKET_CHANGE, CHECK_YOUR_ANSWERS },
+  EXPORT_CONTRACT: {
+    AGENT,
+    DECLINED_BY_PRIVATE_MARKET_SAVE_AND_BACK,
+    DECLINED_BY_PRIVATE_MARKET_CHANGE,
+    DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE,
+    CHECK_YOUR_ANSWERS,
+  },
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -163,6 +170,18 @@ describe('controllers/insurance/export-contract/declined-by-private-market', () 
           await post(req, res);
 
           const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+
+          expect(res.redirect).toHaveBeenCalledWith(expected);
+        });
+      });
+
+      describe("when the answer is false and the url's last substring is `check-and-change`", () => {
+        it(`should redirect to ${CHECK_AND_CHANGE_ROUTE}`, async () => {
+          req.originalUrl = DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE;
+
+          await post(req, res);
+
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/index.ts
@@ -10,11 +10,13 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/private-market';
 import isChangeRoute from '../../../../helpers/is-change-route';
+import isCheckAndChangeRoute from '../../../../helpers/is-check-and-change-route';
 import { Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
   EXPORT_CONTRACT: { AGENT, DECLINED_BY_PRIVATE_MARKET_SAVE_AND_BACK, CHECK_YOUR_ANSWERS },
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -110,8 +112,20 @@ export const post = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
+    /**
+     * If the URL is a "change" route,
+     * redirect to CHECK_YOUR_ANSWERS.
+     */
     if (isChangeRoute(req.originalUrl)) {
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`);
+    }
+
+    /**
+     * If the URL is a "check and change" route,
+     * redirect to CHECK_AND_CHANGE_ROUTE.
+     */
+    if (isCheckAndChangeRoute(req.originalUrl)) {
+      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`);
     }
 
     return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${AGENT}`);

--- a/src/ui/server/controllers/insurance/export-contract/private-market/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/private-market/index.test.ts
@@ -18,9 +18,12 @@ const {
     CHECK_YOUR_ANSWERS,
     DECLINED_BY_PRIVATE_MARKET,
     DECLINED_BY_PRIVATE_MARKET_CHANGE,
+    DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE,
     PRIVATE_MARKET_SAVE_AND_BACK,
     PRIVATE_MARKET_CHANGE,
+    PRIVATE_MARKET_CHECK_AND_CHANGE,
   },
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -224,6 +227,36 @@ describe('controllers/insurance/export-contract/private-market', () => {
           await post(req, res);
 
           const expected = `${INSURANCE_ROOT}/${referenceNumber}${DECLINED_BY_PRIVATE_MARKET_CHANGE}`;
+
+          expect(res.redirect).toHaveBeenCalledWith(expected);
+        });
+      });
+
+      describe("when the answer is false and the url's last substring is `check-and-change`", () => {
+        it(`should redirect to ${CHECK_AND_CHANGE_ROUTE}`, async () => {
+          req.originalUrl = PRIVATE_MARKET_CHECK_AND_CHANGE;
+
+          await post(req, res);
+
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+
+          expect(res.redirect).toHaveBeenCalledWith(expected);
+        });
+      });
+
+      describe(`when the answer is true, no ${DECLINED_DESCRIPTION} available and the url's last substring is 'check-and-change'`, () => {
+        it(`should redirect to ${DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE}`, async () => {
+          req.body = {
+            [FIELD_ID]: 'true',
+          };
+
+          req.originalUrl = PRIVATE_MARKET_CHECK_AND_CHANGE;
+
+          delete res.locals.application?.exportContract.privateMarket[DECLINED_DESCRIPTION];
+
+          await post(req, res);
+
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds the ability to change the "attempted" field in the "Private market" form via the "Check your answers - Export contract" page of a No PDF application.

## Resolution :heavy_check_mark:
- Add E2E test coverage for:
  - Changing the `ATTEMPTED` field from "yes" to "no".
  - Changing the `ATTEMPTED` field from "no" to "yes".
- Update `PRIVATE_MARKET` POST controller redirects.
- Update `DECLINED_BY_PRIVATE_MARKET` POST controller redirects.