### PR TITLE
fix(EMS-3633): data migration - financial vector columns

### DIFF
--- a/src/api/data-migration/version-1-to-version-2/README.md
+++ b/src/api/data-migration/version-1-to-version-2/README.md
@@ -99,7 +99,9 @@ This is because, during `npm run dev`, KeystoneJS/prisma checks the schema again
 
 We manage our own data migration, so we do not need these checks to run.
 
-To run `npm run dev` after running the migration script, it can be achieved by adding a `--no-db-push` to the command. However, this should not be necessary since this is for development environments only. In a data migration scenario, `npm run start` should be used.
+To run `npm run dev` after running the migration script, it can be achieved by adding a `--no-db-push` to the `package.json` `dev` script. However, this should only be used for debugging purposes in development environments only.
+
+In a data migration scenario outside of a development environment, `npm run start` should be used.
 
 ## SQL and KeystoneJS queries
 

--- a/src/api/data-migration/version-1-to-version-2/create-new-application-relationships/index.ts
+++ b/src/api/data-migration/version-1-to-version-2/create-new-application-relationships/index.ts
@@ -38,11 +38,14 @@ const createNewApplicationRelationships = async (connection: Connection) => {
       updateCompanyDifferentTradingAddress(connection),
       createDeclarationVersionRelationship(connection),
       updateDeclarationVersionField(connection, applications),
+    ]);
+
+    const financialVectorRelationships = await Promise.all([
       updateLossPayeeFinancialUkVector(connection),
       updateLossPayeeFinancialInternationalVector(connection),
     ]);
 
-    return newRelationships;
+    return [...newRelationships, ...financialVectorRelationships];
   } catch (err) {
     console.error(`🚨 error ${loggingMessage} %O`, err);
 

--- a/src/api/data-migration/version-1-to-version-2/create-new-application-relationships/loss-payee/create-loss-payee-financial-uk.ts
+++ b/src/api/data-migration/version-1-to-version-2/create-new-application-relationships/loss-payee/create-loss-payee-financial-uk.ts
@@ -4,12 +4,12 @@ import createCuid from '../../create-cuid';
 import executeSqlQuery from '../../execute-sql-query';
 
 /**
- * lossPayeeFinancialInternational
+ * lossPayeeFinancialUk
  * Create new "nominated loss payee - financial UK" entries
  * @param {Connection} connection: SQL database connection
  * @returns {Promise<Array<object>>} Loss payee - nominated loss payee - financial UK entries
  */
-const lossPayeeFinancialInternational = async (connection: Connection) => {
+const lossPayeeFinancialUk = async (connection: Connection) => {
   const loggingMessage = 'Creating nominatedLossPayees - financial UK';
 
   console.info(`✅ ${loggingMessage}`);
@@ -41,4 +41,4 @@ const lossPayeeFinancialInternational = async (connection: Connection) => {
   }
 };
 
-export default lossPayeeFinancialInternational;
+export default lossPayeeFinancialUk;

--- a/src/api/data-migration/version-1-to-version-2/create-new-application-relationships/loss-payee/update-loss-payee-financial-international-vector.ts
+++ b/src/api/data-migration/version-1-to-version-2/create-new-application-relationships/loss-payee/update-loss-payee-financial-international-vector.ts
@@ -18,6 +18,18 @@ const updateLossPayeeFinancialInternationalVector = async (connection: Connectio
     const financialInternationals = await getAllLossPayeeFinancialInternational(connection);
     const vectors = await getAllLossPayeeFinancialInternationalVectors(connection);
 
+    if (!financialInternationals.length) {
+      console.info('🚨 No financial internationals available - unable to update vector columns');
+
+      throw new Error('🚨 No financial internationals available - unable to update vector columns');
+    }
+
+    if (!vectors.length) {
+      console.info('🚨 No financial international vectors available - unable to update vector columns');
+
+      throw new Error('🚨 No financial international vectors available - unable to update vector columns');
+    }
+
     const promises = financialInternationals.map(async (financialInternational: object, index: number) => {
       const vector = vectors[index];
 

--- a/src/api/data-migration/version-1-to-version-2/create-new-application-relationships/loss-payee/update-loss-payee-financial-uk-vector.ts
+++ b/src/api/data-migration/version-1-to-version-2/create-new-application-relationships/loss-payee/update-loss-payee-financial-uk-vector.ts
@@ -18,6 +18,18 @@ const updateLossPayeeFinancialUkVector = async (connection: Connection) => {
     const financialUks = await getAllLossPayeeFinancialUk(connection);
     const vectors = await getAllLossPayeeFinancialUkVectors(connection);
 
+    if (!financialUks.length) {
+      console.info('🚨 No financial UKs available - unable to update vector columns');
+
+      throw new Error('🚨 No financial UKs available - unable to update vector columns');
+    }
+
+    if (!vectors.length) {
+      console.info('🚨 No financial UK vectors available - unable to update vector columns');
+
+      throw new Error('🚨 No financial UK vectors available - unable to update vector columns');
+    }
+
     const promises = financialUks.map(async (financialUk: object, index: number) => {
       const vector = vectors[index];
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where, when the data migration script is run, the international and UK financial database tables would have a NULL vector column.

Therefore, after migration, a user would not be able to complete the "Policy" section and the service would redirect to the "problem with service" page.

## Resolution :heavy_check_mark:
- Update `createNewApplicationRelationships` to update the vector columns _after_ other promises have resolved.

## Miscellaneous :heavy_plus_sign:
- Minor README improvement.
- Fix a typo.
- Add some logging/error handling to `updateLossPayeeFinancialInternationalVector` and `updateLossPayeeFinancialUkVector` so that if some particular data is empty, an error will be thrown.
