### PR TITLE
fix(EMS-3518): no pdf - application submission - XLSX - final destination

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-fully-populated.spec.js
@@ -31,6 +31,7 @@ context(
         hasConnectionToBuyer: true,
         buyerOutstandingPayments: true,
         buyerFailedToPayOnTime: true,
+        finalDestinationKnown: true,
         fullyPopulatedBuyerTradingHistory: true,
         hasHadCreditInsuranceCoverWithBuyer: true,
         exporterHasBuyerFinancialAccounts: true,

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-fully-populated.spec.js
@@ -29,6 +29,7 @@ context(
         hasConnectionToBuyer: true,
         buyerOutstandingPayments: true,
         buyerFailedToPayOnTime: true,
+        finalDestinationKnown: true,
         fullyPopulatedBuyerTradingHistory: true,
         hasHadCreditInsuranceCoverWithBuyer: true,
         exporterHasBuyerFinancialAccounts: true,

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -7390,7 +7390,7 @@ var mapFinalDestination = (exportContract, countries) => {
   const mapped = [xlsx_row_default(String(FIELDS25.EXPORT_CONTRACT[FINAL_DESTINATION_KNOWN3]), map_yes_no_field_default({ answer: finalDestinationKnownAnswer }))];
   if (finalDestinationKnownAnswer) {
     const country = get_country_by_iso_code_default(countries, exportContract[FINAL_DESTINATION2]);
-    mapped.push(xlsx_row_default(String(CONTENT_STRINGS8[FINAL_DESTINATION2]), String(country)));
+    mapped.push(xlsx_row_default(String(CONTENT_STRINGS8[FINAL_DESTINATION2].SUMMARY?.TITLE), country.name));
   }
   return mapped;
 };

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-final-destination/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-final-destination/index.test.ts
@@ -33,7 +33,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-export-contract/map-fina
 
       const expected = [
         xlsxRow(String(FIELDS.EXPORT_CONTRACT[FINAL_DESTINATION_KNOWN]), mapYesNoField({ answer: finalDestinationKnownAnswer })),
-        xlsxRow(String(CONTENT_STRINGS[FINAL_DESTINATION]), String(country)),
+        xlsxRow(String(CONTENT_STRINGS[FINAL_DESTINATION].SUMMARY?.TITLE), String(country.name)),
       ];
 
       expect(result).toEqual(expected);

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-final-destination/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-final-destination/index.ts
@@ -29,7 +29,7 @@ const mapFinalDestination = (exportContract: ApplicationExportContract, countrie
   if (finalDestinationKnownAnswer) {
     const country = getCountryByIsoCode(countries, exportContract[FINAL_DESTINATION]);
 
-    mapped.push(xlsxRow(String(CONTENT_STRINGS[FINAL_DESTINATION]), String(country)));
+    mapped.push(xlsxRow(String(CONTENT_STRINGS[FINAL_DESTINATION].SUMMARY?.TITLE), country.name));
   }
 
   return mapped;

--- a/src/api/test-mocks/mock-application.ts
+++ b/src/api/test-mocks/mock-application.ts
@@ -78,7 +78,7 @@ export const mockExportContractAgent = {
 };
 
 export const mockExportContractAgentFullyPopulated = {
-  countryCode: mockCountries[0].isoCode,
+  finalDestinationCountryCode: mockCountries[0].isoCode,
   fullAddress: 'Mock export contract agent address',
   isUsingAgent: false,
   name: 'Mock export contract agent name',


### PR DESCRIPTION
## Introduction :pencil2:

This PR fixes an issue where the "final destination" row in the XLSX would display as `[Object] [Object]`.

## Resolution :heavy_check_mark:

- Update `mapFinalDestination` XLSX mapping function.
- Update some E2E tests to include a `finalDestinationKnown` flag.
