### PR TITLE
fix(EMS-3471): no PDF - Account - Incorrect resend confirmation email url

### DIFF
--- a/src/ui/server/controllers/insurance/account/create/verify-email-expired-link/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/verify-email-expired-link/index.test.ts
@@ -96,7 +96,7 @@ describe('controllers/insurance/account/create/verify-email-expired-link', () =>
 
       expect(sendEmailConfirmEmailAddressSpy).toHaveBeenCalledTimes(1);
 
-      const expectedUrlOrigin = `https://${req.headers.origin}`;
+      const expectedUrlOrigin = req.headers.origin;
 
       expect(sendEmailConfirmEmailAddressSpy).toHaveBeenCalledWith(expectedUrlOrigin, sanitisedId);
     });

--- a/src/ui/server/controllers/insurance/account/create/verify-email-expired-link/index.ts
+++ b/src/ui/server/controllers/insurance/account/create/verify-email-expired-link/index.ts
@@ -69,7 +69,7 @@ export const post = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    const urlOrigin = `https://${req.headers.origin}`;
+    const urlOrigin = req.headers.origin;
 
     const sanitisedId = String(sanitiseValue({ value: id }));
 


### PR DESCRIPTION
## Introduction :pencil2:

This PR fixes an issue where the resend confirmation email had 2 https'

## Resolution :heavy_check_mark:

* Removed extra https from urlOrigin
* Updated test