### PR TITLE
fix(EMS-3195-3238): No PDF - Export contract - Agent charges - Country input - Layout issue

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/validation/trading-history-outstanding-payments-yes-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/validation/trading-history-outstanding-payments-yes-validation.spec.js
@@ -163,7 +163,6 @@ context('Insurance - Your Buyer - Trading history page - Outstanding payments ye
     it('should render validation errors', () => {
       submitAndAssertBothFields({
         value: SPECIAL_CHARACTERS,
-        assertExpectedValue: false,
         errorTotalOutstanding: ERRORS[TOTAL_OUTSTANDING_PAYMENTS].INCORRECT_FORMAT,
         errorAmountOverdue: ERRORS[TOTAL_AMOUNT_OVERDUE].INCORRECT_FORMAT,
       });

--- a/src/ui/templates/components/accessible-autocomplete-select.njk
+++ b/src/ui/templates/components/accessible-autocomplete-select.njk
@@ -6,6 +6,7 @@
   {% set fieldId = params.fieldId %}
   {% set integrity = params.integrity %}
   {% set options = params.options %}
+  {% set inputContainerClasses = params.inputContainerClasses %}
 
   {% if errorMessage %}
     {{ govukErrorMessage({
@@ -16,17 +17,20 @@
     }) }}
   {% endif %}
 
-  <select class="govuk-select" id="{{ fieldId }}" name="{{ fieldId }}">
-    <option value="" disabled selected></option>
+  <div class="{{ inputContainerClasses }}">
 
-    {% for option in options %}
-      {% if option.selected %}
-        <option value="{{ option.value }}" selected>{{ option.text }}</option>
-      {% else %}
-        <option value="{{ option.value }}">{{ option.text }}</option>
-      {% endif %}
-    {% endfor %}
-  </select>
+    <select class="govuk-select" id="{{ fieldId }}" name="{{ fieldId }}">
+      <option value="" disabled selected></option>
+
+      {% for option in options %}
+        {% if option.selected %}
+          <option value="{{ option.value }}" selected>{{ option.text }}</option>
+        {% else %}
+          <option value="{{ option.value }}">{{ option.text }}</option>
+        {% endif %}
+      {% endfor %}
+    </select>
+  </div>
 
   <script src="/assets/js/accessibleAutocomplete.js" type="module" integrity="{{ integrity }}" crossorigin="anonymous"></script>
 

--- a/src/ui/templates/insurance/export-contract/agent-charges.njk
+++ b/src/ui/templates/insurance/export-contract/agent-charges.njk
@@ -126,37 +126,39 @@
         }) }}
       </div>
     </div>
+    
+    {% set containerClassName = "govuk-form-group govuk-!-margin-bottom-8" %}
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">
+    {% set errorMessage = validationErrors.errorList[FIELDS.PAYABLE_COUNTRY_CODE.ID].text %}
 
-        {% set containerClassName = "govuk-form-group" %}
+    {% if errorMessage %}
+      {% set containerClassName = "govuk-form-group govuk-!-margin-bottom-8 govuk-form-group--error" %}
+    {% endif %}
 
-        {% set errorMessage = validationErrors.errorList[FIELDS.PAYABLE_COUNTRY_CODE.ID].text %}
+    <div class="{{ containerClassName }}">
+      {{ govukLabel({
+        for: FIELDS.PAYABLE_COUNTRY_CODE.ID,
+        classes: "govuk-!-font-weight-bold",
+        text: FIELDS.PAYABLE_COUNTRY_CODE.LABEL,
+        attributes: {
+          id: FIELDS.PAYABLE_COUNTRY_CODE.ID + "-label",
+          "data-cy": FIELDS.PAYABLE_COUNTRY_CODE.ID + "-label"
+        }
+      }) }}
 
-        {% if errorMessage %}
-          {% set containerClassName = "govuk-form-group govuk-form-group--error" %}
-        {% endif %}
-
-        <div class="{{ containerClassName }}">
-          {{ govukLabel({
-            for: FIELDS.PAYABLE_COUNTRY_CODE.ID,
-            classes: "govuk-!-font-weight-bold",
-            text: FIELDS.PAYABLE_COUNTRY_CODE.LABEL,
-            attributes: {
-              id: FIELDS.PAYABLE_COUNTRY_CODE.ID + "-label",
-              "data-cy": FIELDS.PAYABLE_COUNTRY_CODE.ID + "-label"
-            }
-          }) }}
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
 
           {{ accessibleAutoCompleteSelect.render({
             errorMessage: validationErrors.errorList[FIELDS.PAYABLE_COUNTRY_CODE.ID].text,
             fieldId: FIELDS.PAYABLE_COUNTRY_CODE.ID,
             integrity: SRI.ACCESSIBILITY,
-            options: countries
+            options: countries,
+            inputContainerClasses: "govuk-input--width-20"
           }) }}
         </div>
       </div>
+
     </div>
 
     {{ formButtons.render({


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue in the "Export - contract - Agent charges" form as part of the No PDF application where, when a validation error renders, the error text would display across 2 lines.

## Resolution :heavy_check_mark:
- Update the Accessible autocomplete nunjucks component to render an optional input container class name.
- Update the Agent charges nunjucks rows and classes.

## Miscellaneous :heavy_plus_sign:
- Remove a `assertExpectedValue: false` flag from an E2E test (EMS-3195).
