### PR TITLE
fix(EMS-3241-3235): No PDF - Change your answers - Export contract - Agent details - Redirect logic

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/change-your-answers-agent-details.spec.js
@@ -11,6 +11,7 @@ const {
     EXPORT_CONTRACT,
   },
   EXPORT_CONTRACT: {
+    AGENT_SERVICE_CHECK_AND_CHANGE,
     AGENT_DETAILS_CHECK_AND_CHANGE,
   },
 } = INSURANCE_ROUTES;
@@ -40,6 +41,7 @@ const baseUrl = Cypress.config('baseUrl');
 context('Insurance - Change your answers - Export contract - Summary list - Agent details', () => {
   let referenceNumber;
   let url;
+  let agentServiceUrl;
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
@@ -56,6 +58,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT}`;
+      agentServiceUrl = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_SERVICE_CHECK_AND_CHANGE}`;
 
       cy.assertUrl(url);
     });
@@ -88,15 +91,19 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
 
       beforeEach(() => {
         cy.navigateToUrl(url);
+      });
 
+      it(`should redirect to ${AGENT_SERVICE_CHECK_AND_CHANGE} and then ${EXPORT_CONTRACT} after completing (now required) ${AGENT_SERVICE_CHECK_AND_CHANGE} fields`, () => {
         summaryList.field(fieldId).changeLink().click();
 
         cy.keyboardInput(field(fieldId).input(), newAnswer);
 
         cy.clickSubmitButton();
-      });
 
-      it(`should redirect to ${EXPORT_CONTRACT}`, () => {
+        cy.assertUrl(`${agentServiceUrl}#${fieldId}-label`);
+
+        cy.completeAndSubmitAgentServiceForm({ agentIsCharging: false });
+
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId });
       });
 
@@ -126,13 +133,19 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
 
       beforeEach(() => {
         cy.navigateToUrl(url);
-
-        summaryList.field(fieldId).changeLink().click();
-
-        cy.changeAnswerField(fieldVariables, field(fieldId).textarea());
       });
 
-      it(`should redirect to ${EXPORT_CONTRACT}`, () => {
+      it(`should redirect to ${AGENT_SERVICE_CHECK_AND_CHANGE} and then ${EXPORT_CONTRACT} after completing (now required) ${AGENT_SERVICE_CHECK_AND_CHANGE} fields`, () => {
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.keyboardInput(field(fieldId).textarea(), newAnswer);
+
+        cy.clickSubmitButton();
+
+        cy.assertUrl(`${agentServiceUrl}#${fieldId}-label`);
+
+        cy.completeAndSubmitAgentServiceForm({ agentIsCharging: false });
+
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId });
       });
 
@@ -161,14 +174,19 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
 
       beforeEach(() => {
         cy.navigateToUrl(url);
+      });
 
+      it(`should redirect to ${AGENT_SERVICE_CHECK_AND_CHANGE} and then ${EXPORT_CONTRACT} after completing (now required) ${AGENT_SERVICE_CHECK_AND_CHANGE} fields`, () => {
         summaryList.field(fieldId).changeLink().click();
 
         cy.autocompleteKeyboardInput(fieldId, fieldVariables.newValue);
-        cy.clickSubmitButton();
-      });
 
-      it(`should redirect to ${EXPORT_CONTRACT}`, () => {
+        cy.clickSubmitButton();
+
+        cy.assertUrl(`${agentServiceUrl}#${fieldId}-label`);
+
+        cy.completeAndSubmitAgentServiceForm({ agentIsCharging: false });
+
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId });
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent/change-your-answers-agent-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent/change-your-answers-agent-details.spec.js
@@ -9,6 +9,7 @@ const {
   EXPORT_CONTRACT: {
     CHECK_YOUR_ANSWERS,
     AGENT_DETAILS_CHANGE,
+    AGENT_SERVICE_CHANGE,
   },
 } = INSURANCE_ROUTES;
 
