### PR TITLE
fix(EMS-3399): no PDF - Export contract - Agent charges - Changing back to standard currency

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-fixed-sum-amount-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-fixed-sum-amount-alternative-currency.spec.js
@@ -8,9 +8,7 @@ import formatCurrency from '../../../../../../../../helpers/format-currency';
 
 const {
   ROOT,
-  CHECK_YOUR_ANSWERS: {
-    EXPORT_CONTRACT,
-  },
+  CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT },
   EXPORT_CONTRACT: { AGENT_CHARGES_CHECK_AND_CHANGE },
 } = INSURANCE_ROUTES;
 
@@ -26,102 +24,67 @@ const fieldId = FIXED_SUM_AMOUNT;
 
 const baseUrl = Cypress.config('baseUrl');
 
-context(`Insurance - Change your answers - Export contract - Summary list - Agent charges - ${FIXED_SUM_AMOUNT} - As an exporter, I want to change my answers to an alternative currency`, () => {
-  let referenceNumber;
-  let checkYourAnswersUrl;
+context(
+  `Insurance - Change your answers - Export contract - Summary list - Agent charges - ${FIXED_SUM_AMOUNT} - As an exporter, I want to change my answers to an alternative currency`,
+  () => {
+    let referenceNumber;
+    let checkYourAnswersUrl;
 
-  before(() => {
-    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
-      referenceNumber = refNumber;
+    before(() => {
+      cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+        referenceNumber = refNumber;
 
-      cy.completePrepareApplicationSinglePolicyType({
-        referenceNumber,
-        isUsingAgent: true,
-        agentIsCharging: true,
-        agentChargeMethodFixedSum: true,
-      });
+        cy.completePrepareApplicationSinglePolicyType({
+          referenceNumber,
+          isUsingAgent: true,
+          agentIsCharging: true,
+          agentChargeMethodFixedSum: true,
+        });
 
-      task.link().click();
+        task.link().click();
 
-      // To get past previous "Check your answers" pages
-      cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });
+        // To get past previous "Check your answers" pages
+        cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });
 
-      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT}`;
+        checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT}`;
 
-      cy.assertUrl(checkYourAnswersUrl);
-    });
-  });
-
-  beforeEach(() => {
-    cy.saveSession();
-
-    cy.navigateToUrl(checkYourAnswersUrl);
-  });
-
-  after(() => {
-    cy.deleteApplication(referenceNumber);
-  });
-
-  describe(`changing ${PAYABLE_COUNTRY_CODE} to ${SYMBOLS.EUR}`, () => {
-    const currencyCode = EUR_CURRENCY_CODE;
-
-    describe('when clicking the `change` link', () => {
-      it(`should redirect to ${AGENT_CHARGES_CHECK_AND_CHANGE}`, () => {
-        cy.navigateToUrl(checkYourAnswersUrl);
-
-        summaryList.field(fieldId).changeLink().click();
-
-        cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHECK_AND_CHANGE, fieldId });
+        cy.assertUrl(checkYourAnswersUrl);
       });
     });
 
     beforeEach(() => {
+      cy.saveSession();
+
       cy.navigateToUrl(checkYourAnswersUrl);
-
-      summaryList.field(fieldId).changeLink().click();
-
-      cy.completeAndSubmitAlternativeCurrencyForm({ isoCode: EUR_CURRENCY_CODE });
-
-      cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHECK_AND_CHANGE });
-
-      // submit the AGENT_CHARGES form
-      cy.clickSubmitButton();
     });
 
-    it(`should redirect to ${AGENT_CHARGES_CHECK_AND_CHANGE} and then ${EXPORT_CONTRACT}`, () => {
-      cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT });
+    after(() => {
+      cy.deleteApplication(referenceNumber);
     });
 
