### PR TITLE
fix(EMS-3508): no pdf - application submission - XLSX - buyer conditions

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-buyer-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-buyer-minimal.spec.js
@@ -1,0 +1,32 @@
+import { APPLICATION } from '../../../../../../../constants';
+
+context('Insurance - submit an application - multiple policy type, minimal buyer', () => {
+  let referenceNumber;
+
+  before(() => {
+    cy.completeSignInAndSubmitAnApplication({
+      policyType: APPLICATION.POLICY_TYPE.MULTIPLE,
+      hasConnectionToBuyer: false,
+      exporterHasTradedWithBuyer: false,
+      buyerOutstandingPayments: false,
+      buyerFailedToPayOnTime: false,
+      hasHadCreditInsuranceCoverWithBuyer: false,
+      exporterHasBuyerFinancialAccounts: false,
+      totalContractValueOverThreshold: false,
+    }).then((refNumber) => {
+      referenceNumber = refNumber;
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  it('should successfully submit the application and redirect to `application submitted`', () => {
+    cy.assertApplicationSubmittedUrl(referenceNumber);
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-buyer-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-buyer-minimal.spec.js
@@ -1,0 +1,29 @@
+context('Insurance - submit an application - Single policy type, minimal buyer', () => {
+  let referenceNumber;
+
+  before(() => {
+    cy.completeSignInAndSubmitAnApplication({
+      hasConnectionToBuyer: false,
+      exporterHasTradedWithBuyer: false,
+      buyerOutstandingPayments: false,
+      buyerFailedToPayOnTime: false,
+      hasHadCreditInsuranceCoverWithBuyer: false,
+      exporterHasBuyerFinancialAccounts: false,
+      totalContractValueOverThreshold: false,
+    }).then((refNumber) => {
+      referenceNumber = refNumber;
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  it('should successfully submit the application and redirect to `application submitted`', () => {
+    cy.assertApplicationSubmittedUrl(referenceNumber);
+  });
+});

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -878,7 +878,7 @@ var XLSX_ROW_INDEXES = (application2) => {
     broker,
     buyer: {
       buyerTradingHistory: { exporterHasTradedWithBuyer, outstandingPayments: buyerHasOutstandingPayments },
-      relationship: { exporterHasPreviousCreditInsuranceWithBuyer }
+      relationship: { exporterHasPreviousCreditInsuranceWithBuyer, exporterIsConnectedWithBuyer }
     },
     company: {
       differentTradingAddress: { fullAddress: hasDifferentTradingAddress },
@@ -958,6 +958,10 @@ var XLSX_ROW_INDEXES = (application2) => {
     indexes.TITLES.EXPORT_CONTRACT += 5;
     indexes.BUYER_ADDRESS += 5;
   }
+  if (exporterIsConnectedWithBuyer) {
+    indexes.TITLES.DECLARATIONS += 1;
+    indexes.TITLES.EXPORT_CONTRACT += 1;
+  }
   if (exporterHasTradedWithBuyer) {
     indexes.TITLES.DECLARATIONS += 2;
     indexes.TITLES.EXPORT_CONTRACT += 2;
@@ -966,9 +970,14 @@ var XLSX_ROW_INDEXES = (application2) => {
       indexes.TITLES.EXPORT_CONTRACT += 2;
     }
   }
-  if (exporterHasPreviousCreditInsuranceWithBuyer) {
+  const totalContractValueOverThreshold = totalContractValue.value === TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE;
+  if (totalContractValueOverThreshold) {
     indexes.TITLES.DECLARATIONS += 1;
     indexes.TITLES.EXPORT_CONTRACT += 1;
+    if (exporterHasPreviousCreditInsuranceWithBuyer) {
+      indexes.TITLES.DECLARATIONS += 1;
+      indexes.TITLES.EXPORT_CONTRACT += 1;
+    }
   }
   if (attemptedPrivateMarket) {
     indexes.TITLES.DECLARATIONS += 1;
@@ -992,15 +1001,15 @@ var XLSX_ROW_INDEXES = (application2) => {
     indexes.TITLES.DECLARATIONS += 1;
     indexes.AGENT_ADDRESS += 1;
   }
+  if (totalContractValueOverThreshold) {
+    indexes.AGENT_ADDRESS += 1;
+  }
   if (finalDestinationKnown) {
     indexes.TITLES.DECLARATIONS += 1;
     indexes.AGENT_ADDRESS += 1;
   }
-  const totalContractValueOverThreshold = totalContractValue.value === TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE;
   if (totalContractValueOverThreshold) {
     indexes.TITLES.DECLARATIONS += 1;
-    indexes.TITLES.EXPORT_CONTRACT += 1;
-    indexes.AGENT_ADDRESS += 1;
   }
   return indexes;
 };

--- a/src/api/constants/XLSX-CONFIG/index-multiple-contract-policy-export-contract-conditions.test.ts
+++ b/src/api/constants/XLSX-CONFIG/index-multiple-contract-policy-export-contract-conditions.test.ts
@@ -50,7 +50,7 @@ describe(`api/constants/XLSX-CONFIG - XLSX_ROW_INDEXES - ${APPLICATION.POLICY_TY
       TITLES: {
         ...indexes.TITLES,
         BUYER: indexes.TITLES.BUYER + 1,
-        DECLARATIONS: indexes.TITLES.DECLARATIONS + 12,
+        DECLARATIONS: indexes.TITLES.DECLARATIONS + 13,
         EXPORT_CONTRACT: indexes.TITLES.EXPORT_CONTRACT + 2,
       },
     };

--- a/src/api/constants/XLSX-CONFIG/index-multiple-contract-policy-total-contract-value-over-threshold.test.ts
+++ b/src/api/constants/XLSX-CONFIG/index-multiple-contract-policy-total-contract-value-over-threshold.test.ts
@@ -19,7 +19,7 @@ describe(`api/constants/XLSX-CONFIG - XLSX_ROW_INDEXES - ${APPLICATION.POLICY_TY
       TITLES: {
         ...indexes.TITLES,
         BUYER: indexes.TITLES.BUYER + 1,
-        DECLARATIONS: indexes.TITLES.DECLARATIONS + 2,
+        DECLARATIONS: indexes.TITLES.DECLARATIONS + 3,
         EXPORT_CONTRACT: indexes.TITLES.EXPORT_CONTRACT + 2,
       },
     };

--- a/src/api/constants/XLSX-CONFIG/index-single-contract-policy-export-contract-conditions.test.ts
+++ b/src/api/constants/XLSX-CONFIG/index-single-contract-policy-export-contract-conditions.test.ts
@@ -36,7 +36,7 @@ describe(`api/constants/XLSX-CONFIG - XLSX_ROW_INDEXES - ${APPLICATION.POLICY_TY
       AGENT_ADDRESS: 79,
       TITLES: {
         ...indexes.TITLES,
-        DECLARATIONS: indexes.TITLES.DECLARATIONS + 10,
+        DECLARATIONS: indexes.TITLES.DECLARATIONS + 11,
         EXPORT_CONTRACT: indexes.TITLES.EXPORT_CONTRACT + 1,
       },
     };

--- a/src/api/constants/XLSX-CONFIG/index-single-contract-policy-total-contract-value-over-threshold.test.ts
+++ b/src/api/constants/XLSX-CONFIG/index-single-contract-policy-total-contract-value-over-threshold.test.ts
@@ -14,7 +14,7 @@ describe(`api/constants/XLSX-CONFIG - XLSX_ROW_INDEXES - ${APPLICATION.POLICY_TY
       AGENT_ADDRESS: indexes.AGENT_ADDRESS + 1,
       TITLES: {
         ...indexes.TITLES,
-        DECLARATIONS: indexes.TITLES.DECLARATIONS + 1,
+        DECLARATIONS: indexes.TITLES.DECLARATIONS + 2,
         EXPORT_CONTRACT: indexes.TITLES.EXPORT_CONTRACT + 1,
       },
     };

--- a/src/api/constants/XLSX-CONFIG/index.ts
+++ b/src/api/constants/XLSX-CONFIG/index.ts
@@ -170,7 +170,6 @@ export const XLSX_ROW_INDEXES = (application: Application): XLSXRowIndexes => {
   const totalContractValueOverThreshold = totalContractValue.value === TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE;
 
   if (totalContractValueOverThreshold) {
-    // increment for HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER field/row.
     indexes.TITLES.DECLARATIONS += 1;
     indexes.TITLES.EXPORT_CONTRACT += 1;
 

--- a/src/api/constants/XLSX-CONFIG/index.ts
+++ b/src/api/constants/XLSX-CONFIG/index.ts
@@ -24,6 +24,8 @@ const {
  * - If "policy - using a nominated loss payee" is true, the XLSX has 5 additional rows.
  * - If "buyer section - traded with buyer before" is true, the XLSX has 2 additional rows.
  * - If "buyer section - traded with buyer before" is true and "buyer has outstanding payments" is true, the XLSX has 2 additional rows.
+ * - If "total contract value over threshold", the buyer section has 2 additional rows.
+ * - If "total contract value over threshold" and has previous credit insurance with buyer, the buyer section has 2 additional rows.
  * - If "buyer section - has previous credit insurance cover with buyer" is true, the XLSX has 1 additional row.
  * - If "export contract section - final destination is known" is true, the XLSX has 1 additional row.
  * - If "export contract section - has attempted private market cover" is true, the XLSX has 1 additional row.
@@ -38,7 +40,7 @@ export const XLSX_ROW_INDEXES = (application: Application): XLSXRowIndexes => {
     broker,
     buyer: {
       buyerTradingHistory: { exporterHasTradedWithBuyer, outstandingPayments: buyerHasOutstandingPayments },
-      relationship: { exporterHasPreviousCreditInsuranceWithBuyer },
+      relationship: { exporterHasPreviousCreditInsuranceWithBuyer, exporterIsConnectedWithBuyer },
     },
     company: {
       differentTradingAddress: { fullAddress: hasDifferentTradingAddress },
@@ -149,6 +151,11 @@ export const XLSX_ROW_INDEXES = (application: Application): XLSXRowIndexes => {
    * Increment some specific indexes,
    * depending on answers in the "Buyer" section of an application.
    */
+  if (exporterIsConnectedWithBuyer) {
+    indexes.TITLES.DECLARATIONS += 1;
+    indexes.TITLES.EXPORT_CONTRACT += 1;
+  }
+
   if (exporterHasTradedWithBuyer) {
     indexes.TITLES.DECLARATIONS += 2;
     indexes.TITLES.EXPORT_CONTRACT += 2;
@@ -159,9 +166,18 @@ export const XLSX_ROW_INDEXES = (application: Application): XLSXRowIndexes => {
     }
   }
 
-  if (exporterHasPreviousCreditInsuranceWithBuyer) {
+  // TODO: EMS-3467: move to getPopulatedApplication.
+  const totalContractValueOverThreshold = totalContractValue.value === TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE;
+
+  if (totalContractValueOverThreshold) {
+    // increment for HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER field/row.
     indexes.TITLES.DECLARATIONS += 1;
     indexes.TITLES.EXPORT_CONTRACT += 1;
+
+    if (exporterHasPreviousCreditInsuranceWithBuyer) {
+      indexes.TITLES.DECLARATIONS += 1;
+      indexes.TITLES.EXPORT_CONTRACT += 1;
+    }
   }
 
   /**
@@ -199,6 +215,10 @@ export const XLSX_ROW_INDEXES = (application: Application): XLSXRowIndexes => {
     indexes.AGENT_ADDRESS += 1;
   }
 
+  if (totalContractValueOverThreshold) {
+    indexes.AGENT_ADDRESS += 1;
+  }
+
   if (finalDestinationKnown) {
     indexes.TITLES.DECLARATIONS += 1;
     indexes.AGENT_ADDRESS += 1;
@@ -206,16 +226,11 @@ export const XLSX_ROW_INDEXES = (application: Application): XLSXRowIndexes => {
 
   /**
    * Increment some specific indexes,
-   * depending on generic answers in the application.
+   * depending on generic answers in the application,
+   * that affect the final "declarations" section of an application.
    */
-  // TODO: EMS-3467: move to getPopulatedApplication.
-  const totalContractValueOverThreshold = totalContractValue.value === TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE;
-
   if (totalContractValueOverThreshold) {
     indexes.TITLES.DECLARATIONS += 1;
-    indexes.TITLES.EXPORT_CONTRACT += 1;
-
-    indexes.AGENT_ADDRESS += 1;
   }
 
   return indexes;

--- a/src/api/test-mocks/index.ts
+++ b/src/api/test-mocks/index.ts
@@ -64,6 +64,7 @@ export const mockApplicationMinimalBrokerBuyerAndCompany = {
     relationship: {
       ...mockApplication.buyer.relationship,
       exporterHasPreviousCreditInsuranceWithBuyer: false,
+      exporterIsConnectedWithBuyer: false,
     },
   },
   company: companyScenarios.noDifferentTradingNameOrAddress,


### PR DESCRIPTION
## Introduction :pencil2:

This PR fixes an issue with the XLSX where the formatting index for the "declarations" title be incorrect due to a missing buyer condition.

## Resolution :heavy_check_mark:

- Update `XLSX_ROW_INDEXES` to:
  - Increment 2x titles if `exporterIsConnectedWithBuyer` is true.
  - Increment 2x titles if `totalContractValueOverThreshold` and `exporterHasPreviousCreditInsuranceWithBuyer` are true.
  - Increment `AGENT_ADDRESS if `totalContractValueOverThreshold` is true.
- Update API test mocks.

## Miscellaneous :heavy_plus_sign:

- Add E2E tests for submitting an application (single and multiple contracts) with minimal buyer conditions.
