### PR TITLE
fix(EMS-3194): No PDF - Buyer - Trading history - Validation - Missing/stripped submitted values

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/validation/trading-history-outstanding-payments-yes-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/validation/trading-history-outstanding-payments-yes-validation.spec.js
@@ -130,7 +130,7 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
     it('should render validation errors', () => {
       submitAndAssertBothFields({
         value: '1,250.5',
-        expectedValue: '1250.5',
+        expectedValue: '1,250.5',
         errorTotalOutstanding: ERRORS[TOTAL_OUTSTANDING_PAYMENTS].INCORRECT_FORMAT,
         errorAmountOverdue: ERRORS[TOTAL_AMOUNT_OVERDUE].INCORRECT_FORMAT,
       });
@@ -147,7 +147,6 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
     it('should render validation errors', () => {
       submitAndAssertBothFields({
         value: '0',
-        assertExpectedValue: false,
         errorTotalOutstanding: ERRORS[TOTAL_OUTSTANDING_PAYMENTS].BELOW_MINIMUM,
         errorAmountOverdue: ERRORS[TOTAL_AMOUNT_OVERDUE].BELOW_MINIMUM,
       });
@@ -171,7 +170,7 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
     });
   });
 
-  describe(`when entering valid values  for ${TOTAL_AMOUNT_OVERDUE} and ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
+  describe(`when entering valid values for ${TOTAL_AMOUNT_OVERDUE} and ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
     });

--- a/src/ui/server/controllers/insurance/your-buyer/trading-history/index.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/trading-history/index.ts
@@ -10,7 +10,6 @@ import generateValidationErrors from './validation';
 import { Request, Response, Currency } from '../../../../../types';
 import constructPayload from '../../../../helpers/construct-payload';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
-import { sanitiseData } from '../../../../helpers/sanitise-data';
 import mapAndSave from '../map-and-save/buyer-trading-history';
 import isChangeRoute from '../../../../helpers/is-change-route';
 import isCheckAndChangeRoute from '../../../../helpers/is-check-and-change-route';
@@ -250,7 +249,7 @@ export const post = async (req: Request, res: Response) => {
         ...generatedPageVariables,
         userName: getUserNameFromSession(req.session.user),
         validationErrors,
-        submittedValues: sanitiseData(payload),
+        submittedValues: payload,
       });
     }
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue in the "Buyer - Trading history" form, where if a monetary field is submitted as "0" and there are validation errors, the previously submitted "0"'s, would not be rendered in the input.

## Resolution :heavy_check_mark:
- Update E2E test coverage.
- Remove `sanitiseData` from the POST controller's `submittedValues`.
  - This was not only (correctly) transforming a zero from a string into a number, but was also stripping previously submitted special characters (E.g commas), which should remain intact during validation errors - so that we playback to a user exactly what was entered.

## Miscellaneous :heavy_plus_sign:
- Fix a typo.
