### PR TITLE
chore(EMS-3550): no pdf - updateCompanyPostDataMigration unit test coverage

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -4598,14 +4598,14 @@ var map_sic_codes_default = mapSicCodes;
 var createCompanySicCodes = async (context, sicCodes, industrySectorNames2, companyId) => {
   console.info("Creating company SIC codes for ", companyId);
   try {
-    const mappedSicCodes = map_sic_codes_default(sicCodes, industrySectorNames2, companyId);
-    let createdSicCodes = [];
     if (sicCodes.length) {
-      createdSicCodes = await context.db.CompanySicCode.createMany({
+      const mappedSicCodes = map_sic_codes_default(sicCodes, industrySectorNames2, companyId);
+      const createdSicCodes = await context.db.CompanySicCode.createMany({
         data: mappedSicCodes
       });
+      return createdSicCodes;
     }
-    return createdSicCodes;
+    return [];
   } catch (err) {
     console.error("Error creating company SIC codes %O", err);
     throw new Error(`Creating company SIC codes ${err}`);
@@ -7801,6 +7801,10 @@ var updateCompanyPostDataMigration = async (root, variables, context) => {
       data: otherFields
     });
     const { id: addressId, ...addressFields } = registeredOfficeAddress;
+    if (!updatedCompany.registeredOfficeAddressId) {
+      console.error("Unable to update company address - does not exist (post data migration) %O", id);
+      throw new Error(`Unable to update company address - does not exist (post data migration) ${id}`);
+    }
     await context.db.CompanyAddress.updateOne({
       where: {
         id: updatedCompany.registeredOfficeAddressId

--- a/src/api/custom-resolvers/mutations/update-company-post-data-migration/index.test.ts
+++ b/src/api/custom-resolvers/mutations/update-company-post-data-migration/index.test.ts
@@ -124,5 +124,38 @@ describe('custom-resolvers/update-company-post-data-migration', () => {
     });
   });
 
-  // TODO: EMS-3550 error handling for CompanyAddress, CompanySicCode
+  describe('when an error occurs whilst updating company SIC codes', () => {
+    it('should throw an error', async () => {
+      const mockVariables = {
+        ...variables,
+        company: {
+          ...variables.company,
+          sicCodes: 'a, b, c',
+        },
+      };
+
+      const expectedMessage = 'Updating company (post data migration) Error: Creating company SIC codes TypeError: sicCodes.forEach is not a function';
+
+      await expect(updateCompanyPostDataMigration({}, mockVariables, context)).rejects.toThrow(expectedMessage);
+    });
+  });
+
+  describe('when an error occurs whilst updating company address data', () => {
+    it('should throw an error', async () => {
+      /**
+       * delete all company address entires
+       * so that the company does not have an address relationship.
+       */
+
+      const companyAddresses = await context.query.CompanyAddress.findMany();
+
+      await context.query.CompanyAddress.deleteMany({
+        where: companyAddresses,
+      });
+
+      const expectedMessage = 'Updating company (post data migration) Error: Unable to update company address - does not exist (post data migration)';
+
+      await expect(updateCompanyPostDataMigration({}, variables, context)).rejects.toThrow(expectedMessage);
+    });
+  });
 });

--- a/src/api/custom-resolvers/mutations/update-company-post-data-migration/index.ts
+++ b/src/api/custom-resolvers/mutations/update-company-post-data-migration/index.ts
@@ -30,6 +30,11 @@ const updateCompanyPostDataMigration = async (root: any, variables: UpdateCompan
 
     const { id: addressId, ...addressFields } = registeredOfficeAddress;
 
+    if (!updatedCompany.registeredOfficeAddressId) {
+      console.error('Unable to update company address - does not exist (post data migration) %O', id);
+      throw new Error(`Unable to update company address - does not exist (post data migration) ${id}`);
+    }
+
     await context.db.CompanyAddress.updateOne({
       where: {
         id: updatedCompany.registeredOfficeAddressId,

--- a/src/api/helpers/create-company-sic-codes/index.test.ts
+++ b/src/api/helpers/create-company-sic-codes/index.test.ts
@@ -24,7 +24,7 @@ describe('helpers/create-company-sic-codes', () => {
     company = (await companyHelpers.createCompany({ context })) as object;
   });
 
-  test('it should return mapped SIC codes with company ID', async () => {
+  it('should return mapped SIC codes with company ID', async () => {
     const result = await createCompanySicCodes(context, mockSicCodes, mocIndustrySectorNames, company.id);
 
     const [firstEntry, secondEntry] = result;
@@ -44,8 +44,18 @@ describe('helpers/create-company-sic-codes', () => {
     expect(secondEntry.industrySectorName).toEqual('');
   });
 
+  describe('when sicCodes is not populated', () => {
+    it('should return an empty array', async () => {
+      const emptySicCodes = [] as Array<string>;
+
+      const result = await createCompanySicCodes(context, emptySicCodes, mocIndustrySectorNames, company.id);
+
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('when an invalid company ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createCompanySicCodes(context, mockSicCodes, mocIndustrySectorNames, invalidId);
       } catch (err) {

--- a/src/api/helpers/create-company-sic-codes/index.ts
+++ b/src/api/helpers/create-company-sic-codes/index.ts
@@ -19,17 +19,17 @@ const createCompanySicCodes = async (
   console.info('Creating company SIC codes for ', companyId);
 
   try {
-    const mappedSicCodes = mapSicCodes(sicCodes, industrySectorNames, companyId);
-
-    let createdSicCodes = [] as Array<SicCode>;
-
     if (sicCodes.length) {
-      createdSicCodes = (await context.db.CompanySicCode.createMany({
+      const mappedSicCodes = mapSicCodes(sicCodes, industrySectorNames, companyId);
+
+      const createdSicCodes = (await context.db.CompanySicCode.createMany({
         data: mappedSicCodes,
       })) as Array<SicCode>;
+
+      return createdSicCodes;
     }
 
-    return createdSicCodes;
+    return [];
   } catch (err) {
     console.error('Error creating company SIC codes %O', err);
 


### PR DESCRIPTION
## Introduction :pencil2:

This PR improves unit test coverage for error handling in the `updateCompanyPostDataMigration` GraphQL mutation.

## Resolution :heavy_check_mark:

- Add unit tests for when there is an error:
  - Updating company SIC codes.
  - Updating a company address.
- Update `updateCompanyPostDataMigration` to throw an error if there is no `registeredOfficeAddressId`.
- Simplify `createCompanySicCodes` helper function, improve unit test coverage.