### PR TITLE
chore(debug): Application submission - temporary logging

### DIFF
--- a/src/ui/server/api/keystone/application/submit.ts
+++ b/src/ui/server/api/keystone/application/submit.ts
@@ -16,6 +16,9 @@ const submitApplication = async (applicationId: string) => {
 
     const response = (await apollo('POST', submitApplicationMutation, variables)) as ApolloResponse;
 
+    console.info('temporary logs for debugging in dev environment - submit application response ', response);
+    console.info('temporary logs for debugging in dev environment - submit application response.data ', response?.data);
+
     if (response.errors) {
       console.error('GraphQL error submitting application %O', response.errors);
     }


### PR DESCRIPTION
## Introduction :pencil2:

Currently some application submission scenarios are failing in the `dev` and `feature` environments.

## Resolution :heavy_check_mark:

- Add some temporary logs to the UI, to log out the API response.
