### PR TITLE
feat(EMS-3547): Azure MySQL Flexible server version set

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -261,6 +261,7 @@ jobs:
             --storage-size ${{ vars.DB_STORAGE_SIZE_GB }} \
             --sku-name ${{ env.DB_SKU }} \
             --tier ${{ env.DB_TIER }} \
+            --version ${{ vars.DB_VERSION }} \
             --vnet vnet-${{ env.PRODUCT }}-${{ env.TARGET }}-${{ vars.VERSION }} \
             --subnet snet-database-${{ env.PRODUCT }}-${{ vars.VERSION }} \
             --address-prefixes ${{ vars.VNET_ADDRESS_PREFIX }} \


### PR DESCRIPTION
## Introduction :pencil2:
Ensure MySQL server on Azure version can be explicitly specified and matches the local docker tagged image version.

## Resolution :heavy_check_mark:
* Added `--version` flag to `az mysql flexible-server create` command, with value set to latest supported version by [Azure](https://learn.microsoft.com/en-us/azure/mysql/concepts-version-policy).
