### PR TITLE
chore(mysql-authentication): docker-compose - MySQL authentication

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mysql:8.0.36
     container_name: exip_db
     restart: always
-    command: --default-authentication-plugin=mysql_native_password
+    command: --default-authentication-plugin=caching_sha2_password
     ports:
       - '${DATABASE_PORT}:${DATABASE_PORT}'
     volumes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@typescript-eslint/eslint-plugin": "^7.15.0",
         "@typescript-eslint/parser": "^7.15.0",
         "commitlint": "^18.6.1",
-        "cspell": "^8.10.1",
+        "cspell": "^8.10.4",
         "eslint": "^8.57.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -3643,9 +3643,9 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.10.2.tgz",
-      "integrity": "sha512-0hNGgY+/MjOBo756K4081Oh5rsDKcD5vHL7yjI8hANbyXFNnpsjyhg5psN+BJrBnvc9myW7oSaY/9hB+kgWEhA==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.10.4.tgz",
+      "integrity": "sha512-QmgvIp9/NM60Jj6ft5oaiCFidwPwKYS9FfpfABrDLw/Jx6wwcTdy9cVbuPxT8n4LwkHpswkmIzOf4zSlnrd4MQ==",
       "dev": true,
       "dependencies": {
         "@cspell/dict-ada": "^4.0.2",
@@ -3706,30 +3706,30 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.10.2.tgz",
-      "integrity": "sha512-ijXzAwLx5S9YC2C1wvqiGbduOMVH6DSfHFeGKgeUlpkgNdPvFVwhza+Uva9/ToGUAwUe5+EcrzFhavrNj/QPDw==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.10.4.tgz",
+      "integrity": "sha512-W6aUZ2LkKkDEKgx1sjik2xQT7m6CrLxcuJiF7MkPPZMdsnXyg5jsRalkQTn7my7RZ+n5xxEO69r6jM4IImvWAg==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-types": "8.10.2"
+        "@cspell/cspell-types": "8.10.4"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.10.2.tgz",
-      "integrity": "sha512-6k5IcNZnaJsP79omKOzZY8Jc9PjTbVMipHNNlSA+FqRBE0Pn0WZfyINGQN8JZbUkahi2YFvXTArGuQH72Mz6AQ==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.10.4.tgz",
+      "integrity": "sha512-yN+A9EIgdSkNiQnrFgsy5dzFl879ddMRHw/u38Zw4HdHIGr+xLpw5UVSKK6OacPMro853engM3dTJJDzRzh+rA==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.10.2.tgz",
-      "integrity": "sha512-t3BuRKBVFtB50/xuN+StL8TZwFPnRsNC5M1CSSLZZ178RQBc50Qh4593FrK2qTkuNK7VmveRi5Ij8E85D702vQ==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.10.4.tgz",
+      "integrity": "sha512-f0Y+Tol1aqrj9LsDT1oQOoj0P9uJ0ZW5PbhVlKqFeIDhrA5rYLy0ffnFESLNBRxWXaB/cznzpgMUyNfpVCXJpg==",
       "dev": true,
       "dependencies": {
         "global-directory": "^4.0.1"
@@ -3739,18 +3739,18 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.10.2.tgz",
-      "integrity": "sha512-oZjZjTGK0u8U06u9mYQ4jS6laoGm1GtaSSigHcRJn+ABwapxCheqYywmUrZmt0/Z5JzDU/YJ+iBxsT+sY55mrQ==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.10.4.tgz",
+      "integrity": "sha512-bXIllG6C1rKjWGlKdrAfs0AKrs/iQ6ZL6kSXrzHh5NB8oyBzX8tf5v4BX3Bnh5yrjBzkT2qhL+teEcvWjjvu2w==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.10.2.tgz",
-      "integrity": "sha512-hVOlZNOCn2c69lHO8Gu4qSj0myUhbvPxebJCknBczaPfB2xwgd1gTrKRYCDCR6ci+PxlgHSoOhV8rvh+RKy78A==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.10.4.tgz",
+      "integrity": "sha512-K/7JALR417KYHoovk18LTJCnKXF8ToNraWX4P3NFkYZNffc62fPn0y7nV9kphdK/biLM7np9gWtHq22MhX4qgw==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -3763,9 +3763,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-aws": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.2.tgz",
-      "integrity": "sha512-aNGHWSV7dRLTIn8WJemzLoMF62qOaiUQlgnsCwH5fRCD/00gsWCwg106pnbkmK4AyabyxzneOV4dfecDJWkSxw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.3.tgz",
+      "integrity": "sha512-0C0RQ4EM29fH0tIYv+EgDQEum0QI6OrmjENC9u98pB8UcnYxGG/SqinuPxo+TgcEuInj0Q73MsBpJ1l5xUnrsw==",
       "dev": true
     },
     "node_modules/@cspell/dict-bash": {
@@ -4036,9 +4036,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.4.9.tgz",
-      "integrity": "sha512-J2uNH3ScBPQijXyzLfxsC1CYgq36MWvbynJzQJ15ZazTsecC0pQHynm3/6VH4X/BphV2eXB0GRJT3yMicYLGCw==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.4.10.tgz",
+      "integrity": "sha512-S5S2sz98v4GWJ9TMo62Vp4L5RM/329e5UQfFn7yJfieTcrfXRH4IweVdz34rZcK9o5coGptgBUIv/Jcrd4cMpg==",
       "dev": true
     },
     "node_modules/@cspell/dict-sql": {
@@ -4078,9 +4078,9 @@
       "dev": true
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.10.2.tgz",
-      "integrity": "sha512-EFcoKLLW/5pnHfGwF0ESsXohRpekep+sVoHGrHORUV4LesFCxBvtanubaTjV40IypWqUquinJwbsflrlkOPf8w==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.10.4.tgz",
+      "integrity": "sha512-YxpzOgrP/u0nxEMR4hUfV+4z3b0rLWnKsKIv6pLpRez7ACvrMeb53FedSMZW/YaF3NjWTpUEdqFHaemPkmwnRA==",
       "dev": true,
       "dependencies": {
         "import-meta-resolve": "^4.1.0"
@@ -4090,18 +4090,18 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.10.2.tgz",
-      "integrity": "sha512-6oG4kx439Lnxy24HZqvXw/7ExCkcqHg+ORBI2lE6BIrYdDpsmatSgTXdhIlGPrra0Ut0jBGMqCN5dehC+CnfnQ==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.10.4.tgz",
+      "integrity": "sha512-QyL8mvv8HDnIHU/wKqWf04yMHCHv3icakZF4UdAk181tl8gymzrtyXSSbMaVlySlK9p+7OQlEG/KUF8R0LR75Q==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/url": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.10.2.tgz",
-      "integrity": "sha512-ImrFRopPDzyc1ZtRuSNGVGAT2Kgq5YaR1bSQio9Je8V4IizFP5kzg1rPiJxJL0pbqlWDJe226xlPUfJhj/ygjw==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.10.4.tgz",
+      "integrity": "sha512-4+Bxm43py50W872FjUvKoT9+EQoK9pqOblxu7GRfFx7CjEgYJB03Cb4rHiKYzLuJakUk6IyAlgPD2vNZO37Vzg==",
       "dev": true,
       "engines": {
         "node": ">=18.0"
@@ -9973,22 +9973,22 @@
       "integrity": "sha512-N3ASg0C4kNPUaNxt1XAvzHIVuzdtr8KLgfk1O8WDyimp1GisPAHESupArO2ieHk9QWbrJ/WkQODyh21Ps/xhxw=="
     },
     "node_modules/cspell": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.10.2.tgz",
-      "integrity": "sha512-xPvxr7pYWmNEteWcgkqe6fCyL5V6nmlZL4SjGLM9a17pWR9ybLg5ajKlbIPcK9QbDMXUWoUY4VPk2DCr1lwgEQ==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.10.4.tgz",
+      "integrity": "sha512-6eu42atG3ohf1r8vkRCKHBgUED+MOY7ErwPodeEtiHOqCXBtTCoPQXbqJozRy5Jfr2VMCMiryknxI4dH5yzjuQ==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.10.2",
-        "@cspell/cspell-pipe": "8.10.2",
-        "@cspell/cspell-types": "8.10.2",
-        "@cspell/dynamic-import": "8.10.2",
+        "@cspell/cspell-json-reporter": "8.10.4",
+        "@cspell/cspell-pipe": "8.10.4",
+        "@cspell/cspell-types": "8.10.4",
+        "@cspell/dynamic-import": "8.10.4",
         "chalk": "^5.3.0",
         "chalk-template": "^1.1.0",
         "commander": "^12.1.0",
-        "cspell-gitignore": "8.10.2",
-        "cspell-glob": "8.10.2",
-        "cspell-io": "8.10.2",
-        "cspell-lib": "8.10.2",
+        "cspell-gitignore": "8.10.4",
+        "cspell-glob": "8.10.4",
+        "cspell-io": "8.10.4",
+        "cspell-lib": "8.10.4",
         "fast-glob": "^3.3.2",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^8.0.0",
@@ -10009,12 +10009,12 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.10.2.tgz",
-      "integrity": "sha512-U7quH8Br4mAbAnRQE06cIpNsWGIY5kshpUh2fg7PLJO0gbXpE7UVz03Wz8j1A6EOe3oEPm6mQdEPqruOpy+RCg==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.10.4.tgz",
+      "integrity": "sha512-0VgnDEU4/+PWG+8x0FBN0QPun14sox9n7DBMvKGwAORhfiuYJ9w8kdrS/QqHdpHsRRQhXP1SWR8Nfg/5dUxsPg==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-types": "8.10.2",
+        "@cspell/cspell-types": "8.10.4",
         "comment-json": "^4.2.4",
         "yaml": "^2.4.5"
       },
@@ -10023,14 +10023,14 @@
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.10.2.tgz",
-      "integrity": "sha512-k9qgdmgN/mzdU6PorxsA37InKqsFxl9r26xVPDSht725xB5C1a8UlTjpo1C9VfTI4KVxiBhkEHBtg6xaDwe+JA==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.10.4.tgz",
+      "integrity": "sha512-9Hg2eTYbTKMoPy0r/IjGwcIII7PLGpeZlG1XzCDP4MW/bV4TGB6EfY8RAmhUt8cTwo7f6fxqu53WLaR3YPEozg==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.10.2",
-        "@cspell/cspell-types": "8.10.2",
-        "cspell-trie-lib": "8.10.2",
+        "@cspell/cspell-pipe": "8.10.4",
+        "@cspell/cspell-types": "8.10.4",
+        "cspell-trie-lib": "8.10.4",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0"
       },
@@ -10039,14 +10039,14 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.10.2.tgz",
-      "integrity": "sha512-6jvqUhanyORdqXndKJR4P0Xg5NMsqHucjZFzEWxca0Uj5ndFC+Dsk3uslN4iR6NmKAZeiv+cQCSoEpsGcqIPeA==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.10.4.tgz",
+      "integrity": "sha512-OtN/nZAxgFYGdV+hCK8tF3drlGJJ+42W278cIM67H67cHYupVICFgsDLiNBz/iR/J9S4pEU5WXu2yPtHFHvVUQ==",
       "dev": true,
       "dependencies": {
-        "@cspell/url": "8.10.2",
-        "cspell-glob": "8.10.2",
-        "cspell-io": "8.10.2",
+        "@cspell/url": "8.10.4",
+        "cspell-glob": "8.10.4",
+        "cspell-io": "8.10.4",
         "find-up-simple": "^1.0.0"
       },
       "bin": {
@@ -10057,12 +10057,12 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.10.2.tgz",
-      "integrity": "sha512-GnrPWoKdQaMqRha+slwoyzZNpfM5boeVE52gPVTGWKTP/nw7w2hg4r3jVliYEVWMJbFknFEyg+WSd3C+KIP5zQ==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.10.4.tgz",
+      "integrity": "sha512-HPRK6ZtHBzY/zGMhajzJ2MOgHMgY74/FijtaZkYc09QTEjONhIO4VWcrxrr1/qoM/qAp2Y/CKcBM/OOiHls7+A==",
       "dev": true,
       "dependencies": {
-        "@cspell/url": "8.10.2",
+        "@cspell/url": "8.10.4",
         "micromatch": "^4.0.7"
       },
       "engines": {
@@ -10070,13 +10070,13 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.10.2.tgz",
-      "integrity": "sha512-nOHufnGwGSvf22L6bMS/AYMX9eATMf+dqTeIMG+x61zPIkGgxq5ahI1TNRtm2QBoPHnpPHD0tNCSD5VI7ymAQA==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.10.4.tgz",
+      "integrity": "sha512-AW9JqEmMJLrbBwN/3BAwpHgOz5WFyb4syS+pjFRdZGx/w9e9ZSn4xyfnQ3mjNaFc/oZUcXy+q032bNZQppjGXA==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.10.2",
-        "@cspell/cspell-types": "8.10.2"
+        "@cspell/cspell-pipe": "8.10.4",
+        "@cspell/cspell-types": "8.10.4"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -10086,39 +10086,39 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.10.2.tgz",
-      "integrity": "sha512-NgcWcXD6uhsPfCZfOrrHWisuIDS18dxrDTDrl80cMG7pdzcfvb9nbP3vzbadAN11Ivf/fEaJtZHcXkkjC4v77g==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.10.4.tgz",
+      "integrity": "sha512-IU+w0hNUQSR99ftC5Jr5D3Vtg70AOUSvdFXHO13qVf3GBnfYxbltQirbY5afLFUWDY6ayNO3GsZisCMdywmlwg==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.10.2",
-        "@cspell/url": "8.10.2"
+        "@cspell/cspell-service-bus": "8.10.4",
+        "@cspell/url": "8.10.4"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.10.2.tgz",
-      "integrity": "sha512-p/41Gr18b38J1v1XrRn8L/DSFjOXAYn3BpqP/Tv44RNUrtGNlXkfVY/Xh0L9Gq8CKqrg1BVRH+qTp1NqP1qsYw==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.10.4.tgz",
+      "integrity": "sha512-u1Edp5p2zwnBuQ9pBFg+YfAWB1c1uERWSZkteD5uClVz21zY5Aiikl41gOLi6Qm5+oWCWW+nP1HcC6B6wlFLHQ==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.10.2",
-        "@cspell/cspell-pipe": "8.10.2",
-        "@cspell/cspell-resolver": "8.10.2",
-        "@cspell/cspell-types": "8.10.2",
-        "@cspell/dynamic-import": "8.10.2",
-        "@cspell/strong-weak-map": "8.10.2",
-        "@cspell/url": "8.10.2",
+        "@cspell/cspell-bundled-dicts": "8.10.4",
+        "@cspell/cspell-pipe": "8.10.4",
+        "@cspell/cspell-resolver": "8.10.4",
+        "@cspell/cspell-types": "8.10.4",
+        "@cspell/dynamic-import": "8.10.4",
+        "@cspell/strong-weak-map": "8.10.4",
+        "@cspell/url": "8.10.4",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.4",
-        "cspell-config-lib": "8.10.2",
-        "cspell-dictionary": "8.10.2",
-        "cspell-glob": "8.10.2",
-        "cspell-grammar": "8.10.2",
-        "cspell-io": "8.10.2",
-        "cspell-trie-lib": "8.10.2",
+        "cspell-config-lib": "8.10.4",
+        "cspell-dictionary": "8.10.4",
+        "cspell-glob": "8.10.4",
+        "cspell-grammar": "8.10.4",
+        "cspell-io": "8.10.4",
+        "cspell-trie-lib": "8.10.4",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0",
@@ -10145,13 +10145,13 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.10.2.tgz",
-      "integrity": "sha512-U1bSyTr5+6qQv1fjQrMlnFm8+U5RrrLwSkU4FkNkUgloRqnCp1CNPgiDy9M7WWFYEX8X9va5smXAzR1HtGE2wg==",
+      "version": "8.10.4",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.10.4.tgz",
+      "integrity": "sha512-PQDwEYI10sp9nwnUA8HFFZr1c5j1Zrk9p8oqk7KUy+QUF3XcJn3ayLenPNUG95U/ysg3RBHc7/Vmh7unvXNRlQ==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.10.2",
-        "@cspell/cspell-types": "8.10.2",
+        "@cspell/cspell-pipe": "8.10.4",
+        "@cspell/cspell-types": "8.10.4",
         "gensequence": "^7.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@typescript-eslint/eslint-plugin": "^7.15.0",
     "@typescript-eslint/parser": "^7.15.0",
     "commitlint": "^18.6.1",
-    "cspell": "^8.10.1",
+    "cspell": "^8.10.4",
     "eslint": "^8.57.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@types/google-libphonenumber": "^7.4.30",
         "@types/is-url": "^1.2.32",
         "@types/morgan": "^1.9.9",
-        "@types/node": "^20.14.9",
+        "@types/node": "^20.14.10",
         "@types/nunjucks": "^3.2.6",
         "accessible-autocomplete": "^2.0.4",
         "apollo-cache-inmemory": "^1.6.6",
@@ -81,7 +81,7 @@
         "eslint-plugin-prettier": "5.0.1",
         "jest": "29.6.2",
         "prettier": "^3.3.2",
-        "ts-jest": "^29.1.5"
+        "ts-jest": "^29.2.0"
       },
       "engines": {
         "node": ">=21",
@@ -3070,9 +3070,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "version": "20.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -12963,9 +12963,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/ts-jest": {
-      "version": "29.1.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.5.tgz",
-      "integrity": "sha512-UuClSYxM7byvvYfyWdFI+/2UxMmwNyJb0NPkZPQE2hew3RurV7l7zURgOHAd/1I1ZdPpe3GUsXNXAcN8TFKSIg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.0.tgz",
+      "integrity": "sha512-eFmkE9MG0+oT6nqSOcUwL+2UUmK2IvhhUV8hFDsCHnc++v2WCCbQQZh5vvjsa8sgOY/g9T0325hmkEmi6rninA==",
       "dev": true,
       "dependencies": {
         "bs-logger": "0.x",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -34,7 +34,7 @@
     "@types/google-libphonenumber": "^7.4.30",
     "@types/is-url": "^1.2.32",
     "@types/morgan": "^1.9.9",
-    "@types/node": "^20.14.9",
+    "@types/node": "^20.14.10",
     "@types/nunjucks": "^3.2.6",
     "accessible-autocomplete": "^2.0.4",
     "apollo-cache-inmemory": "^1.6.6",
@@ -94,7 +94,7 @@
     "eslint-plugin-prettier": "5.0.1",
     "jest": "29.6.2",
     "prettier": "^3.3.2",
-    "ts-jest": "^29.1.5"
+    "ts-jest": "^29.2.0"
   },
   "engines": {
     "node": ">=21",


### PR DESCRIPTION
## Introduction :pencil2:

This PR changes `default-authentication-plugin` from `mysql_native_password` to `caching_sha2_password`. 
`mysql_native_password` is deprecated in newer versions of MySQL and `caching_sha2_password` is now the default authentication method
`caching_sha2_password` is also more secure

## Resolution :heavy_check_mark:

* Changed to caching_sha2_password

## Miscellaneous :heavy_plus_sign:

- Dependency updates

