### PR TITLE
fix(iac): afd custom domains association

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -121,6 +121,7 @@
         "pinojs",
         "plusplus",
         "productgroup",
+        "rdbms",
         "recorsets",
         "Robo",
         "sanitisation",

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -85,6 +85,7 @@ jobs:
         with:
           inlineScript: |
             az config set extension.use_dynamic_install=yes_without_prompt
+            az extension add --name rdbms-connect
 
       - name: Import ⬇
         if: ${{ '1' == vars.DATABASE }}

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -1159,3 +1159,10 @@ jobs:
             --endpoint-name ${{ env.PRODUCT }}-ui-${{ env.TARGET }}-${{ vars.VERSION }} \
             --profile-name frontdoor-${{ env.PRODUCT }}-${{ env.TARGET }}-${{ vars.VERSION }} \
             --custom-domains $(az afd custom-domain list --profile-name frontdoor-${{ env.PRODUCT }}-${{ env.TARGET }}-${{ vars.VERSION }} --query '[?contains(hostName, `${{ vars.DOMAIN_QUOTE }}`)]'.name -o tsv) $(az afd custom-domain list --profile-name frontdoor-${{ env.PRODUCT }}-${{ env.TARGET }}-${{ vars.VERSION }} --query '[?contains(hostName, `${{ vars.DOMAIN_INSURANCE }}`)]'.name -o tsv)
+
+            # Associate FD
+            az afd security-policy update \
+            --security-policy-name security-policy-${{ env.PRODUCT }}-${{ env.TARGET }}-${{ vars.VERSION }} \
+            --waf-policy $(az network front-door waf-policy list --query '[]'.id -o tsv) \
+            --domains $(az afd endpoint list --profile-name frontdoor-${{ env.PRODUCT }}-${{ env.TARGET }}-${{ vars.VERSION }} --query '[]'.id -o tsv) $(az afd custom-domain list --profile-name frontdoor-${{ env.PRODUCT }}-${{ env.TARGET }}-${{ vars.VERSION }} --query '[?contains(hostName, `${{ vars.DOMAIN_QUOTE }}`)]'.id -o tsv) $(az afd custom-domain list --profile-name frontdoor-${{ env.PRODUCT }}-${{ env.TARGET }}-${{ vars.VERSION }} --query '[?contains(hostName, `${{ vars.DOMAIN_INSURANCE }}`)]'.id -o tsv) \
+            --profile-name frontdoor-${{ env.PRODUCT }}-${{ env.TARGET }}-${{ vars.VERSION }}


### PR DESCRIPTION
## Introduction :pencil2:
Ensure Azure Front Door WAF security policy is also associated with custom domains.

## Resolution :heavy_check_mark:
* Added ` az afd security-policy update` CLI command to associate with:
  * AFD endpoint
  * AFD custom domains

## Miscellaneous :heavy_plus_sign:
* Minor deployment fix, ensure AZ CLI extension is pre-installed `rdbms-connect`.
* CSpell update
