### PR TITLE
feat(EMS-3237): No PDF - Change your answers - Export contract - Agent charges

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-charges-fixed-sum-amount.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-charges-fixed-sum-amount.spec.js
@@ -1,0 +1,99 @@
+import { status, summaryList } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import application from '../../../../../../../fixtures/application';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    EXPORT_CONTRACT,
+  },
+  EXPORT_CONTRACT: { AGENT_CHARGES_CHECK_AND_CHANGE },
+} = INSURANCE_ROUTES;
+
+const {
+  AGENT_CHARGES: { FIXED_SUM_AMOUNT },
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const fieldId = FIXED_SUM_AMOUNT;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context(`Insurance - Change your answers - Export contract - Summary list - Agent charges - ${FIXED_SUM_AMOUNT}`, () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({
+        referenceNumber,
+        isUsingAgent: true,
+        agentIsCharging: true,
+        agentChargeMethodFixedSum: true,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${AGENT_CHARGES_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(fieldId).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHECK_AND_CHANGE, fieldId });
+    });
+  });
+
+  describe('form submission with a new answer', () => {
+    const newValueInput = application.EXPORT_CONTRACT.AGENT_CHARGES[fieldId] + 1;
+
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    it(`should redirect to ${EXPORT_CONTRACT}`, () => {
+      summaryList.field(fieldId).changeLink().click();
+
+      cy.completeAndSubmitAgentChargesForm({
+        fixedSumMethod: true,
+        fixedSumAmount: newValueInput,
+      });
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId });
+    });
+
+    it('should render the new answer', () => {
+      cy.assertSummaryListRowValue(summaryList, fieldId, newValueInput);
+    });
+
+    it('should retain a `completed` status tag', () => {
+      cy.checkTaskStatusCompleted(status);
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-charges-fixed-sum-to-percentage.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-charges-fixed-sum-to-percentage.spec.js
@@ -1,0 +1,96 @@
+import { status, summaryList } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import checkSummaryList from '../../../../../../../commands/insurance/check-export-contract-summary-list';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    EXPORT_CONTRACT,
+  },
+  EXPORT_CONTRACT: { AGENT_CHARGES_CHECK_AND_CHANGE },
+} = INSURANCE_ROUTES;
+
+const {
+  AGENT_CHARGES: {
+    FIXED_SUM_AMOUNT, PERCENTAGE_CHARGE, PAYABLE_COUNTRY_CODE,
+  },
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Change your answers - Export contract - Summary list - Agent charges - Fixed sum to percentage', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({
+        referenceNumber,
+        isUsingAgent: true,
+        agentIsCharging: true,
+        agentChargeMethodFixedSum: true,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${AGENT_CHARGES_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(FIXED_SUM_AMOUNT).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHECK_AND_CHANGE, fieldId: FIXED_SUM_AMOUNT });
+    });
+  });
+
+  describe('form submission with a new answer', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    it(`should redirect to ${EXPORT_CONTRACT}`, () => {
+      summaryList.field(FIXED_SUM_AMOUNT).changeLink().click();
+
+      cy.completeAndSubmitAgentChargesForm({ percentageMethod: true });
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId: FIXED_SUM_AMOUNT });
+    });
+
+    it(`should render only ${PERCENTAGE_CHARGE} and ${PAYABLE_COUNTRY_CODE} fields/values`, () => {
+      checkSummaryList[FIXED_SUM_AMOUNT]({ shouldRender: false });
+      checkSummaryList[PERCENTAGE_CHARGE]({ shouldRender: true });
+      checkSummaryList[PAYABLE_COUNTRY_CODE]({ shouldRender: true });
+    });
+
+    it('should retain a `completed` status tag', () => {
+      cy.checkTaskStatusCompleted(status);
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-charges-payable-country.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-charges-payable-country.spec.js
@@ -1,0 +1,99 @@
+import { status, summaryList } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import { XAD } from '../../../../../../../fixtures/countries';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    EXPORT_CONTRACT,
+  },
+  EXPORT_CONTRACT: { AGENT_CHARGES_CHECK_AND_CHANGE },
+} = INSURANCE_ROUTES;
+
+const {
+  AGENT_CHARGES: { PAYABLE_COUNTRY_CODE },
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const NEW_COUNTRY_INPUT = XAD.NAME;
+
+const fieldId = PAYABLE_COUNTRY_CODE;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context(`Insurance - Change your answers - Export contract - Summary list - Agent charges - ${PAYABLE_COUNTRY_CODE}`, () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({
+        referenceNumber,
+        isUsingAgent: true,
+        agentIsCharging: true,
+        agentChargeMethodFixedSum: true,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${AGENT_CHARGES_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(fieldId).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHECK_AND_CHANGE, fieldId });
+    });
+  });
+
+  describe('form submission with a new answer', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    it(`should redirect to ${EXPORT_CONTRACT}`, () => {
+      summaryList.field(fieldId).changeLink().click();
+
+      cy.completeAndSubmitAgentChargesForm({
+        percentageCharge: '',
+        payableCountry: NEW_COUNTRY_INPUT,
+      });
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId });
+    });
+
+    it('should render the new answer', () => {
+      cy.assertSummaryListRowValue(summaryList, fieldId, NEW_COUNTRY_INPUT);
+    });
+
+    it('should retain a `completed` status tag', () => {
+      cy.checkTaskStatusCompleted(status);
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-charges-percentage-charge.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-charges-percentage-charge.spec.js
@@ -1,0 +1,99 @@
+import { status, summaryList } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import application from '../../../../../../../fixtures/application';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    EXPORT_CONTRACT,
+  },
+  EXPORT_CONTRACT: { AGENT_CHARGES_CHECK_AND_CHANGE },
+} = INSURANCE_ROUTES;
+
+const {
+  AGENT_CHARGES: { PERCENTAGE_CHARGE },
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const fieldId = PERCENTAGE_CHARGE;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context(`Insurance - Change your answers - Export contract - Summary list - Agent charges - ${PERCENTAGE_CHARGE}`, () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({
+        referenceNumber,
+        isUsingAgent: true,
+        agentIsCharging: true,
+        agentChargeMethodPercentage: true,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${AGENT_CHARGES_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(fieldId).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHECK_AND_CHANGE, fieldId });
+    });
+  });
+
+  describe('form submission with a new answer', () => {
+    const newValueInput = application.EXPORT_CONTRACT.AGENT_CHARGES[PERCENTAGE_CHARGE] - 1;
+
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    it(`should redirect to ${EXPORT_CONTRACT}`, () => {
+      summaryList.field(fieldId).changeLink().click();
+
+      cy.completeAndSubmitAgentChargesForm({
+        percentageMethod: true,
+        percentageCharge: newValueInput,
+      });
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId });
+    });
+
+    it('should render the new answer', () => {
+      cy.assertSummaryListRowValue(summaryList, fieldId, `${newValueInput}%`);
+    });
+
+    it('should retain a `completed` status tag', () => {
+      cy.checkTaskStatusCompleted(status);
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-charges-percentage-to-fixed-sum.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-charges-percentage-to-fixed-sum.spec.js
@@ -1,0 +1,98 @@
+import { status, summaryList } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import checkSummaryList from '../../../../../../../commands/insurance/check-export-contract-summary-list';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    EXPORT_CONTRACT,
+  },
+  EXPORT_CONTRACT: { AGENT_CHARGES_CHECK_AND_CHANGE },
+} = INSURANCE_ROUTES;
+
+const {
+  AGENT_CHARGES: {
+    FIXED_SUM_AMOUNT, PERCENTAGE_CHARGE, PAYABLE_COUNTRY_CODE,
+  },
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const fieldId = PERCENTAGE_CHARGE;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Change your answers - Export contract - Summary list - Percentage to Fixed sum', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({
+        referenceNumber,
+        isUsingAgent: true,
+        agentIsCharging: true,
+        agentChargeMethodPercentage: true,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${AGENT_CHARGES_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(fieldId).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHECK_AND_CHANGE, fieldId });
+    });
+  });
+
+  describe('form submission with a new answer', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    it(`should redirect to ${EXPORT_CONTRACT}`, () => {
+      summaryList.field(fieldId).changeLink().click();
+
+      cy.completeAndSubmitAgentChargesForm({ fixedSumMethod: true });
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId });
+    });
+
+    it(`should render only ${FIXED_SUM_AMOUNT} and ${PAYABLE_COUNTRY_CODE} fields/values`, () => {
+      checkSummaryList[PERCENTAGE_CHARGE]({ shouldRender: false });
+      checkSummaryList[FIXED_SUM_AMOUNT]({ shouldRender: true });
+      checkSummaryList[PAYABLE_COUNTRY_CODE]({ shouldRender: true });
+    });
+
+    it('should retain a `completed` status tag', () => {
+      cy.checkTaskStatusCompleted(status);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/export-contract/agent-charges/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-charges/index.ts
@@ -15,12 +15,14 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import mapAndSave from '../map-and-save/export-contract-agent-service-charge';
+import isCheckAndChangeRoute from '../../../../helpers/is-check-and-change-route';
 import { Currency, Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
   PROBLEM_WITH_SERVICE,
   EXPORT_CONTRACT: { AGENT_CHARGES_SAVE_AND_BACK, AGENT_CHARGES_ALTERNATIVE_CURRENCY, CHECK_YOUR_ANSWERS },
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
 } = INSURANCE_ROUTES;
 
 const {
@@ -190,6 +192,15 @@ export const post = async (req: Request, res: Response) => {
 
     if (!saveResponse) {
       return res.redirect(PROBLEM_WITH_SERVICE);
+    }
+
+    /**
+     * If the route is a "check and change" route,
+     * redirect to CHECK_AND_CHANGE_ROUTE.
+     * Otherwise, redirect to CHECK_YOUR_ANSWERS.
+     */
+    if (isCheckAndChangeRoute(req.originalUrl)) {
+      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`);
     }
 
     return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`);


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds the ability to change all fields in the "Agent charges" form via the "Check your answers - Export contract" page of a No PDF application.


## Resolution :heavy_check_mark:
- Add E2E test coverage for: 
  - Fixed sum method - changing the `FIXED_SUM_AMOUNT` field.
  - Fixed sum method - change to Percentage method.
  - Changing the `PAYABLE_COUNTRY_CODE` field.
  - Percentage method - changing the `PERCENTAGE_CHARGE` field.
  - Percentage method - change to Fixed sum method.
