### PR TITLE
feat(EMS-3285-3286): No PDF - Change your answers - Policy - Loss payee

### DIFF
--- a/e2e-tests/fixtures/account-numbers.js
+++ b/e2e-tests/fixtures/account-numbers.js
@@ -1,0 +1,2 @@
+export const mockAccountNumber0 = '12345678';
+export const mockAccountNumber1 = '91011121';

--- a/e2e-tests/fixtures/addresses.js
+++ b/e2e-tests/fixtures/addresses.js
@@ -1,0 +1,4 @@
+import { MULTI_LINE_STRING } from '../constants';
+
+export const mockAddress0 = MULTI_LINE_STRING;
+export const mockAddress1 = 'Mock new address';

--- a/e2e-tests/fixtures/application.js
+++ b/e2e-tests/fixtures/application.js
@@ -3,14 +3,18 @@ import {
   COVER_PERIOD as COVER_PERIOD_CONSTANTS,
   FIELD_IDS,
   FIELD_VALUES,
-  MULTI_LINE_STRING,
   TOTAL_CONTRACT_VALUE as TOTAL_CONTRACT_VALUE_CONSTANTS,
   WEBSITE_EXAMPLES,
 } from '../constants';
 import { COMPANIES_HOUSE_NUMBER } from '../constants/examples';
+import { mockAccountNumber0 } from './account-numbers';
 import { GBP_CURRENCY_CODE } from './currencies';
 import { COUNTRY_APPLICATION_SUPPORT } from './countries';
+import { mockAddress0 } from './addresses';
+import { mockBicSwiftCode0 } from './bic-swift-codes';
 import mockCompanies from './companies';
