### PR TITLE
chore(EMS-3643): clean constants index

### DIFF
--- a/src/ui/server/constants/index.ts
+++ b/src/ui/server/constants/index.ts
@@ -18,16 +18,14 @@ export * from './integrity';
 export * from './pagination';
 export * from './percentages-of-cover';
 export * from './phone-number-countries';
+export * from './quote';
 export * from './regex';
 export * from './routes';
 export * from './supported-currencies';
+export * from './service-name';
 export * from './task-ids';
 export * from './templates';
 export * from './tls';
 export * from './total-contract-value';
 export * from './ukef-contact-details';
 export * from './validation';
-
-// TODO: Refactor below constants
-export const SERVICE_NAME = 'EXIP';
-export const QUOTE = 'Quote';

--- a/src/ui/server/constants/quote.ts
+++ b/src/ui/server/constants/quote.ts
@@ -1,0 +1,1 @@
+export const QUOTE = 'Quote';

--- a/src/ui/server/constants/service-name.ts
+++ b/src/ui/server/constants/service-name.ts
@@ -1,0 +1,1 @@
+export const SERVICE_NAME = 'EXIP';


### PR DESCRIPTION
## Introduction :pencil2:
This PR addresses a TODO comment where 2x single line constants were stored in the index file.

## Resolution :heavy_check_mark:
- Move 2x single line constants into their own directories.