-    it(`should render the new answer for ${FIXED_SUM_AMOUNT} including ${SYMBOLS.EUR}`, () => {
-      const row = summaryList.field(FIXED_SUM_AMOUNT);
-      const expected = formatCurrency(application.EXPORT_CONTRACT.AGENT_CHARGES[FIXED_SUM_AMOUNT], currencyCode);
+    describe(`changing ${PAYABLE_COUNTRY_CODE} to ${SYMBOLS.EUR}`, () => {
+      const currencyCode = EUR_CURRENCY_CODE;
 
-      cy.checkText(row.value(), expected);
-    });
-  });
+      describe('when clicking the `change` link', () => {
+        it(`should redirect to ${AGENT_CHARGES_CHECK_AND_CHANGE}`, () => {
+          cy.navigateToUrl(checkYourAnswersUrl);
 
-  describe(`changing ${PAYABLE_COUNTRY_CODE} to an alternative currency`, () => {
-    const currencyCode = NON_STANDARD_CURRENCY_CODE;
+          summaryList.field(fieldId).changeLink().click();
 
-    describe('when clicking the `change` link', () => {
-      it(`should redirect to ${AGENT_CHARGES_CHECK_AND_CHANGE}`, () => {
-        cy.navigateToUrl(checkYourAnswersUrl);
-
-        summaryList.field(fieldId).changeLink().click();
-
-        cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHECK_AND_CHANGE, fieldId });
+          cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHECK_AND_CHANGE, fieldId });
+        });
       });
-    });
 
-    describe('form submission with a new answer', () => {
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);
 
         summaryList.field(fieldId).changeLink().click();
 
-        cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency: true });
+        cy.completeAndSubmitAlternativeCurrencyForm({ isoCode: EUR_CURRENCY_CODE });
 
-        // submit AGENT_CHARGES form
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHECK_AND_CHANGE });
+
+        // submit the AGENT_CHARGES form
         cy.clickSubmitButton();
       });
 
