### PR TITLE
chore(mysql-upgrade): upgrade mysql version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mysql
     container_name: exip_db
     restart: always
-    command: --caching_sha2_password=ON
+    command: --default-authentication-plugin=caching_sha2_password
     ports:
       - '${DATABASE_PORT}:${DATABASE_PORT}'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     image: mysql
     container_name: exip_db
     restart: always
-    command: --default-authentication-plugin=caching_sha2_password
     ports:
       - '${DATABASE_PORT}:${DATABASE_PORT}'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mysql
     container_name: exip_db
     restart: always
-    command: --default-authentication-plugin=caching_sha2_password
+    command: --caching_sha2_password=ON
     ports:
       - '${DATABASE_PORT}:${DATABASE_PORT}'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mysql
     container_name: exip_db
     restart: always
-    command: --mysql-native-password=ON
+    command: --default-authentication-plugin=caching_sha2_password
     ports:
       - '${DATABASE_PORT}:${DATABASE_PORT}'
     volumes:


### PR DESCRIPTION
## Introduction :pencil2:

On the mysql update to 9.0, `--mysql-native-password=ON` is deprecated

## Resolution :heavy_check_mark:

* Remove the line

