### PR TITLE
chore(EMS-3287): No PDF - Change your answers - Policy - Broker - E2E tests

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker-no-to-yes.spec.js
@@ -1,0 +1,100 @@
+import { status, summaryList } from '../../../../../../../../pages/shared';
+import partials from '../../../../../../../../partials';
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
+import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
+import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    TYPE_OF_POLICY,
+  },
+  POLICY: { BROKER_CHECK_AND_CHANGE },
+} = INSURANCE_ROUTES;
+
+const {
+  USING_BROKER: FIELD_ID,
+  BROKER_DETAILS: {
+    NAME,
+    EMAIL,
+    FULL_ADDRESS,
+  },
+} = POLICY_FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Change your answers - Policy - Summary list - Broker - No to yes', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({ referenceNumber, usingBroker: false });
+
+      task.link().click();
+
+      // To get past previous "Check your answers" pages
+      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    it(`should redirect to ${BROKER_CHECK_AND_CHANGE}`, () => {
+      cy.navigateToUrl(url);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: BROKER_CHECK_AND_CHANGE, fieldId: FIELD_ID });
+    });
+  });
+
+  describe('after changing the answer from no to yes and completing (now required) broker details fields', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    it(`should redirect to ${TYPE_OF_POLICY}`, () => {
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.completeAndSubmitBrokerForm({ usingBroker: true });
+      cy.completeAndSubmitBrokerDetailsForm({ usingBroker: true });
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId: FIELD_ID });
+    });
+
+    it(`should render new ${FIELD_ID} answer and broker details fields`, () => {
+      checkSummaryList[FIELD_ID]({ usingBroker: true });
+      checkSummaryList.BROKER[NAME]({});
+      checkSummaryList.BROKER[FULL_ADDRESS]();
+      checkSummaryList.BROKER[EMAIL]();
+    });
+
+    it('should retain a `completed` status tag', () => {
+      cy.checkTaskStatusCompleted(status);
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker-no-to-yes.spec.js
@@ -27,7 +27,7 @@ const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
-context('Insurance - Change your answers - Policy - Summary list - Broker - No to yes', () => {
+context('Insurance - Change your answers - Policy - Broker - No to yes - As an exporter, I want to change my answers to the broker section', () => {
   let referenceNumber;
   let url;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker-yes-to-no.spec.js
@@ -34,7 +34,7 @@ const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
-context('Insurance - Change your answers - Policy - Summary list - Broker - Yes to no', () => {
+context('Insurance - Change your answers - Policy - Broker - Yes to no - As an exporter, I want to change my answers to the broker section', () => {
   let referenceNumber;
   let url;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker.spec.js
@@ -46,7 +46,7 @@ const getFieldVariables = (fieldId, referenceNumber) => ({
   changeLink: summaryList.field(fieldId).changeLink,
 });
 
-context('Insurance - Change your answers - Policy - Broker - Summary list', () => {
+context('Insurance - Change your answers - Policy - Broker - As an exporter, I want to change my answers to the broker section', () => {
   let referenceNumber;
   let url;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-with-broker-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-with-broker-summary-list.spec.js
@@ -10,7 +10,10 @@ const {
   },
 } = INSURANCE_ROUTES;
 
-const { USING_BROKER, BROKER_DETAILS } = POLICY_FIELD_IDS;
+const {
+  USING_BROKER,
+  BROKER_DETAILS: { NAME, EMAIL, FULL_ADDRESS },
+} = POLICY_FIELD_IDS;
 
 const { taskList } = partials.insurancePartials;
 
@@ -56,15 +59,15 @@ context('Insurance - Check your answers - Policy - Multiple contract policy - Wi
     checkSummaryList[USING_BROKER]({ usingBroker: true });
   });
 
-  it(`should render a ${BROKER_DETAILS.NAME} summary list row`, () => {
-    checkSummaryList.BROKER[BROKER_DETAILS.NAME]({});
+  it(`should render a ${NAME} summary list row`, () => {
+    checkSummaryList.BROKER[NAME]({});
   });
 
-  it(`should render a ${BROKER_DETAILS.FULL_ADDRESS} summary list row`, () => {
-    checkSummaryList.BROKER[BROKER_DETAILS.FULL_ADDRESS]();
+  it(`should render a ${FULL_ADDRESS} summary list row`, () => {
+    checkSummaryList.BROKER[FULL_ADDRESS]();
   });
 
-  it(`should render a ${BROKER_DETAILS.EMAIL} summary list row`, () => {
-    checkSummaryList.BROKER[BROKER_DETAILS.EMAIL]();
+  it(`should render a ${EMAIL} summary list row`, () => {
+    checkSummaryList.BROKER[EMAIL]();
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-with-broker-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-with-broker-summary-list.spec.js
@@ -10,7 +10,10 @@ const {
   },
 } = INSURANCE_ROUTES;
 
-const { USING_BROKER, BROKER_DETAILS } = POLICY_FIELD_IDS;
+const {
+  USING_BROKER,
+  BROKER_DETAILS: { NAME, EMAIL, FULL_ADDRESS },
+} = POLICY_FIELD_IDS;
 
 const { taskList } = partials.insurancePartials;
 
@@ -56,15 +59,15 @@ context('Insurance - Check your answers - Policy - Single contract policy - With
     checkSummaryList[USING_BROKER]({ usingBroker: true });
   });
 
-  it(`should render a ${BROKER_DETAILS.NAME} summary list row`, () => {
-    checkSummaryList.BROKER[BROKER_DETAILS.NAME]({});
+  it(`should render a ${NAME} summary list row`, () => {
+    checkSummaryList.BROKER[NAME]({});
   });
 
-  it(`should render a ${BROKER_DETAILS.FULL_ADDRESS} summary list row`, () => {
-    checkSummaryList.BROKER[BROKER_DETAILS.FULL_ADDRESS]();
+  it(`should render a ${FULL_ADDRESS} summary list row`, () => {
+    checkSummaryList.BROKER[FULL_ADDRESS]();
   });
 
-  it(`should render a ${BROKER_DETAILS.EMAIL} summary list row`, () => {
-    checkSummaryList.BROKER[BROKER_DETAILS.EMAIL]();
+  it(`should render a ${EMAIL} summary list row`, () => {
+    checkSummaryList.BROKER[EMAIL]();
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/broker/change-your-answers-change-broker-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/broker/change-your-answers-change-broker-no-to-yes.spec.js
@@ -1,0 +1,75 @@
+import { summaryList } from '../../../../../../../pages/shared';
+import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import checkSummaryList from '../../../../../../../commands/insurance/check-policy-summary-list';
+
+const {
+  USING_BROKER: FIELD_ID,
+  BROKER_DETAILS: {
+    NAME,
+    EMAIL,
+    FULL_ADDRESS,
+  },
+} = POLICY_FIELD_IDS;
+
+const {
+  ROOT,
+  POLICY: { BROKER_CHANGE, CHECK_YOUR_ANSWERS },
+} = INSURANCE_ROUTES;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Policy - Change your answers - Broker - No to yes - As an exporter, I want to change my answers to the broker section', () => {
+  let referenceNumber;
+  let checkYourAnswersUrl;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePolicySection({ usingBroker: false });
+
+      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${BROKER_CHANGE}`, () => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: BROKER_CHANGE, fieldId: FIELD_ID });
+    });
+  });
+
+  describe('after changing the answer from no to yes and completing (now required) broker details fields', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(checkYourAnswersUrl);
+    });
+
+    it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+      summaryList.field(FIELD_ID).changeLink().click();
+
+      cy.completeAndSubmitBrokerForm({ usingBroker: true });
+      cy.completeAndSubmitBrokerDetailsForm({ usingBroker: true });
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId: FIELD_ID });
+    });
+
+    it(`should render new ${FIELD_ID} answer and broker details fields`, () => {
+      checkSummaryList[FIELD_ID]({ usingBroker: true });
+      checkSummaryList.BROKER[NAME]({});
+      checkSummaryList.BROKER[FULL_ADDRESS]();
+      checkSummaryList.BROKER[EMAIL]();
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/broker/change-your-answers-change-broker-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/broker/change-your-answers-change-broker-yes-to-no.spec.js
@@ -45,57 +45,55 @@ context('Insurance - Policy - Change your answers - Broker - Yes to no - As an e
     cy.deleteApplication(referenceNumber);
   });
 
-  describe(FIELD_ID, () => {
-    describe('when clicking the `change` link', () => {
-      it(`should redirect to ${BROKER_CHANGE}`, () => {
-        cy.navigateToUrl(checkYourAnswersUrl);
+  describe('when clicking the `change` link', () => {
+    it(`should redirect to ${BROKER_CHANGE}`, () => {
+      cy.navigateToUrl(checkYourAnswersUrl);
 
-        summaryList.field(FIELD_ID).changeLink().click();
+      summaryList.field(FIELD_ID).changeLink().click();
 
-        cy.assertChangeAnswersPageUrl({ referenceNumber, route: BROKER_CHANGE, fieldId: FIELD_ID });
-      });
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: BROKER_CHANGE, fieldId: FIELD_ID });
+    });
+  });
+
+  describe('after changing the answer from yes to no', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(checkYourAnswersUrl);
     });
 
-    describe('after changing the answer from yes to no', () => {
-      beforeEach(() => {
-        cy.navigateToUrl(checkYourAnswersUrl);
-      });
+    it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+      summaryList.field(FIELD_ID).changeLink().click();
 
-      it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+      cy.completeAndSubmitBrokerForm({ usingBroker: false });
+
+      cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId: FIELD_ID });
+    });
+
+    it(`should render new ${FIELD_ID} answer and change link, with no other broker details fields`, () => {
+      cy.assertSummaryListRowValue(summaryList, FIELD_ID, FIELD_VALUES.NO);
+
+      cy.assertSummaryListRowDoesNotExist(summaryList, NAME);
+
+      /**
+       * Here, we can only assert the EMAIL field's "change" link.
+       * Otherwise, the other (non-broker) EMAIL field's key and value is picked up.
+       */
+      summaryList.field(EMAIL).changeLink().should('not.exist');
+
+      cy.assertSummaryListRowDoesNotExist(summaryList, FULL_ADDRESS);
+    });
+
+    describe(`when changing the answer again from no to yes and going back to ${BROKER_DETAILS_ROOT}`, () => {
+      it('should have empty field values', () => {
         summaryList.field(FIELD_ID).changeLink().click();
 
-        cy.completeAndSubmitBrokerForm({ usingBroker: false });
+        cy.completeAndSubmitBrokerForm({ usingBroker: true });
 
-        cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId: FIELD_ID });
-      });
+        cy.checkValue(field(NAME), '');
+        cy.checkValue(field(EMAIL), '');
 
-      it(`should render new ${FIELD_ID} answer and change link, with no other broker details fields`, () => {
-        cy.assertSummaryListRowValue(summaryList, FIELD_ID, FIELD_VALUES.NO);
-
-        cy.assertSummaryListRowDoesNotExist(summaryList, NAME);
-
-        /**
-         * Here, we can only assert the EMAIL field's "change" link.
-         * Otherwise, the other (non-broker) EMAIL field's key and value is picked up.
-         */
-        summaryList.field(EMAIL).changeLink().should('not.exist');
-
-        cy.assertSummaryListRowDoesNotExist(summaryList, FULL_ADDRESS);
-      });
-
-      describe(`when changing the answer again from no to yes and going back to ${BROKER_DETAILS_ROOT}`, () => {
-        it('should have empty field values', () => {
-          summaryList.field(FIELD_ID).changeLink().click();
-
-          cy.completeAndSubmitBrokerForm({ usingBroker: true });
-
-          cy.checkValue(field(NAME), '');
-          cy.checkValue(field(EMAIL), '');
-
-          cy.checkTextareaValue({
-            fieldId: FULL_ADDRESS,
-            expectedValue: '',
-          });
+        cy.checkTextareaValue({
+          fieldId: FULL_ADDRESS,
+          expectedValue: '',
         });
       });
     });


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds E2E test coverage for changing the "Policy - Using broker" answers via the "Application - Check your answers - Policy" summary list.

## Resolution :heavy_check_mark:
- Add E2E test coverage for changing `USING_BROKER` from "no" to "yes" via: 
  - "Application - Check your answers".
  - "Policy - Check your answers".

## Miscellaneous :heavy_plus_sign:
- Simplify some `checkSummaryList.BROKER` instances to use destructuring.
