### PR TITLE
feat(EMS-3231): No PDF - Change your answers - Export contract - Agent

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-no-to-yes.spec.js
@@ -1,8 +1,9 @@
-import { status, summaryList } from '../../../../../../../pages/shared';
+import { field, status, summaryList } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../commands/insurance/check-export-contract-summary-list';
+import { checkAutocompleteInput } from '../../../../../../../shared-test-assertions';
 
 const {
   ROOT,
@@ -11,6 +12,7 @@ const {
   },
   EXPORT_CONTRACT: {
     AGENT_CHECK_AND_CHANGE,
+    AGENT_DETAILS,
     AGENT_DETAILS_CHECK_AND_CHANGE,
     AGENT_SERVICE_CHECK_AND_CHANGE,
   },
@@ -112,6 +114,25 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
 
     it('should retain a `completed` status tag', () => {
       cy.checkTaskStatusCompleted(status);
+    });
+
+    describe(`when changing the answer again from no to yes and going back to ${AGENT_DETAILS}`, () => {
+      it('should have empty field values', () => {
+        summaryList.field(FIELD_ID).changeLink().click();
+
+        cy.completeAndSubmitAgentForm({
+          isUsingAgent: true,
+        });
+
+        cy.checkValue(field(NAME), '');
+
+        cy.checkTextareaValue({
+          fieldId: FULL_ADDRESS,
+          expectedValue: '',
+        });
+
+        checkAutocompleteInput.checkEmptyResults(COUNTRY_CODE);
+      });
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-no-to-yes.spec.js
@@ -1,9 +1,8 @@
-import { field, status, summaryList } from '../../../../../../../pages/shared';
+import { status, summaryList } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../commands/insurance/check-export-contract-summary-list';
-import { checkAutocompleteInput } from '../../../../../../../shared-test-assertions';
 
 const {
   ROOT,
@@ -12,7 +11,6 @@ const {
   },
   EXPORT_CONTRACT: {
     AGENT_CHECK_AND_CHANGE,
-    AGENT_DETAILS,
     AGENT_DETAILS_CHECK_AND_CHANGE,
     AGENT_SERVICE_CHECK_AND_CHANGE,
   },
@@ -114,25 +112,6 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
 
     it('should retain a `completed` status tag', () => {
       cy.checkTaskStatusCompleted(status);
-    });
-
-    describe(`when changing the answer again from no to yes and going back to ${AGENT_DETAILS}`, () => {
-      it('should have empty field values', () => {
-        summaryList.field(FIELD_ID).changeLink().click();
-
-        cy.completeAndSubmitAgentForm({
-          isUsingAgent: true,
-        });
-
-        cy.checkValue(field(NAME), '');
-
-        cy.checkTextareaValue({
-          fieldId: FULL_ADDRESS,
-          expectedValue: '',
-        });
-
-        checkAutocompleteInput.checkEmptyResults(COUNTRY_CODE);
-      });
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-no-to-yes.spec.js
@@ -1,0 +1,117 @@
+import { status, summaryList } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import checkSummaryList from '../../../../../../../commands/insurance/check-export-contract-summary-list';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    EXPORT_CONTRACT,
+  },
+  EXPORT_CONTRACT: {
+    AGENT_CHECK_AND_CHANGE,
+    AGENT_DETAILS_CHECK_AND_CHANGE,
+    AGENT_SERVICE_CHECK_AND_CHANGE,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  USING_AGENT: FIELD_ID,
+  AGENT_DETAILS: { NAME, FULL_ADDRESS, COUNTRY_CODE },
+  AGENT_SERVICE: { SERVICE_DESCRIPTION, IS_CHARGING },
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Change your answers - Export contract - Summary list - Agent - No to yes', () => {
+  let referenceNumber;
+  let url;
+  let agentDetailsUrl;
+  let agentServiceUrl;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({
+        referenceNumber,
+        isUsingAgent: false,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT}`;
+      agentDetailsUrl = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_DETAILS_CHECK_AND_CHANGE}`;
+      agentServiceUrl = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_SERVICE_CHECK_AND_CHANGE}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${AGENT_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHECK_AND_CHANGE, fieldId: FIELD_ID });
+    });
+  });
+
+  describe('after changing the answer from no to yes', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    it(`should redirect to ${AGENT_DETAILS_CHECK_AND_CHANGE}, ${AGENT_SERVICE_CHECK_AND_CHANGE} and then ${EXPORT_CONTRACT} after completing (now required) agent details and service fields`, () => {
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.completeAndSubmitAgentForm({
+        isUsingAgent: true,
+      });
+
+      let expectedUrl = `${agentDetailsUrl}#${FIELD_ID}-label`;
+      cy.assertUrl(expectedUrl);
+
+      cy.completeAndSubmitAgentDetailsForm({});
+
+      expectedUrl = `${agentServiceUrl}#${FIELD_ID}-label`;
+      cy.assertUrl(expectedUrl);
+
+      cy.completeAndSubmitAgentServiceForm({ agentIsCharging: false });
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId: FIELD_ID });
+    });
+
+    it(`should render new answers and change links for ${FIELD_ID} and all agent details, agent service fields`, () => {
+      checkSummaryList[FIELD_ID]({ isYes: true });
+      checkSummaryList[NAME]({ shouldRender: true });
+      checkSummaryList[FULL_ADDRESS]({ shouldRender: true });
+      checkSummaryList[COUNTRY_CODE]({ shouldRender: true });
+      checkSummaryList[SERVICE_DESCRIPTION]({ shouldRender: true });
+      checkSummaryList[IS_CHARGING]({ shouldRender: true, isYes: false });
+    });
+
+    it('should retain a `completed` status tag', () => {
+      cy.checkTaskStatusCompleted(status);
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-yes-to-no.spec.js
@@ -1,0 +1,99 @@
+import { status, summaryList } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import checkSummaryList from '../../../../../../../commands/insurance/check-export-contract-summary-list';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    EXPORT_CONTRACT,
+  },
+  EXPORT_CONTRACT: { AGENT_CHECK_AND_CHANGE },
+} = INSURANCE_ROUTES;
+
+const {
+  USING_AGENT: FIELD_ID,
+  AGENT_DETAILS: { NAME, FULL_ADDRESS, COUNTRY_CODE },
+  AGENT_SERVICE: { SERVICE_DESCRIPTION, IS_CHARGING },
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Change your answers - Export contract - Summary list - Agent - Yes to no', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({
+        referenceNumber,
+        isUsingAgent: true,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${AGENT_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHECK_AND_CHANGE, fieldId: FIELD_ID });
+    });
+  });
+
+  describe('after changing the answer from yes to no', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    it(`should redirect to ${EXPORT_CONTRACT}`, () => {
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.completeAndSubmitAgentForm({
+        isUsingAgent: false,
+      });
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId: FIELD_ID });
+    });
+
+    it(`should render new answers and change links for ${FIELD_ID} and all agent details, agent service fields`, () => {
+      checkSummaryList[FIELD_ID]({ isYes: false });
+      checkSummaryList[NAME]({ shouldRender: false });
+      checkSummaryList[FULL_ADDRESS]({ shouldRender: false });
+      checkSummaryList[COUNTRY_CODE]({ shouldRender: false });
+      checkSummaryList[SERVICE_DESCRIPTION]({ shouldRender: false });
+      checkSummaryList[IS_CHARGING]({ shouldRender: false });
+    });
+
+    it('should retain a `completed` status tag', () => {
+      cy.checkTaskStatusCompleted(status);
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-yes-to-no.spec.js
@@ -1,15 +1,16 @@
-import { status, summaryList } from '../../../../../../../pages/shared';
+import { field, status, summaryList } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../commands/insurance/check-export-contract-summary-list';
+import { checkAutocompleteInput } from '../../../../../../../shared-test-assertions';
 
 const {
   ROOT,
   CHECK_YOUR_ANSWERS: {
     EXPORT_CONTRACT,
   },
-  EXPORT_CONTRACT: { AGENT_CHECK_AND_CHANGE },
+  EXPORT_CONTRACT: { AGENT_CHECK_AND_CHANGE, AGENT_DETAILS },
 } = INSURANCE_ROUTES;
 
 const {
@@ -94,6 +95,25 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
 
     it('should retain a `completed` status tag', () => {
       cy.checkTaskStatusCompleted(status);
+    });
+
+    describe(`when changing the answer again from no to yes and going back to ${AGENT_DETAILS}`, () => {
+      it('should have empty field values', () => {
+        summaryList.field(FIELD_ID).changeLink().click();
+
+        cy.completeAndSubmitAgentForm({
+          isUsingAgent: true,
+        });
+
+        cy.checkValue(field(NAME), '');
+
+        cy.checkTextareaValue({
+          fieldId: FULL_ADDRESS,
+          expectedValue: '',
+        });
+
+        checkAutocompleteInput.checkEmptyResults(COUNTRY_CODE);
+      });
     });
   });
 });

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
@@ -13,7 +13,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/export-contract-agent';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockCountries, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockApplicationAgentServiceEmpty, mockCountries, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -25,6 +25,7 @@ const {
     AGENT_SERVICE_CHECK_AND_CHANGE,
     CHECK_YOUR_ANSWERS,
   },
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -275,11 +276,27 @@ describe('controllers/insurance/export-contract/agent-details', () => {
         });
       });
 
