### PR TITLE
fix(EMS-3299): No PDF - Export contract - Change your answers - Using agent - Yes to no

### DIFF
--- a/e2e-tests/commands/shared-commands/assertions/assert-empty-agent-charges-field-values.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-empty-agent-charges-field-values.js
@@ -1,0 +1,33 @@
+import { field } from '../../../pages/shared';
+import FIELD_IDS from '../../../constants/field-ids/insurance/export-contract';
+import { SYMBOLS } from '../../../constants';
+import { checkAutocompleteInput } from '../../../shared-test-assertions';
+
+const {
+  AGENT_CHARGES: {
+    METHOD,
+    FIXED_SUM,
+    FIXED_SUM_AMOUNT,
+    PERCENTAGE,
+    PERCENTAGE_CHARGE,
+    COUNTRY_CODE,
+  },
+} = FIELD_IDS;
+
+/**
+ * assertEmptyAgentChargesFieldValues
+ * Assert all field values in the "agent charges" form are empty.
+ */
+const assertEmptyAgentChargesFieldValues = () => {
+  cy.assertRadioOptionIsNotChecked(field(`${METHOD}-${FIXED_SUM}`).input());
+  cy.checkValue(field(FIXED_SUM_AMOUNT), '');
+
+  cy.assertPrefix({ fieldId: FIXED_SUM_AMOUNT, value: SYMBOLS.GBP });
+
+  cy.assertRadioOptionIsNotChecked(field(`${METHOD}-${PERCENTAGE}`).input());
+  cy.checkValue(field(PERCENTAGE_CHARGE), '');
+
+  checkAutocompleteInput.checkEmptyResults(COUNTRY_CODE);
+};
+
+export default assertEmptyAgentChargesFieldValues;

--- a/e2e-tests/commands/shared-commands/assertions/assert-empty-agent-details-field-values.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-empty-agent-details-field-values.js
@@ -1,0 +1,24 @@
+import { field } from '../../../pages/shared';
+import FIELD_IDS from '../../../constants/field-ids/insurance/export-contract';
+import { checkAutocompleteInput } from '../../../shared-test-assertions';
+
+const {
+  AGENT_DETAILS: { NAME, FULL_ADDRESS, COUNTRY_CODE },
+} = FIELD_IDS;
+
+/**
+ * assertEmptyAgentDetailsFieldValues
+ * Assert all field values in the "agent details" form are empty.
+ */
+const assertEmptyAgentDetailsFieldValues = () => {
+  cy.checkValue(field(NAME), '');
+
+  cy.checkTextareaValue({
+    fieldId: FULL_ADDRESS,
+    expectedValue: '',
+  });
+
+  checkAutocompleteInput.checkEmptyResults(COUNTRY_CODE);
+};
+
+export default assertEmptyAgentDetailsFieldValues;

--- a/e2e-tests/commands/shared-commands/assertions/assert-empty-agent-service-field-values.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-empty-agent-service-field-values.js
@@ -1,0 +1,21 @@
+import FIELD_IDS from '../../../constants/field-ids/insurance/export-contract';
+
+const {
+  AGENT_SERVICE: { SERVICE_DESCRIPTION },
+} = FIELD_IDS;
+
+/**
+ * assertEmptyAgentServiceFieldValues
+ * Assert all field values in the "agent service" form are empty.
+ */
+const assertEmptyAgentServiceFieldValues = () => {
+  cy.checkTextareaValue({
+    fieldId: SERVICE_DESCRIPTION,
+    expectedValue: '',
+  });
+
+  cy.assertYesRadioOptionIsNotChecked();
+  cy.assertNoRadioOptionIsNotChecked();
+};
+
+export default assertEmptyAgentServiceFieldValues;

--- a/e2e-tests/commands/shared-commands/assertions/index.js
+++ b/e2e-tests/commands/shared-commands/assertions/index.js
@@ -66,8 +66,12 @@ Cypress.Commands.add('assertLossPayeeFinancialUkFieldValues', require('./assert-
 Cypress.Commands.add('assertLossPayeeFinancialInternationalFieldValues', require('./assert-loss-payee-financial-international-field-values'));
 
 Cypress.Commands.add('assertAgentDetailsFieldValues', require('./assert-agent-details-field-values'));
+Cypress.Commands.add('assertEmptyAgentDetailsFieldValues', require('./assert-empty-agent-details-field-values'));
+
 Cypress.Commands.add('assertAgentServiceFieldValues', require('./assert-agent-service-field-values'));
+Cypress.Commands.add('assertEmptyAgentServiceFieldValues', require('./assert-empty-agent-service-field-values'));
 
 Cypress.Commands.add('assertAgentChargesFieldValues', require('./assert-agent-charges-field-values'));
+Cypress.Commands.add('assertEmptyAgentChargesFieldValues', require('./assert-empty-agent-charges-field-values'));
 
 Cypress.Commands.add('submitAndAssertChangeAnswersPageUrl', require('./submit-and-assert-change-answers-page-url'));

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent/change-your-answers-agent-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent/change-your-answers-agent-yes-to-no.spec.js
@@ -1,22 +1,27 @@
-import { field, status, summaryList } from '../../../../../../../../pages/shared';
+import { status, summaryList } from '../../../../../../../../pages/shared';
 import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-export-contract-summary-list';
-import { checkAutocompleteInput } from '../../../../../../../../shared-test-assertions';
 
 const {
   ROOT,
-  CHECK_YOUR_ANSWERS: {
-    EXPORT_CONTRACT,
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT },
+  EXPORT_CONTRACT: {
+    AGENT_CHECK_AND_CHANGE,
+    AGENT_DETAILS,
+    AGENT_SERVICE,
+    AGENT_CHARGES,
   },
-  EXPORT_CONTRACT: { AGENT_CHECK_AND_CHANGE, AGENT_DETAILS },
 } = INSURANCE_ROUTES;
 
 const {
   USING_AGENT: FIELD_ID,
   AGENT_DETAILS: { NAME, FULL_ADDRESS, COUNTRY_CODE },
-  AGENT_SERVICE: { SERVICE_DESCRIPTION, IS_CHARGING },
+  AGENT_SERVICE: {
+    IS_CHARGING,
+    SERVICE_DESCRIPTION,
+  },
 } = FIELD_IDS;
 
 const { taskList } = partials.insurancePartials;
@@ -97,22 +102,21 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
       cy.checkTaskStatusCompleted(status);
     });
 