@@ -23,6 +24,7 @@ const baseUrl = Cypress.config('baseUrl');
 context('Insurance - Export contract - Change your answers - Agent details - As an Exporter, I want to be able to review my input regarding whether an agent helped me win the export contract, So that I can be assured I am providing UKEF with the right information', () => {
   let referenceNumber;
   let checkYourAnswersUrl;
+  let agentServiceUrl;
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
@@ -33,6 +35,7 @@ context('Insurance - Export contract - Change your answers - Agent details - As 
       });
 
       checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+      agentServiceUrl = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_SERVICE_CHANGE}`;
 
       cy.assertUrl(checkYourAnswersUrl);
     });
@@ -64,15 +67,19 @@ context('Insurance - Export contract - Change your answers - Agent details - As 
 
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);
+      });
 
+      it(`should redirect to ${AGENT_SERVICE_CHANGE} and then ${CHECK_YOUR_ANSWERS} after completing (now required) ${AGENT_SERVICE_CHANGE} fields`, () => {
         summaryList.field(fieldId).changeLink().click();
 
         cy.keyboardInput(field(fieldId).input(), newAnswer);
 
         cy.clickSubmitButton();
-      });
 
-      it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+        cy.assertUrl(`${agentServiceUrl}#${fieldId}-label`);
+
+        cy.completeAndSubmitAgentServiceForm({ agentIsCharging: false });
+
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId });
       });
 
@@ -100,15 +107,20 @@ context('Insurance - Export contract - Change your answers - Agent details - As 
 
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);
+      });
 
+      it(`should redirect to ${AGENT_SERVICE_CHANGE} and then ${CHECK_YOUR_ANSWERS} after completing (now required) ${AGENT_SERVICE_CHANGE} fields`, () => {
         summaryList.field(fieldId).changeLink().click();
 
         cy.keyboardInput(field(fieldId).textarea(), newAnswer);
 
         cy.clickSubmitButton();
-      });
 
-      it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+        const expectedUrl = `${agentServiceUrl}#${fieldId}-label`;
+        cy.assertUrl(expectedUrl);
+
+        cy.completeAndSubmitAgentServiceForm({ agentIsCharging: false });
+
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId });
       });
 
@@ -134,15 +146,20 @@ context('Insurance - Export contract - Change your answers - Agent details - As 
     describe('form submission with a new destination/country answer', () => {
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);
+      });
 
+      it(`should redirect to ${AGENT_SERVICE_CHANGE} and then ${CHECK_YOUR_ANSWERS} after completing (now required) ${AGENT_SERVICE_CHANGE} fields`, () => {
         summaryList.field(fieldId).changeLink().click();
 
         cy.keyboardInput(autoCompleteField(fieldId).input(), NEW_COUNTRY_INPUT);
 
         cy.clickSubmitButton();
-      });
 
-      it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+        const expectedUrl = `${agentServiceUrl}#${fieldId}-label`;
+        cy.assertUrl(expectedUrl);
+
+        cy.completeAndSubmitAgentServiceForm({ agentIsCharging: false });
+
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId });
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent/change-your-answers-agent-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent/change-your-answers-agent-no-to-yes.spec.js
@@ -9,6 +9,7 @@ const {
     CHECK_YOUR_ANSWERS,
     AGENT_CHANGE,
     AGENT_DETAILS_CHANGE,
+    AGENT_SERVICE_CHANGE,
   },
 } = INSURANCE_ROUTES;
 
@@ -23,6 +24,7 @@ context('Insurance - Export contract - Change your answers - Agent - No to yes -
   let referenceNumber;
   let checkYourAnswersUrl;
   let agentDetailsUrl;
+  let agentServiceUrl;
 
   before(() => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
@@ -34,6 +36,7 @@ context('Insurance - Export contract - Change your answers - Agent - No to yes -
 
       checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       agentDetailsUrl = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_DETAILS_CHANGE}`;
+      agentServiceUrl = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_SERVICE_CHANGE}`;
 
       cy.assertUrl(checkYourAnswersUrl);
     });
