### PR TITLE
chore(EMS-3191): No PDF - Export contract - Agent details - Validation - Improve E2E test coverage

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-details/validation/agent-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-details/validation/agent-details-validation.spec.js
@@ -87,6 +87,16 @@ context('Insurance - Export contract - Agent details page - form validation', ()
 
       cy.submitAndAssertFieldErrors({ ...assertions, value, expectedErrorMessage: ERROR_MESSAGES_OBJECT.INCORRECT_FORMAT });
     });
+
+    it('should retain all submitted values', () => {
+      cy.completeAndSubmitAgentDetailsForm({
+        name: null,
+      });
+
+      cy.assertAgentDetailsFieldValues({
+        expectedName: null,
+      });
+    });
   });
 
   describe(FULL_ADDRESS, () => {
@@ -122,17 +132,39 @@ context('Insurance - Export contract - Agent details page - form validation', ()
         expectedErrorMessage: ERROR_MESSAGES_OBJECT.ABOVE_MAXIMUM,
       });
     });
+
+    it('should retain all submitted values', () => {
+      cy.completeAndSubmitAgentDetailsForm({
+        fullAddress: null,
+      });
+
+      cy.assertAgentDetailsFieldValues({
+        expectedFullAddress: null,
+      });
+    });
   });
 
   describe(COUNTRY_CODE, () => {
-    it(`should render validation errors when ${COUNTRY_CODE} is left empty`, () => {
+    beforeEach(() => {
       cy.navigateToUrl(url);
+    });
 
+    it(`should render validation errors when ${COUNTRY_CODE} is left empty`, () => {
       cy.submitAndAssertFieldErrors({
         field: autoCompleteField(COUNTRY_CODE),
         errorIndex: 2,
         expectedErrorsCount,
         expectedErrorMessage: AGENT_DETAILS_ERROR_MESSAGES[COUNTRY_CODE].IS_EMPTY,
+      });
+    });
+
+    it('should retain all submitted values', () => {
+      cy.completeAndSubmitAgentDetailsForm({
+        countryCode: null,
+      });
+
+      cy.assertAgentDetailsFieldValues({
+        expectedCountryCode: null,
       });
     });
   });


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the E2E test coverage for the "Agent details" form, in the Export contract section of a No PDF application.

A bug was raised where the `COUNTRY_CODE` field in this page would not render a previously submitted value, if other fields have errors.

Unable to replicate this, but have added E2E test coverage for all fields, to ensure that every field retains a previously submitted value, when there are validation errors for other fields.

## Resolution :heavy_check_mark:
- Update E2E test coverage.