@@ -129,12 +92,81 @@ context(`Insurance - Change your answers - Export contract - Summary list - Agen
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT });
       });
 
-      it(`should render the new answer for ${FIXED_SUM_AMOUNT}`, () => {
+      it(`should render the new answer for ${FIXED_SUM_AMOUNT} including ${SYMBOLS.EUR}`, () => {
         const row = summaryList.field(FIXED_SUM_AMOUNT);
         const expected = formatCurrency(application.EXPORT_CONTRACT.AGENT_CHARGES[FIXED_SUM_AMOUNT], currencyCode);
 
         cy.checkText(row.value(), expected);
       });
     });
-  });
-});
+
+    describe(`changing ${PAYABLE_COUNTRY_CODE} to an alternative currency`, () => {
+      const currencyCode = NON_STANDARD_CURRENCY_CODE;
+
+      describe('when clicking the `change` link', () => {
+        it(`should redirect to ${AGENT_CHARGES_CHECK_AND_CHANGE}`, () => {
+          cy.navigateToUrl(checkYourAnswersUrl);
+
+          summaryList.field(fieldId).changeLink().click();
+
+          cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHECK_AND_CHANGE, fieldId });
+        });
+      });
+
+      describe('form submission with a new answer', () => {
+        beforeEach(() => {
+          cy.navigateToUrl(checkYourAnswersUrl);
+
+          summaryList.field(fieldId).changeLink().click();
+
+          cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency: true });
+
+          // submit AGENT_CHARGES form
+          cy.clickSubmitButton();
+        });
+
+        it(`should redirect to ${AGENT_CHARGES_CHECK_AND_CHANGE} and then ${EXPORT_CONTRACT}`, () => {
+          cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT });
+        });
+
+        it(`should render the new answer for ${FIXED_SUM_AMOUNT}`, () => {
+          const row = summaryList.field(FIXED_SUM_AMOUNT);
+          const expected = formatCurrency(application.EXPORT_CONTRACT.AGENT_CHARGES[FIXED_SUM_AMOUNT], currencyCode);
+
+          cy.checkText(row.value(), expected);
+        });
+      });
+    });
+
+    describe(`changing ${PAYABLE_COUNTRY_CODE} from an alternative currency to ${SYMBOLS.EUR}`, () => {
+      const currencyCode = EUR_CURRENCY_CODE;
+
+      describe('form submission with a new answer', () => {
+        beforeEach(() => {
+          cy.navigateToUrl(checkYourAnswersUrl);
+
+          summaryList.field(fieldId).changeLink().click();
+
+          cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency: true });
+
+          // submit AGENT_CHARGES form
+          cy.clickSubmitButton();
+
+          summaryList.field(fieldId).changeLink().click();
+
+          cy.completeAndSubmitAlternativeCurrencyForm({ isoCode: EUR_CURRENCY_CODE });
+
+          // submit AGENT_CHARGES form
+          cy.clickSubmitButton();
+        });
+
+        it(`should render the new answer for ${FIXED_SUM_AMOUNT}`, () => {
+          const row = summaryList.field(FIXED_SUM_AMOUNT);
+          const expected = formatCurrency(application.EXPORT_CONTRACT.AGENT_CHARGES[FIXED_SUM_AMOUNT], currencyCode);
+
+          cy.checkText(row.value(), expected);
+        });
+      });
+    });
+  },
+);

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-fixed-sum-amount-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-fixed-sum-amount-alternative-currency.spec.js
@@ -7,10 +7,7 @@ import formatCurrency from '../../../../../../../helpers/format-currency';
 
 const {
   ROOT,
-  EXPORT_CONTRACT: {
-    CHECK_YOUR_ANSWERS,
-    AGENT_CHARGES_CHANGE,
-  },
+  EXPORT_CONTRACT: { CHECK_YOUR_ANSWERS, AGENT_CHARGES_CHANGE },
 } = INSURANCE_ROUTES;
 
 const {
@@ -21,94 +18,59 @@ const fieldId = PAYABLE_COUNTRY_CODE;
 
 const baseUrl = Cypress.config('baseUrl');
 
-context(`Insurance - Export contract - Change your answers - Agent charges - ${FIXED_SUM_AMOUNT} - As an exporter, I want to change my answers to an alternative currency`, () => {
-  let referenceNumber;
-  let checkYourAnswersUrl;
+context(
+  `Insurance - Export contract - Change your answers - Agent charges - ${FIXED_SUM_AMOUNT} - As an exporter, I want to change my answers to an alternative currency`,
+  () => {
+    let referenceNumber;
+    let checkYourAnswersUrl;
 
-  before(() => {
-    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
-      referenceNumber = refNumber;
+    before(() => {
+      cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+        referenceNumber = refNumber;
 
-      cy.completeExportContractSection({
-        isUsingAgent: true,
-        agentIsCharging: true,
-        agentChargeMethodFixedSum: true,
-      });
+        cy.completeExportContractSection({
+          isUsingAgent: true,
+          agentIsCharging: true,
+          agentChargeMethodFixedSum: true,
+        });
 
-      checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+        checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
-      cy.assertUrl(checkYourAnswersUrl);
-    });
-  });
-
-  beforeEach(() => {
-    cy.saveSession();
-  });
-
-  after(() => {
-    cy.deleteApplication(referenceNumber);
-  });
-
-  describe(`changing ${PAYABLE_COUNTRY_CODE} to ${SYMBOLS.EUR}`, () => {
-    const currencyCode = EUR_CURRENCY_CODE;
-
-    describe('when clicking the `change` link', () => {
-      it(`should redirect to ${AGENT_CHARGES_CHANGE}`, () => {
-        cy.navigateToUrl(checkYourAnswersUrl);
-
-        summaryList.field(fieldId).changeLink().click();
-
-        cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHANGE, fieldId });
+        cy.assertUrl(checkYourAnswersUrl);
       });
     });
 
     beforeEach(() => {
-      cy.navigateToUrl(checkYourAnswersUrl);
-
-      summaryList.field(fieldId).changeLink().click();
-
-      cy.completeAndSubmitAlternativeCurrencyForm({ isoCode: EUR_CURRENCY_CODE });
-
-      cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHANGE });
-
-      // submit the AGENT_CHARGES form
-      cy.clickSubmitButton();
+      cy.saveSession();
     });
 
-    it(`should redirect to ${AGENT_CHARGES_CHANGE} and then ${CHECK_YOUR_ANSWERS}`, () => {
-      cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS });
+    after(() => {
+      cy.deleteApplication(referenceNumber);
     });
 
-    it(`should render the new answer for ${FIXED_SUM_AMOUNT} including ${SYMBOLS.EUR}`, () => {
-      const row = summaryList.field(FIXED_SUM_AMOUNT);
-      const expected = formatCurrency(application.EXPORT_CONTRACT.AGENT_CHARGES[FIXED_SUM_AMOUNT], currencyCode);
+    describe(`changing ${PAYABLE_COUNTRY_CODE} to ${SYMBOLS.EUR}`, () => {
+      const currencyCode = EUR_CURRENCY_CODE;
 
-      cy.checkText(row.value(), expected);
-    });
-  });
+      describe('when clicking the `change` link', () => {
+        it(`should redirect to ${AGENT_CHARGES_CHANGE}`, () => {
+          cy.navigateToUrl(checkYourAnswersUrl);
 
-  describe(`changing ${PAYABLE_COUNTRY_CODE} to an alternative currency`, () => {
-    const currencyCode = NON_STANDARD_CURRENCY_CODE;
+          summaryList.field(fieldId).changeLink().click();
 
-    describe('when clicking the `change` link', () => {
-      it(`should redirect to ${AGENT_CHARGES_CHANGE}`, () => {
-        cy.navigateToUrl(checkYourAnswersUrl);
-
-        summaryList.field(fieldId).changeLink().click();
-
-        cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHANGE, fieldId });
+          cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHANGE, fieldId });
+        });
       });
-    });
 
-    describe('form submission with a new answer', () => {
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);
 
         summaryList.field(fieldId).changeLink().click();
 
-        cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency: true });
+        cy.completeAndSubmitAlternativeCurrencyForm({ isoCode: EUR_CURRENCY_CODE });
 
-        // submit AGENT_CHARGES form
+        cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHANGE });
+
+        // submit the AGENT_CHARGES form
         cy.clickSubmitButton();
       });
 
@@ -116,12 +78,81 @@ context(`Insurance - Export contract - Change your answers - Agent charges - ${F
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS });
       });
 
