### PR TITLE
fix(EMS-3125-3316): No PDF - Buyer - Organsation name error message, Application submitted page content

### DIFF
--- a/e2e-tests/content-strings/links.js
+++ b/e2e-tests/content-strings/links.js
@@ -10,6 +10,7 @@ export const LINKS = {
   },
   FEEDBACK: 'feedback',
   GIVE_FEEDBACK: 'Give feedback',
+  GIVE_US_FEEDBACK: 'Give us feedback',
   SKIP_TO_MAIN_CONTENT: 'Skip to main content',
   EXTERNAL: {
     GUIDANCE: 'https://www.gov.uk/guidance/export-insurance-policy#eligibility',

--- a/e2e-tests/content-strings/pages/insurance/application-submitted/index.js
+++ b/e2e-tests/content-strings/pages/insurance/application-submitted/index.js
@@ -32,7 +32,7 @@ const APPLICATION_SUBMITTED = {
     FEEDBACK: {
       INTRO: 'You can also',
       LINK: {
-        TEXT: LINKS.GIVE_FEEDBACK,
+        TEXT: LINKS.GIVE_US_FEEDBACK,
         HREF: ROUTES.INSURANCE.FEEDBACK,
       },
     },

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-name.spec.js
@@ -49,9 +49,9 @@ context('Insurance - Your Buyer - Company or organisation page - form validation
     cy.deleteApplication(referenceNumber);
   });
 
-  describe(`when ${FIELD_ID} is over ${MAXIMUM_CHARACTERS.BUYER.REGISTRATION_NUMBER} characters`, () => {
+  describe(`when ${FIELD_ID} is over ${MAXIMUM_CHARACTERS.BUYER.COMPANY_OR_ORGANISATION} characters`, () => {
     it('should display validation errors and retain the submitted value', () => {
-      const submittedValue = 'a'.repeat(MAXIMUM_CHARACTERS.BUYER.REGISTRATION_NUMBER + 1);
+      const submittedValue = 'a'.repeat(MAXIMUM_CHARACTERS.BUYER.COMPANY_OR_ORGANISATION + 1);
 
       cy.submitAndAssertFieldErrors({
         field: fieldSelector(FIELD_ID),

--- a/src/ui/server/content-strings/links.ts
+++ b/src/ui/server/content-strings/links.ts
@@ -10,6 +10,7 @@ export const LINKS = {
   },
   FEEDBACK: 'feedback',
   GIVE_FEEDBACK: 'Give feedback',
+  GIVE_US_FEEDBACK: 'Give us feedback',
   SKIP_TO_MAIN_CONTENT: 'Skip to main content',
   EXTERNAL: {
     GUIDANCE: 'https://www.gov.uk/guidance/export-insurance-policy#eligibility',

--- a/src/ui/server/content-strings/pages/insurance/application-submitted/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/application-submitted/index.ts
@@ -32,7 +32,7 @@ const APPLICATION_SUBMITTED = {
     FEEDBACK: {
       INTRO: 'You can also',
       LINK: {
-        TEXT: LINKS.GIVE_FEEDBACK,
+        TEXT: LINKS.GIVE_US_FEEDBACK,
         HREF: ROUTES.INSURANCE.FEEDBACK,
       },
     },

--- a/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/validation/rules/organisation-name.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/validation/rules/organisation-name.test.ts
@@ -25,7 +25,7 @@ describe('controllers/insurance/your-buyer/validation/organisation-name', () => 
   it('should return the result of providedAndMaxLength', () => {
     const result = companyOrOrganisationNameRules(mockBody, mockErrors);
 
-    const expected = providedAndMaxLength(mockBody, FIELD_ID, ERROR_MESSAGES_OBJECT, mockErrors, MAXIMUM_CHARACTERS.BUYER.REGISTRATION_NUMBER);
+    const expected = providedAndMaxLength(mockBody, FIELD_ID, ERROR_MESSAGES_OBJECT, mockErrors, MAXIMUM_CHARACTERS.BUYER.COMPANY_OR_ORGANISATION);
 
     expect(result).toEqual(expected);
   });

--- a/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/validation/rules/organisation-name.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/validation/rules/organisation-name.ts
@@ -25,6 +25,6 @@ const {
  * @returns {ValidationErrors} providedAndMaxLength
  */
 const companyOrOrganisationNameRules = (formBody: RequestBody, errors: object) =>
-  providedAndMaxLength(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MAXIMUM_CHARACTERS.BUYER.REGISTRATION_NUMBER);
+  providedAndMaxLength(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MAXIMUM_CHARACTERS.BUYER.COMPANY_OR_ORGANISATION);
 
 export default companyOrOrganisationNameRules;


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes 2x issues where:
- The "Buyer - Organisation name" `ABOVE_MAXIMUM` error message had the invalid character count.
- The "Application submitted - give feedback" copy should say "Give us feedback", instead of "Give feedback".

## Resolution :heavy_check_mark:
- Update`COMPANY_OR_ORGANISATION.NAME` validation function.
- Update content strings.
