### PR TITLE
fix(EMS-3524): no pdf - data migration - account, buyer relationships

### DIFF
--- a/src/api/data-migration/version-1-to-version-2/README.md
+++ b/src/api/data-migration/version-1-to-version-2/README.md
@@ -50,6 +50,7 @@ To set up and run the API locally, you'll need the following prerequisites:
 - The `DATABASE_URL` environment variable should be configured to point to your local MySQL database, for example: `mysql://root:@localhost:1234/db-name`.
 - The local `NODE_ENV` environment variable set to `migration`.
 - The local `DATABASE_USER` environment variable set to the database's user.
+- The local `DATABASE_PASSWORD` environment variable set to the database's password.
 - `mysql2` NPM package installed as an API dependency.
 
 ## Running Locally :computer:

--- a/src/api/data-migration/version-1-to-version-2/README.md
+++ b/src/api/data-migration/version-1-to-version-2/README.md
@@ -52,6 +52,7 @@ To set up and run the API locally, you'll need the following prerequisites:
 - The local `DATABASE_USER` environment variable set to the database's user.
 - The local `DATABASE_PASSWORD` environment variable set to the database's password.
 - `mysql2` NPM package installed as an API dependency.
+- `ts-node` NPM package installed locally.
 
 ## Running Locally :computer:
 

--- a/src/api/data-migration/version-1-to-version-2/connect-to-database.ts
+++ b/src/api/data-migration/version-1-to-version-2/connect-to-database.ts
@@ -15,7 +15,8 @@ const connectToDatabase = async () => {
     const connection = (await mysql.createConnection({
       host: '127.0.0.1',
       user: process.env.DATABASE_USER,
-      database: 'exip-migration',
+      password: process.env.DATABASE_PASSWORD,
+      database: 'exip',
       port: Number(process.env.DATABASE_PORT),
     })) as Connection;
 

--- a/src/api/data-migration/version-1-to-version-2/create-new-account-status-relationships/index.ts
+++ b/src/api/data-migration/version-1-to-version-2/create-new-account-status-relationships/index.ts
@@ -11,7 +11,7 @@ import { AccountMvp } from '../../../types';
  * 2) Create an array of "account status" data - using isVerified and isBlocked from the original accounts data.
  * 3) Create new "account status" entries.
  * @param {Connection} connection: SQL database connection