-    describe(`when changing the answer again from no to yes and going back to ${AGENT_DETAILS}`, () => {
-      it('should have empty field values', () => {
+    describe(`when changing the answer again from no to yes and going back to ${AGENT_DETAILS}, ${AGENT_SERVICE} and ${AGENT_CHARGES}`, () => {
+      it('should have empty field values and default currency prefix', () => {
         summaryList.field(FIELD_ID).changeLink().click();
 
         cy.completeAndSubmitAgentForm({
           isUsingAgent: true,
         });
 
-        cy.checkValue(field(NAME), '');
+        cy.assertEmptyAgentDetailsFieldValues();
+        cy.completeAndSubmitAgentDetailsForm({});
 
-        cy.checkTextareaValue({
-          fieldId: FULL_ADDRESS,
-          expectedValue: '',
-        });
+        cy.assertEmptyAgentServiceFieldValues();
+        cy.completeAndSubmitAgentServiceForm({ agentIsCharging: true });
 
-        checkAutocompleteInput.checkEmptyResults(COUNTRY_CODE);
+        cy.assertEmptyAgentChargesFieldValues();
       });
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent/change-your-answers-agent-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent/change-your-answers-agent-yes-to-no.spec.js
@@ -1,17 +1,23 @@
-import { field, summaryList } from '../../../../../../../pages/shared';
+import { summaryList } from '../../../../../../../pages/shared';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import FIELD_IDS from '../../../../../../../constants/field-ids/insurance/export-contract';
 import checkSummaryList from '../../../../../../../commands/insurance/check-export-contract-summary-list';
-import { checkAutocompleteInput } from '../../../../../../../shared-test-assertions';
 
 const {
   ROOT,
-  EXPORT_CONTRACT: { CHECK_YOUR_ANSWERS, AGENT_DETAILS, AGENT_CHANGE },
+  EXPORT_CONTRACT: {
+    CHECK_YOUR_ANSWERS,
+    AGENT_CHANGE,
+    AGENT_DETAILS,
+    AGENT_SERVICE,
+    AGENT_CHARGES,
+  },
 } = INSURANCE_ROUTES;
 
 const {
   USING_AGENT: FIELD_ID,
   AGENT_DETAILS: { NAME, FULL_ADDRESS, COUNTRY_CODE },
+  AGENT_SERVICE: { IS_CHARGING, SERVICE_DESCRIPTION },
 } = FIELD_IDS;
 
 const baseUrl = Cypress.config('baseUrl');
@@ -73,24 +79,25 @@ context('Insurance - Export contract - Change your answers - Agent - Yes to no -
         checkSummaryList[NAME]({ shouldRender: false });
         checkSummaryList[FULL_ADDRESS]({ shouldRender: false });
         checkSummaryList[COUNTRY_CODE]({ shouldRender: false });
+        checkSummaryList[SERVICE_DESCRIPTION]({ shouldRender: false });
+        checkSummaryList[IS_CHARGING]({ shouldRender: false });
       });
 
-      describe(`when changing the answer again from no to yes and going back to ${AGENT_DETAILS}`, () => {
-        it('should have empty field values', () => {
+      describe(`when changing the answer again from no to yes and going back to ${AGENT_DETAILS}, ${AGENT_SERVICE} and ${AGENT_CHARGES}`, () => {
+        it('should have empty field values and default currency prefix', () => {
           summaryList.field(FIELD_ID).changeLink().click();
 
           cy.completeAndSubmitAgentForm({
             isUsingAgent: true,
           });
 
-          cy.checkValue(field(NAME), '');
+          cy.assertEmptyAgentDetailsFieldValues();
+          cy.completeAndSubmitAgentDetailsForm({});
 
-          cy.checkTextareaValue({
-            fieldId: FULL_ADDRESS,
-            expectedValue: '',
-          });
+          cy.assertEmptyAgentServiceFieldValues();
+          cy.completeAndSubmitAgentServiceForm({ agentIsCharging: true });
 
-          checkAutocompleteInput.checkEmptyResults(COUNTRY_CODE);
+          cy.assertEmptyAgentChargesFieldValues();
         });
       });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@typescript-eslint/eslint-plugin": "^7.8.0",
         "@typescript-eslint/parser": "^7.8.0",
         "commitlint": "^19.3.0",
-        "cspell": "^8.8.0",
+        "cspell": "^8.8.1",
         "eslint": "^8.56.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -2430,9 +2430,9 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.8.0.tgz",
-      "integrity": "sha512-wK1qGhy6DiCj9LqGnMKutIQcMPD8J9oczM1sr3J+zmh6WggP1xkuCHu8XSxxO4Q2AOLdtcVW/4SXJ7gzT7Azbg==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.8.1.tgz",
+      "integrity": "sha512-zP/cC7ABk9PM6X1/itEOYa9raWrdUtUXCcUtHLnEr83HhPUHZ8vzaBgMJ176No/7EgZ4BHGXVvA0v079ukXVxw==",
       "dev": true,
       "dependencies": {
         "@cspell/dict-ada": "^4.0.2",
@@ -2492,30 +2492,30 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.8.0.tgz",
-      "integrity": "sha512-MlyEMnTXkLJxNSXcS7j9xV/zFS4/38qOoaH0W5xWGAtDgiFSa9/NXVBnZTNWpdhjtm0UNCfIQenl/l7d3O9Luw==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.8.1.tgz",
+      "integrity": "sha512-HtendGGO0w1gElhSYsD4D9iKT1nMBoUP31y0Ndw3AtQRzH6I31lx6DWnrXIef1bTL4wdq7ocxgG5HGQBQ8PWfA==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-types": "8.8.0"
+        "@cspell/cspell-types": "8.8.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.8.0.tgz",
-      "integrity": "sha512-R9YEI8+GVa98mEMCtCHJMqX4xHNwhdHo31lGhmyUpYiuLcD9HZ96n+ExCGbnFBUXyugSHCmTA/lubdfo7CPZrw==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.8.1.tgz",
+      "integrity": "sha512-AMQ0s7qH71tNnrpX8ILl+OZceDHt//h/T3Yk//qvn69x1Dzfg4Saqv/qhfG1VClQVyV5F4y7tIa4UNd5X6mW4g==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.8.0.tgz",
-      "integrity": "sha512-+o1fwkE36Wi8JTnjDHdLScB99U8YtLQ7XbnEe61Hj2ES1G5TsYCZ1r7RFCw2Kzn2qrkE2mnxknKwbf9h0Db4Ng==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.8.1.tgz",
+      "integrity": "sha512-K5sPp05Pz3tYU9roFGILSB6OdSVYqyr4Y/NW1CxZsXgq+hmwxAJQag/RyhW6cUp/1Jhy5RKYGNy0H0u/jODx3A==",
       "dev": true,
       "dependencies": {
         "global-directory": "^4.0.1"
@@ -2525,18 +2525,18 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.8.0.tgz",
-      "integrity": "sha512-BvQgBbrsXmKmaEXhXSGQPzBTM37EMk696u6+ThuJuIikP54pKJpUc7rOV1NKretxC32Mj37mS750X1YR02Z80w==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.8.1.tgz",
+      "integrity": "sha512-dxZ/ymwP6XNMGkU5iIUVgFP2JEqEvpJZavpAerB/y5E560Agv1WuUpkZE/PMCmseoLjSiV5yQzcnLNoT5X/w7A==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.8.0.tgz",
-      "integrity": "sha512-CGIYttfpp0M/y4a7vfVQljeJqBcIsGYIM4iwJU+F3MQUqFqvNFeU58S27GfK5VzkMAJumsOnmJqSgm+h/g7n0Q==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.8.1.tgz",
+      "integrity": "sha512-JEbLN+b3XdHIpEaoZJnpPfL8iTKWraqE7x1VwG7FIQ9wjP6fCPwfNRVM0CUWEmT+85O/zvbYVOlTJn1uIOLnZw==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -2858,9 +2858,9 @@
       "dev": true
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.8.0.tgz",
-      "integrity": "sha512-oNe8IPaTDsbfGbGCt7Ss+g8RRI7c9zpTnp/G/eG+PuWvH8Isps4+dWE/4qhxS7e3XTyQwfD89b3H3TAPAuwstQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.8.1.tgz",
+      "integrity": "sha512-IyKEbSaHkw9V4Oc4JDasF96+BHKV8motBrepjLIMUjdJ152fBg8zqbvF769POdCJg0QouZVUV+h9V7zC6v45/g==",
       "dev": true,
       "dependencies": {
         "import-meta-resolve": "^4.1.0"
@@ -2870,9 +2870,9 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.8.0.tgz",
-      "integrity": "sha512-A0mkSdPiZkbF3e+OGM2eO1k0yrdgohvgO2p3fhb1bGylj8n6po+H6iNh2zpumTtfy1xVIrfpYPdOT7Z6TvvbIw==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.8.1.tgz",
+      "integrity": "sha512-QNnMY5jKP/ItVYRGS4w3KF+1iXBUUjldZNVtEoQe2dFergxvbIYQ0S++TZb25G/o9nRF5GmOpecJaOvwUBZsiw==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -7289,25 +7289,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/configstore": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-6.0.0.tgz",
-      "integrity": "sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==",
-      "dev": true,
-      "dependencies": {
-        "dot-prop": "^6.0.1",
-        "graceful-fs": "^4.2.6",
-        "unique-string": "^3.0.0",
-        "write-file-atomic": "^3.0.3",
-        "xdg-basedir": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/yeoman/configstore?sponsor=1"
-      }
-    },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
       "dev": true,
@@ -7497,59 +7478,32 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypto-random-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
-      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/crypto-random-string/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/csp_evaluator": {
       "version": "1.1.1",
       "license": "Apache-2.0"
     },
     "node_modules/cspell": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.8.0.tgz",
-      "integrity": "sha512-WDysxJ1IVbPSK+bO0coGDgaA2+on9ubS+Ya2sw7opKEVpp5a0T+Fd7rEkaAmvD0ipsn8hm/S60tVNz4+m2kRUg==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.8.1.tgz",
+      "integrity": "sha512-YDJ62Q400LqxKTQV5Nk+Ub2IZGm5L0p832KbFUMy7FXDwkPLaxp3mfcLFV677FRiTcnGUtGYD+SnPkFJ2hiqsg==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.8.0",
-        "@cspell/cspell-pipe": "8.8.0",
-        "@cspell/cspell-types": "8.8.0",
-        "@cspell/dynamic-import": "8.8.0",
+        "@cspell/cspell-json-reporter": "8.8.1",
+        "@cspell/cspell-pipe": "8.8.1",
+        "@cspell/cspell-types": "8.8.1",
+        "@cspell/dynamic-import": "8.8.1",
         "chalk": "^5.3.0",
         "chalk-template": "^1.1.0",
         "commander": "^12.0.0",
-        "cspell-gitignore": "8.8.0",
-        "cspell-glob": "8.8.0",
-        "cspell-io": "8.8.0",
-        "cspell-lib": "8.8.0",
+        "cspell-gitignore": "8.8.1",
+        "cspell-glob": "8.8.1",
+        "cspell-io": "8.8.1",
+        "cspell-lib": "8.8.1",
         "fast-glob": "^3.3.2",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^8.0.0",
         "get-stdin": "^9.0.0",
-        "semver": "^7.6.0",
+        "semver": "^7.6.1",
         "strip-ansi": "^7.1.0",
         "vscode-uri": "^3.0.8"
       },
@@ -7565,12 +7519,12 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.8.0.tgz",
-      "integrity": "sha512-Sz+bKXV9qpEVdi0e+MSUVMwbJ5Kin3m+6tyJp/Rk2rXKjBIXVmFBmnixv964rhr6c5GzbblV7GuMn94B2p7B3Q==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.8.1.tgz",
+      "integrity": "sha512-NTFfwL7Si1jp+0TINS9miXGdtPtDq95PhSbZKF9jnuBwnsnAURHCGALryLHlkRvj5JZk6dpkDfw4WxqQXdULNw==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-types": "8.8.0",
+        "@cspell/cspell-types": "8.8.1",
         "comment-json": "^4.2.3",
         "yaml": "^2.4.2"
       },
@@ -7579,14 +7533,14 @@
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.8.0.tgz",
-      "integrity": "sha512-Iloe3GBJV3sVkZG0j0rmxwuNxIcuOHy+eLhFfSHKiLK62FyOBL3T2Rm50h2Q6fCiLONu/3CNp0Z3BKbQ8cZxZg==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.8.1.tgz",
+      "integrity": "sha512-WJqCLR/icyZc0rphEO6dZZDlSIaWIXd95QjZu3agL7a1LRLjorqhVJty6WZrV4zkOLT6PPB+qcjMxcCCxIlWiw==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.8.0",
-        "@cspell/cspell-types": "8.8.0",
-        "cspell-trie-lib": "8.8.0",
+        "@cspell/cspell-pipe": "8.8.1",
+        "@cspell/cspell-types": "8.8.1",
+        "cspell-trie-lib": "8.8.1",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0"
       },
@@ -7595,12 +7549,12 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.8.0.tgz",
-      "integrity": "sha512-djM1Z0SnA1MehJHLiSRnfhY9sMPvJgQ9Gbnuub/l4VZeC0YDKIf+nAu+GPMQPtsL4QBvqj/oSy0GmUNWiMhbew==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.8.1.tgz",
+      "integrity": "sha512-j7wbz/VT/uZ+7oL8xwtxfA05FCv41ZrEKh1aNuMa4BI1xv/VRBmv6thOTz7aq7UcDYPNr8K5VVfBlXT/SvkEvA==",
       "dev": true,
       "dependencies": {
-        "cspell-glob": "8.8.0",
+        "cspell-glob": "8.8.1",
         "find-up-simple": "^1.0.0"
       },
       "bin": {
@@ -7611,9 +7565,9 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.8.0.tgz",
-      "integrity": "sha512-LAq4PrE92vvuKoIbZN6B6HqmNlSEw9yds6pkmugYYpd6vLMBvzMbtTGjIEq0o+KhfoJPOnfOxRssPoiezwvIhA==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.8.1.tgz",
+      "integrity": "sha512-x2rS6gJzaF3KZB6FuNkuS3Kb3ynYns0zfC0uG/QJb9V/xc0DmAjQGQhiLIDx6XmvvDvowKmyQ/kBjY/K4VjCvQ==",
       "dev": true,
       "dependencies": {
         "micromatch": "^4.0.5"
@@ -7623,13 +7577,13 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.8.0.tgz",
-      "integrity": "sha512-sB9IvSQ89Q5TgmAwXwXubs5U8dfZFvvaMT5LGKKW/XMGO4gVSBTAwRwGP2INZXdHHzFXUaVhEd+Tf4S3djoOdw==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.8.1.tgz",
+      "integrity": "sha512-YTyrutwIkiPH9t255l+BQtneGAkgE3uZXmnRHeIi6X+qdmnf61i8XYaSaO66VKQJX6VPZG18hBVMSUPZmYtoSw==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.8.0",
-        "@cspell/cspell-types": "8.8.0"
+        "@cspell/cspell-pipe": "8.8.1",
+        "@cspell/cspell-types": "8.8.1"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -7639,57 +7593,70 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.8.0.tgz",
-      "integrity": "sha512-98sPDQiwLTI3eNqGe6ksJv6ue5BJCMjM6CDF686Sxx2GlYe50saJK1XizM1yuhBcaHPZysSYHzbsLTMb7aSzWQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.8.1.tgz",
+      "integrity": "sha512-qwKEV2kfwT9gbq6EpYt6gcEs0oe0sDPG1YJunt8niuX4YoBe7/9ZHBfUyqNOEA+sBmvI/tjY/Wy6g9mmSRaOYA==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.8.0"
+        "@cspell/cspell-service-bus": "8.8.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.8.0.tgz",
-      "integrity": "sha512-P6WBilxNOXFWBgAFtTJn8VIBgBwn39v/TuA7d9uUWiRI/bhcMddEMCwVyjSZ3YYW/OmDEyN/c+R/4HjOw1Ny8A==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.8.1.tgz",
+      "integrity": "sha512-xntkgDGwDtUehM+fZudp4GbB87a2tY29G6ZqDF7WBcQsg3eyDVK/nc9KzbIfCvdWUCrsB9p+SGBoOmjYTwcocg==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.8.0",
-        "@cspell/cspell-pipe": "8.8.0",
-        "@cspell/cspell-resolver": "8.8.0",
-        "@cspell/cspell-types": "8.8.0",
-        "@cspell/dynamic-import": "8.8.0",
-        "@cspell/strong-weak-map": "8.8.0",
+        "@cspell/cspell-bundled-dicts": "8.8.1",
+        "@cspell/cspell-pipe": "8.8.1",
+        "@cspell/cspell-resolver": "8.8.1",
+        "@cspell/cspell-types": "8.8.1",
+        "@cspell/dynamic-import": "8.8.1",
+        "@cspell/strong-weak-map": "8.8.1",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.3",
-        "configstore": "^6.0.0",
-        "cspell-config-lib": "8.8.0",
-        "cspell-dictionary": "8.8.0",
-        "cspell-glob": "8.8.0",
-        "cspell-grammar": "8.8.0",
-        "cspell-io": "8.8.0",
-        "cspell-trie-lib": "8.8.0",
+        "cspell-config-lib": "8.8.1",
+        "cspell-dictionary": "8.8.1",
+        "cspell-glob": "8.8.1",
+        "cspell-grammar": "8.8.1",
+        "cspell-io": "8.8.1",
+        "cspell-trie-lib": "8.8.1",
+        "env-paths": "^3.0.0",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0",
         "import-fresh": "^3.3.0",
         "resolve-from": "^5.0.0",
         "vscode-languageserver-textdocument": "^1.0.11",
-        "vscode-uri": "^3.0.8"
+        "vscode-uri": "^3.0.8",
+        "xdg-basedir": "^5.1.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/cspell-lib/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cspell-trie-lib": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.8.0.tgz",
-      "integrity": "sha512-0UJp2Y5QMaBdapyIWtZ5DTH9BlM0tMcAYxOeqwmbnsdyfe2Ix8w9Ur3ZSQAAVnHEFhPJA83D0D1rMsKdYdQ4zQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.8.1.tgz",
+      "integrity": "sha512-S84XzQYGqKGApjVgamMp8tbHfKCeGZFxMwqedb4vxEJTYnUuCHaVPX2BK2SKaLSv/Vrd8mrJ/57sx5f8C44cFg==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.8.0",
-        "@cspell/cspell-types": "8.8.0",
+        "@cspell/cspell-pipe": "8.8.1",
+        "@cspell/cspell-types": "8.8.1",
         "gensequence": "^7.0.0"
       },
       "engines": {
@@ -15391,31 +15358,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "license": "ISC"
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -16635,21 +16586,6 @@
       "dev": true,
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/unique-string": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
-      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
-      "dev": true,
-      "dependencies": {
-        "crypto-random-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@typescript-eslint/eslint-plugin": "^7.8.0",
     "@typescript-eslint/parser": "^7.8.0",
     "commitlint": "^19.3.0",
-    "cspell": "^8.8.0",
+    "cspell": "^8.8.1",
     "eslint": "^8.56.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service-charge/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service-charge/index.ts
@@ -9,7 +9,7 @@ import { Application, RequestBody, ValidationErrors } from '../../../../../../ty
  * @param {RequestBody} formBody: Form body
  * @param {Application}
  * @param {Object} Validation errors
- * @returns {Boolean}
+ * @returns {Promise<Boolean>}
  */
 const exportContractAgentServiceCharge = async (formBody: RequestBody, application: Application, validationErrors?: ValidationErrors) => {
   try {

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service/index.test.ts
@@ -72,7 +72,11 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
       });
 
       it('should return true', async () => {
-        const result = await mapAndSave.exportContractAgentService(mapSubmittedData(mockFormBody.isCharging), mockApplication.noChargeData, mockValidationErrors);
+        const result = await mapAndSave.exportContractAgentService(
+          mapSubmittedData(mockFormBody.isCharging),
+          mockApplication.noChargeData,
+          mockValidationErrors,
+        );
 
         expect(result).toEqual(true);
       });

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service/index.test.ts
@@ -1,5 +1,6 @@
 import mapAndSave from '.';
 import FIELD_IDS from '../../../../../constants/field-ids/insurance/export-contract';
+import mapSubmittedData from '../../map-submitted-data/agent-service';
 import saveService from '../../save-data/export-contract-agent-service';
 import saveCharge from '../../save-data/export-contract-agent-service-charge';
 import nullifyAgentServiceChargeData from '../../../../../helpers/nullify-agent-service-charge-data';
@@ -59,7 +60,7 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
         expect(saveService.exportContractAgentService).toHaveBeenCalledTimes(1);
         expect(saveService.exportContractAgentService).toHaveBeenCalledWith(
           mockApplication.noChargeData,
-          mockFormBody.isCharging,
+          mapSubmittedData(mockFormBody.isCharging),
           mockValidationErrors?.errorList,
         );
       });
@@ -71,7 +72,7 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
       });
 
       it('should return true', async () => {
-        const result = await mapAndSave.exportContractAgentService(mockFormBody.isCharging, mockApplication.noChargeData, mockValidationErrors);
+        const result = await mapAndSave.exportContractAgentService(mapSubmittedData(mockFormBody.isCharging), mockApplication.noChargeData, mockValidationErrors);
 
         expect(result).toEqual(true);
       });
@@ -86,7 +87,7 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
         await mapAndSave.exportContractAgentService(mockFormBody.isCharging, mockApplication.noChargeData);
 
         expect(saveService.exportContractAgentService).toHaveBeenCalledTimes(1);
-        expect(saveService.exportContractAgentService).toHaveBeenCalledWith(mockApplication.noChargeData, mockFormBody.isCharging);
+        expect(saveService.exportContractAgentService).toHaveBeenCalledWith(mockApplication.noChargeData, mapSubmittedData(mockFormBody.isCharging));
       });
 
       it('should NOT call saveCharge.exportContractAgentServiceCharge with application and submitted data', async () => {
@@ -115,7 +116,7 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
         expect(saveService.exportContractAgentService).toHaveBeenCalledTimes(1);
         expect(saveService.exportContractAgentService).toHaveBeenCalledWith(
           mockApplication.withChargeData,
-          mockFormBody.isNotCharging,
+          mapSubmittedData(mockFormBody.isNotCharging),
           mockValidationErrors?.errorList,
         );
       });
@@ -143,7 +144,7 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
         await mapAndSave.exportContractAgentService(mockFormBody.isNotCharging, mockApplication.withChargeData);
 
         expect(saveService.exportContractAgentService).toHaveBeenCalledTimes(1);
-        expect(saveService.exportContractAgentService).toHaveBeenCalledWith(mockApplication.withChargeData, mockFormBody.isNotCharging);
+        expect(saveService.exportContractAgentService).toHaveBeenCalledWith(mockApplication.withChargeData, mapSubmittedData(mockFormBody.isNotCharging));
       });
 
       it('should call saveCharge.exportContractAgentServiceCharge with application and nullified agent charges data', async () => {

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service/index.ts
@@ -15,7 +15,7 @@ import { Application, RequestBody, ValidationErrors } from '../../../../../../ty
  * @param {RequestBody} formBody: Form body
  * @param {Application}
  * @param {Object} Validation errors
- * @returns {Boolean}
+ * @returns {Promise<Boolean>}
  */
 const exportContractAgentService = async (formBody: RequestBody, application: Application, validationErrors?: ValidationErrors) => {
   try {

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service/index.ts
@@ -8,7 +8,7 @@ import { Application, RequestBody, ValidationErrors } from '../../../../../../ty
 /**
  * mapAndSave
  * Map and save any valid "export contract agent service charge" fields.
- * If the form is submitted with the agent charging as false (IS_CHARGING),
+ * If the form is submitted with the "agent charging" as false (IS_CHARGING),
  * and AGENT_CHARGES data exists in the application,
  * Nullify all AGENT_CHARGES data.
  * @param {RequestBody} formBody: Form body

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service/index.ts
@@ -1,4 +1,5 @@
 import hasFormData from '../../../../../helpers/has-form-data';
+import mapSubmittedData from '../../map-submitted-data/agent-service';
 import saveService from '../../save-data/export-contract-agent-service';
 import shouldNullifyAgentServiceChargeData from '../../../../../helpers/should-nullify-agent-service-charge-data';
 import nullifyAgentServiceChargeData from '../../../../../helpers/nullify-agent-service-charge-data';
@@ -19,6 +20,8 @@ import { Application, RequestBody, ValidationErrors } from '../../../../../../ty
 const exportContractAgentService = async (formBody: RequestBody, application: Application, validationErrors?: ValidationErrors) => {
   try {
     if (hasFormData(formBody)) {
+      const populatedData = mapSubmittedData(formBody);
+
       let saveResponse;
 
       /**
@@ -26,9 +29,9 @@ const exportContractAgentService = async (formBody: RequestBody, application: Ap
        * Otherwise, simply save all data.
        */
       if (validationErrors) {
-        saveResponse = await saveService.exportContractAgentService(application, formBody, validationErrors.errorList);
+        saveResponse = await saveService.exportContractAgentService(application, populatedData, validationErrors.errorList);
       } else {
-        saveResponse = await saveService.exportContractAgentService(application, formBody);
+        saveResponse = await saveService.exportContractAgentService(application, populatedData);
       }
 
       if (!saveResponse) {
@@ -39,7 +42,7 @@ const exportContractAgentService = async (formBody: RequestBody, application: Ap
        * If AGENT_CHARGES data should be nullified,
        * Nullify and save the data.
        */
-      if (shouldNullifyAgentServiceChargeData(formBody, application.exportContract.agent.service.charge)) {
+      if (shouldNullifyAgentServiceChargeData(populatedData, application.exportContract.agent.service.charge)) {
         const nullifiedData = nullifyAgentServiceChargeData();
 
         saveResponse = await saveCharge.exportContractAgentServiceCharge(application, nullifiedData);

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent/index-no-agent-and-agent-service-data.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent/index-no-agent-and-agent-service-data.test.ts
@@ -1,11 +1,8 @@
 import mapAndSave from '.';
 import saveAgent from '../../save-data/export-contract-agent';
-import saveAgentService from '../../save-data/export-contract-agent-service';
-import saveAgentServiceCharge from '../../save-data/export-contract-agent-service-charge';
 import EXPORT_CONTRACT_FIELD_IDS from '../../../../../constants/field-ids/insurance/export-contract';
 import mapSubmittedData from '../../map-submitted-data/agent';
-import nullifyAgentServiceData from '../../../../../helpers/nullify-agent-service-data';
-import nullifyAgentServiceChargeData from '../../../../../helpers/nullify-agent-service-charge-data';
+import nullify from '../nullify-export-contract-agent-service';
 import generateValidationErrors from '../../../../../helpers/validation';
 import { mockApplication, mockSpyPromise } from '../../../../../test-mocks';
 
@@ -13,6 +10,7 @@ const { USING_AGENT } = EXPORT_CONTRACT_FIELD_IDS;
 
 describe('controllers/insurance/export-contract/map-and-save/export-contract-agent - with USING_AGENT=true and agent service data', () => {
   jest.mock('../../save-data/export-contract-agent');
+  jest.mock('../nullify-export-contract-agent-service');
 
   const mockCsrf = '1234';
 
@@ -24,19 +22,16 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
   const mockValidationErrors = generateValidationErrors(USING_AGENT, 'error', {});
 
   let mockSaveExportContractAgent;
-  let mockSaveExportContractAgentService;
-  let mockSaveExportContractAgentServiceCharge;
+  let mockNullifyExportContractAgentServiceAndCharge;
 
   const setupMocks = () => {
     jest.resetAllMocks();
 
     mockSaveExportContractAgent = mockSpyPromise();
-    mockSaveExportContractAgentService = mockSpyPromise();
-    mockSaveExportContractAgentServiceCharge = mockSpyPromise();
+    mockNullifyExportContractAgentServiceAndCharge = mockSpyPromise();
 
     saveAgent.exportContractAgent = mockSaveExportContractAgent;
-    saveAgentService.exportContractAgentService = mockSaveExportContractAgentService;
-    saveAgentServiceCharge.exportContractAgentServiceCharge = mockSaveExportContractAgentServiceCharge;
+    nullify.exportContractAgentServiceAndCharge = mockNullifyExportContractAgentServiceAndCharge;
   };
 
   describe('when the form has validation errors', () => {
@@ -51,18 +46,11 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
       expect(saveAgent.exportContractAgent).toHaveBeenCalledWith(mockApplication, mapSubmittedData(mockFormBody), mockValidationErrors?.errorList);
     });
 
-    it('should call saveAgentServiceCharge.exportContractAgentServiceCharge', async () => {
+    it('should call nullify.exportContractAgentServiceAndCharge', async () => {
       await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
 
-      expect(saveAgentServiceCharge.exportContractAgentServiceCharge).toHaveBeenCalledTimes(1);
-      expect(saveAgentServiceCharge.exportContractAgentServiceCharge).toHaveBeenCalledWith(mockApplication, nullifyAgentServiceChargeData());
-    });
-
-    it('should call saveAgentService.exportContractAgentService', async () => {
-      await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
-
-      expect(saveAgentService.exportContractAgentService).toHaveBeenCalledTimes(1);
-      expect(saveAgentService.exportContractAgentService).toHaveBeenCalledWith(mockApplication, nullifyAgentServiceData());
+      expect(nullify.exportContractAgentServiceAndCharge).toHaveBeenCalledTimes(1);
+      expect(nullify.exportContractAgentServiceAndCharge).toHaveBeenCalledWith(mockApplication);
     });
 
     it('should return true', async () => {
@@ -84,18 +72,11 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
       expect(saveAgent.exportContractAgent).toHaveBeenCalledWith(mockApplication, mapSubmittedData(mockFormBody));
     });
 
-    it('should call saveAgentServiceCharge.exportContractAgentServiceCharge', async () => {
+    it('should call nullify.exportContractAgentServiceAndCharge', async () => {
       await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
 
-      expect(saveAgentServiceCharge.exportContractAgentServiceCharge).toHaveBeenCalledTimes(1);
-      expect(saveAgentServiceCharge.exportContractAgentServiceCharge).toHaveBeenCalledWith(mockApplication, nullifyAgentServiceChargeData());
-    });
-
-    it('should call saveAgentService.exportContractAgentService', async () => {
-      await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
-
-      expect(saveAgentService.exportContractAgentService).toHaveBeenCalledTimes(1);
-      expect(saveAgentService.exportContractAgentService).toHaveBeenCalledWith(mockApplication, nullifyAgentServiceData());
+      expect(nullify.exportContractAgentServiceAndCharge).toHaveBeenCalledTimes(1);
+      expect(nullify.exportContractAgentServiceAndCharge).toHaveBeenCalledWith(mockApplication);
     });
 
     it('should return true', async () => {

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent/index-no-agent-and-agent-service-data.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent/index-no-agent-and-agent-service-data.test.ts
@@ -1,0 +1,107 @@
+import mapAndSave from '.';
+import saveAgent from '../../save-data/export-contract-agent';
+import saveAgentService from '../../save-data/export-contract-agent-service';
+import saveAgentServiceCharge from '../../save-data/export-contract-agent-service-charge';
+import EXPORT_CONTRACT_FIELD_IDS from '../../../../../constants/field-ids/insurance/export-contract';
+import mapSubmittedData from '../../map-submitted-data/agent';
+import nullifyAgentServiceData from '../../../../../helpers/nullify-agent-service-data';
+import nullifyAgentServiceChargeData from '../../../../../helpers/nullify-agent-service-charge-data';
+import generateValidationErrors from '../../../../../helpers/validation';
+import { mockApplication, mockSpyPromise } from '../../../../../test-mocks';
+
+const { USING_AGENT } = EXPORT_CONTRACT_FIELD_IDS;
+
+describe('controllers/insurance/export-contract/map-and-save/export-contract-agent - with USING_AGENT=true and agent service data', () => {
+  jest.mock('../../save-data/export-contract-agent');
+
+  const mockCsrf = '1234';
+
+  const mockFormBody = {
+    _csrf: mockCsrf,
+    [USING_AGENT]: 'false',
+  };
+
+  const mockValidationErrors = generateValidationErrors(USING_AGENT, 'error', {});
+
+  let mockSaveExportContractAgent;
+  let mockSaveExportContractAgentService;
+  let mockSaveExportContractAgentServiceCharge;
+
+  const setupMocks = () => {
+    jest.resetAllMocks();
+
+    mockSaveExportContractAgent = mockSpyPromise();
+    mockSaveExportContractAgentService = mockSpyPromise();
+    mockSaveExportContractAgentServiceCharge = mockSpyPromise();
+
+    saveAgent.exportContractAgent = mockSaveExportContractAgent;
+    saveAgentService.exportContractAgentService = mockSaveExportContractAgentService;
+    saveAgentServiceCharge.exportContractAgentServiceCharge = mockSaveExportContractAgentServiceCharge;
+  };
+
+  describe('when the form has validation errors', () => {
+    beforeEach(() => {
+      setupMocks();
+    });
+
+    it('should call saveAgent.exportContractAgent', async () => {
+      await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
+
+      expect(saveAgent.exportContractAgent).toHaveBeenCalledTimes(1);
+      expect(saveAgent.exportContractAgent).toHaveBeenCalledWith(mockApplication, mapSubmittedData(mockFormBody), mockValidationErrors?.errorList);
+    });
+
+    it('should call saveAgentServiceCharge.exportContractAgentServiceCharge', async () => {
+      await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
+
+      expect(saveAgentServiceCharge.exportContractAgentServiceCharge).toHaveBeenCalledTimes(1);
+      expect(saveAgentServiceCharge.exportContractAgentServiceCharge).toHaveBeenCalledWith(mockApplication, nullifyAgentServiceChargeData());
+    });
+
+    it('should call saveAgentService.exportContractAgentService', async () => {
+      await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
+
+      expect(saveAgentService.exportContractAgentService).toHaveBeenCalledTimes(1);
+      expect(saveAgentService.exportContractAgentService).toHaveBeenCalledWith(mockApplication, nullifyAgentServiceData());
+    });
+
+    it('should return true', async () => {
+      const result = await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
+
+      expect(result).toEqual(true);
+    });
+  });
+
+  describe('when the form does NOT have validation errors', () => {
+    beforeEach(() => {
+      setupMocks();
+    });
+
+    it('should call saveAgent.exportContractAgent', async () => {
+      await mapAndSave.exportContractAgent(mockFormBody, mockApplication);
+
+      expect(saveAgent.exportContractAgent).toHaveBeenCalledTimes(1);
+      expect(saveAgent.exportContractAgent).toHaveBeenCalledWith(mockApplication, mapSubmittedData(mockFormBody));
+    });
+
+    it('should call saveAgentServiceCharge.exportContractAgentServiceCharge', async () => {
+      await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
+
+      expect(saveAgentServiceCharge.exportContractAgentServiceCharge).toHaveBeenCalledTimes(1);
+      expect(saveAgentServiceCharge.exportContractAgentServiceCharge).toHaveBeenCalledWith(mockApplication, nullifyAgentServiceChargeData());
+    });
+
+    it('should call saveAgentService.exportContractAgentService', async () => {
+      await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
+
+      expect(saveAgentService.exportContractAgentService).toHaveBeenCalledTimes(1);
+      expect(saveAgentService.exportContractAgentService).toHaveBeenCalledWith(mockApplication, nullifyAgentServiceData());
+    });
+
+    it('should return true', async () => {
+      const result = await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
+
+      expect(result).toEqual(true);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent/index.api-error.test.ts
@@ -1,18 +1,23 @@
 import mapAndSave from '.';
-import save from '../../save-data/export-contract-agent';
+import saveAgent from '../../save-data/export-contract-agent';
+import saveAgentService from '../../save-data/export-contract-agent-service';
+import saveAgentServiceCharge from '../../save-data/export-contract-agent-service-charge';
+import EXPORT_CONTRACT_FIELD_IDS from '../../../../../constants/field-ids/insurance/export-contract';
 import { mockApplication } from '../../../../../test-mocks';
+
+const { USING_AGENT } = EXPORT_CONTRACT_FIELD_IDS;
 
 describe('controllers/insurance/export-contract/map-and-save/export-contract-agent - api errors', () => {
   jest.mock('../../save-data/export-contract-agent');
 
   const mockFormBody = {
     _csrf: '1234',
-    mock: true,
+    [USING_AGENT]: 'false',
   };
 
-  describe('when save application exportContractAgent call does not return anything', () => {
+  describe('when saveAgent.exportContractAgent call does not return anything', () => {
     beforeEach(() => {
-      save.exportContractAgent = jest.fn(() => Promise.resolve());
+      saveAgent.exportContractAgent = jest.fn(() => Promise.resolve());
     });
 
     it('should return false', async () => {
@@ -22,9 +27,57 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
     });
   });
 
-  describe('when save application exportContractAgent call fails', () => {
+  describe('when saveAgent.exportContractAgent call fails', () => {
     beforeEach(() => {
-      save.exportContractAgent = jest.fn(() => Promise.reject(new Error('mock')));
+      saveAgent.exportContractAgent = jest.fn(() => Promise.reject(new Error('mock')));
+    });
+
+    it('should return false', async () => {
+      const result = await mapAndSave.exportContractAgent(mockFormBody, mockApplication);
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('when save saveAgentServiceCharge.exportContractAgentServiceCharge call does not return anything', () => {
+    beforeEach(() => {
+      saveAgentServiceCharge.exportContractAgentServiceCharge = jest.fn(() => Promise.resolve());
+    });
+
+    it('should return false', async () => {
+      const result = await mapAndSave.exportContractAgent(mockFormBody, mockApplication);
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('when save saveAgentServiceCharge.exportContractAgentServiceCharge call fails', () => {
+    beforeEach(() => {
+      saveAgentServiceCharge.exportContractAgentServiceCharge = jest.fn(() => Promise.reject(new Error('mock')));
+    });
+
+    it('should return false', async () => {
+      const result = await mapAndSave.exportContractAgent(mockFormBody, mockApplication);
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('when save saveAgentService.exportContractAgentService call does not return anything', () => {
+    beforeEach(() => {
+      saveAgentService.exportContractAgentService = jest.fn(() => Promise.resolve());
+    });
+
+    it('should return false', async () => {
+      const result = await mapAndSave.exportContractAgent(mockFormBody, mockApplication);
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('when save saveAgentService.exportContractAgentService call fails', () => {
+    beforeEach(() => {
+      saveAgentService.exportContractAgentService = jest.fn(() => Promise.reject(new Error('mock')));
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent/index.test.ts
@@ -1,53 +1,63 @@
 import mapAndSave from '.';
-import save from '../../save-data/export-contract-agent';
+import saveAgent from '../../save-data/export-contract-agent';
 import EXPORT_CONTRACT_FIELD_IDS from '../../../../../constants/field-ids/insurance/export-contract';
 import mapSubmittedData from '../../map-submitted-data/agent';
 import generateValidationErrors from '../../../../../helpers/validation';
-import { mockApplication, mockSpyPromise } from '../../../../../test-mocks';
+import { mockApplicationAgentServiceEmpty, mockSpyPromise } from '../../../../../test-mocks';
 
 const { USING_AGENT } = EXPORT_CONTRACT_FIELD_IDS;
 
 describe('controllers/insurance/export-contract/map-and-save/export-contract-agent', () => {
   jest.mock('../../save-data/export-contract-agent');
+  jest.mock('../../save-data/export-contract-agent-service');
+  jest.mock('../../save-data/export-contract-agent-service-charge');
 
-  let mockFormBody = {
-    _csrf: '1234',
-    [USING_AGENT]: mockApplication.exportContract.agent[USING_AGENT],
+  const mockCsrf = '1234';
+
+  const mockFormBody = {
+    _csrf: mockCsrf,
+    [USING_AGENT]: 'true',
   };
 
-  const mockSaveExportContract = mockSpyPromise();
-  save.exportContractAgent = mockSaveExportContract;
+  const mockApplication = {
+    withAgentEmptyData: mockApplicationAgentServiceEmpty,
+  };
 
-  const populatedData = mapSubmittedData(mockFormBody);
+  const mockSaveExportContractAgent = mockSpyPromise();
+  saveAgent.exportContractAgent = mockSaveExportContractAgent;
 
   const mockValidationErrors = generateValidationErrors(USING_AGENT, 'error', {});
 
-  describe('when the form has data', () => {
+  describe('when the form has data, USING_AGENT=true, no agent service data', () => {
     describe('when the form has validation errors', () => {
-      it('should call save.exportContractAgent with application, populated submitted data and validationErrors.errorList', async () => {
-        await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
+      it('should call saveAgent.exportContractAgent', async () => {
+        await mapAndSave.exportContractAgent(mockFormBody, mockApplication.withAgentEmptyData, mockValidationErrors);
 
-        expect(save.exportContractAgent).toHaveBeenCalledTimes(1);
-        expect(save.exportContractAgent).toHaveBeenCalledWith(mockApplication, populatedData, mockValidationErrors?.errorList);
+        expect(saveAgent.exportContractAgent).toHaveBeenCalledTimes(1);
+        expect(saveAgent.exportContractAgent).toHaveBeenCalledWith(
+          mockApplication.withAgentEmptyData,
+          mapSubmittedData(mockFormBody),
+          mockValidationErrors?.errorList,
+        );
       });
 
       it('should return true', async () => {
-        const result = await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
+        const result = await mapAndSave.exportContractAgent(mockFormBody, mockApplication.withAgentEmptyData, mockValidationErrors);
 
         expect(result).toEqual(true);
       });
     });
 
     describe('when the form does NOT have validation errors', () => {
-      it('should call save.exportContractAgent with application and populated submitted data', async () => {
-        await mapAndSave.exportContractAgent(mockFormBody, mockApplication);
+      it('should call saveAgent.exportContractAgent', async () => {
+        await mapAndSave.exportContractAgent(mockFormBody, mockApplication.withAgentEmptyData);
 
-        expect(save.exportContractAgent).toHaveBeenCalledTimes(1);
-        expect(save.exportContractAgent).toHaveBeenCalledWith(mockApplication, populatedData);
+        expect(saveAgent.exportContractAgent).toHaveBeenCalledTimes(1);
+        expect(saveAgent.exportContractAgent).toHaveBeenCalledWith(mockApplication.withAgentEmptyData, mapSubmittedData(mockFormBody));
       });
 
       it('should return true', async () => {
-        const result = await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
+        const result = await mapAndSave.exportContractAgent(mockFormBody, mockApplication.withAgentEmptyData, mockValidationErrors);
 
         expect(result).toEqual(true);
       });
@@ -56,9 +66,9 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
 
   describe('when the form does not have any data', () => {
     it('should return true', async () => {
-      mockFormBody = { _csrf: '1234' };
+      const emptyMockFormBody = { _csrf: '1234' };
 
-      const result = await mapAndSave.exportContractAgent(mockFormBody, mockApplication, mockValidationErrors);
+      const result = await mapAndSave.exportContractAgent(emptyMockFormBody, mockApplication.withAgentEmptyData, mockValidationErrors);
 
       expect(result).toEqual(true);
     });

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent/index.ts
@@ -1,11 +1,8 @@
 import hasFormData from '../../../../../helpers/has-form-data';
 import mapSubmittedData from '../../map-submitted-data/agent';
 import saveAgent from '../../save-data/export-contract-agent';
-import saveAgentService from '../../save-data/export-contract-agent-service';
-import saveAgentServiceCharge from '../../save-data/export-contract-agent-service-charge';
 import shouldNullifyAgentServiceData from '../../../../../helpers/should-nullify-agent-service-data';
-import nullifyAgentServiceData from '../../../../../helpers/nullify-agent-service-data';
-import nullifyAgentServiceChargeData from '../../../../../helpers/nullify-agent-service-charge-data';
+import nullify from '../nullify-export-contract-agent-service';
 import { Application, RequestBody, ValidationErrors } from '../../../../../../types';
 
 /**
@@ -16,7 +13,7 @@ import { Application, RequestBody, ValidationErrors } from '../../../../../../ty
  * @param {RequestBody} formBody: Form body
  * @param {Application}
  * @param {Object} Validation errors
- * @returns {Boolean}
+ * @returns {Promise<Boolean>}
  */
 const exportContractAgent = async (formBody: RequestBody, application: Application, validationErrors?: ValidationErrors) => {
   try {
@@ -42,26 +39,7 @@ const exportContractAgent = async (formBody: RequestBody, application: Applicati
        * Nullify and save all AGENT_CHARGES and AGENT_SERVICE data.
        */
       if (shouldNullifyAgentServiceData(isUsingAgent, application.exportContract.agent)) {
-        const nullified = {
-          service: nullifyAgentServiceData(),
-          serviceCharge: nullifyAgentServiceChargeData(),
-        };
-
-        console.info('Mapping and saving application - export contract agent - nullifying agent service charge data');
-
-        saveResponse = await saveAgentServiceCharge.exportContractAgentServiceCharge(application, nullified.serviceCharge);
-
-        if (!saveResponse) {
-          return false;
-        }
-
-        console.info('Mapping and saving application - export contract agent - nullifying agent service data');
-
-        saveResponse = await saveAgentService.exportContractAgentService(application, nullified.service);
-
-        if (!saveResponse) {
-          return false;
-        }
+        await nullify.exportContractAgentServiceAndCharge(application);
       }
 
       return true;

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract/index.ts
@@ -9,7 +9,7 @@ import { Application, Country, RequestBody, ValidationErrors } from '../../../..
  * @param {RequestBody} formBody: Form body
  * @param {Application}
  * @param {Object} Validation errors
- * @returns {Boolean}
+ * @returns {Promise<Boolean>}
  */
 const exportContract = async (formBody: RequestBody, application: Application, validationErrors?: ValidationErrors, countries?: Array<Country>) => {
   try {

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/nullify-export-contract-agent-service/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/nullify-export-contract-agent-service/index.test.ts
@@ -1,0 +1,79 @@
+import nullify from '.';
+import saveAgentService from '../../save-data/export-contract-agent-service';
+import saveAgentServiceCharge from '../../save-data/export-contract-agent-service-charge';
+import nullifyAgentServiceData from '../../../../../helpers/nullify-agent-service-data';
+import nullifyAgentServiceChargeData from '../../../../../helpers/nullify-agent-service-charge-data';
+import { mockApplication, mockSpyPromise } from '../../../../../test-mocks';
+
+describe('controllers/insurance/export-contract/map-and-save/export-contract-agent', () => {
+  jest.mock('../../save-data/export-contract-agent-service');
+  jest.mock('../../save-data/export-contract-agent-service-charge');
+
+  const mockSaveExportContractAgentService = mockSpyPromise();
+  const mockSaveExportContractAgentServiceCharge = mockSpyPromise();
+
+  saveAgentService.exportContractAgentService = mockSaveExportContractAgentService;
+  saveAgentServiceCharge.exportContractAgentServiceCharge = mockSaveExportContractAgentServiceCharge;
+
+  it('should call saveAgentServiceCharge.exportContractAgentServiceCharge', async () => {
+    await nullify.exportContractAgentServiceAndCharge(mockApplication);
+
+    expect(saveAgentServiceCharge.exportContractAgentServiceCharge).toHaveBeenCalledTimes(1);
+    expect(saveAgentServiceCharge.exportContractAgentServiceCharge).toHaveBeenCalledWith(mockApplication, nullifyAgentServiceChargeData());
+  });
+
+  it('should call saveAgentService.exportContractAgentService', async () => {
+    await nullify.exportContractAgentServiceAndCharge(mockApplication);
+
+    expect(saveAgentService.exportContractAgentService).toHaveBeenCalledTimes(1);
+    expect(saveAgentService.exportContractAgentService).toHaveBeenCalledWith(mockApplication, nullifyAgentServiceData());
+  });
+
+  describe('when save saveAgentServiceCharge.exportContractAgentServiceCharge call does not return anything', () => {
+    beforeEach(() => {
+      saveAgentServiceCharge.exportContractAgentServiceCharge = jest.fn(() => Promise.resolve());
+    });
+
+    it('should return false', async () => {
+      const result = await nullify.exportContractAgentServiceAndCharge(mockApplication);
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('when save saveAgentServiceCharge.exportContractAgentServiceCharge call fails', () => {
+    beforeEach(() => {
+      saveAgentServiceCharge.exportContractAgentServiceCharge = jest.fn(() => Promise.reject(new Error('mock')));
+    });
+
+    it('should return false', async () => {
+      const result = await nullify.exportContractAgentServiceAndCharge(mockApplication);
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('when save saveAgentService.exportContractAgentService call does not return anything', () => {
+    beforeEach(() => {
+      saveAgentService.exportContractAgentService = jest.fn(() => Promise.resolve());
+    });
+
+    it('should return false', async () => {
+      const result = await nullify.exportContractAgentServiceAndCharge(mockApplication);
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('when save saveAgentService.exportContractAgentService call fails', () => {
+    beforeEach(() => {
+      saveAgentService.exportContractAgentService = jest.fn(() => Promise.reject(new Error('mock')));
+    });
+
+    it('should return false', async () => {
+      const result = await nullify.exportContractAgentServiceAndCharge(mockApplication);
+
+      expect(result).toEqual(false);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/nullify-export-contract-agent-service/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/nullify-export-contract-agent-service/index.ts
@@ -7,7 +7,7 @@ import { Application } from '../../../../../../types';
 /**
  * exportContractAgentServiceAndCharge
  * Nullify Export contract "agent service" and "agent service charge" data.
- * @param {Application} application 
+ * @param {Application} application
  * @returns {Promise<boolean>}
  */
 const exportContractAgentServiceAndCharge = async (application: Application) => {

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/nullify-export-contract-agent-service/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/nullify-export-contract-agent-service/index.ts
@@ -1,0 +1,46 @@
+import nullifyAgentServiceData from '../../../../../helpers/nullify-agent-service-data';
+import nullifyAgentServiceChargeData from '../../../../../helpers/nullify-agent-service-charge-data';
+import saveAgentService from '../../save-data/export-contract-agent-service';
+import saveAgentServiceCharge from '../../save-data/export-contract-agent-service-charge';
+import { Application } from '../../../../../../types';
+
+/**
+ * exportContractAgentServiceAndCharge
+ * Nullify Export contract "agent service" and "agent service charge" data.
+ * @param {Application} application 
+ * @returns {Promise<boolean>}
+ */
+const exportContractAgentServiceAndCharge = async (application: Application) => {
+  try {
+    console.info('Mapping and saving application - export contract agent - nullifying agent service and charge data');
+
+    const nullified = {
+      service: nullifyAgentServiceData(),
+      serviceCharge: nullifyAgentServiceChargeData(),
+    };
+
+    console.info('Mapping and saving application - export contract agent - nullifying agent service charge data');
+
+    let saveResponse = await saveAgentServiceCharge.exportContractAgentServiceCharge(application, nullified.serviceCharge);
+
+    if (!saveResponse) {
+      return false;
+    }
+
+    console.info('Mapping and saving application - export contract agent - nullifying agent service data');
+
+    saveResponse = await saveAgentService.exportContractAgentService(application, nullified.service);
+
+    if (!saveResponse) {
+      return false;
+    }
+  } catch (err) {
+    console.error('Error mapping and saving application - export contract agent - nullifying agent service and charge data %O', err);
+
+    return false;
+  }
+};
+
+export default {
+  exportContractAgentServiceAndCharge,
+};

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/private-market/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/private-market/index.ts
@@ -9,7 +9,7 @@ import { Application, RequestBody, ValidationErrors } from '../../../../../../ty
  * @param {RequestBody} formBody: Form body
  * @param {Application}
  * @param {Object} Validation errors
- * @returns {Boolean}
+ * @returns {Promise<Boolean>}
  */
 const privateMarket = async (formBody: RequestBody, application: Application, validationErrors?: ValidationErrors) => {
   try {

--- a/src/ui/server/controllers/insurance/export-contract/map-submitted-data/agent-service/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-submitted-data/agent-service/index.test.ts
@@ -1,0 +1,41 @@
+import mapSubmittedData from '.';
+import FIELD_IDS from '../../../../../constants/field-ids/insurance';
+
+const {
+  EXPORT_CONTRACT: {
+    AGENT_SERVICE: { IS_CHARGING },
+  },
+} = FIELD_IDS;
+
+describe('controllers/insurance/export-contract/map-submitted-data/agent-service', () => {
+  describe(`when ${IS_CHARGING} is an empty string`, () => {
+    it('should return the form body with mapped data', () => {
+      const mockFormBody = {
+        mock: true,
+        [IS_CHARGING]: '',
+      };
+
+      const result = mapSubmittedData(mockFormBody);
+
+      const expected = {
+        ...mockFormBody,
+        [IS_CHARGING]: null,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when ${IS_CHARGING} is NOT an empty string`, () => {
+    it('should return the form body as is', () => {
+      const mockFormBody = {
+        mock: true,
+        [IS_CHARGING]: false,
+      };
+
+      const result = mapSubmittedData(mockFormBody);
+
+      expect(result).toEqual(mockFormBody);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/export-contract/map-submitted-data/agent-service/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-submitted-data/agent-service/index.ts
@@ -1,0 +1,27 @@
+import FIELD_IDS from '../../../../../constants/field-ids/insurance';
+import { isEmptyString } from '../../../../../helpers/string';
+import { RequestBody } from '../../../../../../types';
+
+const {
+  EXPORT_CONTRACT: {
+    AGENT_SERVICE: { IS_CHARGING },
+  },
+} = FIELD_IDS;
+
+/**
+ * mapSubmittedData
+ * Map agent service fields.
+ * @param {RequestBody} formBody: Form body
+ * @returns {Object} populatedData
+ */
+const mapSubmittedData = (formBody: RequestBody): object => {
+  const populatedData = formBody;
+
+  if (isEmptyString(formBody[IS_CHARGING])) {
+    populatedData[IS_CHARGING] = null;
+  }
+
+  return populatedData;
+};
+
+export default mapSubmittedData;

--- a/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent-service/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent-service/index.test.ts
@@ -33,7 +33,7 @@ describe('controllers/insurance/export-contract/save-data/export-contract-agent-
   describe('when errorList is provided', () => {
     const mockErrorList = generateValidationErrors(mockFormBody.invalid)?.errorList;
 
-    it('should call api.keystone.application.update.exportContractAgentService with exportContract.agent.service ID and stripped and sanitised data', async () => {
+    it('should call api.keystone.application.update.exportContractAgentService with exportContract.agent.service ID and sanitised data', async () => {
       await save.exportContractAgentService(mockApplication, mockFormBody.invalid, mockErrorList);
 
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);

--- a/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent-service/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent-service/index.ts
@@ -1,6 +1,5 @@
 import api from '../../../../../api';
 import getDataToSave from '../../../../../helpers/get-data-to-save';
-import stripEmptyFormFields from '../../../../../helpers/strip-empty-form-fields';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import { Application, RequestBody } from '../../../../../../types';
 
@@ -14,7 +13,7 @@ import { Application, RequestBody } from '../../../../../../types';
  * @returns {Promise<Object>} Saved data
  */
 const exportContractAgentService = async (application: Application, formBody: RequestBody, errorList?: object) => {
-  const dataToSave = stripEmptyFormFields(getDataToSave(formBody, errorList));
+  const dataToSave = getDataToSave(formBody, errorList);
 
   const sanitisedData = sanitiseData(dataToSave);
 

--- a/src/ui/server/controllers/insurance/policy/map-and-save/loss-payee/index.ts
+++ b/src/ui/server/controllers/insurance/policy/map-and-save/loss-payee/index.ts
@@ -11,7 +11,10 @@ import { Application, RequestBody, ValidationErrors } from '../../../../../../ty
 
 /**
  * mapAndSave nominatedLossPayee
- * Map and save any valid nominatedLossPayee fields
+ * Map and save any valid "nominated loss payee" fields.
+ * If the form is submitted with the "is appointed" as false (IS_APPOINTED),
+ * and if LOSS_PAYEE_FINANCIAL_UK data exists in the application, nullify all LOSS_PAYEE_FINANCIAL_UK data.
+ * and if LOSS_PAYEE_FINANCIAL_INTERNATIONAL data exists in the application, nullify all LOSS_PAYEE_FINANCIAL_INTERNATIONAL data.
  * @param {RequestBody} formBody: Form body
  * @param {Application}
  * @param {Object} Validation errors

--- a/src/ui/server/helpers/nullify-agent-service-data/index.test.ts
+++ b/src/ui/server/helpers/nullify-agent-service-data/index.test.ts
@@ -1,0 +1,19 @@
+import nullifyAgentServiceData from '.';
+import FIELD_IDS from '../../constants/field-ids/insurance/export-contract';
+
+const {
+  AGENT_SERVICE: { IS_CHARGING, SERVICE_DESCRIPTION },
+} = FIELD_IDS;
+
+describe('server/helpers/nullify-agent-service-data', () => {
+  it('should return an object with nullified values', () => {
+    const result = nullifyAgentServiceData();
+
+    const expected = {
+      [IS_CHARGING]: null,
+      [SERVICE_DESCRIPTION]: '',
+    };
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/ui/server/helpers/nullify-agent-service-data/index.ts
+++ b/src/ui/server/helpers/nullify-agent-service-data/index.ts
@@ -1,0 +1,17 @@
+import FIELD_IDS from '../../constants/field-ids/insurance/export-contract';
+
+const {
+  AGENT_SERVICE: { IS_CHARGING, SERVICE_DESCRIPTION },
+} = FIELD_IDS;
+
+/**
+ * nullifyAgentServiceData
+ * Create an object with null AGENT_SERVICE fields.
+ * @returns {ApplicationExportContractAgentService}
+ */
+const nullifyAgentServiceData = () => ({
+  [IS_CHARGING]: null,
+  [SERVICE_DESCRIPTION]: '',
+});
+
+export default nullifyAgentServiceData;

--- a/src/ui/server/helpers/should-nullify-agent-service-charge-data/index.ts
+++ b/src/ui/server/helpers/should-nullify-agent-service-charge-data/index.ts
@@ -9,7 +9,7 @@ const {
 /**
  * shouldNullifyAgentServiceChargeData
  * Check if we should nullify agent service charge data.
- * If IS_CHARGING is true and the application has some charge data, the charge data should be nullified.
+ * If IS_CHARGING is false and the application has some charge data, the charge data should be nullified.
  * @param {RequestBody} formBody: Form body
  * @param {ApplicationExportContractAgentServiceCharge} chargeData: Agent service charge data
  * @returns {Boolean}

--- a/src/ui/server/helpers/should-nullify-agent-service-data/index.test.ts
+++ b/src/ui/server/helpers/should-nullify-agent-service-data/index.test.ts
@@ -1,0 +1,36 @@
+import shouldNullifyAgentServiceChargeData from '.';
+import FIELD_IDS from '../../constants/field-ids/insurance/export-contract';
+import { mockExportContractAgent, mockExportContractAgentIsNotUsing } from '../../test-mocks';
+
+const { USING_AGENT } = FIELD_IDS;
+
+const mockFormBody = {
+  isUsingAgent: 'true',
+  isNotUsingAgent: 'false',
+};
+
+describe('server/helpers/should-nullify-agent-service-data', () => {
+  describe(`when ${USING_AGENT} has a value of 'false' and the application has service data`, () => {
+    it('should return true', () => {
+      const result = shouldNullifyAgentServiceChargeData(mockFormBody.isNotUsingAgent, mockExportContractAgent);
+
+      expect(result).toEqual(true);
+    });
+  });
+
+  describe(`when ${USING_AGENT} has a value of 'false', but the application has no service data`, () => {
+    it('should return false', () => {
+      const result = shouldNullifyAgentServiceChargeData(mockFormBody.isNotUsingAgent, mockExportContractAgentIsNotUsing);
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe(`when ${USING_AGENT} has a value of 'true' and the application has service data`, () => {
+    it('should return false', () => {
+      const result = shouldNullifyAgentServiceChargeData(mockFormBody.isUsingAgent, mockExportContractAgent);
+
+      expect(result).toEqual(false);
+    });
+  });
+});

--- a/src/ui/server/helpers/should-nullify-agent-service-data/index.ts
+++ b/src/ui/server/helpers/should-nullify-agent-service-data/index.ts
@@ -1,0 +1,26 @@
+import { objectHasKeysAndValues } from '../object';
+import { ApplicationExportContractAgent } from '../../../types';
+
+/**
+ * shouldNullifyAgentServiceData
+ * Check if we should nullify agent service data.
+ * If USING_AGENT is false and the application has some agent service data, the agent service data should be nullified.
+ * @param {String} isUsingAgent: Is using agent form field
+ * @param {ApplicationExportContractAgent} agent: Agent data
+ * @returns {Boolean}
+ */
+const shouldNullifyAgentServiceData = (isUsingAgent: string, agent: ApplicationExportContractAgent) => {
+  const {
+    service: { id, charge, ...otherFields },
+  } = agent;
+
+  const hasAgentServiceData = objectHasKeysAndValues(otherFields);
+
+  if (isUsingAgent === 'false' && hasAgentServiceData) {
+    return true;
+  }
+
+  return false;
+};
+
+export default shouldNullifyAgentServiceData;

--- a/src/ui/server/helpers/should-nullify-loss-payee-financial-uk-data/index.ts
+++ b/src/ui/server/helpers/should-nullify-loss-payee-financial-uk-data/index.ts
@@ -9,7 +9,7 @@ const {
 /**
  * shouldNullifyLossPayeeFinancialUkData
  * Check if we should nullify loss payee financial UK data.
- * If IS_APPOINTED is true
+ * If IS_APPOINTED is false
  * Or the location is IS_LOCATED_INTERNATIONALLY
  * and the application has some financial UK data,
  * the UK data should be nullified.

--- a/src/ui/server/test-mocks/index.ts
+++ b/src/ui/server/test-mocks/index.ts
@@ -10,7 +10,11 @@ import mockCurrencies, { EUR, HKD, JPY, GBP, USD, mockCurrenciesResponse, mockCu
 import mockCompaniesHouseResponse from './mock-companies-house-response';
 import mockCompany from './mock-company';
 import mockApplication, {
+  mockExportContractAgent,
+  mockExportContractAgentIsNotUsing,
+  mockExportContractAgentIsUsing,
   mockApplicationAgentServiceChargeEmpty,
+  mockApplicationAgentServiceEmpty,
   mockApplicationMultiplePolicy,
   mockApplicationNominatedLossPayeeAppointedEmptyData,
   mockApplicationNominatedLossPayeeNotAppointedFullFinancialInternationalData,
@@ -123,7 +127,11 @@ export {
   mockAccount,
   mockAnswers,
   mockApplication,
+  mockExportContractAgent,
+  mockExportContractAgentIsNotUsing,
+  mockExportContractAgentIsUsing,
   mockApplicationAgentServiceChargeEmpty,
+  mockApplicationAgentServiceEmpty,
   mockApplicationMultiplePolicy,
   mockApplicationNominatedLossPayeeAppointedEmptyData,
   mockApplicationNominatedLossPayeeNotAppointedFullFinancialInternationalData,

--- a/src/ui/server/test-mocks/mock-application.ts
+++ b/src/ui/server/test-mocks/mock-application.ts
@@ -58,7 +58,7 @@ export const mockExportContractAgentServiceCharge = {
 export const mockExportContractAgentService = {
   id: 'clldfm6pt000noqa6fs6cj5xl',
   agentIsCharging: true,
-  serviceDescription: 'Mock export contract agent service decsription',
+  serviceDescription: 'Mock export contract agent service description',
   charge: mockExportContractAgentServiceCharge,
 };
 
@@ -69,6 +69,22 @@ export const mockExportContractAgent = {
   isUsingAgent: false,
   name: 'Mock export contract agent name',
   service: mockExportContractAgentService,
+};
+
+export const mockExportContractAgentIsUsing = {
+  ...mockExportContractAgent,
+  isUsingAgent: true,
+};
+
+export const mockExportContractAgentIsNotUsing = {
+  id: mockExportContractAgent.id,
+  service: {
+    id: mockExportContractAgent.service.id,
+    charge: {
+      id: mockExportContractAgent.service.charge.id,
+    },
+  },
+  isUsingAgent: false,
 };
 
 export const mockExportContract = {
@@ -209,6 +225,14 @@ export const mockApplicationAgentServiceChargeEmpty = {
         },
       },
     },
+  },
+} as Application;
+
+export const mockApplicationAgentServiceEmpty = {
+  ...mockApplication,
+  exportContract: {
+    ...mockExportContract,
+    agent: mockExportContractAgentIsNotUsing,
   },
 } as Application;
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where, when changing the "Using agent" question from "yes" to "no", some agent data would not be deleted.

## Resolution :heavy_check_mark:
- Create new cypress commands to assert empty agent field values:
   - `assertEmptyAgentChargesFieldValues`
   - `assertEmptyAgentDetailsFieldValues`
   - `assertEmptyAgentServiceFieldValues`
- Update E2E tests to go through all agent forms (after changing from "yes" to "no") and run the above commands.
- Update `mapAndSave.exportContractAgent` to conditionally nullify agent service and agent charges data.
- Update `save.exportContractAgentService` to _not_ strip empty form fields.
- Create `nullifyAgentServiceData` helper function.
- Create `shouldNullifyAgentServiceData` helper function.

## Miscellaneous :heavy_plus_sign:
- Bump `cspell` dependency.
- Fix some typos.
