### PR TITLE
chore(EMS-3292): No PDF - Change your answers - Business - Credit control - E2E tests

### DIFF
--- a/e2e-tests/commands/insurance/check-your-business-summary-list.js
+++ b/e2e-tests/commands/insurance/check-your-business-summary-list.js
@@ -111,7 +111,7 @@ const checkYourBusinessSummaryList = ({
     const fieldId = HAS_CREDIT_CONTROL;
 
     const { expectedKey, expectedChangeLinkText } = getSummaryListField(fieldId, FIELDS);
-    const expectedValue = FIELD_VALUES.YES;
+    const expectedValue = FIELD_VALUES.NO;
 
     cy.assertSummaryListRow(summaryList, fieldId, expectedKey, expectedValue, expectedChangeLinkText);
   },

--- a/e2e-tests/commands/insurance/check-your-business-summary-list.js
+++ b/e2e-tests/commands/insurance/check-your-business-summary-list.js
@@ -107,11 +107,18 @@ const checkYourBusinessSummaryList = ({
 
     cy.assertSummaryListRow(summaryList, fieldId, expectedKey, expectedValue, expectedChangeLinkText);
   },
-  [HAS_CREDIT_CONTROL]: () => {
+  [HAS_CREDIT_CONTROL]: ({ isYes = false }) => {
     const fieldId = HAS_CREDIT_CONTROL;
 
     const { expectedKey, expectedChangeLinkText } = getSummaryListField(fieldId, FIELDS);
-    const expectedValue = FIELD_VALUES.NO;
+
+    let expectedValue;
+
+    if (isYes) {
+      expectedValue = FIELD_VALUES.YES;
+    } else {
+      expectedValue = FIELD_VALUES.NO;
+    }
 
     cy.assertSummaryListRow(summaryList, fieldId, expectedKey, expectedValue, expectedChangeLinkText);
   },

--- a/e2e-tests/commands/insurance/complete-business-section.js
+++ b/e2e-tests/commands/insurance/complete-business-section.js
@@ -3,9 +3,15 @@
  * Complete the "business" section
  * @param {Boolean} viaTaskList: Start the "business" section from the task list.
  * @param {Boolean} differentTradingAddress: Should submit "yes" to "trade from a different address" in the "company details" form.
+ * @param {Boolean} hasCreditControlProcess: Flag whether to submit "yes" or "no" radio input in the "credit control" form.
  * @param {Boolean} submitCheckYourAnswers: Click policy "check your answers" submit button
  */
-const completeBusinessSection = ({ viaTaskList, differentTradingAddress = false, submitCheckYourAnswers = false }) => {
+const completeBusinessSection = ({
+  viaTaskList,
+  differentTradingAddress = false,
+  hasCreditControlProcess = false,
+  submitCheckYourAnswers = false,
+}) => {
   cy.startYourBusinessSection({ viaTaskList });
 
   cy.completeAndSubmitCompanyDetails({ differentTradingAddress });
@@ -16,7 +22,7 @@ const completeBusinessSection = ({ viaTaskList, differentTradingAddress = false,
 
   cy.completeAndSubmitNatureOfYourBusiness();
   cy.completeAndSubmitTurnoverForm();
-  cy.completeAndSubmitCreditControlForm({});
+  cy.completeAndSubmitCreditControlForm({ hasCreditControlProcess });
 
   if (submitCheckYourAnswers) {
     cy.clickSaveAndBackButton();

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
@@ -7,6 +7,7 @@ const { POLICY_TYPE } = APPLICATION;
  * Runs through the full prepare your application journey for multiple policy type
  * @param {Object} Object with flags on how to complete specific parts of the application
  * @param {Boolean} differentTradingAddress: Should submit "yes" to "trade from a different address" in the "company details" form. Defaults to false.
+ * @param {Boolean} hasCreditControlProcess: Flag whether to submit "yes" or "no" radio input in the "credit control" form. Defaults to false.
  * @param {Boolean} hasConnectionToBuyer: Should submit "yes" to "have connection to buyer" radio.
  * @param {Boolean} exporterHasTradedWithBuyer: Should submit "yes" to "have traded with buyer before" in the "working with buyer" form.
  * @param {Boolean} fullyPopulatedBuyerTradingHistory: Submit all possible optional "buyer trading history" form fields.
@@ -29,6 +30,7 @@ const { POLICY_TYPE } = APPLICATION;
  */
 const completePrepareApplicationMultiplePolicyType = ({
   differentTradingAddress = false,
+  hasCreditControlProcess = false,
   hasConnectionToBuyer = false,
   exporterHasTradedWithBuyer = false,
   fullyPopulatedBuyerTradingHistory = false,
@@ -49,7 +51,11 @@ const completePrepareApplicationMultiplePolicyType = ({
   agentChargeMethodPercentage = false,
   submitCheckYourAnswers = true,
 }) => {
-  cy.completeBusinessSection({ differentTradingAddress, submitCheckYourAnswers });
+  cy.completeBusinessSection({
+    differentTradingAddress,
+    hasCreditControlProcess,
+    submitCheckYourAnswers,
+  });
 
   cy.completeBuyerSection({
     hasConnectionToBuyer,

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
@@ -7,6 +7,7 @@ const { POLICY_TYPE } = FIELD_VALUES;
  * Runs through the full prepare your application journey for a single policy type
  * @param {Object} Object with flags on how to complete specific parts of the application
  * @param {Boolean} differentTradingAddress: Should submit "yes" to "trade from a different address" in the "company details" form. Defaults to false.
+ * @param {Boolean} hasCreditControlProcess: Flag whether to submit "yes" or "no" radio input in the "credit control" form. Defaults to false.
  * @param {Boolean} hasConnectionToBuyer: Should submit "yes" to "have connection to buyer" radio.
  * @param {Boolean} exporterHasTradedWithBuyer: Should submit "yes" to "have traded with buyer before" in the "working with buyer" form.
  * @param {Boolean} fullyPopulatedBuyerTradingHistory: Submit all possible optional "buyer trading history" form fields.
@@ -29,6 +30,7 @@ const { POLICY_TYPE } = FIELD_VALUES;
  */
 const completePrepareApplicationSinglePolicyType = ({
   differentTradingAddress = false,
+  hasCreditControlProcess = false,
   hasConnectionToBuyer,
   exporterHasTradedWithBuyer,
   fullyPopulatedBuyerTradingHistory,
@@ -49,7 +51,11 @@ const completePrepareApplicationSinglePolicyType = ({
   agentChargeMethodPercentage = false,
   submitCheckYourAnswers = true,
 }) => {
-  cy.completeBusinessSection({ differentTradingAddress, submitCheckYourAnswers });
+  cy.completeBusinessSection({
+    differentTradingAddress,
+    hasCreditControlProcess,
+    submitCheckYourAnswers,
+  });
 
   cy.completeBuyerSection({
     hasConnectionToBuyer,

--- a/e2e-tests/fixtures/application.js
+++ b/e2e-tests/fixtures/application.js
@@ -141,7 +141,7 @@ const application = {
   [BUYER_COUNTRY]: COUNTRY_APPLICATION_SUPPORT.ONLINE.NAME,
   COMPANY: mockCompanies[COMPANIES_HOUSE_NUMBER],
   YOUR_COMPANY: {
-    [DIFFERENT_TRADING_NAME]: 'test',
+    [DIFFERENT_TRADING_NAME]: 'Mock different trading name',
   },
   POLICY: {
     [REQUESTED_START_DATE]: {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-credit-control-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-credit-control-no-to-yes.spec.js
@@ -1,0 +1,69 @@
+import { status, summaryList } from '../../../../../../../pages/shared';
+import partials from '../../../../../../../partials';
+import { FIELD_VALUES } from '../../../../../../../constants';
+import { EXPORTER_BUSINESS as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/business';
+import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+
+const {
+  ROOT,
+  CHECK_YOUR_ANSWERS: {
+    YOUR_BUSINESS,
+  },
+} = INSURANCE_ROUTES;
+
+const {
+  HAS_CREDIT_CONTROL: FIELD_ID,
+} = FIELD_IDS;
+
+const { taskList } = partials.insurancePartials;
+
+const task = taskList.submitApplication.tasks.checkAnswers;
+
+const baseUrl = Cypress.config('baseUrl');
+
+let referenceNumber;
+
+context('Insurance - Check your answers - Company details - Credit control - No to yes - As an exporter, I want to change my answers to the credit control section', () => {
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({
+        referenceNumber,
+        hasCreditControlProcess: false,
+      });
+
+      task.link().click();
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+
+    summaryList.field(FIELD_ID).changeLink().click();
+
+    cy.completeAndSubmitCreditControlForm({ hasCreditControlProcess: true });
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  it(`should redirect to ${YOUR_BUSINESS}`, () => {
+    cy.assertChangeAnswersPageUrl({ referenceNumber, route: YOUR_BUSINESS, fieldId: FIELD_ID });
+  });
+
+  it('should render the new answer and retain a `completed` status tag', () => {
+    cy.assertSummaryListRowValue(summaryList, FIELD_ID, FIELD_VALUES.YES);
+
+    cy.checkTaskStatusCompleted(status);
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-credit-control-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-credit-control-yes-to-no.spec.js
@@ -1,7 +1,7 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
 import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
-import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
+import { EXPORTER_BUSINESS as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/business';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 
 const {
@@ -13,8 +13,8 @@ const {
 } = INSURANCE_ROUTES;
 
 const {
-  EXPORTER_BUSINESS: { HAS_CREDIT_CONTROL: FIELD_ID },
-} = INSURANCE_FIELD_IDS;
+  HAS_CREDIT_CONTROL: FIELD_ID,
+} = FIELD_IDS;
 
 const { taskList } = partials.insurancePartials;
 
@@ -34,7 +34,7 @@ const getFieldVariables = (fieldId, referenceNumber, route = CREDIT_CONTROL_CHEC
 let fieldVariables;
 let referenceNumber;
 
-context('Insurance - Check your answers - Company details - Credit control - Summary list', () => {
+context('Insurance - Check your answers - Company details - Credit control - Yes to no - As an exporter, I want to change my answers to the credit control section', () => {
   let url;
 
   before(() => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-credit-control.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-credit-control.spec.js
@@ -41,7 +41,10 @@ context('Insurance - Check your answers - Company details - Credit control - Sum
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
+      cy.completePrepareApplicationSinglePolicyType({
+        referenceNumber,
+        hasCreditControlProcess: true,
+      });
 
       task.link().click();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/summary-list/check-your-answers-your-business-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/summary-list/check-your-answers-your-business-summary-list.spec.js
@@ -100,6 +100,6 @@ context('Insurance - Check your answers - Your business - Summary list', () => {
   });
 
   it(`should render a ${HAS_CREDIT_CONTROL} summary list row`, () => {
-    checkSummaryList[HAS_CREDIT_CONTROL]();
+    checkSummaryList[HAS_CREDIT_CONTROL]({ isYes: false });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-credit-control-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-credit-control-no-to-yes.spec.js
@@ -1,0 +1,57 @@
+import { summaryList } from '../../../../../../pages/shared';
+import { FIELD_VALUES } from '../../../../../../constants';
+import { EXPORTER_BUSINESS as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/business';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+
+const { HAS_CREDIT_CONTROL } = FIELD_IDS;
+
+const {
+  ROOT,
+  EXPORTER_BUSINESS: { CHECK_YOUR_ANSWERS },
+} = INSURANCE_ROUTES;
+
+const fieldId = HAS_CREDIT_CONTROL;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Your business - Change your answers - Credit control - No to yes - As an exporter, I want to change my answers to the credit control section', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.startYourBusinessSection({});
+
+      cy.completeAndSubmitCompanyDetails({});
+      cy.completeAndSubmitNatureOfYourBusiness();
+      cy.completeAndSubmitTurnoverForm();
+      cy.completeAndSubmitCreditControlForm({ hasCreditControlProcess: false });
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+
+    cy.navigateToUrl(url);
+
+    summaryList.field(fieldId).changeLink().click();
+
+    cy.completeAndSubmitCreditControlForm({ hasCreditControlProcess: true });
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
+    cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId });
+  });
+
+  it('should render the new answer', () => {
+    cy.assertSummaryListRowValue(summaryList, fieldId, FIELD_VALUES.YES);
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-credit-control-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-credit-control-yes-to-no.spec.js
@@ -1,9 +1,9 @@
 import { summaryList } from '../../../../../../pages/shared';
 import { FIELD_VALUES } from '../../../../../../constants';
-import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';
+import { EXPORTER_BUSINESS as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/business';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
-const { HAS_CREDIT_CONTROL } = INSURANCE_FIELD_IDS.EXPORTER_BUSINESS;
+const { HAS_CREDIT_CONTROL } = FIELD_IDS;
 
 const {
   ROOT,
@@ -17,7 +17,7 @@ const fieldId = HAS_CREDIT_CONTROL;
 
 const baseUrl = Cypress.config('baseUrl');
 
-context('Insurance - Your business - Change your answers - Credit control - As an exporter, I want to change my answers to the credit control section', () => {
+context('Insurance - Your business - Change your answers - Credit control - Yes to no - As an exporter, I want to change my answers to the credit control section', () => {
   let referenceNumber;
   let url;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
@@ -47,7 +47,7 @@ context('Insurance - Your business - Check your answers - Summary list - your bu
         cy.completeAndSubmitCompanyDetails({});
         cy.completeAndSubmitNatureOfYourBusiness();
         cy.completeAndSubmitTurnoverForm();
-        cy.completeAndSubmitCreditControlForm({});
+        cy.completeAndSubmitCreditControlForm({ hasCreditControlProcess: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
@@ -100,7 +100,7 @@ context('Insurance - Your business - Check your answers - Summary list - your bu
     });
 
     it(`should render a ${HAS_CREDIT_CONTROL} summary list row`, () => {
-      checkSummaryList[HAS_CREDIT_CONTROL]();
+      checkSummaryList[HAS_CREDIT_CONTROL]({ isYes: true });
     });
   });
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds E2E tests for changing the `HAS_CREDIT_CONTROL` answer from "yes" to "no" and vice versa.

## Resolution :heavy_check_mark:
- Update various cypress commands to consume and pass a `hasCreditControlProcess` param.
- Add E2E tests for changing the `HAS_CREDIT_CONTROL` answer from "yes" to "no" and vice versa, via:
   - "Application - Check your answers - Business".
   - "Business - Check your answers".

## Miscellaneous :heavy_plus_sign:
- Simplify some field ID constnats imports/destructuring.