- * @returns {Promise<Array<AccountStatus>>} Account status entires
+ * @returns {Promise<Boolean>}
  */
 const createNewAccountStatusRelationships = async (connection: Connection): Promise<boolean> => {
   const loggingMessage = 'Creating new status relationships for all accounts';

--- a/src/api/data-migration/version-1-to-version-2/create-new-account-status-relationships/index.ts
+++ b/src/api/data-migration/version-1-to-version-2/create-new-account-status-relationships/index.ts
@@ -1,7 +1,8 @@
-import { Context } from '.keystone/types'; // eslint-disable-line
+import { format } from 'date-fns';
 import { Connection } from 'mysql2/promise';
 import getAllAccounts from '../get-all-accounts';
-import { AccountMvp, AccountStatus } from '../../../types';
+import executeSqlQuery from '../execute-sql-query';
+import { AccountMvp } from '../../../types';
 
 /**
  * createNewAccountStatusRelationships
@@ -10,10 +11,9 @@ import { AccountMvp, AccountStatus } from '../../../types';
  * 2) Create an array of "account status" data - using isVerified and isBlocked from the original accounts data.
  * 3) Create new "account status" entries.
  * @param {Connection} connection: SQL database connection
- * @param {Context} context: KeystoneJS context API
  * @returns {Promise<Array<AccountStatus>>} Account status entires
  */
-const createNewAccountStatusRelationships = async (connection: Connection, context: Context): Promise<Array<AccountStatus>> => {
+const createNewAccountStatusRelationships = async (connection: Connection): Promise<boolean> => {
   const loggingMessage = 'Creating new status relationships for all accounts';
 
   console.info(`✅ ${loggingMessage}`);
@@ -21,34 +21,17 @@ const createNewAccountStatusRelationships = async (connection: Connection, conte
   try {
     const accounts = await getAllAccounts(connection);
 
-    const mappedAccountStatusData = accounts.map((account: AccountMvp) => {
-      const mapped = {
-        account: {
-          connect: {
-            id: account.id,
-          },
-        },
-        /**
-         * NOTE: The accounts data we receive is raw database data.
-         * In the database, boolean fields are TINYINT/integer values.
-         * The KeystoneJS context/GraphQL API expects these fields to be booleans.
-         * Therefore, since the TINYINT values will be 0 or 1,
-         * we can safely transform these fields to have a boolean value.
-         * KeystoneJS will then automatically handle saving in the database as a TINYINT
-         */
-        isVerified: Boolean(account.isVerified),
-        isBlocked: Boolean(account.isBlocked),
-        updatedAt: account.updatedAt,
-      };
+    const accountStatusData = accounts.map(
+      (account: AccountMvp) => `('${account.id}', ${account.isBlocked}, ${account.isVerified}, '${format(account.updatedAt, 'yyyy-MM-dd HH:mm')}')`,
+    );
 
-      return mapped;
-    });
+    const query = `
+      INSERT INTO AccountStatus (id, isBlocked, isVerified, updatedAt) VALUES ${accountStatusData};
+    `;
 
-    const created = (await context.db.AccountStatus.createMany({
-      data: mappedAccountStatusData,
-    })) as Array<AccountStatus>;
+    await executeSqlQuery({ connection, query, loggingMessage });
 
-    return created;
+    return true;
   } catch (err) {
     console.error(`🚨 error ${loggingMessage} %O`, err);
 

--- a/src/api/data-migration/version-1-to-version-2/get-all-buyer-contacts.ts
+++ b/src/api/data-migration/version-1-to-version-2/get-all-buyer-contacts.ts
@@ -1,0 +1,23 @@
+import { Connection } from 'mysql2/promise';
+import executeSqlQuery from './execute-sql-query';
+import { ApplicationBuyerMvp } from '../../types';
+
+/**
+ * getAllBuyerContacts
+ * Get all buyer contacts in the "BuyerContact" table.
+ * @param {Connection} connection: SQL database connection
+ * @returns {Promise<Array<object>>} executeSqlQuery response
+ */
+const getAllBuyerContacts = async (connection: Connection) => {
+  const loggingMessage = 'Getting all buyer contacts';
+
+  const query = 'SELECT * FROM BuyerContact';
+
+  const [allBuyers] = await executeSqlQuery({ connection, query, loggingMessage });
+
+  const buyers = allBuyers as Array<ApplicationBuyerMvp>;
+
+  return buyers;
+};
+
+export default getAllBuyerContacts;

--- a/src/api/data-migration/version-1-to-version-2/get-all-buyer-contacts.ts
+++ b/src/api/data-migration/version-1-to-version-2/get-all-buyer-contacts.ts
@@ -1,6 +1,5 @@
 import { Connection } from 'mysql2/promise';
 import executeSqlQuery from './execute-sql-query';
-import { ApplicationBuyerMvp } from '../../types';
 
 /**
  * getAllBuyerContacts
@@ -13,11 +12,9 @@ const getAllBuyerContacts = async (connection: Connection) => {
 
   const query = 'SELECT * FROM BuyerContact';
 
-  const [allBuyers] = await executeSqlQuery({ connection, query, loggingMessage });
+  const [contacts] = await executeSqlQuery({ connection, query, loggingMessage });
 
-  const buyers = allBuyers as Array<ApplicationBuyerMvp>;
-
-  return buyers;
+  return contacts;
 };
 
 export default getAllBuyerContacts;

--- a/src/api/data-migration/version-1-to-version-2/get-all-buyer-relationships.ts
+++ b/src/api/data-migration/version-1-to-version-2/get-all-buyer-relationships.ts
@@ -1,6 +1,5 @@
 import { Connection } from 'mysql2/promise';
 import executeSqlQuery from './execute-sql-query';
-import { ApplicationBuyerMvp } from '../../types';
 
 /**
  * getAllBuyerRelationships
@@ -13,11 +12,9 @@ const getAllBuyerRelationships = async (connection: Connection) => {
 
   const query = 'SELECT * FROM BuyerRelationship';
 
-  const [allBuyers] = await executeSqlQuery({ connection, query, loggingMessage });
+  const [relationships] = await executeSqlQuery({ connection, query, loggingMessage });
 
-  const buyers = allBuyers as Array<ApplicationBuyerMvp>;
-
-  return buyers;
+  return relationships;
 };
 
 export default getAllBuyerRelationships;

--- a/src/api/data-migration/version-1-to-version-2/get-all-buyer-relationships.ts
+++ b/src/api/data-migration/version-1-to-version-2/get-all-buyer-relationships.ts
@@ -1,0 +1,23 @@
+import { Connection } from 'mysql2/promise';
+import executeSqlQuery from './execute-sql-query';
+import { ApplicationBuyerMvp } from '../../types';
+
+/**
+ * getAllBuyerRelationships
+ * Get all buyer relationships in the "BuyerRelationship" table.
+ * @param {Connection} connection: SQL database connection
+ * @returns {Promise<Array<object>>} executeSqlQuery response
+ */
+const getAllBuyerRelationships = async (connection: Connection) => {
+  const loggingMessage = 'Getting all buyer relationships';
+
+  const query = 'SELECT * FROM BuyerRelationship';
+
+  const [allBuyers] = await executeSqlQuery({ connection, query, loggingMessage });
+
+  const buyers = allBuyers as Array<ApplicationBuyerMvp>;
+
+  return buyers;
+};
+
+export default getAllBuyerRelationships;

--- a/src/api/data-migration/version-1-to-version-2/get-all-buyer-trading-histories.ts
+++ b/src/api/data-migration/version-1-to-version-2/get-all-buyer-trading-histories.ts
@@ -1,0 +1,21 @@
+import { Connection } from 'mysql2/promise';
+import executeSqlQuery from './execute-sql-query';
+
+/**
+ * getAllBuyerTradingHistories
+ * Get all buyer trading history in the "BuyerTradingHistory" table.
+ * @param {Connection} connection: SQL database connection
+ * @returns {Promise<Array<object>>} executeSqlQuery response
+ */
+const getAllBuyerTradingHistories = async (connection: Connection) => {
+  const loggingMessage = 'Getting all buyer trading histories';
+
+  const query = 'SELECT * FROM BuyerTradingHistory';
+
+  // TODO: allbuyers / trading history etc
+  const [allBuyers] = await executeSqlQuery({ connection, query, loggingMessage });
+
+  return allBuyers;
+};
+
+export default getAllBuyerTradingHistories;

--- a/src/api/data-migration/version-1-to-version-2/get-all-buyer-trading-histories.ts
+++ b/src/api/data-migration/version-1-to-version-2/get-all-buyer-trading-histories.ts
@@ -12,10 +12,9 @@ const getAllBuyerTradingHistories = async (connection: Connection) => {
 
   const query = 'SELECT * FROM BuyerTradingHistory';
 
-  // TODO: allbuyers / trading history etc
-  const [allBuyers] = await executeSqlQuery({ connection, query, loggingMessage });
+  const [tradingHistories] = await executeSqlQuery({ connection, query, loggingMessage });
 
-  return allBuyers;
+  return tradingHistories;
 };
 
 export default getAllBuyerTradingHistories;

--- a/src/api/data-migration/version-1-to-version-2/index.ts
+++ b/src/api/data-migration/version-1-to-version-2/index.ts
@@ -36,13 +36,13 @@ const dataMigration = async () => {
 
     console.info('✅ Obtained keystone context. Executing additional queries');
 
-    await createNewAccountStatusRelationships(connection, context);
-
-    await removeAccountStatusFields(connection);
+    await createNewAccountStatusRelationships(connection);
 
     await updateBuyers(connection, context);
 
     await createNewApplicationRelationships(context);
+
+    await removeAccountStatusFields(connection);
 
     console.info('🎉 Migration complete. Exiting script');
 

--- a/src/api/data-migration/version-1-to-version-2/index.ts
+++ b/src/api/data-migration/version-1-to-version-2/index.ts
@@ -5,6 +5,7 @@ import updateApplications from './update-applications';
 import createNewAccountStatusRelationships from './create-new-account-status-relationships';
 import removeAccountStatusFields from './update-accounts/remove-account-status-fields';
 import createNewApplicationRelationships from './create-new-application-relationships';
+import getAllBuyers from './get-all-buyers';
 import updateBuyers from './update-buyers';
 import getKeystoneContext from '../../test-helpers/get-keystone-context';
 
@@ -38,7 +39,9 @@ const dataMigration = async () => {
 
     await createNewAccountStatusRelationships(connection);
 
-    await updateBuyers(connection, context);
+    const buyers = await getAllBuyers(connection);
+
+    await updateBuyers(connection, buyers);
 
     await createNewApplicationRelationships(context);
 

--- a/src/api/data-migration/version-1-to-version-2/update-buyers/index.ts
+++ b/src/api/data-migration/version-1-to-version-2/update-buyers/index.ts
@@ -1,39 +1,31 @@
-import { Context } from '.keystone/types'; // eslint-disable-line
 import { Connection } from 'mysql2/promise';
-import getAllBuyers from '../get-all-buyers';
 import moveBuyerContactFields from '../update-applications/move-buyer-contact-fields';
 import moveBuyerRelationshipFields from '../update-applications/move-buyer-relationship-fields';
 import moveBuyerTradingHistoryFields from '../update-applications/move-buyer-trading-history-fields';
 import updateBuyerAddressVarChar from '../update-applications/update-buyer-address-var-char';
 import removeBuyerFields from '../update-applications/remove-buyer-fields';
 import updateBuyerRelationshipIds from './update-buyer-relationship-ids';
+import { ApplicationBuyerMvp } from '../../../types';
 
 /**
  * updateBuyers
  * Move MVP "buyers" fields into the new "No PDF" data model/structure.
  * @param {Connection} connection: SQL database connection
- * @param {Context} context: KeystoneJS context API
  * @returns {Promise<Array<object>>} Updated buyers
  */
-const updateBuyers = async (connection: Connection, context: Context) => {
+const updateBuyers = async (connection: Connection, buyers: Array<ApplicationBuyerMvp>) => {
   const loggingMessage = 'Updating buyers';
 
   console.info(`✅ ${loggingMessage}`);
 
   try {
-    const buyers = await getAllBuyers(connection);
+    await Promise.all([
+      moveBuyerContactFields(buyers, connection),
+      moveBuyerRelationshipFields(buyers, connection),
+      moveBuyerTradingHistoryFields(buyers, connection),
+    ]);
 
-    const buyerContacts = await moveBuyerContactFields(buyers, context);
-    const buyerRelationships = await moveBuyerRelationshipFields(buyers, context);
-    const buyerTradingHistories = await moveBuyerTradingHistoryFields(buyers, context);
-
-    const updated = await updateBuyerRelationshipIds({
-      context,
-      buyers,
-      buyerContacts,
-      buyerRelationships,
-      buyerTradingHistories,
-    });
+    const updated = await updateBuyerRelationshipIds({ connection, buyers });
 
     await updateBuyerAddressVarChar(connection);
 


### PR DESCRIPTION
## Introduction :pencil2:

This PR fixes 2x issues with "MVP to no-pdf" data migration, where the following issues would occur:

- `AccountStatus` relationship creations would fail.
- Various `Buyer` relationship creations would fail.

## Resolution :heavy_check_mark:

- Update the following functions to use raw SQL queries, instead of the KeystoneJS context API.
  - `createNewAccountStatusRelationships`
  - `moveBuyerContactFields`
  - `moveBuyerTradingHistoryFields`
  - `updateBuyers`
  - `updateBuyerRelationshipIds`
- Create new buyer relationship functions:
  - `getAllBuyerContacts`
  - `getAllBuyerRelationships`
  - `getAllBuyerTradingHistories`

## Miscellaneous :heavy_plus_sign:

- Update `README.md`.
- Update `connectToDatabase` function.
