### PR TITLE
feat(EMS-3235): No PDF - Export contract - Change your answers - Agent details

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-details.spec.js
@@ -1,0 +1,182 @@
+import { field, status, summaryList } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import application from '../../../../../../../fixtures/application';
+import { XAD } from '../../../../../../../fixtures/countries';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    EXPORT_CONTRACT,
+  },
+  EXPORT_CONTRACT: {
+    AGENT_DETAILS_CHECK_AND_CHANGE,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  AGENT_DETAILS: { NAME, FULL_ADDRESS, COUNTRY_CODE },
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const getFieldVariables = (fieldId, referenceNumber) => ({
+  route: AGENT_DETAILS_CHECK_AND_CHANGE,
+  checkYourAnswersRoute: EXPORT_CONTRACT,
+  newValueInput: '',
+  fieldId,
+  referenceNumber,
+  summaryList,
+  changeLink: summaryList.field(fieldId).changeLink,
+});
+
+const NEW_COUNTRY_INPUT = XAD.NAME;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Change your answers - Export contract - Summary list - Agent details', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({
+        referenceNumber,
+        isUsingAgent: true,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe(NAME, () => {
+    const fieldId = NAME;
+    const fieldVariables = getFieldVariables(fieldId, referenceNumber);
+
+    describe('when clicking the `change` link', () => {
+      it(`should redirect to ${AGENT_DETAILS_CHECK_AND_CHANGE}`, () => {
+        cy.navigateToUrl(url);
+
+        cy.checkChangeLinkUrl(fieldVariables, referenceNumber, fieldId);
+      });
+    });
+
+    describe('form submission with a new answer', () => {
+      const newAnswer = `${application.EXPORT_CONTRACT.AGENT_DETAILS[fieldId]} additional text`;
+
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.keyboardInput(field(fieldId).input(), newAnswer);
+
+        cy.clickSubmitButton();
+      });
+
+      it(`should redirect to ${EXPORT_CONTRACT}`, () => {
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId });
+      });
+
+      it('should render the new answer and retain a `completed` status tag', () => {
+        cy.assertSummaryListRowValue(summaryList, fieldId, newAnswer);
+
+        cy.checkTaskStatusCompleted(status);
+      });
+    });
+  });
+
+  describe(FULL_ADDRESS, () => {
+    const fieldId = FULL_ADDRESS;
+    const fieldVariables = getFieldVariables(fieldId, referenceNumber);
+
+    describe('when clicking the `change` link', () => {
+      it(`should redirect to ${AGENT_DETAILS_CHECK_AND_CHANGE}`, () => {
+        cy.navigateToUrl(url);
+
+        cy.checkChangeLinkUrl(fieldVariables, referenceNumber, fieldId);
+      });
+    });
+
+    describe('form submission with a new answer', () => {
+      const newAnswer = 'Mock new agent details address';
+      fieldVariables.newValueInput = newAnswer;
+
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.changeAnswerField(fieldVariables, field(fieldId).textarea());
+      });
+
+      it(`should redirect to ${EXPORT_CONTRACT}`, () => {
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId });
+      });
+
+      it('should render the new answer and retain a `completed` status tag', () => {
+        cy.assertSummaryListRowValue(summaryList, fieldId, newAnswer);
+
+        cy.checkTaskStatusCompleted(status);
+      });
+    });
+  });
+
+  describe(COUNTRY_CODE, () => {
+    const fieldId = COUNTRY_CODE;
+    const fieldVariables = getFieldVariables(fieldId, referenceNumber);
+
+    describe('when clicking the `change` link', () => {
+      it(`should redirect to ${AGENT_DETAILS_CHECK_AND_CHANGE}`, () => {
+        cy.navigateToUrl(url);
+
+        cy.checkChangeLinkUrl(fieldVariables, referenceNumber, fieldId);
+      });
+    });
+
+    describe('form submission with a new answer', () => {
+      fieldVariables.newValue = NEW_COUNTRY_INPUT;
+
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.autocompleteKeyboardInput(fieldId, fieldVariables.newValue);
+        cy.clickSubmitButton();
+      });
+
+      it(`should redirect to ${EXPORT_CONTRACT}`, () => {
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId });
+      });
+
+      it('should render the new answer and retain a `completed` status tag', () => {
+        cy.checkChangeAnswerRendered({ fieldVariables });
+
+        cy.checkTaskStatusCompleted(status);
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent/change-your-answers-agent-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent/change-your-answers-agent-details.spec.js
@@ -1,7 +1,6 @@
 import { autoCompleteField, field, summaryList } from '../../../../../../../pages/shared';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
-import checkSummaryList from '../../../../../../../commands/insurance/check-export-contract-summary-list';
 import application from '../../../../../../../fixtures/application';
 import { XAD } from '../../../../../../../fixtures/countries';
 
@@ -97,15 +96,14 @@ context('Insurance - Export contract - Change your answers - Agent details - As 
     });
 
     describe('form submission with a new answer', () => {
-      const newAnswer = 'additional text';
-      const fullAnswer = `${application.EXPORT_CONTRACT.AGENT_DETAILS[fieldId]} ${newAnswer}`;
+      const newAnswer = 'Mock new agent details address';
 
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);
 
         summaryList.field(fieldId).changeLink().click();
 
-        cy.keyboardInput(field(fieldId).textarea(), fullAnswer);
+        cy.keyboardInput(field(fieldId).textarea(), newAnswer);
 
         cy.clickSubmitButton();
       });
