### PR TITLE
fix(EMS-3471): no PDF - Account - Verify email expired link

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -3426,7 +3426,7 @@ var update_account_default = update;
 // helpers/send-email-confirm-email-address/index.ts
 var send2 = async (context, urlOrigin, accountId) => {
   try {
-    console.info("Sending email verification");
+    console.info("Sending email verification %s %s", urlOrigin, accountId);
     const account2 = await get_account_by_id_default(context, accountId);
     if (!account2) {
       console.info("Sending email verification - no account exists with the provided account ID");

--- a/src/ui/server/controllers/insurance/account/create/verify-email-expired-link/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/verify-email-expired-link/index.test.ts
@@ -96,7 +96,7 @@ describe('controllers/insurance/account/create/verify-email-expired-link', () =>
 
       expect(sendEmailConfirmEmailAddressSpy).toHaveBeenCalledTimes(1);
 
-      const expectedUrlOrigin = `https://${req.headers.host}`;
+      const expectedUrlOrigin = `https://${req.headers.origin}`;
 
       expect(sendEmailConfirmEmailAddressSpy).toHaveBeenCalledWith(expectedUrlOrigin, sanitisedId);
     });

--- a/src/ui/server/controllers/insurance/account/create/verify-email-expired-link/index.ts
+++ b/src/ui/server/controllers/insurance/account/create/verify-email-expired-link/index.ts
@@ -69,7 +69,7 @@ export const post = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    const urlOrigin = `https://${req.headers.host}`;
+    const urlOrigin = `https://${req.headers.origin}`;
 
     const sanitisedId = String(sanitiseValue({ value: id }));
 


### PR DESCRIPTION
## Introduction :pencil2:

This PR fixes an issue where `verify-email-expired-link` was setting url as container name

## Resolution :heavy_check_mark:

* Changed to `req.headers.origin`
* Updated test

