### PR TITLE
fix(EMS-3494): no pdf - application submission - XLSX date format

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -7206,7 +7206,7 @@ var {
 var { FIELDS: FIELDS18 } = XLSX;
 var mapFinancialYearEndDate = (company) => {
   if (company[FINANCIAL_YEAR_END_DATE2]) {
-    return format_date_default(company[FINANCIAL_YEAR_END_DATE2], "d MMMM");
+    return format_date_default(company[FINANCIAL_YEAR_END_DATE2], DATE_FORMAT.XLSX);
   }
   return FIELDS18.NO_FINANCIAL_YEAR_END_DATE;
 };

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-exporter-business/map-financial-year-end-date/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-exporter-business/map-financial-year-end-date/index.test.ts
@@ -1,4 +1,5 @@
 import mapFinancialYearEndDate from '.';
+import { DATE_FORMAT } from '../../../../constants';
 import FIELD_IDS from '../../../../constants/field-ids/insurance/business';
 import { XLSX } from '../../../../content-strings';
 import formatDate from '../../../../helpers/format-date';
@@ -22,7 +23,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-exporter-business/map-fi
 
       const result = mapFinancialYearEndDate(mockCompany);
 
-      const expected = formatDate(mockCompany[FINANCIAL_YEAR_END_DATE], 'd MMMM');
+      const expected = formatDate(mockCompany[FINANCIAL_YEAR_END_DATE], DATE_FORMAT.XLSX);
 
       expect(result).toEqual(expected);
     });

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-exporter-business/map-financial-year-end-date/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-exporter-business/map-financial-year-end-date/index.ts
@@ -1,3 +1,4 @@
+import { DATE_FORMAT } from '../../../../constants';
 import FIELD_IDS from '../../../../constants/field-ids/insurance/business';
 import { XLSX } from '../../../../content-strings';
 import formatDate from '../../../../helpers/format-date';
@@ -18,7 +19,7 @@ const { FIELDS } = XLSX;
  */
 const mapFinancialYearEndDate = (company: ApplicationCompany) => {
   if (company[FINANCIAL_YEAR_END_DATE]) {
-    return formatDate(company[FINANCIAL_YEAR_END_DATE], 'd MMMM');
+    return formatDate(company[FINANCIAL_YEAR_END_DATE], DATE_FORMAT.XLSX);
   }
 
   return FIELDS.NO_FINANCIAL_YEAR_END_DATE;


### PR DESCRIPTION
## Introduction :pencil2:

This PR fixes an issue where the "financial year end date" format was not aligned with other XLSX date formats.

## Resolution :heavy_check_mark:

- Update `mapFinancialYearEndDate` to use a constant.