### PR TITLE
feat(EMS-3232): No PDF - Change your answers - Export contract - Declined by private market 

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-declined-description.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-declined-description.spec.js
@@ -1,0 +1,108 @@
+import { status, summaryList } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    EXPORT_CONTRACT,
+  },
+  EXPORT_CONTRACT: {
+    DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  PRIVATE_MARKET: { DECLINED_DESCRIPTION: FIELD_ID },
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const getFieldVariables = (referenceNumber) => ({
+  route: DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE,
+  checkYourAnswersRoute: EXPORT_CONTRACT,
+  newValueInput: '',
+  fieldId: FIELD_ID,
+  referenceNumber,
+  summaryList,
+  changeLink: summaryList.field(FIELD_ID).changeLink,
+});
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Change your answers - Export contract - Summary list - Declined description', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({ totalContractValueOverThreshold: true }).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({
+        referenceNumber,
+        totalContractValueOverThreshold: true,
+        attemptedPrivateMarketCover: true,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    it(`should redirect to ${DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(url);
+
+      const fieldVariables = getFieldVariables(referenceNumber);
+
+      cy.checkChangeLinkUrl(fieldVariables, referenceNumber, FIELD_ID);
+    });
+  });
+
+  describe('form submission with a new answer', () => {
+    const newAnswer = 'Mock new description';
+
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.completeAndSubmitDeclinedByPrivateMarketForm({
+        declinedDescription: newAnswer,
+      });
+    });
+
+    it(`should redirect to ${EXPORT_CONTRACT}`, () => {
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId: FIELD_ID });
+    });
+
+    it('should render the new answer and retain a `completed` status tag', () => {
+      cy.assertSummaryListRowValue(summaryList, FIELD_ID, newAnswer);
+
+      cy.checkTaskStatusCompleted(status);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/index.test.ts
@@ -15,7 +15,14 @@ import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../
 
 const {
   INSURANCE_ROOT,
-  EXPORT_CONTRACT: { AGENT, DECLINED_BY_PRIVATE_MARKET_SAVE_AND_BACK, DECLINED_BY_PRIVATE_MARKET_CHANGE, CHECK_YOUR_ANSWERS },
+  EXPORT_CONTRACT: {
+    AGENT,
+    DECLINED_BY_PRIVATE_MARKET_SAVE_AND_BACK,
+    DECLINED_BY_PRIVATE_MARKET_CHANGE,
+    DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE,
+    CHECK_YOUR_ANSWERS,
+  },
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -163,6 +170,18 @@ describe('controllers/insurance/export-contract/declined-by-private-market', () 
           await post(req, res);
 
           const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+
+          expect(res.redirect).toHaveBeenCalledWith(expected);
+        });
+      });
+
+      describe("when the answer is false and the url's last substring is `check-and-change`", () => {
+        it(`should redirect to ${CHECK_AND_CHANGE_ROUTE}`, async () => {
+          req.originalUrl = DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE;
+
+          await post(req, res);
+
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/index.ts
@@ -10,11 +10,13 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/private-market';
 import isChangeRoute from '../../../../helpers/is-change-route';
+import isCheckAndChangeRoute from '../../../../helpers/is-check-and-change-route';
 import { Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
   EXPORT_CONTRACT: { AGENT, DECLINED_BY_PRIVATE_MARKET_SAVE_AND_BACK, CHECK_YOUR_ANSWERS },
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -112,6 +114,14 @@ export const post = async (req: Request, res: Response) => {
 
     if (isChangeRoute(req.originalUrl)) {
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`);
+    }
+
+    /**
+     * If the URL is a "check and change" route,
+     * redirect to CHECK_AND_CHANGE_ROUTE.
+     */
+    if (isCheckAndChangeRoute(req.originalUrl)) {
+      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`);
     }
 
     return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${AGENT}`);


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds the ability to change the "description" field in the "Declined by private market" form via the "Check your answers - Export contract" page of a No PDF application.


## Resolution :heavy_check_mark:
- Add E2E test coverage.
- Update `DECLINED_BY_PRIVATE_MARKET POST` controller redirects.