-      it(`should render the new answer for ${FIXED_SUM_AMOUNT}`, () => {
+      it(`should render the new answer for ${FIXED_SUM_AMOUNT} including ${SYMBOLS.EUR}`, () => {
         const row = summaryList.field(FIXED_SUM_AMOUNT);
         const expected = formatCurrency(application.EXPORT_CONTRACT.AGENT_CHARGES[FIXED_SUM_AMOUNT], currencyCode);
 
         cy.checkText(row.value(), expected);
       });
     });
-  });
-});
+
+    describe(`changing ${PAYABLE_COUNTRY_CODE} to an alternative currency`, () => {
+      const currencyCode = NON_STANDARD_CURRENCY_CODE;
+
+      describe('when clicking the `change` link', () => {
+        it(`should redirect to ${AGENT_CHARGES_CHANGE}`, () => {
+          cy.navigateToUrl(checkYourAnswersUrl);
+
+          summaryList.field(fieldId).changeLink().click();
+
+          cy.assertChangeAnswersPageUrl({ referenceNumber, route: AGENT_CHARGES_CHANGE, fieldId });
+        });
+      });
+
+      describe('form submission with a new answer', () => {
+        beforeEach(() => {
+          cy.navigateToUrl(checkYourAnswersUrl);
+
+          summaryList.field(fieldId).changeLink().click();
+
+          cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency: true });
+
+          // submit AGENT_CHARGES form
+          cy.clickSubmitButton();
+        });
+
+        it(`should redirect to ${AGENT_CHARGES_CHANGE} and then ${CHECK_YOUR_ANSWERS}`, () => {
+          cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS });
+        });
+
+        it(`should render the new answer for ${FIXED_SUM_AMOUNT}`, () => {
+          const row = summaryList.field(FIXED_SUM_AMOUNT);
+          const expected = formatCurrency(application.EXPORT_CONTRACT.AGENT_CHARGES[FIXED_SUM_AMOUNT], currencyCode);
+
+          cy.checkText(row.value(), expected);
+        });
+      });
+    });
+
+    describe(`changing ${PAYABLE_COUNTRY_CODE} from an alternative currency to ${SYMBOLS.EUR}`, () => {
+      const currencyCode = EUR_CURRENCY_CODE;
+
+      describe('form submission with a new answer', () => {
+        beforeEach(() => {
+          cy.navigateToUrl(checkYourAnswersUrl);
+
+          summaryList.field(fieldId).changeLink().click();
+
+          cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency: true });
+
+          // submit AGENT_CHARGES form
+          cy.clickSubmitButton();
+
+          summaryList.field(fieldId).changeLink().click();
+
+          cy.completeAndSubmitAlternativeCurrencyForm({ isoCode: EUR_CURRENCY_CODE });
+
+          // submit AGENT_CHARGES form
+          cy.clickSubmitButton();
+        });
+
+        it(`should render the new answer for ${FIXED_SUM_AMOUNT}`, () => {
+          const row = summaryList.field(FIXED_SUM_AMOUNT);
+          const expected = formatCurrency(application.EXPORT_CONTRACT.AGENT_CHARGES[FIXED_SUM_AMOUNT], currencyCode);
+
+          cy.checkText(row.value(), expected);
+        });
+      });
+    });
+  },
+);

