### PR TITLE
fix(EMS-3633): data migration - declaration versioning

### DIFF
--- a/src/api/data-migration/version-1-to-version-2/create-new-application-relationships/declaration-version-relationship/index.ts
+++ b/src/api/data-migration/version-1-to-version-2/create-new-application-relationships/declaration-version-relationship/index.ts
@@ -14,7 +14,7 @@ const createDeclarationVersionRelationship = async (connection: Connection) => {
   console.info(`✅ ${loggingMessage}`);
 
   try {
-    const promises = Promise.all([submittedApplications(connection), nonSubmittedApplications(connection)]);
+    const promises = await Promise.all([submittedApplications(connection), nonSubmittedApplications(connection)]);
 
     return promises;
   } catch (err) {

--- a/src/api/data-migration/version-1-to-version-2/create-new-application-relationships/declaration-version-relationship/index.ts
+++ b/src/api/data-migration/version-1-to-version-2/create-new-application-relationships/declaration-version-relationship/index.ts
@@ -14,7 +14,7 @@ const createDeclarationVersionRelationship = async (connection: Connection) => {
   console.info(`✅ ${loggingMessage}`);
 
   try {
-    const promises = Promise.all([await submittedApplications(connection), await nonSubmittedApplications(connection)]);
+    const promises = Promise.all([submittedApplications(connection), nonSubmittedApplications(connection)]);
 
     return promises;
   } catch (err) {


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where, when running data migration, the migration would error during declaration versioning updates, if there are any applications that have _not_ been submitted.

## Resolution :heavy_check_mark:
- Remove 2x unnecessary `await`'s from a `Promise.all()`.
- Add `await` to the `Promise.all()`.
