### PR TITLE
fix(EMS-3524): no pdf - data migration - eligibility section review condition

### DIFF
--- a/database/exip.sql
+++ b/database/exip.sql
@@ -154,6 +154,7 @@ CREATE TABLE `Application` (
 	`dealType` varchar(4) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'EXIP',
   `policyContact` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `nominatedLossPayee` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `migratedV1toV2` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `Application_eligibility_idx` (`eligibility`),
   KEY `Application_referenceNumber_idx` (`referenceNumber`),

--- a/e2e-tests/constants/field-ids/insurance/index.js
+++ b/e2e-tests/constants/field-ids/insurance/index.js
@@ -27,6 +27,7 @@ export const INSURANCE_FIELD_IDS = {
     ALTERNATIVE_CURRENCY_CODE: 'alternativeCurrencyCode',
   },
   SUBMISSION_DEADLINE: 'submissionDeadline',
+  MIGRATED_FROM_V1_TO_V2: 'migratedV1toV2',
   ACCOUNT,
   POLICY,
   EXPORTER_BUSINESS,

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -518,6 +518,7 @@ var INSURANCE_FIELD_IDS = {
     ALTERNATIVE_CURRENCY_CODE: "alternativeCurrencyCode"
   },
   SUBMISSION_DEADLINE: "submissionDeadline",
+  MIGRATED_FROM_V1_TO_V2: "migratedV1toV2",
   ACCOUNT: account_default,
   POLICY: policy_default,
   EXPORTER_BUSINESS: business_default,
@@ -1723,7 +1724,8 @@ var lists = {
         defaultValue: DEAL_TYPE,
         validation: { isRequired: true },
         db: { nativeType: "VarChar(4)" }
-      })
+      }),
+      migratedV1toV2: nullable_checkbox_default()
     },
     hooks: {
       resolveInput: async ({ operation, resolvedData, context }) => {
@@ -7238,10 +7240,7 @@ var mapAgentChargeAmount = (charge, countries) => {
   const payableCountryRow = xlsx_row_default(String(FIELDS27.AGENT_CHARGES[PAYABLE_COUNTRY_CODE2]), country.name);
   if (charge[FIXED_SUM_AMOUNT2]) {
     const currencyValue = format_currency_default2(Number(charge[FIXED_SUM_AMOUNT2]), charge[FIXED_SUM_CURRENCY_CODE]);
-    const mapped = [
-      xlsx_row_default(String(FIELDS27.AGENT_CHARGES[FIXED_SUM_AMOUNT2]), currencyValue),
-      payableCountryRow
-    ];
+    const mapped = [xlsx_row_default(String(FIELDS27.AGENT_CHARGES[FIXED_SUM_AMOUNT2]), currencyValue), payableCountryRow];
     return mapped;
   }
   if (charge[PERCENTAGE_CHARGE2]) {

--- a/src/api/constants/field-ids/insurance/index.ts
+++ b/src/api/constants/field-ids/insurance/index.ts
@@ -28,6 +28,7 @@ const INSURANCE_FIELD_IDS = {
     ALTERNATIVE_CURRENCY_CODE: 'alternativeCurrencyCode',
   },
   SUBMISSION_DEADLINE: 'submissionDeadline',
+  MIGRATED_FROM_V1_TO_V2: 'migratedV1toV2',
   ACCOUNT,
   POLICY,
   EXPORTER_BUSINESS,

--- a/src/api/data-migration/version-1-to-version-2/update-applications/add-application-migrated-field.ts
+++ b/src/api/data-migration/version-1-to-version-2/update-applications/add-application-migrated-field.ts
@@ -1,0 +1,18 @@
+import { Connection } from 'mysql2/promise';
+import executeSqlQuery from '../execute-sql-query';
+
+/**
+ * addApplicationMigratedField
+ * Add a migratedV1toV2 field to the application table.
+ * @param {Connection} connection: SQL database connection
+ * @returns {Promise<Array<object>>} executeSqlQuery response
+ */
+const addApplicationMigratedField = (connection: Connection) => {
+  const loggingMessage = 'Adding FIELD migratedV1toV2 to application table';
+
+  const query = `ALTER TABLE Application ADD migratedV1toV2 tinyint(1) DEFAULT NULL`;
+
+  return executeSqlQuery({ connection, query, loggingMessage });
+};
+
+export default addApplicationMigratedField;

--- a/src/api/data-migration/version-1-to-version-2/update-applications/index.ts
+++ b/src/api/data-migration/version-1-to-version-2/update-applications/index.ts
@@ -1,4 +1,5 @@
 import { Connection } from 'mysql2/promise';
+import addApplicationMigratedField from './add-application-migrated-field';
 import { addNominatedLossPayeeField, addNominatedLossPayeeConstraint } from './nominated-loss-payee';
 import addExportContractFields from './add-export-contract-fields';
 import addBuyerFields from './add-buyer-fields';
@@ -12,6 +13,7 @@ import updateExportContractFinalDestinationCountryCodeVarChar from './update-exp
 import updatePolicyCurrencyCodeVarChar from './update-policy-currency-code-var-char';
 import updatePolicyContactPositionCodeVarChar from './update-policy-contact-position-var-char';
 import updateApplicationVersion from './update-application-version';
+import updateApplicationMigrated from './update-application-migrated';
 
 /**
  * updateApplications
@@ -26,6 +28,7 @@ const updateApplications = async (connection: Connection) => {
 
   try {
     const tables = await Promise.all([
+      addApplicationMigratedField(connection),
       addNominatedLossPayeeField(connection),
       addNominatedLossPayeeConstraint(connection),
       addExportContractFields(connection),
@@ -40,6 +43,7 @@ const updateApplications = async (connection: Connection) => {
       updatePolicyCurrencyCodeVarChar(connection),
       updatePolicyContactPositionCodeVarChar(connection),
       updateApplicationVersion(connection),
+      updateApplicationMigrated(connection),
     ]);
 
     return tables;

--- a/src/api/data-migration/version-1-to-version-2/update-applications/update-application-migrated.ts
+++ b/src/api/data-migration/version-1-to-version-2/update-applications/update-application-migrated.ts
@@ -1,0 +1,23 @@
+import { Connection } from 'mysql2/promise';
+import { APPLICATION } from '../../../constants';
+import executeSqlQuery from '../execute-sql-query';
+
+const { STATUS } = APPLICATION;
+
+/**
+ * updateApplicationMigrated
+ * Update IN_PROGRESS applications migratedV1toV2 fields to have a value of 1/true
+ * @param {Connection} connection: SQL database connection
+ * @returns {Promise<Array<object>>} executeSqlQuery response
+ */
+const updateApplicationMigrated = (connection: Connection) => {
+  const loggingMessage = `Updating migratedV1toV2 FIELD to true in the application table`;
+
+  const query = `
+    UPDATE Application SET migratedV1toV2 = 1 WHERE status = '${STATUS.IN_PROGRESS}'
+  `;
+
+  return executeSqlQuery({ connection, query, loggingMessage });
+};
+
+export default updateApplicationMigrated;

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -87,6 +87,7 @@ type Application {
   sectionReview: SectionReview
   version: String
   dealType: String
+  migratedV1toV2: Boolean
 }
 
 scalar DateTime @specifiedBy(url: "https://datatracker.ietf.org/doc/html/rfc3339#section-5.6")
@@ -240,6 +241,7 @@ input ApplicationUpdateInput {
   sectionReview: SectionReviewRelateToOneForUpdateInput
   version: String
   dealType: String
+  migratedV1toV2: Boolean
 }
 
 input EligibilityRelateToOneForUpdateInput {
@@ -343,6 +345,7 @@ input ApplicationCreateInput {
   sectionReview: SectionReviewRelateToOneForCreateInput
   version: String
   dealType: String
+  migratedV1toV2: Boolean
 }
 
 input EligibilityRelateToOneForCreateInput {

--- a/src/api/schema.prisma
+++ b/src/api/schema.prisma
@@ -56,6 +56,7 @@ model Application {
   sectionReviewId                      String?               @map("sectionReview")
   version                              String                @default("2")
   dealType                             String                @default("EXIP") @mysql.VarChar(4)
+  migratedV1toV2                       Boolean?
   from_ReferenceNumber_application     ReferenceNumber[]     @relation("ReferenceNumber_application")
   from_NominatedLossPayee_application  NominatedLossPayee[]  @relation("NominatedLossPayee_application")
   from_Policy_application              Policy[]              @relation("Policy_application")

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -77,6 +77,7 @@ export const lists = {
         validation: { isRequired: true },
         db: { nativeType: 'VarChar(4)' },
       }),
+      migratedV1toV2: nullableCheckbox(),
     },
     hooks: {
       resolveInput: async ({ operation, resolvedData, context }) => {

--- a/src/ui/server/constants/field-ids/insurance/index.ts
+++ b/src/ui/server/constants/field-ids/insurance/index.ts
@@ -28,6 +28,7 @@ const INSURANCE_FIELD_IDS = {
     ALTERNATIVE_CURRENCY_CODE: 'alternativeCurrencyCode',
   },
   SUBMISSION_DEADLINE: 'submissionDeadline',
+  MIGRATED_FROM_V1_TO_V2: 'migratedV1toV2',
   ACCOUNT,
   POLICY,
   EXPORTER_BUSINESS,

--- a/src/ui/server/graphql/queries/application.ts
+++ b/src/ui/server/graphql/queries/application.ts
@@ -10,6 +10,7 @@ const applicationQuery = gql`
         createdAt
         updatedAt
         dealType
+        migratedV1toV2
         submissionCount
         submissionDeadline
         submissionType

--- a/src/ui/server/helpers/can-submit-application/index.ts
+++ b/src/ui/server/helpers/can-submit-application/index.ts
@@ -15,6 +15,8 @@ import { Application } from '../../../types';
  * @returns {Boolean}
  */
 const canSubmitApplication = (application: Application): boolean => {
+  console.info('Checking if an application can be submitted (canSubmitApplication helper)');
+
   const { status, submissionCount, submissionDeadline } = application;
 
   // check the application is complete
@@ -33,8 +35,12 @@ const canSubmitApplication = (application: Application): boolean => {
   const isFirstSubmission = submissionCount === 0;
 
   if (isComplete && isInProgress && validSubmissionDate && isFirstSubmission) {
+    console.info('Checking if an application can be submitted - application is valid (canSubmitApplication helper)');
+
     return true;
   }
+
+  console.info('Checking if an application can be submitted - application is invalid (canSubmitApplication helper)');
 
   return false;
 };

--- a/src/ui/server/helpers/flatten-application-data/index.test.ts
+++ b/src/ui/server/helpers/flatten-application-data/index.test.ts
@@ -149,6 +149,7 @@ describe('server/helpers/flatten-application-data', () => {
         createdAt: mockApplication.createdAt,
         updatedAt: mockApplication.updatedAt,
         dealType: mockApplication.dealType,
+        migratedV1toV2: mockApplication.migratedV1toV2,
         submissionCount: mockApplication.submissionCount,
         submissionDeadline: mockApplication.submissionDeadline,
         submissionType: mockApplication.submissionType,

--- a/src/ui/server/helpers/flatten-application-data/index.ts
+++ b/src/ui/server/helpers/flatten-application-data/index.ts
@@ -123,6 +123,7 @@ const flattenApplicationData = (application: Application): ApplicationFlat => {
       createdAt: application.createdAt,
       updatedAt: application.updatedAt,
       dealType: application.dealType,
+      migratedV1toV2: application.migratedV1toV2,
       submissionCount: application.submissionCount,
       submissionDeadline: application.submissionDeadline,
       submissionType: application.submissionType,

--- a/src/ui/server/helpers/required-fields/check-your-answers/index.test.ts
+++ b/src/ui/server/helpers/required-fields/check-your-answers/index.test.ts
@@ -24,7 +24,7 @@ describe('server/helpers/required-fields/check-your-answers', () => {
       ...requiredEligibilityFields(),
       ...requiredExportContractFields(flatApplicationData),
       ...requiredPolicyFields(flatApplicationData[POLICY_TYPE]),
-      ...requiredSectionReviewFields,
+      ...requiredSectionReviewFields(flatApplicationData),
       ...requiredYourBuyerFields({}),
     ];
 

--- a/src/ui/server/helpers/required-fields/check-your-answers/index.ts
+++ b/src/ui/server/helpers/required-fields/check-your-answers/index.ts
@@ -20,7 +20,7 @@ const requiredFields = (application: ApplicationFlat): Array<string> => [
   ...requiredEligibilityFields(),
   ...requiredExportContractFields(application),
   ...requiredPolicyFields(application[POLICY_TYPE]),
-  ...requiredSectionReviewFields,
+  ...requiredSectionReviewFields(application),
   ...requiredYourBuyerFields({}),
 ];
 

--- a/src/ui/server/helpers/required-fields/section-review/index.test.ts
+++ b/src/ui/server/helpers/required-fields/section-review/index.test.ts
@@ -1,10 +1,41 @@
 import requiredFields from '.';
-import FIELD_IDS from '../../../constants/field-ids/insurance/check-your-answers';
+import FIELD_IDS from '../../../constants/field-ids/insurance';
+import flattenApplicationData from '../../flatten-application-data';
+import { mockApplication } from '../../../test-mocks';
+
+const {
+  MIGRATED_FROM_V1_TO_V2,
+  CHECK_YOUR_ANSWERS: { ELIGIBILITY, EXPORTER_BUSINESS, BUYER, POLICY, EXPORT_CONTRACT },
+} = FIELD_IDS;
 
 describe('server/helpers/required-fields/section-review', () => {
-  it('should return array of required fields', () => {
-    const expected = Object.values(FIELD_IDS);
+  describe(`when application.${MIGRATED_FROM_V1_TO_V2} is true`, () => {
+    it(`should return array of required fields, without ${ELIGIBILITY}`, () => {
+      const application = flattenApplicationData({
+        ...mockApplication,
+        [MIGRATED_FROM_V1_TO_V2]: true,
+      });
 
-    expect(requiredFields).toEqual(expected);
+      const result = requiredFields(application);
+
+      const expected = [EXPORTER_BUSINESS, BUYER, POLICY, EXPORT_CONTRACT];
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when application.${MIGRATED_FROM_V1_TO_V2} is false`, () => {
+    it(`should return array of required fields, with ${ELIGIBILITY}`, () => {
+      const application = flattenApplicationData({
+        ...mockApplication,
+        [MIGRATED_FROM_V1_TO_V2]: false,
+      });
+
+      const result = requiredFields(application);
+
+      const expected = [ELIGIBILITY, EXPORTER_BUSINESS, BUYER, POLICY, EXPORT_CONTRACT];
+
+      expect(result).toEqual(expected);
+    });
   });
 });

--- a/src/ui/server/helpers/required-fields/section-review/index.ts
+++ b/src/ui/server/helpers/required-fields/section-review/index.ts
@@ -1,10 +1,24 @@
 import FIELD_IDS from '../../../constants/field-ids/insurance/check-your-answers';
+import { ApplicationFlat } from '../../../../types';
+
+const { ELIGIBILITY, EXPORTER_BUSINESS, BUYER, POLICY, EXPORT_CONTRACT } = FIELD_IDS;
 
 /**
  * requiredFields
- * Required fields for the insurance - check your answers section
+ * Required fields for the insurance - check your answers section.
+ * If an application has been migrated from V1 to V2, ELIGIBILITY is NOT required.
+ * Otherwise, ELIGIBILITY is required.
+ * This is because:
+ * - In V1, there is no ability to check the ELIGIBILITY answers.
+ * - In V2, there is the ability to check the ELIGIBILITY answers.
  * @returns {Array<string>} Required field IDs
  */
-const requiredFields = Object.values(FIELD_IDS);
+const requiredFields = (application: ApplicationFlat) => {
+  if (application.migratedV1toV2) {
+    return [EXPORTER_BUSINESS, BUYER, POLICY, EXPORT_CONTRACT];
+  }
+
+  return [ELIGIBILITY, EXPORTER_BUSINESS, BUYER, POLICY, EXPORT_CONTRACT];
+};
 
 export default requiredFields;

--- a/src/ui/server/test-mocks/mock-application.ts
+++ b/src/ui/server/test-mocks/mock-application.ts
@@ -208,6 +208,7 @@ const mockApplication = {
   sectionReview: mockSectionReview,
   declaration: mockApplicationDeclaration,
   totalContractValueOverThreshold: false,
+  migratedV1toV2: false,
 };
 
 export const mockApplicationAgentServiceChargeEmpty = {

--- a/src/ui/types/application.ts
+++ b/src/ui/types/application.ts
@@ -264,11 +264,13 @@ interface Application extends ApplicationCore {
   sectionReview: ApplicationSectionReview;
   declaration: ApplicationDeclaration;
   totalContractValueOverThreshold: boolean;
+  migratedV1toV2?: boolean;
 }
 
 interface ApplicationFlatCore extends ApplicationCore, InsuranceEligibilityCore, ApplicationOwner {
   buyerCountry: string;
   totalContractValueOverThreshold?: boolean;
+  migratedV1toV2?: boolean;
 }
 
 type ApplicationFlat = ApplicationFlatCore & ApplicationPolicy & ApplicationBroker & ApplicationCompany & ApplicationDeclaration;


### PR DESCRIPTION
## Introduction :pencil2:

This PR fixes an issue where, when an application is migrated from V1 (MVP) to V2 (No PDF), application submission would fail due to a missing `sectionReview.eligibility` flat being null.

- In MVP, there is no ability to "check your eligibility answers" and so the `sectionReview.eligibility` flag will always be null.
- In No PDF there is the ability to "check your eligibility answers" and so the flag is expected to be true before application submission. Otherwise, application submission will fail.

## Resolution :heavy_check_mark:

- Create a new `migratedV1toV2` flag.
- Update the data migration script to add the `migratedV1toV2` flag to the `Application` table.
- Update the data migration script to set all in progress applications to have a `migratedV1toV2` flag of `true`.
- Update the UI's "get application" GQL query to return `migratedV1toV2`.
- Update the UI's `requiredSectionReviewFields` helper to consume application data only return `ELIGIBILITY`, if `migratedV1toV2` is false.

## Miscellaneous :heavy_plus_sign:

- Add some logs to `canSubmitApplication`, for easier debugging.