--- a/src/ui/server/controllers/insurance/export-contract/map-submitted-data/agent-service-charge/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-submitted-data/agent-service-charge/index.test.ts
@@ -1,7 +1,7 @@
 import mapSubmittedData from '.';
 import { APPLICATION } from '../../../../../constants';
 import FIELD_IDS from '../../../../../constants/field-ids/insurance';
-import { EUR } from '../../../../../test-mocks';
+import { EUR, HKD } from '../../../../../test-mocks';
 
 const {
   EXPORT_CONTRACT: {
@@ -35,6 +35,27 @@ describe('controllers/insurance/export-contract/map-submitted-data/agent-service
         [FIXED_SUM_AMOUNT]: Number(mockFormBody[FIXED_SUM_AMOUNT]),
         [PERCENTAGE_CHARGE]: null,
         [FIXED_SUM_CURRENCY_CODE]: EUR.isoCode,
+      };
+
+      expect(result).toEqual(expected);
+    });
+
+    it(`should set ${ALTERNATIVE_CURRENCY_CODE} to null when ${CURRENCY_CODE} is NOT ${ALTERNATIVE_CURRENCY_CODE}`, () => {
+      const mockFormBody = {
+        [METHOD]: FIXED_SUM,
+        [FIXED_SUM_AMOUNT]: '1',
+        [ALTERNATIVE_CURRENCY_CODE]: HKD.isoCode,
+        [CURRENCY_CODE]: EUR.isoCode,
+      };
+
+      const result = mapSubmittedData(mockFormBody);
+
+      const expected = {
+        ...mockFormBody,
+        [FIXED_SUM_AMOUNT]: Number(mockFormBody[FIXED_SUM_AMOUNT]),
+        [PERCENTAGE_CHARGE]: null,
+        [FIXED_SUM_CURRENCY_CODE]: EUR.isoCode,
+        [ALTERNATIVE_CURRENCY_CODE]: null,
       };
 
       expect(result).toEqual(expected);

--- a/src/ui/server/controllers/insurance/export-contract/map-submitted-data/agent-service-charge/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-submitted-data/agent-service-charge/index.ts
@@ -45,6 +45,16 @@ const mapSubmittedData = (formBody: RequestBody): object => {
     populatedData[FIXED_SUM_CURRENCY_CODE] = populatedData[CURRENCY_CODE];
 
     /**
+     * If the currency code is not the alternative currency code,
+     * nullify the alternative currency code
+     * so currency code can be changed
+     * (else if not null, the alternative currency code will be saved as the currency code when changing the answer)
+     */
+    if (populatedData[CURRENCY_CODE] !== ALTERNATIVE_CURRENCY_CODE) {
+      populatedData[ALTERNATIVE_CURRENCY_CODE] = null;
+    }
+
+    /**
      * CURRENCY_CODE should never exist.
      * This is purely a UI field and so should not be included in the data.
      */


### PR DESCRIPTION
## Introduction :pencil2:

This PR fixes an issue where you could not change back to a standard currency after selecting an alternative currency on the Agent charges page

## Resolution :heavy_check_mark:

* Added to `mapSubmittedData `to set `ALTERNATIVE_CURRENCY_CODE` to null if it does not equal alternativeCurrencyCode
* Updated tests and e2e tests

