### PR TITLE
fix(EMS-3508-3543): no pdf - application submission - XLSX - agent values

### DIFF
--- a/e2e-tests/commands/insurance/complete-export-contract-section.js
+++ b/e2e-tests/commands/insurance/complete-export-contract-section.js
@@ -54,7 +54,7 @@ const completeExportContractSection = ({
       });
 
       if (alternativeCurrency) {
-        cy.go('back');
+        cy.clickBackLink();
 
         cy.clickProvideAlternativeCurrencyLink();
 

--- a/e2e-tests/commands/insurance/complete-export-contract-section.js
+++ b/e2e-tests/commands/insurance/complete-export-contract-section.js
@@ -5,6 +5,7 @@
  * @param {Boolean} agentChargeMethodFixedSum: Agent charge method is "fixed sum"
  * @param {String} agentChargeFixedSumAmount: Agent charge fixed sum amount
  * @param {Boolean} agentChargeMethodPercentage: Agent charge method is "percentage"
+ * @param {Boolean} alternativeCurrency: Should submit an "alternative currency". Defaults to false.
  * @param {Boolean} attemptedPrivateMarketCover: Has attempted to insure through the private market
  * @param {Boolean} finalDestinationKnown: "Final destination known"
  * @param {Boolean} isUsingAgent: Exporter is using an agent
@@ -17,6 +18,7 @@ const completeExportContractSection = ({
   agentChargeMethodFixedSum = false,
   agentChargeFixedSumAmount,
   agentChargeMethodPercentage = false,
+  alternativeCurrency = false,
   attemptedPrivateMarketCover = false,
   finalDestinationKnown,
   isUsingAgent = false,
@@ -50,6 +52,16 @@ const completeExportContractSection = ({
         fixedSumAmount: agentChargeFixedSumAmount,
         percentageMethod: agentChargeMethodPercentage,
       });
+
+      if (alternativeCurrency) {
+        cy.go('back');
+
+        cy.clickProvideAlternativeCurrencyLink();
+
+        cy.clickAlternativeCurrencyRadioAndSubmitCurrency({});
+
+        cy.clickSubmitButton();
+      }
     }
   }
 

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
@@ -10,7 +10,10 @@ const { POLICY_TYPE } = APPLICATION;
  * @param {String} agentChargeFixedSumAmount: Agent charge fixed sum amount
  * @param {Boolean} agentChargeMethodPercentage: Agent charge method is "percentage".
  * @param {Boolean} agentIsCharging: Should submit "yes" to "agent is charging" in the "agent details" form.
- * @param {Boolean} alternativeBuyerCurrency: Should submit an "alternative currency" in the buyer section.
+ * @param {Boolean} alternativeCurrencyBuyer: Should submit an "buyer - alternative currency"
+ * @param {Boolean} alternativeCurrencyExportContract: Select the "agent - alternative currency" option
+ * @param {Boolean} alternativeCurrencyTurnover: Select the "turnover - alternative currency" option
+ * @param {Boolean} alternativeCurrencyPolicy: Select the "policy - alternative currency" option
  * @param {Boolean} attemptedPrivateMarketCover: Should submit "yes" to "attempted to insure through the private market" form.
  * @param {Boolean} buyerOutstandingPayments: Exporter has outstanding payments with the buyer.
  * @param {Boolean} buyerFailedToPayOnTime: Buyer has failed to pay the exporter on the time.
@@ -33,15 +36,16 @@ const { POLICY_TYPE } = APPLICATION;
  * @param {Boolean} submitCheckYourAnswers: Should click each section's "check your answers" submit button.
  * @param {Boolean} totalContractValueOverThreshold: If total contract value in eligibility should be over threshold.
  * @param {Boolean} usingBroker: Should submit "yes" or "no" to "using a broker".
- * @param {Boolean} alternativeCurrencyTurnover: Select the "alternative currency" option
- * @param {Boolean} alternativeCurrencyPolicy: Select the "alternative currency" option
  */
 const completePrepareApplicationMultiplePolicyType = ({
   agentChargeMethodFixedSum = false,
   agentChargeFixedSumAmount,
   agentChargeMethodPercentage = false,
   agentIsCharging = false,
-  alternativeBuyerCurrency = false,
+  alternativeCurrencyBuyer = false,
+  alternativeCurrencyExportContract = false,
+  alternativeCurrencyTurnover = false,
+  alternativeCurrencyPolicy = false,
   attemptedPrivateMarketCover = false,
   buyerOutstandingPayments = false,
   buyerFailedToPayOnTime = false,
@@ -64,8 +68,6 @@ const completePrepareApplicationMultiplePolicyType = ({
   totalContractValueOverThreshold = false,
   submitCheckYourAnswers = true,
   usingBroker = false,
-  alternativeCurrencyTurnover = false,
-  alternativeCurrencyPolicy = false,
 }) => {
   cy.completeBusinessSection({
     differentTradingName,
@@ -76,7 +78,7 @@ const completePrepareApplicationMultiplePolicyType = ({
   });
 
   cy.completeBuyerSection({
-    alternativeCurrency: alternativeBuyerCurrency,
+    alternativeCurrency: alternativeCurrencyBuyer,
     hasConnectionToBuyer,
     exporterHasTradedWithBuyer,
     outstandingPayments: buyerOutstandingPayments,
@@ -106,6 +108,7 @@ const completePrepareApplicationMultiplePolicyType = ({
     agentChargeMethodFixedSum,
     agentChargeFixedSumAmount,
     agentChargeMethodPercentage,
+    alternativeCurrency: alternativeCurrencyExportContract,
     attemptedPrivateMarketCover,
     finalDestinationKnown,
     isUsingAgent,

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
@@ -10,7 +10,10 @@ const { POLICY_TYPE } = FIELD_VALUES;
  * @param {String} agentChargeFixedSumAmount: Agent charge fixed sum amount
  * @param {Boolean} agentChargeMethodPercentage: Agent charge method is "percentage".
  * @param {Boolean} agentIsCharging: Should submit "yes" to "agent is charging" in the "agent details" form.
- * @param {Boolean} alternativeBuyerCurrency: Should submit an "alternative currency" in the buyer section.
+ * @param {Boolean} alternativeCurrencyBuyer: Should submit an "buyer - alternative currency"
+ * @param {Boolean} alternativeCurrencyExportContract: Select the "agent - alternative currency" option
+ * @param {Boolean} alternativeCurrencyTurnover: Select the "turnover - alternative currency" option
+ * @param {Boolean} alternativeCurrencyPolicy: Select the "policy - alternative currency" option
  * @param {Boolean} attemptedPrivateMarketCover: Should submit "yes" to "attempted to insure through the private market" form.
  * @param {Boolean} buyerOutstandingPayments: Exporter has outstanding payments with the buyer.
  * @param {Boolean} buyerFailedToPayOnTime: Buyer has failed to pay the exporter on the time.
@@ -33,11 +36,12 @@ const { POLICY_TYPE } = FIELD_VALUES;
  * @param {Boolean} submitCheckYourAnswers: Should click each section's "check your answers" submit button.
  * @param {Boolean} totalContractValueOverThreshold: If total contract value in eligibility should be over threshold.
  * @param {Boolean} usingBroker: Should submit "yes" or "no" to "using a broker".
- * @param {Boolean} alternativeCurrencyTurnover: Select the "alternative currency" option
- * @param {Boolean} alternativeCurrencyPolicy: Select the "alternative currency" option
  */
 const completePrepareApplicationSinglePolicyType = ({
-  alternativeBuyerCurrency = false,
+  alternativeCurrencyBuyer = false,
+  alternativeCurrencyExportContract = false,
+  alternativeCurrencyTurnover = false,
+  alternativeCurrencyPolicy = false,
   differentTradingName = false,
   differentTradingAddress = false,
   hasCreditControlProcess = false,
@@ -64,8 +68,6 @@ const completePrepareApplicationSinglePolicyType = ({
   agentChargeFixedSumAmount,
   agentChargeMethodPercentage = false,
   submitCheckYourAnswers = true,
-  alternativeCurrencyTurnover = false,
-  alternativeCurrencyPolicy = false,
 }) => {
   cy.completeBusinessSection({
     differentTradingName,
@@ -76,7 +78,7 @@ const completePrepareApplicationSinglePolicyType = ({
   });
 
   cy.completeBuyerSection({
-    alternativeCurrency: alternativeBuyerCurrency,
+    alternativeCurrency: alternativeCurrencyBuyer,
     hasConnectionToBuyer,
     exporterHasTradedWithBuyer,
     outstandingPayments: buyerOutstandingPayments,
@@ -106,6 +108,7 @@ const completePrepareApplicationSinglePolicyType = ({
     agentChargeMethodFixedSum,
     agentChargeFixedSumAmount,
     agentChargeMethodPercentage,
+    alternativeCurrency: alternativeCurrencyExportContract,
     attemptedPrivateMarketCover,
     finalDestinationKnown,
     isUsingAgent,

--- a/e2e-tests/commands/insurance/complete-sign-in-and-submit-an-application.js
+++ b/e2e-tests/commands/insurance/complete-sign-in-and-submit-an-application.js
@@ -11,7 +11,10 @@ import completeSignInAndGoToApplication from './account/complete-sign-in-and-go-
  * @param {Boolean} agentChargeMethodFixedSum: Agent charge method is "fixed sum".
  * @param {Boolean} agentChargeMethodPercentage: Agent charge method is "percentage".
  * @param {Boolean} agentIsCharging: Should submit "yes" to "agent is charging" in the "agent details" form.
- * @param {Boolean} alternativeBuyerCurrency: Should submit an "alternative currency" in the buyer section.
+ * @param {Boolean} alternativeCurrencyBuyer: Should submit an "buyer - alternative currency".
+ * @param {Boolean} alternativeCurrencyExportContract: Select the "export contract - alternative currency" option
+ * @param {Boolean} alternativeCurrencyTurnover: Select the "turnover - alternative currency" option
+ * @param {Boolean} alternativeCurrencyPolicy: Select the "policy - alternative currency" option
  * @param {Boolean} attemptedPrivateMarketCover: Should submit "yes" to "attempted to insure through the private market" form.
  * @param {Boolean} buyerOutstandingPayments: Exporter has outstanding payments with the buyer.
  * @param {Boolean} buyerFailedToPayOnTime: Buyer has failed to pay the exporter on the time.
@@ -34,12 +37,13 @@ import completeSignInAndGoToApplication from './account/complete-sign-in-and-go-
  * @param {Boolean} submitCheckYourAnswers: Should click each section's "check your answers" submit button.
  * @param {Boolean} totalContractValueOverThreshold: If total contract value in eligibility should be over threshold.
  * @param {Boolean} usingBroker: Should submit "yes" or "no" to "using a broker".
- * @param {Boolean} alternativeCurrencyTurnover: Select the "alternative currency" option
- * @param {Boolean} alternativeCurrencyPolicy: Select the "alternative currency" option
  * @return {String} Application reference number
  */
 const completeSignInAndSubmitAnApplication = ({
-  alternativeBuyerCurrency = false,
+  alternativeCurrencyBuyer = false,
+  alternativeCurrencyExportContract = false,
+  alternativeCurrencyTurnover = false,
+  alternativeCurrencyPolicy = false,
   agentIsCharging = false,
   agentChargeMethodFixedSum = false,
   agentChargeMethodPercentage = false,
@@ -66,8 +70,6 @@ const completeSignInAndSubmitAnApplication = ({
   policyValueOverMvpMaximum = false,
   totalContractValueOverThreshold = false,
   usingBroker = false,
-  alternativeCurrencyTurnover = false,
-  alternativeCurrencyPolicy = false,
 }) => {
   completeSignInAndGoToApplication({ totalContractValueOverThreshold }).then(({ referenceNumber }) => {
     if (policyType === APPLICATION.POLICY_TYPE.MULTIPLE) {
@@ -76,7 +78,10 @@ const completeSignInAndSubmitAnApplication = ({
         agentChargeMethodPercentage,
         agentIsCharging,
         attemptedPrivateMarketCover,
-        alternativeBuyerCurrency,
+        alternativeCurrencyBuyer,
+        alternativeCurrencyExportContract,
+        alternativeCurrencyTurnover,
+        alternativeCurrencyPolicy,
         buyerOutstandingPayments,
         buyerFailedToPayOnTime,
         differentPolicyContact,
@@ -97,15 +102,16 @@ const completeSignInAndSubmitAnApplication = ({
         referenceNumber,
         totalContractValueOverThreshold,
         usingBroker,
-        alternativeCurrencyTurnover,
-        alternativeCurrencyPolicy,
       });
     } else {
       cy.completePrepareApplicationSinglePolicyType({
         agentChargeMethodFixedSum,
         agentChargeMethodPercentage,
         agentIsCharging,
-        alternativeBuyerCurrency,
+        alternativeCurrencyBuyer,
+        alternativeCurrencyExportContract,
+        alternativeCurrencyTurnover,
+        alternativeCurrencyPolicy,
         attemptedPrivateMarketCover,
         buyerFailedToPayOnTime,
         buyerOutstandingPayments,
@@ -127,8 +133,6 @@ const completeSignInAndSubmitAnApplication = ({
         referenceNumber,
         totalContractValueOverThreshold,
         usingBroker,
-        alternativeCurrencyTurnover,
-        alternativeCurrencyPolicy,
       });
     }
     cy.completeAndSubmitCheckYourAnswers();

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-alternative-currency.spec.js
@@ -8,7 +8,7 @@ context(
     before(() => {
       cy.completeSignInAndSubmitAnApplication({
         policyType: APPLICATION.POLICY_TYPE.MULTIPLE,
-        alternativeBuyerCurrency: true,
+        alternativeCurrencyBuyer: true,
         exporterHasTradedWithBuyer: true,
         buyerOutstandingPayments: true,
         buyerFailedToPayOnTime: true,

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-alternative-currency.spec.js
@@ -1,12 +1,15 @@
-context('Insurance - submit an application - Single policy type, exporter has traded with buyer, has outstanding payments, alternative currency', () => {
+import { APPLICATION } from '../../../../../../../constants';
+
+context('Insurance - submit an application - Multiple policy type, using an agent, fixed sum method, alternative currency', () => {
   let referenceNumber;
 
   before(() => {
     cy.completeSignInAndSubmitAnApplication({
-      alternativeCurrencyBuyer: true,
-      exporterHasTradedWithBuyer: true,
-      buyerOutstandingPayments: true,
-      buyerFailedToPayOnTime: true,
+      isUsingAgent: true,
+      agentIsCharging: true,
+      agentChargeMethodFixedSum: true,
+      alternativeCurrencyExportContract: true,
+      policyType: APPLICATION.POLICY_TYPE.MULTIPLE,
     }).then((refNumber) => {
       referenceNumber = refNumber;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-no-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-no-charges.spec.js
@@ -1,6 +1,6 @@
 import { APPLICATION } from '../../../../../../../constants';
 
-context('Insurance - submit an application - Multiple policy type, using an agent', () => {
+context('Insurance - submit an application - Multiple policy type, using an agent, no charges', () => {
   let referenceNumber;
 
   before(() => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-percentage-method.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-percentage-method.spec.js
@@ -1,9 +1,14 @@
-context('Insurance - submit an application - Single policy type, using an agent', () => {
+import { APPLICATION } from '../../../../../../../constants';
+
+context('Insurance - submit an application - Multiple policy type, using an agent, charges, percentage method', () => {
   let referenceNumber;
 
   before(() => {
     cy.completeSignInAndSubmitAnApplication({
       isUsingAgent: true,
+      agentIsCharging: true,
+      agentChargeMethodPercentage: true,
+      policyType: APPLICATION.POLICY_TYPE.MULTIPLE,
     }).then((refNumber) => {
       referenceNumber = refNumber;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-fully-populated.spec.js
@@ -9,7 +9,7 @@ context(
     before(() => {
       cy.completeSignInAndSubmitAnApplication({
         policyType: APPLICATION.POLICY_TYPE.MULTIPLE,
-        alternativeBuyerCurrency: true,
+        alternativeCurrencyBuyer: true,
         differentTradingName: true,
         differentTradingAddress: true,
         exporterHasTradedWithBuyer: true,

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-alternative-currency.spec.js
@@ -1,12 +1,12 @@
-context('Insurance - submit an application - Single policy type, exporter has traded with buyer, has outstanding payments, alternative currency', () => {
+context('Insurance - submit an application - Single policy type, using an agent,  fixed sum method, alternative currency', () => {
   let referenceNumber;
 
   before(() => {
     cy.completeSignInAndSubmitAnApplication({
-      alternativeCurrencyBuyer: true,
-      exporterHasTradedWithBuyer: true,
-      buyerOutstandingPayments: true,
-      buyerFailedToPayOnTime: true,
+      isUsingAgent: true,
+      agentIsCharging: true,
+      agentChargeMethodFixedSum: true,
+      alternativeCurrencyExportContract: true,
     }).then((refNumber) => {
       referenceNumber = refNumber;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-no-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-no-charges.spec.js
@@ -1,12 +1,9 @@
-context('Insurance - submit an application - Single policy type, exporter has traded with buyer, has outstanding payments, alternative currency', () => {
+context('Insurance - submit an application - Single policy type, using an agent, no charges', () => {
   let referenceNumber;
 
   before(() => {
     cy.completeSignInAndSubmitAnApplication({
-      alternativeCurrencyBuyer: true,
-      exporterHasTradedWithBuyer: true,
-      buyerOutstandingPayments: true,
-      buyerFailedToPayOnTime: true,
+      isUsingAgent: true,
     }).then((refNumber) => {
       referenceNumber = refNumber;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-percentage-method.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-percentage-method.spec.js
@@ -1,12 +1,11 @@
-context('Insurance - submit an application - Single policy type, exporter has traded with buyer, has outstanding payments, alternative currency', () => {
+context('Insurance - submit an application - Single policy type, using an agent, charges, percentage method', () => {
   let referenceNumber;
 
   before(() => {
     cy.completeSignInAndSubmitAnApplication({
-      alternativeCurrencyBuyer: true,
-      exporterHasTradedWithBuyer: true,
-      buyerOutstandingPayments: true,
-      buyerFailedToPayOnTime: true,
+      isUsingAgent: true,
+      agentIsCharging: true,
+      agentChargeMethodPercentage: true,
     }).then((refNumber) => {
       referenceNumber = refNumber;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-fully-populated.spec.js
@@ -7,7 +7,7 @@ context(
 
     before(() => {
       cy.completeSignInAndSubmitAnApplication({
-        alternativeBuyerCurrency: true,
+        alternativeCurrencyBuyer: true,
         differentTradingName: true,
         differentTradingAddress: true,
         exporterHasTradedWithBuyer: true,

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -7237,8 +7237,9 @@ var mapAgentChargeAmount = (charge, countries) => {
   const country = get_country_by_iso_code_default(countries, charge[PAYABLE_COUNTRY_CODE2]);
   const payableCountryRow = xlsx_row_default(String(FIELDS27.AGENT_CHARGES[PAYABLE_COUNTRY_CODE2]), country.name);
   if (charge[FIXED_SUM_AMOUNT2]) {
+    const currencyValue = format_currency_default2(Number(charge[FIXED_SUM_AMOUNT2]), charge[FIXED_SUM_CURRENCY_CODE]);
     const mapped = [
-      xlsx_row_default(String(FIELDS27.AGENT_CHARGES[FIXED_SUM_AMOUNT2]), format_currency_default2(charge[FIXED_SUM_AMOUNT2], charge[FIXED_SUM_CURRENCY_CODE])),
+      xlsx_row_default(String(FIELDS27.AGENT_CHARGES[FIXED_SUM_AMOUNT2]), currencyValue),
       payableCountryRow
     ];
     return mapped;

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -7233,8 +7233,9 @@ var { FIELDS: FIELDS27 } = XLSX;
 var {
   AGENT_CHARGES: { FIXED_SUM_AMOUNT: FIXED_SUM_AMOUNT2, FIXED_SUM_CURRENCY_CODE, PAYABLE_COUNTRY_CODE: PAYABLE_COUNTRY_CODE2, PERCENTAGE_CHARGE: PERCENTAGE_CHARGE2 }
 } = export_contract_default;
-var mapAgentChargeAmount = (charge) => {
-  const payableCountryRow = xlsx_row_default(String(FIELDS27.AGENT_CHARGES[PAYABLE_COUNTRY_CODE2]), charge[PAYABLE_COUNTRY_CODE2]);
+var mapAgentChargeAmount = (charge, countries) => {
+  const country = get_country_by_iso_code_default(countries, charge[PAYABLE_COUNTRY_CODE2]);
+  const payableCountryRow = xlsx_row_default(String(FIELDS27.AGENT_CHARGES[PAYABLE_COUNTRY_CODE2]), country.name);
   if (charge[FIXED_SUM_AMOUNT2]) {
     const mapped = [
       xlsx_row_default(String(FIELDS27.AGENT_CHARGES[FIXED_SUM_AMOUNT2]), format_currency_default2(charge[FIXED_SUM_AMOUNT2], charge[FIXED_SUM_CURRENCY_CODE])),
@@ -7255,12 +7256,12 @@ var { FIELDS: FIELDS28 } = XLSX;
 var {
   AGENT_SERVICE: { IS_CHARGING: IS_CHARGING2 }
 } = export_contract_default;
-var mapAgentCharge = (service) => {
+var mapAgentCharge = (service, countries) => {
   const { charge } = service;
   const chargingAnswer = service[IS_CHARGING2];
   let mapped = [xlsx_row_default(String(FIELDS28.AGENT_SERVICE[IS_CHARGING2]), map_yes_no_field_default({ answer: chargingAnswer }))];
   if (chargingAnswer) {
-    mapped = [...mapped, ...map_agent_charge_amount_default(charge)];
+    mapped = [...mapped, ...map_agent_charge_amount_default(charge, countries)];
   }
   return mapped;
 };
@@ -7285,7 +7286,7 @@ var mapAgent = (agent, countries) => {
       xlsx_row_default(String(FIELDS29.AGENT[FULL_ADDRESS5]), agent[FULL_ADDRESS5]),
       xlsx_row_default(String(FIELDS29.AGENT[COUNTRY_CODE3]), country.name),
       xlsx_row_default(String(FIELDS29.AGENT_SERVICE[SERVICE_DESCRIPTION2]), service[SERVICE_DESCRIPTION2]),
-      ...map_agent_charge_default(service)
+      ...map_agent_charge_default(service, countries)
     ];
   }
   return mapped;

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/index.test.ts
@@ -40,7 +40,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-export-contract/map-agen
         xlsxRow(String(FIELDS.AGENT[COUNTRY_CODE]), country.name),
         xlsxRow(String(FIELDS.AGENT_SERVICE[SERVICE_DESCRIPTION]), mockAgent.service[SERVICE_DESCRIPTION]),
 
-        ...mapAgentCharge(mockAgent.service),
+        ...mapAgentCharge(mockAgent.service, mockCountries),
       ];
 
       expect(result).toEqual(expected);

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/index.ts
@@ -38,7 +38,7 @@ const mapAgent = (agent: ApplicationExportContractAgent, countries: Array<Countr
       xlsxRow(String(FIELDS.AGENT[COUNTRY_CODE]), country.name),
       xlsxRow(String(FIELDS.AGENT_SERVICE[SERVICE_DESCRIPTION]), service[SERVICE_DESCRIPTION]),
 
-      ...mapAgentCharge(service),
+      ...mapAgentCharge(service, countries),
     ];
   }
 

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/map-agent-charge/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/map-agent-charge/index.test.ts
@@ -4,7 +4,7 @@ import { XLSX } from '../../../../../content-strings';
 import xlsxRow from '../../../helpers/xlsx-row';
 import mapYesNoField from '../../../helpers/map-yes-no-field';
 import mapAgentChargeAmount from './map-agent-charge-amount';
-import { mockApplicationMinimalBrokerBuyerAndCompany as mockApplication } from '../../../../../test-mocks';
+import { mockApplicationMinimalBrokerBuyerAndCompany as mockApplication, mockCountries } from '../../../../../test-mocks';
 
 const { FIELDS } = XLSX;
 
@@ -26,11 +26,11 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-export-contract/map-agen
     };
 
     it('should return an array of mapped fields', () => {
-      const result = mapAgentCharge(mockService);
+      const result = mapAgentCharge(mockService, mockCountries);
 
       const expected = [
         xlsxRow(String(FIELDS.AGENT_SERVICE[IS_CHARGING]), mapYesNoField({ answer: mockService[IS_CHARGING] })),
-        ...mapAgentChargeAmount(mockService.charge),
+        ...mapAgentChargeAmount(mockService.charge, mockCountries),
       ];
 
       expect(result).toEqual(expected);
@@ -44,7 +44,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-export-contract/map-agen
     };
 
     it('should return an array with one field', () => {
-      const result = mapAgentCharge(mockService);
+      const result = mapAgentCharge(mockService, mockCountries);
 
       const expected = [xlsxRow(String(FIELDS.AGENT_SERVICE[IS_CHARGING]), mapYesNoField({ answer: mockService[IS_CHARGING] }))];
 

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/map-agent-charge/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/map-agent-charge/index.ts
@@ -3,7 +3,7 @@ import { XLSX } from '../../../../../content-strings';
 import xlsxRow from '../../../helpers/xlsx-row';
 import mapYesNoField from '../../../helpers/map-yes-no-field';
 import mapAgentChargeAmount from './map-agent-charge-amount';
-import { ApplicationExportContractAgentService } from '../../../../../types';
+import { ApplicationExportContractAgentService, Country } from '../../../../../types';
 
 const { FIELDS } = XLSX;
 
@@ -15,9 +15,10 @@ const {
  * mapAgentCharge
  * Map an application's "export contract agent charge" fields into an array of objects for XLSX generation
  * @param {ApplicationExportContractAgentService} agent: Export contract agent
+ * @param {Array<Country>} countries
  * @returns {Array<object>} Array of objects for XLSX generation
  */
-const mapAgentCharge = (service: ApplicationExportContractAgentService) => {
+const mapAgentCharge = (service: ApplicationExportContractAgentService, countries: Array<Country>) => {
   const { charge } = service;
 
   const chargingAnswer = service[IS_CHARGING];
@@ -25,7 +26,7 @@ const mapAgentCharge = (service: ApplicationExportContractAgentService) => {
   let mapped = [xlsxRow(String(FIELDS.AGENT_SERVICE[IS_CHARGING]), mapYesNoField({ answer: chargingAnswer }))];
 
   if (chargingAnswer) {
-    mapped = [...mapped, ...mapAgentChargeAmount(charge)];
+    mapped = [...mapped, ...mapAgentChargeAmount(charge, countries)];
   }
 
   return mapped;

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/map-agent-charge/map-agent-charge-amount/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/map-agent-charge/map-agent-charge-amount/index.test.ts
@@ -33,8 +33,10 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-export-contract/map-agen
 
       const country = getCountryByIsoCode(mockCountries, mockCharge[PAYABLE_COUNTRY_CODE]);
 
+      const currencyValue = formatCurrency(Number(charge[FIXED_SUM_AMOUNT]), charge[FIXED_SUM_CURRENCY_CODE]);
+
       const expected = [
-        xlsxRow(String(FIELDS.AGENT_CHARGES[FIXED_SUM_AMOUNT]), formatCurrency(mockCharge[FIXED_SUM_AMOUNT], charge[FIXED_SUM_CURRENCY_CODE])),
+        xlsxRow(String(FIELDS.AGENT_CHARGES[FIXED_SUM_AMOUNT]), currencyValue),
         xlsxRow(String(FIELDS.AGENT_CHARGES[PAYABLE_COUNTRY_CODE]), country.name),
       ];
 

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/map-agent-charge/map-agent-charge-amount/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/map-agent-charge/map-agent-charge-amount/index.test.ts
@@ -2,8 +2,9 @@ import mapAgentChargeAmount from '.';
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/export-contract';
 import { XLSX } from '../../../../../../content-strings';
 import xlsxRow from '../../../../helpers/xlsx-row';
+import getCountryByIsoCode from '../../../../../../helpers/get-country-by-iso-code';
 import formatCurrency from '../../../../helpers/format-currency';
-import { mockApplicationMinimalBrokerBuyerAndCompany } from '../../../../../../test-mocks';
+import { mockApplicationMinimalBrokerBuyerAndCompany, mockCountries } from '../../../../../../test-mocks';
 
 const { FIELDS } = XLSX;
 
@@ -28,11 +29,13 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-export-contract/map-agen
     };
 
     it('should return an array of mapped fields', () => {
-      const result = mapAgentChargeAmount(mockCharge);
+      const result = mapAgentChargeAmount(mockCharge, mockCountries);
+
+      const country = getCountryByIsoCode(mockCountries, mockCharge[PAYABLE_COUNTRY_CODE]);
 
       const expected = [
         xlsxRow(String(FIELDS.AGENT_CHARGES[FIXED_SUM_AMOUNT]), formatCurrency(mockCharge[FIXED_SUM_AMOUNT], charge[FIXED_SUM_CURRENCY_CODE])),
-        xlsxRow(String(FIELDS.AGENT_CHARGES[PAYABLE_COUNTRY_CODE]), mockCharge[PAYABLE_COUNTRY_CODE]),
+        xlsxRow(String(FIELDS.AGENT_CHARGES[PAYABLE_COUNTRY_CODE]), country.name),
       ];
 
       expect(result).toEqual(expected);
@@ -47,11 +50,13 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-export-contract/map-agen
     };
 
     it('should return an array of mapped fields', () => {
-      const result = mapAgentChargeAmount(mockCharge);
+      const result = mapAgentChargeAmount(mockCharge, mockCountries);
+
+      const country = getCountryByIsoCode(mockCountries, mockCharge[PAYABLE_COUNTRY_CODE]);
 
       const expected = [
         xlsxRow(String(FIELDS.AGENT_CHARGES[PERCENTAGE_CHARGE]), `${charge[PERCENTAGE_CHARGE]}%`),
-        xlsxRow(String(FIELDS.AGENT_CHARGES[PAYABLE_COUNTRY_CODE]), mockCharge[PAYABLE_COUNTRY_CODE]),
+        xlsxRow(String(FIELDS.AGENT_CHARGES[PAYABLE_COUNTRY_CODE]), country.name),
       ];
 
       expect(result).toEqual(expected);
@@ -66,7 +71,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-export-contract/map-agen
         [PERCENTAGE_CHARGE]: false,
       };
 
-      const result = mapAgentChargeAmount(mockCharge);
+      const result = mapAgentChargeAmount(mockCharge, mockCountries);
 
       expect(result).toEqual([]);
     });

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/map-agent-charge/map-agent-charge-amount/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/map-agent-charge/map-agent-charge-amount/index.test.ts
@@ -33,10 +33,11 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-export-contract/map-agen
 
       const country = getCountryByIsoCode(mockCountries, mockCharge[PAYABLE_COUNTRY_CODE]);
 
-      const currencyValue = formatCurrency(Number(charge[FIXED_SUM_AMOUNT]), charge[FIXED_SUM_CURRENCY_CODE]);
+      const currencyValue = formatCurrency(Number(mockCharge[FIXED_SUM_AMOUNT]), mockCharge[FIXED_SUM_CURRENCY_CODE]);
 
       const expected = [
         xlsxRow(String(FIELDS.AGENT_CHARGES[FIXED_SUM_AMOUNT]), currencyValue),
+
         xlsxRow(String(FIELDS.AGENT_CHARGES[PAYABLE_COUNTRY_CODE]), country.name),
       ];
 

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/map-agent-charge/map-agent-charge-amount/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/map-agent-charge/map-agent-charge-amount/index.ts
@@ -1,8 +1,9 @@
 import FIELD_IDS from '../../../../../../constants/field-ids/insurance/export-contract';
 import { XLSX } from '../../../../../../content-strings';
 import xlsxRow from '../../../../helpers/xlsx-row';
+import getCountryByIsoCode from '../../../../../../helpers/get-country-by-iso-code';
 import formatCurrency from '../../../../helpers/format-currency';
-import { ApplicationExportContractAgentServiceCharge } from '../../../../../../types';
+import { ApplicationExportContractAgentServiceCharge, Country } from '../../../../../../types';
 
 const { FIELDS } = XLSX;
 
@@ -14,10 +15,13 @@ const {
  * mapAgentChargeAmount
  * Map an application's "export contract agent charge amount" fields into an array of objects for XLSX generation
  * @param {ApplicationExportContractAgentServiceCharge} charge: Export contract agent charge
+ * @param {Array<Country>} countries
  * @returns {Array<object>} Array of objects for XLSX generation
  */
-const mapAgentChargeAmount = (charge: ApplicationExportContractAgentServiceCharge) => {
-  const payableCountryRow = xlsxRow(String(FIELDS.AGENT_CHARGES[PAYABLE_COUNTRY_CODE]), charge[PAYABLE_COUNTRY_CODE]);
+const mapAgentChargeAmount = (charge: ApplicationExportContractAgentServiceCharge, countries: Array<Country>) => {
+  const country = getCountryByIsoCode(countries, charge[PAYABLE_COUNTRY_CODE]);
+
+  const payableCountryRow = xlsxRow(String(FIELDS.AGENT_CHARGES[PAYABLE_COUNTRY_CODE]), country.name);
 
   if (charge[FIXED_SUM_AMOUNT]) {
     const mapped = [

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/map-agent-charge/map-agent-charge-amount/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-agent/map-agent-charge/map-agent-charge-amount/index.ts
@@ -24,10 +24,9 @@ const mapAgentChargeAmount = (charge: ApplicationExportContractAgentServiceCharg
   const payableCountryRow = xlsxRow(String(FIELDS.AGENT_CHARGES[PAYABLE_COUNTRY_CODE]), country.name);
 
   if (charge[FIXED_SUM_AMOUNT]) {
-    const mapped = [
-      xlsxRow(String(FIELDS.AGENT_CHARGES[FIXED_SUM_AMOUNT]), formatCurrency(charge[FIXED_SUM_AMOUNT], charge[FIXED_SUM_CURRENCY_CODE])),
-      payableCountryRow,
-    ];
+    const currencyValue = formatCurrency(Number(charge[FIXED_SUM_AMOUNT]), charge[FIXED_SUM_CURRENCY_CODE]);
+
+    const mapped = [xlsxRow(String(FIELDS.AGENT_CHARGES[FIXED_SUM_AMOUNT]), currencyValue), payableCountryRow];
 
     return mapped;
   }


### PR DESCRIPTION
## Introduction :pencil2:

This PR fixes 2x issues in the XLSX where:

- The "Agent country" field was rendering a country code instead of the country name.
- The "Agent charge amount" field was not rendering a currency code.

## Resolution :heavy_check_mark:

- Update `mapAgentChargeAmount` to:
  - Consume a list of countries
  - Call `getCountryByIsoCode`.
  - Call `formatCurrency` with `FIXED_SUM_AMOUNT` as a number (it's saved as a string).

## Miscellaneous :heavy_plus_sign:

- Various application submission E2E test improvements.