@@ -115,7 +113,7 @@ context('Insurance - Export contract - Change your answers - Agent details - As 
       });
 
       it('should render the new answer', () => {
-        checkSummaryList[fieldId]({ shouldRender: true, newAnswer });
+        cy.assertSummaryListRowValue(summaryList, fieldId, newAnswer);
       });
     });
   });

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
@@ -17,7 +17,8 @@ import { mockReq, mockRes, mockApplication, mockCountries, referenceNumber } fro
 
 const {
   INSURANCE_ROOT,
-  EXPORT_CONTRACT: { AGENT_DETAILS_CHANGE, AGENT_DETAILS_SAVE_AND_BACK, AGENT_SERVICE, CHECK_YOUR_ANSWERS },
+  EXPORT_CONTRACT: { AGENT_DETAILS_SAVE_AND_BACK, AGENT_DETAILS_CHANGE, AGENT_DETAILS_CHECK_AND_CHANGE, AGENT_SERVICE, CHECK_YOUR_ANSWERS },
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -263,6 +264,20 @@ describe('controllers/insurance/export-contract/agent-details', () => {
           await post(req, res);
 
           const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+
+          expect(res.redirect).toHaveBeenCalledWith(expected);
+        });
+      });
+
+      describe("when the url's last substring is `check-and-change`", () => {
+        it(`should redirect to ${CHECK_AND_CHANGE_ROUTE}`, async () => {
+          req.body = validBody;
+
+          req.originalUrl = AGENT_DETAILS_CHECK_AND_CHANGE;
+
+          await post(req, res);
+
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/index.ts
@@ -13,11 +13,13 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/export-contract-agent';
 import isChangeRoute from '../../../../helpers/is-change-route';
+import isCheckAndChangeRoute from '../../../../helpers/is-check-and-change-route';
 import { Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
   EXPORT_CONTRACT: { AGENT_SERVICE, AGENT_DETAILS_SAVE_AND_BACK, CHECK_YOUR_ANSWERS },
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -153,6 +155,10 @@ export const post = async (req: Request, res: Response) => {
 
     if (isChangeRoute(req.originalUrl)) {
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`);
+    }
+
+    if (isCheckAndChangeRoute(req.originalUrl)) {
+      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`);
     }
 
     return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${AGENT_SERVICE}`);


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds the ability to change all fields in the "Agent details" form via the "Check your answers - Export contract" page of a No PDF application.

## Resolution :heavy_check_mark:
- Add E2E test coverage.
- Update `AGENT_DETAILS` POST controller redirects.


## Miscellaneous :heavy_plus_sign:
- Update previously created "Change agent details answers" test to correctly assert a new `FULL_ADDRESS` answer.