@@ -63,17 +66,20 @@ context('Insurance - Export contract - Change your answers - Agent - No to yes -
         cy.navigateToUrl(checkYourAnswersUrl);
       });
 
-      it(`should redirect to ${AGENT_DETAILS_CHANGE} and then ${CHECK_YOUR_ANSWERS} after completing (now required) ${AGENT_DETAILS_CHANGE} fields`, () => {
+      it(`should redirect to ${AGENT_DETAILS_CHANGE}, ${AGENT_SERVICE_CHANGE} and then ${CHECK_YOUR_ANSWERS} after completing (now required) ${AGENT_DETAILS_CHANGE} fields`, () => {
         summaryList.field(FIELD_ID).changeLink().click();
 
         cy.completeAndSubmitAgentForm({
           isUsingAgent: true,
         });
 
-        const expectedUrl = `${agentDetailsUrl}#${FIELD_ID}-label`;
-        cy.assertUrl(expectedUrl);
+        cy.assertUrl(`${agentDetailsUrl}#${FIELD_ID}-label`);
 
         cy.completeAndSubmitAgentDetailsForm({});
+
+        cy.assertUrl(`${agentServiceUrl}#${FIELD_ID}-label`);
+
+        cy.completeAndSubmitAgentServiceForm({ agentIsCharging: false });
 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId: FIELD_ID });
       });

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
@@ -13,7 +13,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/export-contract-agent';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockApplicationAgentServiceEmpty, mockCountries, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockCountries, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -22,10 +22,9 @@ const {
     AGENT_DETAILS_CHECK_AND_CHANGE,
     AGENT_DETAILS_SAVE_AND_BACK,
     AGENT_SERVICE,
+    AGENT_SERVICE_CHANGE,
     AGENT_SERVICE_CHECK_AND_CHANGE,
-    CHECK_YOUR_ANSWERS,
   },
