### PR TITLE
fix(iac): explicit RBAC authorisation to false for Azure KV

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -379,6 +379,7 @@ jobs:
             --name kv-${{ env.PRODUCT }}-${{ env.TARGET }}-${{ vars.VERSION }} \
             --default-action Deny \
             --public-network-access Disabled \
+            --enable-rbac-authorization false \
             --network-acls-ips ${{ secrets.WAF_ALLOWED_IP }} \
             --network-acls-vnets $(az network vnet subnet list --vnet-name vnet-${{ env.PRODUCT }}-${{ env.TARGET }}-${{ vars.VERSION }} --query '[?contains(name, `keyvault`)].id' -o tsv)
 


### PR DESCRIPTION
## Introduction :pencil2:
When executing Azure KV creation CLI RBAC is now set as default authorisation method, thus ailing rest of the IaC script due to `Access Policy` usage.

## Resolution :heavy_check_mark:
* Set RBAC usage to false.
