### PR TITLE
chore(EMS-3307): No PDF - Your buyer - Change your answers - Connection with buyer

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-connection-with-buyer-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-connection-with-buyer-no-to-yes.spec.js
@@ -1,0 +1,91 @@
+import { summaryList } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
+import checkSummaryList from '../../../../../../../commands/insurance/check-your-buyer-summary-list';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    YOUR_BUYER,
+  },
+  YOUR_BUYER: {
+    CONNECTION_WITH_BUYER_CHECK_AND_CHANGE,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  CONNECTION_WITH_BUYER: FIELD_ID,
+  CONNECTION_WITH_BUYER_DESCRIPTION,
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context(`Insurance - Connection with buyer - Check your answers - ${FIELD_ID} - No to yes`, () => {
+  let referenceNumber;
+  let checkYourAnswersUrl;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({ referenceNumber, hasConnectionToBuyer: false });
+
+      task.link().click();
+
+      // To get past "Your business" check your answers page
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });
+
+      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUYER}`;
+
+      cy.assertUrl(checkYourAnswersUrl);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(checkYourAnswersUrl);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+    });
+
+    it(`should redirect to ${CONNECTION_WITH_BUYER_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: CONNECTION_WITH_BUYER_CHECK_AND_CHANGE, fieldId: FIELD_ID });
+    });
+  });
+
+  describe('after changing the answer from no to yes', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.completeAndSubmitConnectionToTheBuyerForm({ hasConnectionToBuyer: true });
+    });
+
+    it(`should redirect to ${YOUR_BUYER}`, () => {
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: YOUR_BUYER, fieldId: FIELD_ID });
+    });
+
+    it(`should render new ${FIELD_ID} answer and change link, with other buyer connection fields`, () => {
+      checkSummaryList[FIELD_ID]({ isYes: true });
+      checkSummaryList[CONNECTION_WITH_BUYER_DESCRIPTION]({ shouldRender: true });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-connection-with-buyer-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-connection-with-buyer-yes-to-no.spec.js
@@ -1,0 +1,127 @@
+import { field, summaryList } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import { FIELD_VALUES } from '../../../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
+import application from '../../../../../../../fixtures/application';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    YOUR_BUYER,
+  },
+  YOUR_BUYER: {
+    CONNECTION_WITH_BUYER,
+    CONNECTION_WITH_BUYER_CHECK_AND_CHANGE,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  CONNECTION_WITH_BUYER: FIELD_ID,
+  CONNECTION_WITH_BUYER_DESCRIPTION,
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context(`Insurance - Connection with buyer - Check your answers - ${FIELD_ID} - Yes to no`, () => {
+  let referenceNumber;
+  let checkYourAnswersUrl;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({ referenceNumber, hasConnectionToBuyer: true });
+
+      task.link().click();
+
+      // To get past "Your business" check your answers page
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });
+
+      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUYER}`;
+
+      cy.assertUrl(checkYourAnswersUrl);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(checkYourAnswersUrl);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+    });
+
+    it(`should redirect to ${CONNECTION_WITH_BUYER_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: CONNECTION_WITH_BUYER_CHECK_AND_CHANGE, fieldId: FIELD_ID });
+    });
+  });
+
+  describe('after changing the answer from yes to no', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.completeAndSubmitConnectionToTheBuyerForm({ hasConnectionToBuyer: false });
+    });
+
+    it(`should redirect to ${YOUR_BUYER}`, () => {
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: YOUR_BUYER, fieldId: FIELD_ID });
+    });
+
+    it(`should render new ${FIELD_ID} answer and change link, with no other buyer connection fields`, () => {
+      cy.assertSummaryListRowValue(summaryList, FIELD_ID, FIELD_VALUES.NO);
+
+      cy.assertSummaryListRowDoesNotExist(summaryList, CONNECTION_WITH_BUYER_DESCRIPTION);
+    });
+
+    describe('when changing the answer again from no to yes', () => {
+      beforeEach(() => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
+        summaryList.field(FIELD_ID).changeLink().click();
+      });
+
+      it('should have an empty textarea', () => {
+        cy.clickYesRadioInput();
+
+        cy.checkTextareaValue({
+          fieldId: CONNECTION_WITH_BUYER_DESCRIPTION,
+          expectedValue: '',
+        });
+      });
+
+      describe(`when going back to ${CONNECTION_WITH_BUYER}`, () => {
+        it('should have the submitted value', () => {
+          cy.completeAndSubmitConnectionToTheBuyerForm({ hasConnectionToBuyer: true });
+
+          summaryList.field(FIELD_ID).changeLink().click();
+
+          // TODO:
+          // TODO: DRY command
+
+          cy.assertNoRadioOptionIsNotChecked();
+          cy.assertYesRadioOptionIsChecked();
+
+          cy.checkText(field(CONNECTION_WITH_BUYER_DESCRIPTION).textarea(), application.BUYER[CONNECTION_WITH_BUYER_DESCRIPTION]);
+        });
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer.spec.js
@@ -137,7 +137,7 @@ context('Insurance - Check your answers - Working with buyer - Your buyer page -
         cy.checkTaskStatusCompleted(status);
       });
 
-      it(`should not render a ${CONNECTION_WITH_BUYER_DESCRIPTION} row and retain a "completed" status tag`, () => {
+      it(`should NOT render a ${CONNECTION_WITH_BUYER_DESCRIPTION} row and retain a "completed" status tag`, () => {
         cy.assertSummaryListRowDoesNotExist(summaryList, CONNECTION_WITH_BUYER_DESCRIPTION);
 
         cy.checkTaskStatusCompleted(status);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/validation/loss-payee-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/validation/loss-payee-details-validation.spec.js
@@ -80,7 +80,7 @@ context('Insurance - Policy - Loss Payee Details - Validation', () => {
       cy.submitAndAssertFieldErrors({ ...assertions, value, expectedErrorMessage: ERROR.ABOVE_MAXIMUM });
     });
 
-    it(`should not render validation errors when ${FIELD_ID} contains numbers and special characters`, () => {
+    it(`should NOT render validation errors when ${FIELD_ID} contains numbers and special characters`, () => {
       const nameValue = mockNameWithSpecialCharacters('name');
       cy.keyboardInput(fieldSelector(FIELD_ID).input(), nameValue);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/sort-code-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/sort-code-validation.spec.js
@@ -104,7 +104,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Sort code - Vali
   });
 
   describe(`when ${FIELD_ID} is correctly entered`, () => {
-    it(`should not render validation errors when ${FIELD_ID} does not have spaces and is only numbers`, () => {
+    it(`should NOT render validation errors when ${FIELD_ID} does not have spaces and is only numbers`, () => {
       cy.keyboardInput(fieldSelector(FIELD_ID).input(), '112233');
 
       cy.clickSubmitButton();
@@ -112,7 +112,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Sort code - Vali
       cy.assertErrorSummaryListLength(2);
     });
 
-    it(`should not render validation errors when ${FIELD_ID} is only numbers and dashes`, () => {
+    it(`should NOT render validation errors when ${FIELD_ID} is only numbers and dashes`, () => {
       cy.keyboardInput(fieldSelector(FIELD_ID).input(), '11-22-33');
 
       cy.clickSubmitButton();
@@ -120,7 +120,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Sort code - Vali
       cy.assertErrorSummaryListLength(2);
     });
 
-    it(`should not render validation errors when ${FIELD_ID} is only numbers and spaces`, () => {
+    it(`should NOT render validation errors when ${FIELD_ID} is only numbers and spaces`, () => {
       cy.keyboardInput(fieldSelector(FIELD_ID).input(), '11 22 33');
 
       cy.clickSubmitButton();
@@ -128,7 +128,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Sort code - Vali
       cy.assertErrorSummaryListLength(2);
     });
 
-    it(`should not render validation errors when ${FIELD_ID} is only numbers and spaces and dashes`, () => {
+    it(`should NOT render validation errors when ${FIELD_ID} is only numbers and spaces and dashes`, () => {
       cy.keyboardInput(fieldSelector(FIELD_ID).input(), '11-22 33');
 
       cy.clickSubmitButton();

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/validation/pre-credit-period-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/validation/pre-credit-period-validation.spec.js
@@ -91,7 +91,7 @@ context('Insurance - Policy - Pre-credit period page - validation', () => {
       });
     });
 
-    it(`should not render any validation errors when ${FIELD_ID} is below the minimum`, () => {
+    it(`should NOT render any validation errors when ${FIELD_ID} is below the minimum`, () => {
       cy.completeAndSubmitPreCreditPeriodForm({ needPreCreditPeriod: true });
 
       cy.assertErrorSummaryListDoesNotExist();

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-buyer-connection-with-buyer-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-buyer-connection-with-buyer-no-to-yes.spec.js
@@ -1,0 +1,76 @@
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { YOUR_BUYER as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/your-buyer';
+import { summaryList } from '../../../../../../pages/shared';
+import checkSummaryList from '../../../../../../commands/insurance/check-your-buyer-summary-list';
+
+const {
+  ROOT,
+  YOUR_BUYER: {
+    CONNECTION_WITH_BUYER_CHANGE,
+    CHECK_YOUR_ANSWERS,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  CONNECTION_WITH_BUYER: FIELD_ID,
+  CONNECTION_WITH_BUYER_DESCRIPTION,
+} = FIELD_IDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context(`Insurance - Your buyer - Change your answers - Connection with buyer - ${FIELD_ID} - No to yes`, () => {
+  let referenceNumber;
+  let checkYourAnswersUrl;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.startInsuranceYourBuyerSection({});
+
+      cy.completeAndSubmitCompanyOrOrganisationForm({});
+      cy.completeAndSubmitConnectionToTheBuyerForm({ hasConnectionToBuyer: false });
+      cy.completeAndSubmitTradedWithBuyerForm({});
+      cy.completeAndSubmitBuyerFinancialInformationForm({});
+
+      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${CONNECTION_WITH_BUYER_CHANGE}`, () => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: CONNECTION_WITH_BUYER_CHANGE, fieldId: FIELD_ID });
+    });
+  });
+
+  describe('after changing the answer from no to yes', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.completeAndSubmitConnectionToTheBuyerForm({ hasConnectionToBuyer: true });
+    });
+
+    it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId: FIELD_ID });
+    });
+
+    it(`should render new ${FIELD_ID} answer and change link, with other buyer fields`, () => {
+      checkSummaryList[FIELD_ID]({ isYes: true });
+      checkSummaryList[CONNECTION_WITH_BUYER_DESCRIPTION]({ shouldRender: true });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-buyer-connection-with-buyer-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-buyer-connection-with-buyer-yes-to-no.spec.js
@@ -1,0 +1,111 @@
+import { field, summaryList } from '../../../../../../pages/shared';
+import { FIELD_VALUES } from '../../../../../../constants';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { YOUR_BUYER as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/your-buyer';
+import application from '../../../../../../fixtures/application';
+
+const {
+  ROOT,
+  YOUR_BUYER: {
+    CONNECTION_WITH_BUYER,
+    CONNECTION_WITH_BUYER_CHANGE,
+    CHECK_YOUR_ANSWERS,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  CONNECTION_WITH_BUYER: FIELD_ID,
+  CONNECTION_WITH_BUYER_DESCRIPTION,
+} = FIELD_IDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context(`Insurance - Your buyer - Change your answers - Connection with buyer - ${FIELD_ID} - Yes to no`, () => {
+  let referenceNumber;
+  let checkYourAnswersUrl;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.startInsuranceYourBuyerSection({});
+
+      cy.completeAndSubmitCompanyOrOrganisationForm({});
+      cy.completeAndSubmitConnectionToTheBuyerForm({ hasConnectionToBuyer: true });
+      cy.completeAndSubmitTradedWithBuyerForm({});
+      cy.completeAndSubmitBuyerFinancialInformationForm({});
+
+      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${CONNECTION_WITH_BUYER_CHANGE}`, () => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: CONNECTION_WITH_BUYER_CHANGE, fieldId: FIELD_ID });
+    });
+  });
+
+  describe('after changing the answer from yes to no', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.completeAndSubmitConnectionToTheBuyerForm({ hasConnectionToBuyer: false });
+    });
+
+    it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId: FIELD_ID });
+    });
+
+    it(`should render new ${FIELD_ID} answer and change link, with no other buyer connection fields`, () => {
+      cy.assertSummaryListRowValue(summaryList, FIELD_ID, FIELD_VALUES.NO);
+
+      cy.assertSummaryListRowDoesNotExist(summaryList, CONNECTION_WITH_BUYER_DESCRIPTION);
+    });
+
+    describe('when changing the answer again from no to yes', () => {
+      beforeEach(() => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
+        summaryList.field(FIELD_ID).changeLink().click();
+      });
+
+      it('should have an empty textarea', () => {
+        cy.clickYesRadioInput();
+
+        cy.checkTextareaValue({
+          fieldId: CONNECTION_WITH_BUYER_DESCRIPTION,
+          expectedValue: '',
+        });
+      });
+
+      describe(`when going back to ${CONNECTION_WITH_BUYER}`, () => {
+        it('should have the submitted value', () => {
+          cy.completeAndSubmitConnectionToTheBuyerForm({ hasConnectionToBuyer: true });
+
+          summaryList.field(FIELD_ID).changeLink().click();
+
+          // TODO:
+          // TODO: DRY command
+          cy.assertNoRadioOptionIsNotChecked();
+          cy.assertYesRadioOptionIsChecked();
+
+          cy.checkText(field(CONNECTION_WITH_BUYER_DESCRIPTION).textarea(), application.BUYER[CONNECTION_WITH_BUYER_DESCRIPTION]);
+        });
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-connection-to-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-connection-to-buyer.spec.js
@@ -102,7 +102,7 @@ context('Insurance - Your buyer - Change your answers - Connection to the buyer 
         cy.assertSummaryListRowValue(summaryList, fieldId, FIELD_VALUES.NO);
       });
 
-      it(`should not render the new answer for ${CONNECTION_WITH_BUYER_DESCRIPTION}`, () => {
+      it(`should NOT render the new answer for ${CONNECTION_WITH_BUYER_DESCRIPTION}`, () => {
         cy.assertSummaryListRowDoesNotExist(summaryList, CONNECTION_WITH_BUYER_DESCRIPTION);
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-credit-insurance-history.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-credit-insurance-history.spec.js
@@ -101,7 +101,7 @@ context('Insurance - Your buyer - Change your answers - Credit insurance history
         cy.assertSummaryListRowValue(summaryList, fieldId, FIELD_VALUES.NO);
       });
 
-      it(`should not render the new answer for ${PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER}`, () => {
+      it(`should NOT render the new answer for ${PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER}`, () => {
         cy.assertSummaryListRowDoesNotExist(summaryList, PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER);
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-trading-history.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-trading-history.spec.js
@@ -165,11 +165,11 @@ context('Insurance - Your buyer - Change your answers - Trading history - As an 
         cy.assertSummaryListRowValue(summaryList, fieldId, FIELD_VALUES.NO);
       });
 
-      it(`should not render a value for ${TOTAL_AMOUNT_OVERDUE}`, () => {
+      it(`should NOT render a value for ${TOTAL_AMOUNT_OVERDUE}`, () => {
         cy.assertSummaryListRowDoesNotExist(summaryList, TOTAL_AMOUNT_OVERDUE);
       });
 
-      it(`should not render a value for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
+      it(`should NOT render a value for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
         cy.assertSummaryListRowDoesNotExist(summaryList, TOTAL_OUTSTANDING_PAYMENTS);
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-page.spec.js
@@ -105,19 +105,19 @@ context('Insurance - Your Buyer - Trading history page - As an exporter, I want 
           field(TOTAL_OUTSTANDING_PAYMENTS).heading().should('not.be.visible');
         });
 
-        it(`should not render a label for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
+        it(`should NOT render a label for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
           field(TOTAL_OUTSTANDING_PAYMENTS).label().should('not.be.visible');
         });
 
-        it(`should not render an input for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
+        it(`should NOT render an input for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
           field(TOTAL_OUTSTANDING_PAYMENTS).input().should('not.be.visible');
         });
 
-        it(`should not render a label for ${TOTAL_AMOUNT_OVERDUE}`, () => {
+        it(`should NOT render a label for ${TOTAL_AMOUNT_OVERDUE}`, () => {
           field(TOTAL_AMOUNT_OVERDUE).label().should('not.be.visible');
         });
 
-        it(`should not render an input for ${TOTAL_AMOUNT_OVERDUE}`, () => {
+        it(`should NOT render an input for ${TOTAL_AMOUNT_OVERDUE}`, () => {
           field(TOTAL_AMOUNT_OVERDUE).input().should('not.be.visible');
         });
       });


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds E2E test coverage for changing the answer to "Connection with buyer" .

## Resolution :heavy_check_mark:
- Add E2E test for changing `CONNECTION_WITH_BUYER` from "Yes" to "No" and then back to "Yes" via:
  - "Your buyer - Change your answers".
  - "Application - Change your answers - Your buyer".
- Add E2E test for changing `CONNECTION_WITH_BUYER` from "No" to "Yes" via:
  - "Your buyer - Change your answers".
  - "Application - Change your answers - Your buyer".

## Miscellaneous :heavy_plus_sign:
- Align some E2E test descriptions to have capitalised "not"'s.