-  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
@@ -263,42 +262,24 @@ describe('controllers/insurance/export-contract/agent-details', () => {
       });
 
       describe("when the url's last substring is `change`", () => {
-        it(`should redirect to ${CHECK_YOUR_ANSWERS}`, async () => {
+        it(`should redirect to ${AGENT_SERVICE_CHANGE}`, async () => {
           req.body = validBody;
 
           req.originalUrl = AGENT_DETAILS_CHANGE;
 
           await post(req, res);
 
-          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${AGENT_SERVICE_CHANGE}`;
 
           expect(res.redirect).toHaveBeenCalledWith(expected);
         });
       });
 
-      describe("when the url's last substring is `check-and-change` and agent service data is available", () => {
-        it(`should redirect to ${CHECK_AND_CHANGE_ROUTE}`, async () => {
-          req.body = validBody;
-
-          req.originalUrl = AGENT_DETAILS_CHECK_AND_CHANGE;
-
-          res.locals.application = mockApplication;
-
-          await post(req, res);
-
-          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
-
-          expect(res.redirect).toHaveBeenCalledWith(expected);
-        });
-      });
-
-      describe("when the url's last substring is `check-and-change` and no agent service data is available", () => {
+      describe("when the url's last substring is `check-and-change", () => {
         it(`should redirect to ${AGENT_SERVICE_CHECK_AND_CHANGE}`, async () => {
           req.body = validBody;
 
           req.originalUrl = AGENT_DETAILS_CHECK_AND_CHANGE;
-
-          res.locals.application = mockApplicationAgentServiceEmpty;
 
           await post(req, res);
 

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/index.ts
@@ -18,14 +18,12 @@ import { Request, Response } from '../../../../../types';
 
 const {
   INSURANCE_ROOT,
-  EXPORT_CONTRACT: { AGENT_SERVICE, AGENT_SERVICE_CHECK_AND_CHANGE, AGENT_DETAILS_SAVE_AND_BACK, CHECK_YOUR_ANSWERS },
-  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT: CHECK_AND_CHANGE_ROUTE },
+  EXPORT_CONTRACT: { AGENT_SERVICE, AGENT_SERVICE_CHANGE, AGENT_SERVICE_CHECK_AND_CHANGE, AGENT_DETAILS_SAVE_AND_BACK },
   PROBLEM_WITH_SERVICE,
 } = INSURANCE_ROUTES;
 
 const {
   AGENT_DETAILS: { NAME, FULL_ADDRESS, COUNTRY_CODE },
-  AGENT_SERVICE: { IS_CHARGING, SERVICE_DESCRIPTION },
 } = EXPORT_CONTRACT_FIELD_IDS;
 
 export const FIELD_IDS = [NAME, FULL_ADDRESS, COUNTRY_CODE];
@@ -112,10 +110,7 @@ export const post = async (req: Request, res: Response) => {
     return res.redirect(PROBLEM_WITH_SERVICE);
   }
 
-  const {
-    referenceNumber,
-    exportContract: { agent },
-  } = application;
+  const { referenceNumber } = application;
 
   const payload = constructPayload(req.body, FIELD_IDS);
 
@@ -157,28 +152,21 @@ export const post = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    const hasAgentServiceData = agent.service[SERVICE_DESCRIPTION] && agent.service[IS_CHARGING] !== null;
-
     /**
      * If the route is a "change" route,
-     * redirect to CHECK_YOUR_ANSWERS.
+     * redirect to AGENT_SERVICE_CHANGE.
      */
     if (isChangeRoute(req.originalUrl)) {
-      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`);
+      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${AGENT_SERVICE_CHANGE}`);
     }
 
     /**
      * If the route is a "check and change" route,
-     * no agent service data is available,
      * redirect to AGENT_SERVICE_CHECK_AND_CHANGE form.
      * Otherwise, redirect to CHECK_YOUR_ANSWERS.
      */
     if (isCheckAndChangeRoute(req.originalUrl)) {
-      if (!hasAgentServiceData) {
-        return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${AGENT_SERVICE_CHECK_AND_CHANGE}`);
-      }
-
-      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`);
+      return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${AGENT_SERVICE_CHECK_AND_CHANGE}`);
     }
 
     return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${AGENT_SERVICE}`);

--- a/src/ui/server/test-mocks/index.ts
+++ b/src/ui/server/test-mocks/index.ts
@@ -11,7 +11,6 @@ import mockCompaniesHouseResponse from './mock-companies-house-response';
 import mockCompany from './mock-company';
 import mockApplication, {
   mockApplicationAgentServiceChargeEmpty,
-  mockApplicationAgentServiceEmpty,
   mockApplicationMultiplePolicy,
   mockApplicationTotalContractValueThresholdTrue,
   mockApplicationTotalContractValueThresholdFalse,
@@ -121,7 +120,6 @@ export {
   mockAnswers,
   mockApplication,
   mockApplicationAgentServiceChargeEmpty,
-  mockApplicationAgentServiceEmpty,
   mockApplicationMultiplePolicy,
   mockApplications,
   mockApplicationTotalContractValueThresholdTrue,

--- a/src/ui/server/test-mocks/mock-application.ts
+++ b/src/ui/server/test-mocks/mock-application.ts
@@ -218,21 +218,6 @@ export const mockApplicationTotalContractValueThresholdFalse = {
   totalContractValueOverThreshold: false,
 } as Application;
 
-export const mockApplicationAgentServiceEmpty = {
-  ...mockApplication,
-  exportContract: {
-    ...mockExportContract,
-    agent: {
-      ...mockExportContractAgent,
-      service: {
-        ...mockExportContractAgentService,
-        serviceDescription: '',
-        charge: mockExportContractAgentServiceCharge,
-      },
-    },
-  },
-} as Application;
-
 export const mockApplicationAgentServiceChargeEmpty = {
   ...mockApplication,
   exportContract: {


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the user flow when in the "Agent details" form via the "Check your answers - Export contract" page of a No PDF application; So that a user is always redirected to "Agent service" after submitting "Agent details"

## Resolution :heavy_check_mark:
- Update E2E tests.
- Update `AGENT_DETAILS` POST controller redirect logic.
- Remove UI `mockApplicationAgentServiceEmpty` mock.
