### PR TITLE
style(EMS-3316): No PDF - Application submitted - Feedback link - Add missing full stop

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/application-submitted.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/application-submitted.spec.js
@@ -135,7 +135,7 @@ context('Insurance - application submitted page', () => {
         cy.checkLink(
           helpUsImprove.feedback.link(),
           FEEDBACK,
-          CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.LINK.TEXT,
+          `${CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.LINK.TEXT}.`,
         );
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/application-submitted.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/application-submitted.spec.js
@@ -132,10 +132,15 @@ context('Insurance - application submitted page', () => {
       });
 
       it('renders a `feedback` link', () => {
+        cy.checkText(
+          helpUsImprove.feedback.text(),
+          `${CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.LINK.TEXT}.`,
+        );
+
         cy.checkLink(
           helpUsImprove.feedback.link(),
           FEEDBACK,
-          `${CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.LINK.TEXT}.`,
+          CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.LINK.TEXT,
         );
       });
     });

--- a/e2e-tests/pages/insurance/applicationSubmitted.js
+++ b/e2e-tests/pages/insurance/applicationSubmitted.js
@@ -24,6 +24,7 @@ const applicationSubmittedPage = {
     ifYouLike: () => cy.get('[data-cy="help-us-improve-if-you-like"]'),
     feedback: {
       intro: () => cy.get('[data-cy="help-us-improve-feedback-intro"]'),
+      text: () => cy.get('[data-cy="help-us-improve-feedback-text"]'),
       link: () => cy.get('[data-cy="help-us-improve-feedback-link"]'),
     },
   },

--- a/src/ui/templates/insurance/application-submitted.njk
+++ b/src/ui/templates/insurance/application-submitted.njk
@@ -51,7 +51,7 @@
         <span data-cy="help-us-improve-if-you-like">{{ CONTENT_STRINGS.HELP_US_IMPROVE.IF_YOU_LIKE }}</span>
 
         <span data-cy="help-us-improve-feedback-intro">{{ CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.INTRO }}</span>
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.LINK.HREF }}" data-cy="help-us-improve-feedback-link">{{ CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.LINK.TEXT }}</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.LINK.HREF }}" data-cy="help-us-improve-feedback-link">{{ CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.LINK.TEXT }}</a>.
       </p>
 
     </div>

--- a/src/ui/templates/insurance/application-submitted.njk
+++ b/src/ui/templates/insurance/application-submitted.njk
@@ -51,7 +51,9 @@
         <span data-cy="help-us-improve-if-you-like">{{ CONTENT_STRINGS.HELP_US_IMPROVE.IF_YOU_LIKE }}</span>
 
         <span data-cy="help-us-improve-feedback-intro">{{ CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.INTRO }}</span>
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.LINK.HREF }}" data-cy="help-us-improve-feedback-link">{{ CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.LINK.TEXT }}</a>.
+        <span data-cy="help-us-improve-feedback-text">
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.LINK.HREF }}" data-cy="help-us-improve-feedback-link">{{ CONTENT_STRINGS.HELP_US_IMPROVE.FEEDBACK.LINK.TEXT }}</a>.
+        </span>
       </p>
 
     </div>


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds a missing full stop to the "give feedback" link/text, in the "Application submitted" page.

## Resolution :heavy_check_mark:
- Update nunjucks template.
- Add E2E test.