+import { mockIban0 } from './ibans';
+import { mockSortCode0 } from './sort-codes';
 
 const {
   AGENT_SERVICE_CHARGE,
@@ -159,14 +163,14 @@ const application = {
     [CREDIT_PERIOD_WITH_BUYER]: 'Mock description',
     [LOSS_PAYEE_NAME]: 'Mock name',
     LOSS_PAYEE_FINANCIAL_UK: {
-      [SORT_CODE]: '102030',
-      [ACCOUNT_NUMBER]: '12345678',
-      [FINANCIAL_ADDRESS]: MULTI_LINE_STRING,
+      [SORT_CODE]: mockSortCode0,
+      [ACCOUNT_NUMBER]: mockAccountNumber0,
+      [FINANCIAL_ADDRESS]: mockAddress0,
     },
     LOSS_PAYEE_FINANCIAL_INTERNATIONAL: {
-      [BIC_SWIFT_CODE]: 'BKENGB2L123',
-      [IBAN]: 'GB33BUKB20201555555555',
-      [FINANCIAL_ADDRESS]: MULTI_LINE_STRING,
+      [BIC_SWIFT_CODE]: mockBicSwiftCode0,
+      [IBAN]: mockIban0,
+      [FINANCIAL_ADDRESS]: mockAddress0,
     },
   },
   REQUESTED_JOINTLY_INSURED_PARTY: {
@@ -178,20 +182,20 @@ const application = {
     [DESCRIPTION]: 'Mock description',
     [FINAL_DESTINATION]: COUNTRY_APPLICATION_SUPPORT.ONLINE.ISO_CODE,
     HOW_WILL_YOU_GET_PAID: {
-      [PAYMENT_TERMS_DESCRIPTION]: MULTI_LINE_STRING,
+      [PAYMENT_TERMS_DESCRIPTION]: mockAddress0,
     },
     PRIVATE_MARKET: {
       [ATTEMPTED]: true,
-      [DECLINED_DESCRIPTION]: MULTI_LINE_STRING,
+      [DECLINED_DESCRIPTION]: mockAddress0,
     },
     AGENT_DETAILS: {
       [AGENT_NAME]: 'Mock export contract agent name',
       [AGENT_COUNTRY_CODE]: COUNTRY_APPLICATION_SUPPORT.ONLINE.NAME,
-      [AGENT_FULL_ADDRESS]: MULTI_LINE_STRING,
+      [AGENT_FULL_ADDRESS]: mockAddress0,
     },
     AGENT_SERVICE: {
       [IS_CHARGING]: false,
-      [SERVICE_DESCRIPTION]: MULTI_LINE_STRING,
+      [SERVICE_DESCRIPTION]: mockAddress0,
     },
     AGENT_CHARGES: {
       [PERCENTAGE_CHARGE]: '10',
@@ -212,7 +216,7 @@ const application = {
     [USING_BROKER]: true,
     [NAME]: 'Mock broker name',
     [EMAIL]: Cypress.env('GOV_NOTIFY_EMAIL_RECIPIENT_1'),
-    [BROKER_FULL_ADDRESS]: MULTI_LINE_STRING,
+    [BROKER_FULL_ADDRESS]: mockAddress0,
   },
   BUYER: {
     [COMPANY_OR_ORGANISATION_NAME]: 'Test name',

--- a/e2e-tests/fixtures/bic-swift-codes.js
+++ b/e2e-tests/fixtures/bic-swift-codes.js
@@ -1,0 +1,2 @@
+export const mockBicSwiftCode0 = 'BKENGB2L123';
+export const mockBicSwiftCode1 = 'ACCDB011M45';

--- a/e2e-tests/fixtures/ibans.js
+++ b/e2e-tests/fixtures/ibans.js
@@ -1,0 +1,2 @@
+export const mockIban0 = 'GB33BUKB20201555555555';
+export const mockIban1 = 'AC44BALE12124666666666';

--- a/e2e-tests/fixtures/sort-codes.js
+++ b/e2e-tests/fixtures/sort-codes.js
@@ -1,0 +1,2 @@
+export const mockSortCode0 = '102030';
+export const mockSortCode1 = '910121';

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker.spec.js
@@ -8,6 +8,7 @@ import { POLICY_FIELDS as FIELDS } from '../../../../../../../../content-strings
 import { FIELD_VALUES } from '../../../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
+import { mockAddress1 } from '../../../../../../../../fixtures/addresses';
 
 const {
   ROOT,
@@ -132,7 +133,7 @@ context('Insurance - Change your answers - Policy - Broker - Summary list', () =
     });
 
     describe('form submission with a new answer', () => {
-      const mockNewAddress = 'Mock new address';
+      const mockNewAddress = mockAddress1;
 
       beforeEach(() => {
         cy.navigateToUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-international-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-international-name.spec.js
@@ -1,0 +1,91 @@
+import partials from '../../../../../../../../partials';
+import { field, summaryList } from '../../../../../../../../pages/shared';
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
+import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
+import application from '../../../../../../../../fixtures/application';
+
+const {
+  LOSS_PAYEE_DETAILS: { NAME },
+} = POLICY_FIELD_IDS;
+
+const {
+  ROOT,
+  POLICY: { LOSS_PAYEE_DETAILS_CHECK_AND_CHANGE },
+  CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY },
+} = INSURANCE_ROUTES;
+
+const fieldId = NAME;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context(`Insurance - Change your answers - Policy - - Loss payee details - International - ${NAME} - As an exporter, I want to change my answers to the loss payee section`, () => {
+  let referenceNumber;
+  let checkYourAnswersUrl;
+  let lossPayeeDetailsUrl;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationMultiplePolicyType({
+        referenceNumber,
+        isAppointingLossPayee: true,
+        lossPayeeIsLocatedInUK: false,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });
+
+      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;
+      lossPayeeDetailsUrl = `${baseUrl}${ROOT}/${referenceNumber}${LOSS_PAYEE_DETAILS_CHECK_AND_CHANGE}`;
+
+      cy.assertUrl(checkYourAnswersUrl);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${LOSS_PAYEE_DETAILS_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+
+      summaryList.field(fieldId).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: LOSS_PAYEE_DETAILS_CHECK_AND_CHANGE, fieldId });
+    });
+  });
+
+  describe('form submission with a new answer', () => {
+    const newValueInput = `${application.POLICY[fieldId]} additional text`;
+
+    beforeEach(() => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+    });
+
+    it(`should redirect to ${TYPE_OF_POLICY}`, () => {
+      summaryList.field(fieldId).changeLink().click();
+
+      cy.assertUrl(`${lossPayeeDetailsUrl}#${NAME}-label`);
+
+      cy.changeAnswerField({ newValueInput }, field(fieldId).input());
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+    });
+
+    it('should render the new answer', () => {
+      cy.assertSummaryListRowValue(summaryList, fieldId, newValueInput);
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-international.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-international.spec.js
@@ -3,6 +3,9 @@ import { field, summaryList } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../../content-strings/fields/insurance/policy';
+import { mockBicSwiftCode1 } from '../../../../../../../../fixtures/bic-swift-codes';
+import { mockIban1 } from '../../../../../../../../fixtures/ibans';
+import { mockAddress1 } from '../../../../../../../../fixtures/addresses';
 
 const {
   LOSS_PAYEE_FINANCIAL_INTERNATIONAL: { BIC_SWIFT_CODE, IBAN },
@@ -68,7 +71,7 @@ context('Insurance - Change your answers - Policy - Loss payee details - Interna
     });
 
     describe('form submission with a new answer', () => {
-      const newAnswer = 'ACCDB011M45';
+      const newAnswer = mockBicSwiftCode1;
 
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);
@@ -104,7 +107,7 @@ context('Insurance - Change your answers - Policy - Loss payee details - Interna
     });
 
     describe('form submission with a new answer', () => {
-      const newAnswer = 'AC44BALE12124666666666';
+      const newAnswer = mockIban1;
 
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);
@@ -140,7 +143,7 @@ context('Insurance - Change your answers - Policy - Loss payee details - Interna
     });
 
     describe('form submission with a new answer', () => {
-      const mockNewAddress = 'Mock new address';
+      const mockNewAddress = mockAddress1;
 
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-international.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-international.spec.js
@@ -1,0 +1,173 @@
+import partials from '../../../../../../../../partials';
+import { field, summaryList } from '../../../../../../../../pages/shared';
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
+import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
+import { POLICY_FIELDS as FIELDS } from '../../../../../../../../content-strings/fields/insurance/policy';
+
+const {
+  LOSS_PAYEE_FINANCIAL_INTERNATIONAL: { BIC_SWIFT_CODE, IBAN },
+  FINANCIAL_ADDRESS,
+} = POLICY_FIELD_IDS;
+
+const {
+  ROOT,
+  POLICY: { LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHECK_AND_CHANGE },
+  CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY },
+} = INSURANCE_ROUTES;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Change your answers - Policy - Loss payee details - International - As an exporter, I want to change my answers to the loss payee section', () => {
+  let referenceNumber;
+  let checkYourAnswersUrl;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationMultiplePolicyType({
+        referenceNumber,
+        isAppointingLossPayee: true,
+        lossPayeeIsLocatedInUK: false,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });
+
+      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;
+
+      cy.assertUrl(checkYourAnswersUrl);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe(BIC_SWIFT_CODE, () => {
+    const fieldId = BIC_SWIFT_CODE;
+
+    describe('when clicking the `change` link', () => {
+      it(`should redirect to ${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHECK_AND_CHANGE}`, () => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHECK_AND_CHANGE, fieldId });
+      });
+    });
+
+    describe('form submission with a new answer', () => {
+      const newAnswer = 'ACCDB011M45';
+
+      beforeEach(() => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.keyboardInput(field(fieldId).input(), newAnswer);
+
+        cy.clickSubmitButton();
+      });
+
+      it(`should redirect to ${TYPE_OF_POLICY}`, () => {
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+      });
+
+      it('should render the new answer', () => {
+        cy.assertSummaryListRowValue(summaryList, fieldId, newAnswer);
+      });
+    });
+  });
+
+  describe(IBAN, () => {
+    const fieldId = IBAN;
+
+    describe('when clicking the `change` link', () => {
+      it(`should redirect to ${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHECK_AND_CHANGE}`, () => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHECK_AND_CHANGE, fieldId });
+      });
+    });
+
+    describe('form submission with a new answer', () => {
+      const newAnswer = 'AC44BALE12124666666666';
+
+      beforeEach(() => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.keyboardInput(field(fieldId).input(), newAnswer);
+
+        cy.clickSubmitButton();
+      });
+
+      it(`should redirect to ${TYPE_OF_POLICY}`, () => {
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+      });
+
+      it('should render the new answer', () => {
+        cy.assertSummaryListRowValue(summaryList, fieldId, newAnswer);
+      });
+    });
+  });
+
+  describe(FINANCIAL_ADDRESS, () => {
+    const fieldId = FINANCIAL_ADDRESS;
+
+    describe('when clicking the `change` link', () => {
+      it(`should redirect to ${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHECK_AND_CHANGE}`, () => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHECK_AND_CHANGE, fieldId });
+      });
+    });
+
+    describe('form submission with a new answer', () => {
+      const mockNewAddress = 'Mock new address';
+
+      beforeEach(() => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.keyboardInput(field(fieldId).textarea(), mockNewAddress);
+
+        cy.clickSubmitButton();
+      });
+
+      it(`should redirect to ${TYPE_OF_POLICY}`, () => {
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+      });
+
+      it('should render the new answer', () => {
+        const expectedKey = FIELDS.LOSS_PAYEE_FINANCIAL_INTERNATIONAL[fieldId].SUMMARY.TITLE;
+
+        const row = summaryList.field(fieldId);
+
+        cy.checkText(
+          row.key(),
+          expectedKey,
+        );
+
+        row.value().contains(mockNewAddress);
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-uk-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-uk-name.spec.js
@@ -1,0 +1,91 @@
+import partials from '../../../../../../../../partials';
+import { field, summaryList } from '../../../../../../../../pages/shared';
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
+import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
+import application from '../../../../../../../../fixtures/application';
+
+const {
+  LOSS_PAYEE_DETAILS: { NAME },
+} = POLICY_FIELD_IDS;
+
+const {
+  ROOT,
+  POLICY: { LOSS_PAYEE_DETAILS_CHECK_AND_CHANGE },
+  CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY },
+} = INSURANCE_ROUTES;
+
+const fieldId = NAME;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context(`Insurance - Change your answers - Policy - - Loss payee details - UK - ${NAME} - As an exporter, I want to change my answers to the loss payee section`, () => {
+  let referenceNumber;
+  let checkYourAnswersUrl;
+  let lossPayeeDetailsUrl;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationMultiplePolicyType({
+        referenceNumber,
+        isAppointingLossPayee: true,
+        lossPayeeIsLocatedInUK: true,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });
+
+      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;
+      lossPayeeDetailsUrl = `${baseUrl}${ROOT}/${referenceNumber}${LOSS_PAYEE_DETAILS_CHECK_AND_CHANGE}`;
+
+      cy.assertUrl(checkYourAnswersUrl);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${LOSS_PAYEE_DETAILS_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+
+      summaryList.field(fieldId).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: LOSS_PAYEE_DETAILS_CHECK_AND_CHANGE, fieldId });
+    });
+  });
+
+  describe('form submission with a new answer', () => {
+    const newValueInput = `${application.POLICY[fieldId]} additional text`;
+
+    beforeEach(() => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+    });
+
+    it(`should redirect to ${TYPE_OF_POLICY}`, () => {
+      summaryList.field(fieldId).changeLink().click();
+
+      cy.assertUrl(`${lossPayeeDetailsUrl}#${NAME}-label`);
+
+      cy.changeAnswerField({ newValueInput }, field(fieldId).input());
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+    });
+
+    it('should render the new answer', () => {
+      cy.assertSummaryListRowValue(summaryList, fieldId, newValueInput);
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-uk.spec.js
@@ -1,0 +1,176 @@
+import partials from '../../../../../../../../partials';
+import { field, summaryList } from '../../../../../../../../pages/shared';
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
+import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
+import { POLICY_FIELDS as FIELDS } from '../../../../../../../../content-strings/fields/insurance/policy';
+import formatSortCode from '../../../../../../../../helpers/format-sort-code';
+
+const {
+  LOSS_PAYEE_FINANCIAL_UK: { SORT_CODE, ACCOUNT_NUMBER },
+  FINANCIAL_ADDRESS,
+} = POLICY_FIELD_IDS;
+
+const {
+  ROOT,
+  POLICY: { LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHECK_AND_CHANGE },
+  CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY },
+} = INSURANCE_ROUTES;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Change your answers - Policy - Loss payee details - UK - As an exporter, I want to change my answers to the loss payee section', () => {
+  let referenceNumber;
+  let checkYourAnswersUrl;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationMultiplePolicyType({
+        referenceNumber,
+        isAppointingLossPayee: true,
+        lossPayeeIsLocatedInUK: true,
+      });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });
+
+      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;
+
+      cy.assertUrl(checkYourAnswersUrl);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe(SORT_CODE, () => {
+    const fieldId = SORT_CODE;
+
+    describe('when clicking the `change` link', () => {
+      it(`should redirect to ${LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHECK_AND_CHANGE}`, () => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHECK_AND_CHANGE, fieldId });
+      });
+    });
+
+    describe('form submission with a new answer', () => {
+      const newAnswer = '405060';
+
+      beforeEach(() => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.keyboardInput(field(fieldId).input(), newAnswer);
+
+        cy.clickSubmitButton();
+      });
+
+      it(`should redirect to ${TYPE_OF_POLICY}`, () => {
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+      });
+
+      it('should render the new answer', () => {
+        const expectedAnswer = formatSortCode(newAnswer);
+
+        cy.assertSummaryListRowValue(summaryList, fieldId, expectedAnswer);
+      });
+    });
+  });
+
+  describe(ACCOUNT_NUMBER, () => {
+    const fieldId = ACCOUNT_NUMBER;
+
+    describe('when clicking the `change` link', () => {
+      it(`should redirect to ${LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHECK_AND_CHANGE}`, () => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHECK_AND_CHANGE, fieldId });
+      });
+    });
+
+    describe('form submission with a new answer', () => {
+      const newAnswer = '91011121';
+
+      beforeEach(() => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.keyboardInput(field(fieldId).input(), newAnswer);
+
+        cy.clickSubmitButton();
+      });
+
+      it(`should redirect to ${TYPE_OF_POLICY}`, () => {
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+      });
+
+      it('should render the new answer', () => {
+        cy.assertSummaryListRowValue(summaryList, fieldId, newAnswer);
+      });
+    });
+  });
+
+  describe(FINANCIAL_ADDRESS, () => {
+    const fieldId = FINANCIAL_ADDRESS;
+
+    describe('when clicking the `change` link', () => {
+      it(`should redirect to ${LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHECK_AND_CHANGE}`, () => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHECK_AND_CHANGE, fieldId });
+      });
+    });
+
+    describe('form submission with a new answer', () => {
+      const mockNewAddress = 'Mock new address';
+
+      beforeEach(() => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
+        summaryList.field(fieldId).changeLink().click();
+
+        cy.keyboardInput(field(fieldId).textarea(), mockNewAddress);
+
+        cy.clickSubmitButton();
+      });
+
+      it(`should redirect to ${TYPE_OF_POLICY}`, () => {
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+      });
+
+      it('should render the new answer', () => {
+        const expectedKey = FIELDS.LOSS_PAYEE_FINANCIAL_UK[fieldId].SUMMARY.TITLE;
+
+        const row = summaryList.field(fieldId);
+
+        cy.checkText(
+          row.key(),
+          expectedKey,
+        );
+
+        row.value().contains(mockNewAddress);
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-uk.spec.js
@@ -4,6 +4,9 @@ import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/fi
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../../content-strings/fields/insurance/policy';
 import formatSortCode from '../../../../../../../../helpers/format-sort-code';
+import { mockAccountNumber1 } from '../../../../../../../../fixtures/account-numbers';
+import { mockAddress1 } from '../../../../../../../../fixtures/addresses';
+import { mockSortCode0 } from '../../../../../../../../fixtures/sort-codes';
 
 const {
   LOSS_PAYEE_FINANCIAL_UK: { SORT_CODE, ACCOUNT_NUMBER },
@@ -69,7 +72,7 @@ context('Insurance - Change your answers - Policy - Loss payee details - UK - As
     });
 
     describe('form submission with a new answer', () => {
-      const newAnswer = '405060';
+      const newAnswer = mockSortCode0;
 
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);
@@ -107,7 +110,7 @@ context('Insurance - Change your answers - Policy - Loss payee details - UK - As
     });
 
     describe('form submission with a new answer', () => {
-      const newAnswer = '91011121';
+      const newAnswer = mockAccountNumber1;
 
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);
@@ -143,7 +146,7 @@ context('Insurance - Change your answers - Policy - Loss payee details - UK - As
     });
 
     describe('form submission with a new answer', () => {
-      const mockNewAddress = 'Mock new address';
+      const mockNewAddress = mockAddress1;
 
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/broker/change-your-answers-change-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/broker/change-your-answers-change-broker.spec.js
@@ -3,6 +3,7 @@ import { FIELD_VALUES } from '../../../../../../../constants';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import { mockAddress1 } from '../../../../../../../fixtures/addresses';
 
 const {
   USING_BROKER,
@@ -96,7 +97,7 @@ context('Insurance - Policy - Change your answers - Broker - As an exporter, I w
     });
 
     describe('form submission with a new answer', () => {
-      const mockNewAddress = 'Mock new address';
+      const mockNewAddress = mockAddress1;
 
       beforeEach(() => {
         cy.navigateToUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-international.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-international.spec.js
@@ -2,6 +2,9 @@ import { field, summaryList } from '../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
+import { mockBicSwiftCode1 } from '../../../../../../../fixtures/bic-swift-codes';
+import { mockIban1 } from '../../../../../../../fixtures/ibans';
+import { mockAddress1 } from '../../../../../../../fixtures/addresses';
 
 const {
   LOSS_PAYEE_FINANCIAL_INTERNATIONAL: { BIC_SWIFT_CODE, IBAN },
@@ -57,7 +60,7 @@ context('Insurance - Policy - Change your answers - Loss payee details - Financi
     });
 
     describe('form submission with a new answer', () => {
-      const newAnswer = 'ACCDB011M45';
+      const newAnswer = mockBicSwiftCode1;
 
       beforeEach(() => {
         cy.navigateToUrl(url);
@@ -93,7 +96,7 @@ context('Insurance - Policy - Change your answers - Loss payee details - Financi
     });
 
     describe('form submission with a new answer', () => {
-      const newAnswer = 'AC44BALE12124666666666';
+      const newAnswer = mockIban1;
 
       beforeEach(() => {
         cy.navigateToUrl(url);
@@ -129,7 +132,7 @@ context('Insurance - Policy - Change your answers - Loss payee details - Financi
     });
 
     describe('form submission with a new answer', () => {
-      const mockNewAddress = 'Mock new address';
+      const mockNewAddress = mockAddress1;
 
       beforeEach(() => {
         cy.navigateToUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-uk.spec.js
@@ -3,6 +3,9 @@ import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
 import formatSortCode from '../../../../../../../helpers/format-sort-code';
+import { mockAccountNumber1 } from '../../../../../../../fixtures/account-numbers';
+import { mockAddress1 } from '../../../../../../../fixtures/addresses';
+import { mockSortCode0 } from '../../../../../../../fixtures/sort-codes';
 
 const {
   LOSS_PAYEE_FINANCIAL_UK: { SORT_CODE, ACCOUNT_NUMBER },
@@ -58,7 +61,7 @@ context('Insurance - Policy - Change your answers - Loss payee details - Financi
     });
 
     describe('form submission with a new answer', () => {
-      const newAnswer = '405060';
+      const newAnswer = mockSortCode0;
 
       beforeEach(() => {
         cy.navigateToUrl(url);
@@ -96,7 +99,7 @@ context('Insurance - Policy - Change your answers - Loss payee details - Financi
     });
 
     describe('form submission with a new answer', () => {
-      const newAnswer = '91011121';
+      const newAnswer = mockAccountNumber1;
 
       beforeEach(() => {
         cy.navigateToUrl(url);
@@ -132,7 +135,7 @@ context('Insurance - Policy - Change your answers - Loss payee details - Financi
     });
 
     describe('form submission with a new answer', () => {
-      const mockNewAddress = 'Mock new address';
+      const mockNewAddress = mockAddress1;
 
       beforeEach(() => {
         cy.navigateToUrl(url);

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -21,8 +21,8 @@ describe('routes/insurance', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(196);
-    expect(post).toHaveBeenCalledTimes(203);
+    expect(get).toHaveBeenCalledTimes(198);
+    expect(post).toHaveBeenCalledTimes(205);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
     expect(post).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startPost);

--- a/src/ui/server/routes/insurance/policy/loss-payee/index.test.ts
+++ b/src/ui/server/routes/insurance/policy/loss-payee/index.test.ts
@@ -27,9 +27,11 @@ const {
   LOSS_PAYEE_FINANCIAL_DETAILS_UK_ROOT,
   LOSS_PAYEE_FINANCIAL_DETAILS_UK_SAVE_AND_BACK,
   LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHANGE,
+  LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHECK_AND_CHANGE,
   LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT,
   LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_SAVE_AND_BACK,
   LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHANGE,
+  LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHECK_AND_CHANGE,
 } = POLICY;
 
 describe('routes/insurance/policy/loss-payee', () => {
@@ -42,8 +44,8 @@ describe('routes/insurance/policy/loss-payee', () => {
   });
 
   it('should setup all routes', () => {
-    expect(get).toHaveBeenCalledTimes(10);
-    expect(post).toHaveBeenCalledTimes(14);
+    expect(get).toHaveBeenCalledTimes(12);
+    expect(post).toHaveBeenCalledTimes(16);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${LOSS_PAYEE_ROOT}`, getLossPayee);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${LOSS_PAYEE_ROOT}`, postLossPayee);
@@ -66,6 +68,8 @@ describe('routes/insurance/policy/loss-payee', () => {
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_UK_SAVE_AND_BACK}`, postLossPayeeFinancialDetailsUkSaveAndBack);
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHANGE}`, getLossPayeeFinancialDetailsUk);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHANGE}`, postLossPayeeFinancialDetailsUk);
+    expect(get).toHaveBeenCalledWith(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHECK_AND_CHANGE}`, getLossPayeeFinancialDetailsUk);
+    expect(post).toHaveBeenCalledWith(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHECK_AND_CHANGE}`, postLossPayeeFinancialDetailsUk);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT}`, getLossPayeeFinancialInternational);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT}`, postLossPayeeFinancialInternational);
@@ -75,5 +79,7 @@ describe('routes/insurance/policy/loss-payee', () => {
     );
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHANGE}`, getLossPayeeFinancialInternational);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHANGE}`, postLossPayeeFinancialInternational);
+    expect(get).toHaveBeenCalledWith(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHECK_AND_CHANGE}`, getLossPayeeFinancialInternational);
+    expect(post).toHaveBeenCalledWith(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHECK_AND_CHANGE}`, postLossPayeeFinancialInternational);
   });
 });

--- a/src/ui/server/routes/insurance/policy/loss-payee/index.ts
+++ b/src/ui/server/routes/insurance/policy/loss-payee/index.ts
@@ -27,9 +27,11 @@ const {
   LOSS_PAYEE_FINANCIAL_DETAILS_UK_ROOT,
   LOSS_PAYEE_FINANCIAL_DETAILS_UK_SAVE_AND_BACK,
   LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHANGE,
+  LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHECK_AND_CHANGE,
   LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT,
   LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_SAVE_AND_BACK,
   LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHANGE,
+  LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHECK_AND_CHANGE,
 } = POLICY;
 
 // @ts-ignore
@@ -56,11 +58,15 @@ router.post(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_UK_ROOT}`, postLoss
 router.post(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_UK_SAVE_AND_BACK}`, postLossPayeeFinancialDetailsUkSaveAndBack);
 router.get(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHANGE}`, getLossPayeeFinancialDetailsUk);
 router.post(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHANGE}`, postLossPayeeFinancialDetailsUk);
+router.get(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHECK_AND_CHANGE}`, getLossPayeeFinancialDetailsUk);
+router.post(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHECK_AND_CHANGE}`, postLossPayeeFinancialDetailsUk);
 
 router.get(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT}`, getLossPayeeFinancialInternational);
 router.post(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT}`, postLossPayeeFinancialInternational);
 router.post(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_SAVE_AND_BACK}`, postLossPayeeFinancialInternationalSaveAndBack);
 router.get(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHANGE}`, getLossPayeeFinancialInternational);
 router.post(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHANGE}`, postLossPayeeFinancialInternational);
+router.get(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHECK_AND_CHANGE}`, getLossPayeeFinancialInternational);
+router.post(`/:referenceNumber${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHECK_AND_CHANGE}`, postLossPayeeFinancialInternational);
 
 export default router;


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds "change your answers" functionality for "Policy - Loss payee", via the "Application - Check your answers" summary list in a No PDF application.

## Resolution :heavy_check_mark:
- Add E2E test coverage for:
  - Changing the "Loss payee - Name" field when financial details are UK.
  - Changing the "Loss payee - Name" field when financial details are international.
  - Changing the "Loss payee - Financal details - International" fields.
  - Changing the "Loss payee - Financal details - UK" fields.
- Add "check and change" UI routes. 

## Miscellaneous :heavy_plus_sign:
- Introduce DRY E2E fixtures for:
  - Account numbers.
  - Addresses.
  - BIC/Swift codes.
  - IBANs.
  - Sort codes.
