### PR TITLE
fix(EMS-3459): no pdf - account creation - validation rules

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/your-details/account-create-your-details-validation-account-already-exists-verified-valid-password.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/your-details/account-create-your-details-validation-account-already-exists-verified-valid-password.spec.js
@@ -9,7 +9,7 @@ const {
 } = ACCOUNT_ROUTES;
 
 const {
-  ACCOUNT: { EMAIL, PASSWORD },
+  ACCOUNT: { EMAIL },
 } = INSURANCE_FIELD_IDS;
 
 const {
@@ -56,17 +56,7 @@ context(
         cy.submitAndAssertFieldErrors({
           field: fieldSelector(EMAIL),
           value: mockAccount[EMAIL],
-          expectedErrorsCount: 2,
-          expectedErrorMessage: YOUR_DETAILS_ERROR_MESSAGES.ACCOUNT_ALREADY_EXISTS,
-        });
-      });
-
-      it(`should render an ${PASSWORD} validation error`, () => {
-        cy.submitAndAssertFieldErrors({
-          field: fieldSelector(PASSWORD),
-          value: mockAccount[PASSWORD],
-          errorIndex: 1,
-          expectedErrorsCount: 2,
+          expectedErrorsCount: 1,
           expectedErrorMessage: YOUR_DETAILS_ERROR_MESSAGES.ACCOUNT_ALREADY_EXISTS,
         });
       });

--- a/src/ui/server/controllers/insurance/account/create/your-details/validation/account-already-exists/already-verified/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/validation/account-already-exists/already-verified/index.test.ts
@@ -1,11 +1,9 @@
 import accountAlreadyExistsAlreadyVerifiedValidation from '.';
-import INSURANCE_FIELD_IDS from '../../../../../../../../constants/field-ids/insurance';
+import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/account';
 import { ERROR_MESSAGES } from '../../../../../../../../content-strings';
 import generateValidationErrors from '../../../../../../../../helpers/validation';
 
-const {
-  ACCOUNT: { EMAIL, PASSWORD },
-} = INSURANCE_FIELD_IDS;
+const { EMAIL } = FIELD_IDS;
 
 const {
   ACCOUNT: {
@@ -17,9 +15,7 @@ describe('controllers/insurance/account/create/your-details/validation/account-a
   it('should return the result of generateValidationErrors', () => {
     const result = accountAlreadyExistsAlreadyVerifiedValidation();
 
-    const emailError = generateValidationErrors(EMAIL, ERROR_MESSAGES_OBJECT.ACCOUNT_ALREADY_EXISTS, {});
-
-    const expected = generateValidationErrors(PASSWORD, ERROR_MESSAGES_OBJECT.ACCOUNT_ALREADY_EXISTS, emailError);
+    const expected = generateValidationErrors(EMAIL, ERROR_MESSAGES_OBJECT.ACCOUNT_ALREADY_EXISTS, {});
 
     expect(result).toEqual(expected);
   });

--- a/src/ui/server/controllers/insurance/account/create/your-details/validation/account-already-exists/already-verified/index.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/validation/account-already-exists/already-verified/index.ts
@@ -1,11 +1,9 @@
-import INSURANCE_FIELD_IDS from '../../../../../../../../constants/field-ids/insurance';
+import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/account';
 import { ERROR_MESSAGES } from '../../../../../../../../content-strings';
 import generateValidationErrors from '../../../../../../../../helpers/validation';
 import { ValidationErrors } from '../../../../../../../../../types';
 
-const {
-  ACCOUNT: { EMAIL, PASSWORD },
-} = INSURANCE_FIELD_IDS;
+const { EMAIL } = FIELD_IDS;
 
 const {
   ACCOUNT: {
@@ -18,12 +16,6 @@ const {
  * Generate an error count, error list and summary for GOV design errors.
  * @returns {ValidationErrors} Error count, error list and summary
  */
-const accountAlreadyExistsAlreadyVerifiedValidation = (): ValidationErrors => {
-  const emailError = generateValidationErrors(EMAIL, ERROR_MESSAGES_OBJECT.ACCOUNT_ALREADY_EXISTS, {});
-
-  const emailAndPasswordError = generateValidationErrors(PASSWORD, ERROR_MESSAGES_OBJECT.ACCOUNT_ALREADY_EXISTS, emailError);
-
-  return emailAndPasswordError;
-};
+const accountAlreadyExistsAlreadyVerifiedValidation = (): ValidationErrors => generateValidationErrors(EMAIL, ERROR_MESSAGES_OBJECT.ACCOUNT_ALREADY_EXISTS, {});
 
 export default accountAlreadyExistsAlreadyVerifiedValidation;


### PR DESCRIPTION
## Introduction :pencil2:

This PR fixes an issue where, when a user submits the "create account" form with valid credentials for an account that already exists, an error message would appear in both the email and password fields.

In this scenario, only one error should render in the email field.

## Resolution :heavy_check_mark:

- Update UI validation rule.
- Update E2E test.
