### PR TITLE
fix(EMS-3412): no PDF - check your answers - your business - heading update

### DIFF
--- a/e2e-tests/content-strings/pages/insurance/check-your-answers/index.js
+++ b/e2e-tests/content-strings/pages/insurance/check-your-answers/index.js
@@ -9,7 +9,7 @@ export const START_NEW_APPLICATION = {
 
 export const YOUR_BUSINESS = {
   ...SHARED,
-  PAGE_TITLE: 'About your business',
+  PAGE_TITLE: 'Your business',
 };
 
 export const YOUR_BUYER = {

--- a/src/ui/server/content-strings/pages/insurance/check-your-answers/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/check-your-answers/index.ts
@@ -17,7 +17,7 @@ const START_NEW_APPLICATION = {
 
 const YOUR_BUSINESS = {
   ...SHARED,
-  PAGE_TITLE: 'About your business',
+  PAGE_TITLE: 'Your business',
 };
 
 const YOUR_BUYER = {


### PR DESCRIPTION
## Introduction :pencil2:

This PR fixes an issue where the "Check your answers - your business" heading did not have the latest No PDF content.

## Resolution :heavy_check_mark:

- Update content strings.