-      describe("when the url's last substring is `check-and-change`", () => {
+      describe("when the url's last substring is `check-and-change` and agent service data is available", () => {
+        it(`should redirect to ${CHECK_AND_CHANGE_ROUTE}`, async () => {
+          req.body = validBody;
+
+          req.originalUrl = AGENT_DETAILS_CHECK_AND_CHANGE;
+
+          await post(req, res);
+
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+
+          expect(res.redirect).toHaveBeenCalledWith(expected);
+        });
+      });
+
+      describe("when the url's last substring is `check-and-change` and no agent service data is available", () => {
         it(`should redirect to ${AGENT_SERVICE_CHECK_AND_CHANGE}`, async () => {
           req.body = validBody;
 
           req.originalUrl = AGENT_DETAILS_CHECK_AND_CHANGE;
+
+          res.locals.application = mockApplicationAgentServiceEmpty;
 
           await post(req, res);
 

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
@@ -17,7 +17,14 @@ import { mockReq, mockRes, mockApplication, mockCountries, referenceNumber } fro
 
 const {
   INSURANCE_ROOT,
-  EXPORT_CONTRACT: { AGENT_DETAILS_CHANGE, AGENT_DETAILS_SAVE_AND_BACK, AGENT_SERVICE, CHECK_YOUR_ANSWERS },
+  EXPORT_CONTRACT: {
+    AGENT_DETAILS_CHANGE,
+    AGENT_DETAILS_CHECK_AND_CHANGE,
+    AGENT_DETAILS_SAVE_AND_BACK,
+    AGENT_SERVICE,
+    AGENT_SERVICE_CHECK_AND_CHANGE,
+    CHECK_YOUR_ANSWERS,
+  },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -263,6 +270,20 @@ describe('controllers/insurance/export-contract/agent-details', () => {
           await post(req, res);
 
           const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+
+          expect(res.redirect).toHaveBeenCalledWith(expected);
+        });
+      });
+
+      describe("when the url's last substring is `check-and-change`", () => {
+        it(`should redirect to ${AGENT_SERVICE_CHECK_AND_CHANGE}`, async () => {
+          req.body = validBody;
+
+          req.originalUrl = AGENT_DETAILS_CHECK_AND_CHANGE;
+
+          await post(req, res);
+
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${AGENT_SERVICE_CHECK_AND_CHANGE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/index.ts
@@ -13,11 +13,12 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/export-contract-agent';
 import isChangeRoute from '../../../../helpers/is-change-route';
+import isCheckChangeRoute from '../../../../helpers/is-check-and-change-route';
 import { Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
-  EXPORT_CONTRACT: { AGENT_SERVICE, AGENT_DETAILS_SAVE_AND_BACK, CHECK_YOUR_ANSWERS },
+  EXPORT_CONTRACT: { AGENT_SERVICE, AGENT_SERVICE_CHECK_AND_CHANGE, AGENT_DETAILS_SAVE_AND_BACK, CHECK_YOUR_ANSWERS },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -153,6 +154,10 @@ export const post = async (req: Request, res: Response) => {
 
     if (isChangeRoute(req.originalUrl)) {
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`);
+    }
+
+    if (isCheckChangeRoute(req.originalUrl)) {
+      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${AGENT_SERVICE_CHECK_AND_CHANGE}`);
     }
 
     return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${AGENT_SERVICE}`);

--- a/src/ui/server/controllers/insurance/export-contract/agent-service/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-service/index.test.ts
@@ -17,7 +17,16 @@ import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
 const {
   INSURANCE_ROOT,
   PROBLEM_WITH_SERVICE,
-  EXPORT_CONTRACT: { AGENT_CHARGES, AGENT_CHARGES_CHANGE, CHECK_YOUR_ANSWERS, AGENT_SERVICE_CHANGE, AGENT_SERVICE_SAVE_AND_BACK },
+  EXPORT_CONTRACT: {
+    AGENT_CHARGES,
+    AGENT_CHARGES_CHANGE,
+    AGENT_CHARGES_CHECK_AND_CHANGE,
+    CHECK_YOUR_ANSWERS,
+    AGENT_SERVICE_CHANGE,
+    AGENT_SERVICE_CHECK_AND_CHANGE,
+    AGENT_SERVICE_SAVE_AND_BACK,
+  },
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
 } = INSURANCE_ROUTES;
 
 const {
@@ -247,6 +256,40 @@ describe('controllers/insurance/export-contract/agent-service', () => {
         await post(req, res);
 
         const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+
+        expect(res.redirect).toHaveBeenCalledWith(expected);
+      });
+    });
+
+    describe(`when ${IS_CHARGING} is true and the url's last substring is 'check-and-change'`, () => {
+      it(`should redirect to ${AGENT_CHARGES_CHECK_AND_CHANGE}`, async () => {
+        req.body = {
+          ...validBody,
+          [IS_CHARGING]: 'true',
+        };
+
+        req.originalUrl = AGENT_SERVICE_CHECK_AND_CHANGE;
+
+        await post(req, res);
+
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${AGENT_CHARGES_CHECK_AND_CHANGE}`;
+
+        expect(res.redirect).toHaveBeenCalledWith(expected);
+      });
+    });
+
+    describe(`when ${IS_CHARGING} is false and the url's last substring is 'check-and-change'`, () => {
+      it(`should redirect to ${CHECK_YOUR_ANSWERS}`, async () => {
+        req.body = {
+          ...validBody,
+          [IS_CHARGING]: 'false',
+        };
+
+        req.originalUrl = AGENT_SERVICE_CHECK_AND_CHANGE;
+
+        await post(req, res);
+
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
         expect(res.redirect).toHaveBeenCalledWith(expected);
       });

--- a/src/ui/server/controllers/insurance/export-contract/agent-service/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-service/index.ts
@@ -143,6 +143,12 @@ export const post = async (req: Request, res: Response) => {
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`);
     }
 
+    /**
+     * If the route is a "check and change" route,
+     * the agent IS_CHARGING,
+     * redirect to AGENT_CHARGES_CHECK_AND_CHANGE form.
+     * Otherwise, redirect to CHECK_YOUR_ANSWERS.
+     */
     if (isCheckAndChangeRoute(req.originalUrl)) {
       if (agentIsCharging) {
         return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${AGENT_CHARGES_CHECK_AND_CHANGE}`);

--- a/src/ui/server/controllers/insurance/export-contract/agent-service/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-service/index.ts
@@ -11,12 +11,14 @@ import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/export-contract-agent-service';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import isChangeRoute from '../../../../helpers/is-change-route';
+import isCheckChangeRoute from '../../../../helpers/is-check-and-change-route';
 import { Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
   PROBLEM_WITH_SERVICE,
-  EXPORT_CONTRACT: { CHECK_YOUR_ANSWERS, AGENT_CHARGES, AGENT_SERVICE_SAVE_AND_BACK, AGENT_CHARGES_CHANGE },
+  EXPORT_CONTRACT: { CHECK_YOUR_ANSWERS, AGENT_CHARGES, AGENT_SERVICE_SAVE_AND_BACK, AGENT_CHARGES_CHANGE, AGENT_CHARGES_CHECK_AND_CHANGE },
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
 } = INSURANCE_ROUTES;
 
 const {
@@ -139,6 +141,14 @@ export const post = async (req: Request, res: Response) => {
       }
 
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`);
+    }
+
+    if (isCheckChangeRoute(req.originalUrl)) {
+      if (agentIsCharging) {
+        return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${AGENT_CHARGES_CHECK_AND_CHANGE}`);
+      }
+
+      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`);
     }
 
     /**

--- a/src/ui/server/controllers/insurance/export-contract/agent/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent/index.test.ts
@@ -15,7 +15,16 @@ import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../
 const {
   INSURANCE_ROOT,
   PROBLEM_WITH_SERVICE,
-  EXPORT_CONTRACT: { AGENT_DETAILS, AGENT_SAVE_AND_BACK, AGENT_CHANGE, AGENT_DETAILS_CHANGE, CHECK_YOUR_ANSWERS },
+  EXPORT_CONTRACT: {
+    AGENT_CHECK_AND_CHANGE,
+    AGENT_DETAILS,
+    AGENT_DETAILS_CHECK_AND_CHANGE,
+    AGENT_SAVE_AND_BACK,
+    AGENT_CHANGE,
+    AGENT_DETAILS_CHANGE,
+    CHECK_YOUR_ANSWERS,
+  },
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
 } = INSURANCE_ROUTES;
 
 const { USING_AGENT } = EXPORT_CONTRACT_FIELD_IDS;
@@ -211,6 +220,38 @@ describe('controllers/insurance/export-contract/agent', () => {
           await post(req, res);
 
           const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+
+          expect(res.redirect).toHaveBeenCalledWith(expected);
+        });
+      });
+
+      describe("when the answer is true and the url's last substring is `check-and-change`", () => {
+        it(`should redirect to ${AGENT_DETAILS_CHECK_AND_CHANGE}`, async () => {
+          req.body = {
+            [FIELD_ID]: 'true',
+          };
+
+          req.originalUrl = AGENT_CHECK_AND_CHANGE;
+
+          await post(req, res);
+
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${AGENT_DETAILS_CHECK_AND_CHANGE}`;
+
+          expect(res.redirect).toHaveBeenCalledWith(expected);
+        });
+      });
+
+      describe("when the answer is false and the url's last substring is `check-and-change`", () => {
+        it(`should redirect to ${CHECK_AND_CHANGE_ROUTE}`, async () => {
+          req.body = {
+            [FIELD_ID]: 'false',
+          };
+
+          req.originalUrl = AGENT_CHECK_AND_CHANGE;
+
+          await post(req, res);
+
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });

--- a/src/ui/server/controllers/insurance/export-contract/agent/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent/index.ts
@@ -9,12 +9,14 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../map-and-save/export-contract-agent';
 import isChangeRoute from '../../../../helpers/is-change-route';
+import isCheckChangeRoute from '../../../../helpers/is-check-and-change-route';
 import { Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
   PROBLEM_WITH_SERVICE,
-  EXPORT_CONTRACT: { AGENT_DETAILS, AGENT_DETAILS_CHANGE, AGENT_SAVE_AND_BACK, CHECK_YOUR_ANSWERS },
+  EXPORT_CONTRACT: { AGENT_DETAILS, AGENT_DETAILS_CHANGE, AGENT_DETAILS_CHECK_AND_CHANGE, AGENT_SAVE_AND_BACK, CHECK_YOUR_ANSWERS },
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
 } = INSURANCE_ROUTES;
 
 const { USING_AGENT } = EXPORT_CONTRACT_FIELD_IDS;
@@ -124,6 +126,20 @@ export const post = async (req: Request, res: Response) => {
       }
 
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`);
+    }
+
+    /**
+     * If the route is a "check and change" route,
+     * the exporter is USING_AGENT,
+     * redirect to AGENT_DETAILS_CHECK_AND_CHANGE form.
+     * Otherwise, redirect to CHECK_YOUR_ANSWERS.
+     */
+    if (isCheckChangeRoute(req.originalUrl)) {
+      if (isUsingAnAgent) {
+        return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${AGENT_DETAILS_CHECK_AND_CHANGE}`);
+      }
+
+      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`);
     }
 
     /**

--- a/src/ui/server/test-mocks/index.ts
+++ b/src/ui/server/test-mocks/index.ts
@@ -11,6 +11,7 @@ import mockCompaniesHouseResponse from './mock-companies-house-response';
 import mockCompany from './mock-company';
 import mockApplication, {
   mockApplicationAgentServiceChargeEmpty,
+  mockApplicationAgentServiceEmpty,
   mockApplicationMultiplePolicy,
   mockApplicationTotalContractValueThresholdTrue,
   mockApplicationTotalContractValueThresholdFalse,
@@ -120,6 +121,7 @@ export {
   mockAnswers,
   mockApplication,
   mockApplicationAgentServiceChargeEmpty,
+  mockApplicationAgentServiceEmpty,
   mockApplicationMultiplePolicy,
   mockApplications,
   mockApplicationTotalContractValueThresholdTrue,

--- a/src/ui/server/test-mocks/mock-application.ts
+++ b/src/ui/server/test-mocks/mock-application.ts
@@ -218,6 +218,21 @@ export const mockApplicationTotalContractValueThresholdFalse = {
   totalContractValueOverThreshold: false,
 } as Application;
 
+export const mockApplicationAgentServiceEmpty = {
+  ...mockApplication,
+  exportContract: {
+    ...mockExportContract,
+    agent: {
+      ...mockExportContractAgent,
+      service: {
+        ...mockExportContractAgentService,
+        serviceDescription: '',
+        charge: mockExportContractAgentServiceCharge,
+      },
+    },
+  },
+} as Application;
+
 export const mockApplicationAgentServiceChargeEmpty = {
   ...mockApplication,
   exportContract: {


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds the ability to change the "Using agent" field in the "Agent" form via the "Check your answers - Export contract" page of a No PDF application.

## Resolution :heavy_check_mark:
- Add E2E test coverage for:
  - Changing the `ATTEMPTED` field from "yes" to "no".
  - Changing the `ATTEMPTED` field from "no" to "yes".
- Update `AGENT_DETAILS` POST controller to redirect to `AGENT_SERVICE_CHECK_AND_CHANGE`, if the URL is a "check and change" route and `AGENT_SERVICE` data is not available.
- Update `AGENT_DETAILS` POST controller to redirect to `CHECK_AND_CHANGE_ROUTE`, if the URL is a "check and change" route and `AGENT_SERVICE` data is available.
- Update `AGENT_SERVICE` POST controller to redirect to `AGENT_CHARGES_CHECK_AND_CHANGE`, if the URL is a "check and change" route and the agent is charging.
- Update `AGENT_SERVICE` POST controller to redirect to `CHECK_AND_CHANGE_ROUTE`, if the URL is a "check and change" route and the agent is not charging.