### PR TITLE
chore(EMS-3633): data migration - required fields for in progress applications

### DIFF
--- a/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/index.test.ts
@@ -28,7 +28,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-buyer', () => {
   it('should return an array of mapped buyer fields', () => {
     const result = mapBuyer(mockApplication);
 
-    const { eligibility, buyer } = mockApplication;
+    const { eligibility, buyer, migratedV1toV2 } = mockApplication;
     const { buyerTradingHistory, relationship } = buyer;
 
     const expected = [
@@ -44,7 +44,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-buyer', () => {
 
       ...mapBuyerTradingHistory(buyerTradingHistory),
 
-      ...mapPreviousCoverWithBuyer(eligibility, relationship),
+      ...mapPreviousCoverWithBuyer(eligibility, relationship, migratedV1toV2),
 
       xlsxRow(String(FIELDS[HAS_BUYER_FINANCIAL_ACCOUNTS]), mapYesNoField({ answer: relationship[HAS_BUYER_FINANCIAL_ACCOUNTS] })),
     ];

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/index.ts
@@ -30,7 +30,7 @@ const { FIELDS } = XLSX;
  * @returns {Array<object>} Array of objects for XLSX generation
  */
 const mapBuyer = (application: Application) => {
-  const { buyer, eligibility } = application;
+  const { buyer, eligibility, migratedV1toV2 } = application;
   const { buyerTradingHistory, relationship } = buyer;
 
   const mapped = [
@@ -46,7 +46,7 @@ const mapBuyer = (application: Application) => {
 
     ...mapBuyerTradingHistory(buyerTradingHistory),
 
-    ...mapPreviousCoverWithBuyer(eligibility, relationship),
+    ...mapPreviousCoverWithBuyer(eligibility, relationship, migratedV1toV2),
 
     xlsxRow(String(FIELDS[HAS_BUYER_FINANCIAL_ACCOUNTS]), mapYesNoField({ answer: relationship[HAS_BUYER_FINANCIAL_ACCOUNTS] })),
   ];

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/map-previous-cover-with-buyer/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/map-previous-cover-with-buyer/index.test.ts
@@ -1,12 +1,15 @@
 import mapPreviousCoverWithBuyer from '.';
 import { TOTAL_CONTRACT_VALUE } from '../../../../constants/total-contract-value';
-import FIELD_IDS from '../../../../constants/field-ids/insurance/your-buyer';
+import FIELD_IDS from '../../../../constants/field-ids/insurance';
 import { XLSX } from '../../../../content-strings';
 import mapYesNoField from '../../helpers/map-yes-no-field';
 import xlsxRow from '../../helpers/xlsx-row';
-import { mockApplication, mockApplicationSinglePolicyTotalContractValueOverThreshold } from '../../../../test-mocks';
+import { mockApplicationSinglePolicyTotalContractValueOverThreshold, mockApplicationEligibilityTotalContractValueBelowThreshold } from '../../../../test-mocks';
 
-const { HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER, PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER } = FIELD_IDS;
+const {
+  MIGRATED_FROM_V1_TO_V2,
+  YOUR_BUYER: { HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER, PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER },
+} = FIELD_IDS;
 
 const { FIELDS } = XLSX;
 
@@ -15,45 +18,48 @@ const {
   eligibility,
 } = mockApplicationSinglePolicyTotalContractValueOverThreshold;
 
+const mockRelationshipTrue = {
+  ...relationship,
+  [HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]: true,
+};
+
+const mockRelationshipFalse = {
+  ...relationship,
+  [HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]: false,
+};
+
+const mockMigratedFromV1ToV2True = true;
+const mockMigratedFromV1ToV2False = false;
+
 describe('api/generate-xlsx/map-application-to-xlsx/map-buyer/map-previous-cover-with-buyer', () => {
   describe(`when the total contract value is ${TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE}`, () => {
-    describe(`${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER} is true`, () => {
+    describe(`when ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER} is true`, () => {
       it(`should return an array of mapped fields with ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER}`, () => {
-        const mockRelationship = {
-          ...relationship,
-          [HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]: true,
-        };
-
-        const result = mapPreviousCoverWithBuyer(eligibility, mockRelationship);
+        const result = mapPreviousCoverWithBuyer(eligibility, mockRelationshipTrue, mockMigratedFromV1ToV2False);
 
         const expected = [
           xlsxRow(
             String(FIELDS[HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]),
             mapYesNoField({
-              answer: mockRelationship[HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER],
+              answer: mockRelationshipTrue[HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER],
             }),
           ),
-          xlsxRow(String(FIELDS[PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]), mockRelationship[PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]),
+          xlsxRow(String(FIELDS[PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]), mockRelationshipTrue[PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]),
         ];
 
         expect(result).toEqual(expected);
       });
     });
 
-    describe(`${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER} is false`, () => {
-      it(`should return an array of mapped fields without ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER}`, () => {
-        const mockRelationship = {
-          ...relationship,
-          exporterHasPreviousCreditInsuranceWithBuyer: false,
-        };
-
-        const result = mapPreviousCoverWithBuyer(eligibility, mockRelationship);
+    describe(`when ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER} is false`, () => {
+      it('should return an array with one field', () => {
+        const result = mapPreviousCoverWithBuyer(eligibility, mockRelationshipFalse, mockMigratedFromV1ToV2False);
 
         const expected = [
           xlsxRow(
             String(FIELDS[HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]),
             mapYesNoField({
-              answer: mockRelationship[HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER],
+              answer: mockRelationshipFalse[HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER],
             }),
           ),
         ];
@@ -63,9 +69,50 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-buyer/map-previous-cover
     });
   });
 
-  describe(`when the total contract value is NOT ${TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE}`, () => {
+  describe(`when ${MIGRATED_FROM_V1_TO_V2} is true`, () => {
+    describe(`when ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER} is true`, () => {
+      it(`should return an array of mapped fields with ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER}`, () => {
+        const result = mapPreviousCoverWithBuyer(mockApplicationEligibilityTotalContractValueBelowThreshold, mockRelationshipTrue, mockMigratedFromV1ToV2True);
+
+        const expected = [
+          xlsxRow(
+            String(FIELDS[HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]),
+            mapYesNoField({
+              answer: mockRelationshipTrue[HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER],
+            }),
+          ),
+          xlsxRow(String(FIELDS[PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]), mockRelationshipTrue[PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]),
+        ];
+
+        expect(result).toEqual(expected);
+      });
+
+      describe(`when ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER} is false`, () => {
+        it('should return an array with one field', () => {
+          const result = mapPreviousCoverWithBuyer(
+            mockApplicationEligibilityTotalContractValueBelowThreshold,
+            mockRelationshipFalse,
+            mockMigratedFromV1ToV2True,
+          );
+
+          const expected = [
+            xlsxRow(
+              String(FIELDS[HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]),
+              mapYesNoField({
+                answer: mockRelationshipFalse[HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER],
+              }),
+            ),
+          ];
+
+          expect(result).toEqual(expected);
+        });
+      });
+    });
+  });
+
+  describe(`when the total contract value is NOT ${TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE} and ${MIGRATED_FROM_V1_TO_V2} is false`, () => {
     it('should return an empty array', () => {
-      const result = mapPreviousCoverWithBuyer(mockApplication.eligibility, relationship);
+      const result = mapPreviousCoverWithBuyer(mockApplicationEligibilityTotalContractValueBelowThreshold, relationship, mockMigratedFromV1ToV2False);
 
       expect(result).toEqual([]);
     });

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/map-previous-cover-with-buyer/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/map-previous-cover-with-buyer/index.test.ts
@@ -28,14 +28,11 @@ const mockRelationshipFalse = {
   [HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]: false,
 };
 
-const mockMigratedFromV1ToV2True = true;
-const mockMigratedFromV1ToV2False = false;
-
 describe('api/generate-xlsx/map-application-to-xlsx/map-buyer/map-previous-cover-with-buyer', () => {
   describe(`when the total contract value is ${TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE}`, () => {
     describe(`when ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER} is true`, () => {
       it(`should return an array of mapped fields with ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER}`, () => {
-        const result = mapPreviousCoverWithBuyer(eligibility, mockRelationshipTrue, mockMigratedFromV1ToV2False);
+        const result = mapPreviousCoverWithBuyer(eligibility, mockRelationshipTrue, false);
 
         const expected = [
           xlsxRow(
@@ -53,7 +50,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-buyer/map-previous-cover
 
     describe(`when ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER} is false`, () => {
       it('should return an array with one field', () => {
-        const result = mapPreviousCoverWithBuyer(eligibility, mockRelationshipFalse, mockMigratedFromV1ToV2False);
+        const result = mapPreviousCoverWithBuyer(eligibility, mockRelationshipFalse, false);
 
         const expected = [
           xlsxRow(
@@ -72,7 +69,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-buyer/map-previous-cover
   describe(`when ${MIGRATED_FROM_V1_TO_V2} is true`, () => {
     describe(`when ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER} is true`, () => {
       it(`should return an array of mapped fields with ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER}`, () => {
-        const result = mapPreviousCoverWithBuyer(mockApplicationEligibilityTotalContractValueBelowThreshold, mockRelationshipTrue, mockMigratedFromV1ToV2True);
+        const result = mapPreviousCoverWithBuyer(mockApplicationEligibilityTotalContractValueBelowThreshold, mockRelationshipTrue, true);
 
         const expected = [
           xlsxRow(
@@ -89,11 +86,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-buyer/map-previous-cover
 
       describe(`when ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER} is false`, () => {
         it('should return an array with one field', () => {
-          const result = mapPreviousCoverWithBuyer(
-            mockApplicationEligibilityTotalContractValueBelowThreshold,
-            mockRelationshipFalse,
-            mockMigratedFromV1ToV2True,
-          );
+          const result = mapPreviousCoverWithBuyer(mockApplicationEligibilityTotalContractValueBelowThreshold, mockRelationshipFalse, true);
 
           const expected = [
             xlsxRow(
@@ -112,7 +105,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-buyer/map-previous-cover
 
   describe(`when the total contract value is NOT ${TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE} and ${MIGRATED_FROM_V1_TO_V2} is false`, () => {
     it('should return an empty array', () => {
-      const result = mapPreviousCoverWithBuyer(mockApplicationEligibilityTotalContractValueBelowThreshold, relationship, mockMigratedFromV1ToV2False);
+      const result = mapPreviousCoverWithBuyer(mockApplicationEligibilityTotalContractValueBelowThreshold, relationship, false);
 
       expect(result).toEqual([]);
     });

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/map-previous-cover-with-buyer/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/map-previous-cover-with-buyer/index.ts
@@ -14,13 +14,14 @@ const { FIELDS } = XLSX;
  * Generate an XLSX row if an exporter has "previous cover" with the buyer.
  * @param {ApplicationEligibility} eligibility: Application eligibility
  * @param {ApplicationBuyerRelationship} relationship: Application buyer relationship
+ * @param {Boolean} migratedV1toV2: Application has been migrated from V1 to V2
  * @returns {Array<object>} Array of objects for XLSX generation
  */
-const mapPreviousCoverWithBuyer = (eligibility: ApplicationEligibility, relationship: ApplicationBuyerRelationship) => {
+const mapPreviousCoverWithBuyer = (eligibility: ApplicationEligibility, relationship: ApplicationBuyerRelationship, migratedV1toV2?: boolean) => {
   // TODO: EMS-3467: move to getPopulatedApplication.
   const totalContractValueOverThreshold = eligibility.totalContractValue.value === TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE;
 
-  if (totalContractValueOverThreshold) {
+  if (totalContractValueOverThreshold || migratedV1toV2) {
     const answer = relationship[HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER];
 
     const mapped = [xlsxRow(String(FIELDS[HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]), mapYesNoField({ answer }))];

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-private-market/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-private-market/index.test.ts
@@ -40,14 +40,11 @@ const mockPrivateMarketAttemptedFalse = {
   [ATTEMPTED]: false,
 };
 
-const mockMigratedFromV1ToV2True = true;
-const mockMigratedFromV1ToV2False = false;
-
 describe('api/generate-xlsx/map-application-to-xlsx/map-private-market', () => {
   describe(`when the total contract value is ${TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE}`, () => {
     describe(`when ${ATTEMPTED} is true`, () => {
       it('should return an array of mapped fields', () => {
-        const result = mapPrivateMarket(mockPrivateMarketAttemptedTrue, mockTotalContractValueOverThreshold, mockMigratedFromV1ToV2False);
+        const result = mapPrivateMarket(mockPrivateMarketAttemptedTrue, mockTotalContractValueOverThreshold, false);
 
         const expected = [
           xlsxRow(String(FIELDS.EXPORT_CONTRACT[ATTEMPTED]), mapYesNoField({ answer: mockPrivateMarketAttemptedTrue[ATTEMPTED] })),
@@ -60,7 +57,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-private-market', () => {
 
     describe(`when ${ATTEMPTED} is false`, () => {
       it('should return an array with one field', () => {
-        const result = mapPrivateMarket(mockPrivateMarketAttemptedFalse, mockTotalContractValueOverThreshold, mockMigratedFromV1ToV2False);
+        const result = mapPrivateMarket(mockPrivateMarketAttemptedFalse, mockTotalContractValueOverThreshold, false);
 
         const expected = [xlsxRow(String(FIELDS.EXPORT_CONTRACT[ATTEMPTED]), mapYesNoField({ answer: mockPrivateMarketAttemptedFalse[ATTEMPTED] }))];
 
@@ -72,7 +69,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-private-market', () => {
   describe(`when ${MIGRATED_FROM_V1_TO_V2} is true`, () => {
     describe(`when ${ATTEMPTED} is true`, () => {
       it('should return an array of mapped fields', () => {
-        const result = mapPrivateMarket(mockPrivateMarketAttemptedTrue, mockTotalContractValueUnderThreshold, mockMigratedFromV1ToV2True);
+        const result = mapPrivateMarket(mockPrivateMarketAttemptedTrue, mockTotalContractValueUnderThreshold, true);
 
         const expected = [
           xlsxRow(String(FIELDS.EXPORT_CONTRACT[ATTEMPTED]), mapYesNoField({ answer: mockPrivateMarketAttemptedTrue[ATTEMPTED] })),
@@ -85,7 +82,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-private-market', () => {
 
     describe(`when ${ATTEMPTED} is false`, () => {
       it('should return an array with one field', () => {
-        const result = mapPrivateMarket(mockPrivateMarketAttemptedFalse, mockTotalContractValueUnderThreshold, mockMigratedFromV1ToV2True);
+        const result = mapPrivateMarket(mockPrivateMarketAttemptedFalse, mockTotalContractValueUnderThreshold, true);
 
         const expected = [xlsxRow(String(FIELDS.EXPORT_CONTRACT[ATTEMPTED]), mapYesNoField({ answer: mockPrivateMarketAttemptedFalse[ATTEMPTED] }))];
 
@@ -96,7 +93,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-private-market', () => {
 
   describe(`when the total contract value is NOT ${TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE} and ${MIGRATED_FROM_V1_TO_V2} is false`, () => {
     it('should return an empty array', () => {
-      const result = mapPrivateMarket(privateMarket, mockTotalContractValueUnderThreshold, mockMigratedFromV1ToV2False);
+      const result = mapPrivateMarket(privateMarket, mockTotalContractValueUnderThreshold, false);
 
       expect(result).toEqual([]);
     });

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-private-market/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-private-market/index.test.ts
@@ -1,6 +1,6 @@
 import mapPrivateMarket from '.';
 import { TOTAL_CONTRACT_VALUE } from '../../../../constants/total-contract-value';
-import FIELD_IDS from '../../../../constants/field-ids/insurance/export-contract';
+import FIELD_IDS from '../../../../constants/field-ids/insurance';
 import { XLSX } from '../../../../content-strings';
 import xlsxRow from '../../helpers/xlsx-row';
 import mapYesNoField from '../../helpers/map-yes-no-field';
@@ -9,7 +9,10 @@ import { mockApplication } from '../../../../test-mocks';
 const { FIELDS } = XLSX;
 
 const {
-  PRIVATE_MARKET: { ATTEMPTED, DECLINED_DESCRIPTION },
+  EXPORT_CONTRACT: {
+    PRIVATE_MARKET: { ATTEMPTED, DECLINED_DESCRIPTION },
+  },
+  MIGRATED_FROM_V1_TO_V2,
 } = FIELD_IDS;
 
 const {
@@ -17,25 +20,38 @@ const {
   exportContract: { privateMarket },
 } = mockApplication;
 
+const mockTotalContractValueOverThreshold = {
+  ...eligibility.totalContractValue,
+  value: TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE,
+};
+
+const mockTotalContractValueUnderThreshold = {
+  ...eligibility.totalContractValue,
+  value: TOTAL_CONTRACT_VALUE.LESS_THAN_250K.VALUE,
+};
+
+const mockPrivateMarketAttemptedTrue = {
+  ...privateMarket,
+  [ATTEMPTED]: true,
+};
+
+const mockPrivateMarketAttemptedFalse = {
+  ...privateMarket,
+  [ATTEMPTED]: false,
+};
+
+const mockMigratedFromV1ToV2True = true;
+const mockMigratedFromV1ToV2False = false;
+
 describe('api/generate-xlsx/map-application-to-xlsx/map-private-market', () => {
   describe(`when the total contract value is ${TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE}`, () => {
-    const mockTotalContractValue = {
-      ...eligibility.totalContractValue,
-      value: TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE,
-    };
-
     describe(`when ${ATTEMPTED} is true`, () => {
       it('should return an array of mapped fields', () => {
-        const mockPrivateMarket = {
-          ...privateMarket,
-          [ATTEMPTED]: true,
-        };
-
-        const result = mapPrivateMarket(mockPrivateMarket, mockTotalContractValue);
+        const result = mapPrivateMarket(mockPrivateMarketAttemptedTrue, mockTotalContractValueOverThreshold, mockMigratedFromV1ToV2False);
 
         const expected = [
-          xlsxRow(String(FIELDS.EXPORT_CONTRACT[ATTEMPTED]), mapYesNoField({ answer: mockPrivateMarket[ATTEMPTED] })),
-          xlsxRow(String(FIELDS.EXPORT_CONTRACT[DECLINED_DESCRIPTION]), mockPrivateMarket[DECLINED_DESCRIPTION]),
+          xlsxRow(String(FIELDS.EXPORT_CONTRACT[ATTEMPTED]), mapYesNoField({ answer: mockPrivateMarketAttemptedTrue[ATTEMPTED] })),
+          xlsxRow(String(FIELDS.EXPORT_CONTRACT[DECLINED_DESCRIPTION]), mockPrivateMarketAttemptedTrue[DECLINED_DESCRIPTION]),
         ];
 
         expect(result).toEqual(expected);
@@ -44,28 +60,43 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-private-market', () => {
 
     describe(`when ${ATTEMPTED} is false`, () => {
       it('should return an array with one field', () => {
-        const mockPrivateMarket = {
-          ...privateMarket,
-          [ATTEMPTED]: false,
-        };
+        const result = mapPrivateMarket(mockPrivateMarketAttemptedFalse, mockTotalContractValueOverThreshold, mockMigratedFromV1ToV2False);
 
-        const result = mapPrivateMarket(mockPrivateMarket, mockTotalContractValue);
-
-        const expected = [xlsxRow(String(FIELDS.EXPORT_CONTRACT[ATTEMPTED]), mapYesNoField({ answer: mockPrivateMarket[ATTEMPTED] }))];
+        const expected = [xlsxRow(String(FIELDS.EXPORT_CONTRACT[ATTEMPTED]), mapYesNoField({ answer: mockPrivateMarketAttemptedFalse[ATTEMPTED] }))];
 
         expect(result).toEqual(expected);
       });
     });
   });
 
-  describe(`when the total contract value is NOT ${TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE}`, () => {
-    it('should return an empty array', () => {
-      const mockTotalContractValue = {
-        ...eligibility.totalContractValue,
-        value: TOTAL_CONTRACT_VALUE.LESS_THAN_250K.VALUE,
-      };
+  describe(`when ${MIGRATED_FROM_V1_TO_V2} is true`, () => {
+    describe(`when ${ATTEMPTED} is true`, () => {
+      it('should return an array of mapped fields', () => {
+        const result = mapPrivateMarket(mockPrivateMarketAttemptedTrue, mockTotalContractValueUnderThreshold, mockMigratedFromV1ToV2True);
 
-      const result = mapPrivateMarket(privateMarket, mockTotalContractValue);
+        const expected = [
+          xlsxRow(String(FIELDS.EXPORT_CONTRACT[ATTEMPTED]), mapYesNoField({ answer: mockPrivateMarketAttemptedTrue[ATTEMPTED] })),
+          xlsxRow(String(FIELDS.EXPORT_CONTRACT[DECLINED_DESCRIPTION]), mockPrivateMarketAttemptedTrue[DECLINED_DESCRIPTION]),
+        ];
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe(`when ${ATTEMPTED} is false`, () => {
+      it('should return an array with one field', () => {
+        const result = mapPrivateMarket(mockPrivateMarketAttemptedFalse, mockTotalContractValueUnderThreshold, mockMigratedFromV1ToV2True);
+
+        const expected = [xlsxRow(String(FIELDS.EXPORT_CONTRACT[ATTEMPTED]), mapYesNoField({ answer: mockPrivateMarketAttemptedFalse[ATTEMPTED] }))];
+
+        expect(result).toEqual(expected);
+      });
+    });
+  });
+
+  describe(`when the total contract value is NOT ${TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE} and ${MIGRATED_FROM_V1_TO_V2} is false`, () => {
+    it('should return an empty array', () => {
+      const result = mapPrivateMarket(privateMarket, mockTotalContractValueUnderThreshold, mockMigratedFromV1ToV2False);
 
       expect(result).toEqual([]);
     });

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-private-market/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-export-contract/map-private-market/index.ts
@@ -16,13 +16,14 @@ const {
  * Map an application's "export contract - private market" fields into an array of objects for XLSX generation
  * @param {Application} application: Application
  * @param {TotalContractValue} totalContractValue: Total contract value
+ * @param {Boolean} migratedV1toV2: Application has been migrated from V1 to V2
  * @returns {Array<object>} Array of objects for XLSX generation
  */
-const mapPrivateMarket = (privateMarket: ApplicationPrivateMarket, totalContractValue: TotalContractValue) => {
+const mapPrivateMarket = (privateMarket: ApplicationPrivateMarket, totalContractValue: TotalContractValue, migratedV1toV2?: boolean) => {
   // TODO: EMS-3467: move to getPopulatedApplication.
   const totalContractValueOverThreshold = totalContractValue.value === TOTAL_CONTRACT_VALUE.MORE_THAN_250K.VALUE;
 
-  if (totalContractValueOverThreshold) {
+  if (totalContractValueOverThreshold || migratedV1toV2) {
     const attempedPrivateMarketAnswer = privateMarket[ATTEMPTED];
 
     const mapped = [xlsxRow(String(FIELDS.EXPORT_CONTRACT[ATTEMPTED]), mapYesNoField({ answer: attempedPrivateMarketAnswer }))];

--- a/src/api/test-mocks/index.ts
+++ b/src/api/test-mocks/index.ts
@@ -87,6 +87,13 @@ export const mockApplicationSinglePolicyTotalContractValueOverThreshold = {
   },
 };
 
+export const mockApplicationEligibilityTotalContractValueBelowThreshold = {
+  ...mockApplicationSinglePolicyTotalContractValueOverThreshold.eligibility,
+  [TOTAL_CONTRACT_VALUE_FIELD_ID]: {
+    value: TOTAL_CONTRACT_VALUE.LESS_THAN_250K.VALUE,
+  },
+};
+
 export const mockApplicationMultiplePolicyTotalContractValueOverThreshold = {
   ...mockApplicationMinimalBrokerBuyerAndCompany,
   policy: {

--- a/src/api/types/application-types/index.ts
+++ b/src/api/types/application-types/index.ts
@@ -282,6 +282,7 @@ export interface Application {
   companySicCodes: Array<ApplicationCompanySicCode>;
   companyAddress: ApplicationCompanyAddress;
   declaration: ApplicationDeclaration;
+  migratedV1toV2?: boolean;
   nominatedLossPayee: ApplicationNominatedLossPayee;
   owner: ApplicationOwner;
   policy: ApplicationPolicy;

--- a/src/ui/server/controllers/insurance/check-your-answers/export-contract/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/export-contract/index.test.ts
@@ -20,7 +20,7 @@ const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE },
 } = ROUTES;
 
-const { exportContract, totalContractValueOverThreshold } = mockApplication;
+const { exportContract, migratedV1toV2, totalContractValueOverThreshold } = mockApplication;
 
 const {
   finalDestinationKnown,
@@ -94,7 +94,14 @@ describe('controllers/insurance/check-your-answers/export-contract', () => {
 
       const checkAndChange = true;
 
-      const summaryList = exportContractSummaryLists(exportContract, totalContractValueOverThreshold, referenceNumber, mockCountries, checkAndChange);
+      const summaryList = exportContractSummaryLists(
+        exportContract,
+        totalContractValueOverThreshold,
+        migratedV1toV2,
+        referenceNumber,
+        mockCountries,
+        checkAndChange,
+      );
 
       const exportContractFields = requiredFields({
         totalContractValueOverThreshold,

--- a/src/ui/server/controllers/insurance/check-your-answers/export-contract/index.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/export-contract/index.ts
@@ -48,7 +48,7 @@ export const get = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    const { referenceNumber, exportContract, totalContractValueOverThreshold } = application;
+    const { referenceNumber, exportContract, totalContractValueOverThreshold, migratedV1toV2 } = application;
 
     const {
       finalDestinationKnown,
@@ -67,7 +67,7 @@ export const get = async (req: Request, res: Response) => {
 
     const countries = await api.keystone.countries.getAll();
 
-    const summaryList = exportContractSummaryLists(exportContract, totalContractValueOverThreshold, referenceNumber, countries, checkAndChange);
+    const summaryList = exportContractSummaryLists(exportContract, totalContractValueOverThreshold, migratedV1toV2, referenceNumber, countries, checkAndChange);
 
     const exportContractFields = requiredFields({
       totalContractValueOverThreshold,

--- a/src/ui/server/controllers/insurance/check-your-answers/your-buyer/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/your-buyer/index.test.ts
@@ -77,6 +77,7 @@ describe('controllers/insurance/check-your-answers/your-buyer', () => {
         mockApplication.eligibility,
         referenceNumber,
         mockApplication.totalContractValueOverThreshold,
+        mockApplication.migratedV1toV2,
         checkAndChange,
       );
 

--- a/src/ui/server/controllers/insurance/check-your-answers/your-buyer/index.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/your-buyer/index.ts
@@ -52,7 +52,7 @@ export const get = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    const { referenceNumber } = application;
+    const { migratedV1toV2, referenceNumber, totalContractValueOverThreshold } = application;
 
     const checkAndChange = true;
 
@@ -60,8 +60,8 @@ export const get = async (req: Request, res: Response) => {
       application.buyer,
       application.eligibility,
       referenceNumber,
-      application.totalContractValueOverThreshold,
-      application.migratedV1toV2,
+      totalContractValueOverThreshold,
+      migratedV1toV2,
       checkAndChange,
     );
 

--- a/src/ui/server/controllers/insurance/check-your-answers/your-buyer/index.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/your-buyer/index.ts
@@ -61,6 +61,7 @@ export const get = async (req: Request, res: Response) => {
       application.eligibility,
       referenceNumber,
       application.totalContractValueOverThreshold,
+      application.migratedV1toV2,
       checkAndChange,
     );
 

--- a/src/ui/server/controllers/insurance/export-contract/check-your-answers/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/check-your-answers/index.test.ts
@@ -12,7 +12,7 @@ import { mockReq, mockRes, mockApplication, mockCountries } from '../../../../te
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
-const { exportContract, referenceNumber, totalContractValueOverThreshold } = mockApplication;
+const { exportContract, referenceNumber, migratedV1toV2, totalContractValueOverThreshold } = mockApplication;
 
 describe('controllers/insurance/export-contract/check-your-answers', () => {
   let req: Request;
@@ -47,7 +47,7 @@ describe('controllers/insurance/export-contract/check-your-answers', () => {
     it('should render template', async () => {
       await get(req, res);
 
-      const summaryLists = exportContractSummaryLists(exportContract, totalContractValueOverThreshold, referenceNumber, mockCountries);
+      const summaryLists = exportContractSummaryLists(exportContract, totalContractValueOverThreshold, migratedV1toV2, referenceNumber, mockCountries);
 
       const expectedVariables = {
         ...insuranceCorePageVariables({

--- a/src/ui/server/controllers/insurance/export-contract/check-your-answers/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/check-your-answers/index.ts
@@ -27,7 +27,7 @@ export const get = async (req: Request, res: Response) => {
     return res.redirect(PROBLEM_WITH_SERVICE);
   }
 
-  const { exportContract, referenceNumber, totalContractValueOverThreshold } = application;
+  const { exportContract, referenceNumber, migratedV1toV2, totalContractValueOverThreshold } = application;
 
   try {
     const countries = await api.keystone.countries.getAll();
@@ -36,7 +36,7 @@ export const get = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    const summaryLists = exportContractSummaryLists(exportContract, totalContractValueOverThreshold, referenceNumber, countries);
+    const summaryLists = exportContractSummaryLists(exportContract, totalContractValueOverThreshold, migratedV1toV2, referenceNumber, countries);
 
     return res.render(TEMPLATE, {
       ...insuranceCorePageVariables({

--- a/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/index.test.ts
@@ -46,6 +46,9 @@ const {
   },
 } = TEMPLATES;
 
+const mockMigratedFromV1ToV2True = true;
+const mockMigratedFromV1ToV2False = false;
+
 describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
   let req: Request;
   let res: Response;
@@ -144,61 +147,103 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
         expect(mapAndSave.exportContract).toHaveBeenCalledWith(payload, res.locals.application);
       });
 
-      describe("when the url's last substring is `change` and application.totalContractValueOverThreshold is true", () => {
-        it(`should redirect to ${PRIVATE_MARKET_CHANGE}`, async () => {
-          req.originalUrl = HOW_WILL_YOU_GET_PAID_CHANGE;
+      describe('when totalContractValueOverThreshold=true, migratedV1toV2=false, check/change routes', () => {
+        beforeEach(() => {
           res.locals.application = mockApplicationTotalContractValueThresholdTrue;
+          res.locals.application.migratedV1toV2 = mockMigratedFromV1ToV2False;
+        });
 
-          await post(req, res);
+        describe("when the url's last substring is `change`", () => {
+          it(`should redirect to ${PRIVATE_MARKET_CHANGE}`, async () => {
+            req.originalUrl = HOW_WILL_YOU_GET_PAID_CHANGE;
 
-          const expected = `${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET_CHANGE}`;
+            await post(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(expected);
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET_CHANGE}`;
+
+            expect(res.redirect).toHaveBeenCalledWith(expected);
+          });
+        });
+
+        describe("when the url's last substring is `check-and-change`", () => {
+          it(`should redirect to ${PRIVATE_MARKET_CHECK_AND_CHANGE}`, async () => {
+            req.originalUrl = HOW_WILL_YOU_GET_PAID_CHECK_AND_CHANGE;
+
+            await post(req, res);
+
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET_CHECK_AND_CHANGE}`;
+
+            expect(res.redirect).toHaveBeenCalledWith(expected);
+          });
         });
       });
 
-      describe("when the url's last substring is `change` and application.totalContractValueOverThreshold is false", () => {
-        it(`should redirect to ${CHECK_YOUR_ANSWERS}`, async () => {
-          req.originalUrl = HOW_WILL_YOU_GET_PAID_CHANGE;
+      describe('when totalContractValueOverThreshold=false, migratedV1toV2=true, check/change routes', () => {
+        beforeEach(() => {
           res.locals.application = mockApplicationTotalContractValueThresholdFalse;
+          res.locals.application.migratedV1toV2 = mockMigratedFromV1ToV2True;
+        });
 
-          await post(req, res);
+        describe("when the url's last substring is `change`", () => {
+          it(`should redirect to ${PRIVATE_MARKET_CHANGE}`, async () => {
+            req.originalUrl = HOW_WILL_YOU_GET_PAID_CHANGE;
 
-          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+            await post(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(expected);
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET_CHANGE}`;
+
+            expect(res.redirect).toHaveBeenCalledWith(expected);
+          });
+        });
+
+        describe("when the url's last substring is `check-and-change`", () => {
+          it(`should redirect to ${PRIVATE_MARKET_CHECK_AND_CHANGE}`, async () => {
+            req.originalUrl = HOW_WILL_YOU_GET_PAID_CHECK_AND_CHANGE;
+
+            await post(req, res);
+
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET_CHECK_AND_CHANGE}`;
+
+            expect(res.redirect).toHaveBeenCalledWith(expected);
+          });
         });
       });
 
-      describe("when the url's last substring is `check-and-change` and application.totalContractValueOverThreshold is true", () => {
-        it(`should redirect to ${PRIVATE_MARKET_CHECK_AND_CHANGE}`, async () => {
-          req.originalUrl = HOW_WILL_YOU_GET_PAID_CHECK_AND_CHANGE;
-          res.locals.application = mockApplicationTotalContractValueThresholdTrue;
-
-          await post(req, res);
-
-          const expected = `${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET_CHECK_AND_CHANGE}`;
-
-          expect(res.redirect).toHaveBeenCalledWith(expected);
-        });
-      });
-
-      describe("when the url's last substring is `check-and-change` and application.totalContractValueOverThreshold is false", () => {
-        it(`should redirect to ${CHECK_AND_CHANGE_ROUTE}`, async () => {
-          req.originalUrl = HOW_WILL_YOU_GET_PAID_CHECK_AND_CHANGE;
+      describe('when totalContractValueOverThreshold=false, migratedV1toV2=false, check/change routes', () => {
+        beforeEach(() => {
           res.locals.application = mockApplicationTotalContractValueThresholdFalse;
+          res.locals.application.migratedV1toV2 = mockMigratedFromV1ToV2False;
+        });
 
-          await post(req, res);
+        describe("when the url's last substring is `change`", () => {
+          it(`should redirect to ${CHECK_YOUR_ANSWERS}`, async () => {
+            req.originalUrl = HOW_WILL_YOU_GET_PAID_CHANGE;
 
-          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+            await post(req, res);
 
-          expect(res.redirect).toHaveBeenCalledWith(expected);
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
+
+            expect(res.redirect).toHaveBeenCalledWith(expected);
+          });
+        });
+
+        describe("when the url's last substring is `check-and-change`", () => {
+          it(`should redirect to ${CHECK_AND_CHANGE_ROUTE}`, async () => {
+            req.originalUrl = HOW_WILL_YOU_GET_PAID_CHECK_AND_CHANGE;
+
+            await post(req, res);
+
+            const expected = `${INSURANCE_ROOT}/${referenceNumber}${CHECK_AND_CHANGE_ROUTE}`;
+
+            expect(res.redirect).toHaveBeenCalledWith(expected);
+          });
         });
       });
 
-      describe('when application.totalContractValueOverThreshold is true', () => {
+      describe('when totalContractValueOverThreshold=true, migratedV1toV2=false, non-check/change routes', () => {
         it(`should redirect to ${PRIVATE_MARKET}`, async () => {
           res.locals.application = mockApplicationTotalContractValueThresholdTrue;
+          res.locals.application.migratedV1toV2 = mockMigratedFromV1ToV2False;
 
           await post(req, res);
 
@@ -208,9 +253,23 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
         });
       });
 
-      describe('when application.totalContractValueOverThreshold is NOT true', () => {
+      describe('when totalContractValueOverThreshold=false, migratedV1toV2=true, non-check/change routes', () => {
+        it(`should redirect to ${PRIVATE_MARKET}`, async () => {
+          res.locals.application = mockApplicationTotalContractValueThresholdFalse;
+          res.locals.application.migratedV1toV2 = mockMigratedFromV1ToV2True;
+
+          await post(req, res);
+
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET}`;
+
+          expect(res.redirect).toHaveBeenCalledWith(expected);
+        });
+      });
+
+      describe('when totalContractValueOverThreshold=false, migratedV1toV2=false, non-check/change routes', () => {
         it(`should redirect to ${AGENT}`, async () => {
           res.locals.application = mockApplicationTotalContractValueThresholdFalse;
+          res.locals.application.migratedV1toV2 = mockMigratedFromV1ToV2False;
 
           await post(req, res);
 

--- a/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/index.test.ts
@@ -46,9 +46,6 @@ const {
   },
 } = TEMPLATES;
 
-const mockMigratedFromV1ToV2True = true;
-const mockMigratedFromV1ToV2False = false;
-
 describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
   let req: Request;
   let res: Response;
@@ -150,7 +147,7 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
       describe('when totalContractValueOverThreshold=true, migratedV1toV2=false, check/change routes', () => {
         beforeEach(() => {
           res.locals.application = mockApplicationTotalContractValueThresholdTrue;
-          res.locals.application.migratedV1toV2 = mockMigratedFromV1ToV2False;
+          res.locals.application.migratedV1toV2 = false;
         });
 
         describe("when the url's last substring is `change`", () => {
@@ -181,7 +178,7 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
       describe('when totalContractValueOverThreshold=false, migratedV1toV2=true, check/change routes', () => {
         beforeEach(() => {
           res.locals.application = mockApplicationTotalContractValueThresholdFalse;
-          res.locals.application.migratedV1toV2 = mockMigratedFromV1ToV2True;
+          res.locals.application.migratedV1toV2 = true;
         });
 
         describe("when the url's last substring is `change`", () => {
@@ -212,7 +209,7 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
       describe('when totalContractValueOverThreshold=false, migratedV1toV2=false, check/change routes', () => {
         beforeEach(() => {
           res.locals.application = mockApplicationTotalContractValueThresholdFalse;
-          res.locals.application.migratedV1toV2 = mockMigratedFromV1ToV2False;
+          res.locals.application.migratedV1toV2 = false;
         });
 
         describe("when the url's last substring is `change`", () => {
@@ -243,7 +240,7 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
       describe('when totalContractValueOverThreshold=true, migratedV1toV2=false, non-check/change routes', () => {
         it(`should redirect to ${PRIVATE_MARKET}`, async () => {
           res.locals.application = mockApplicationTotalContractValueThresholdTrue;
-          res.locals.application.migratedV1toV2 = mockMigratedFromV1ToV2False;
+          res.locals.application.migratedV1toV2 = false;
 
           await post(req, res);
 
@@ -256,7 +253,7 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
       describe('when totalContractValueOverThreshold=false, migratedV1toV2=true, non-check/change routes', () => {
         it(`should redirect to ${PRIVATE_MARKET}`, async () => {
           res.locals.application = mockApplicationTotalContractValueThresholdFalse;
-          res.locals.application.migratedV1toV2 = mockMigratedFromV1ToV2True;
+          res.locals.application.migratedV1toV2 = true;
 
           await post(req, res);
 
@@ -269,7 +266,7 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
       describe('when totalContractValueOverThreshold=false, migratedV1toV2=false, non-check/change routes', () => {
         it(`should redirect to ${AGENT}`, async () => {
           res.locals.application = mockApplicationTotalContractValueThresholdFalse;
-          res.locals.application.migratedV1toV2 = mockMigratedFromV1ToV2False;
+          res.locals.application.migratedV1toV2 = false;
 
           await post(req, res);
 

--- a/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/index.ts
+++ b/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/index.ts
@@ -111,17 +111,18 @@ export const post = async (req: Request, res: Response) => {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    const { totalContractValueOverThreshold } = application;
+    const { totalContractValueOverThreshold, migratedV1toV2 } = application;
 
     if (isChangeRoute(req.originalUrl)) {
       /**
-       * If the URL is a "change" route
+       * If the URL is a "change" route,
        * and totalContractValue is over the threshold,
+       * or the application has been migrated from V1 to V2,
        * redirect to PRIVATE_MARKET with /change in URL.
        * This ensures that the next page can consume /change in the URL
        * and therefore correctly redirect on submission.
        */
-      if (totalContractValueOverThreshold) {
+      if (totalContractValueOverThreshold || migratedV1toV2) {
         return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET_CHANGE}`);
       }
 
@@ -130,15 +131,16 @@ export const post = async (req: Request, res: Response) => {
 
     if (isCheckAndChangeRoute(req.originalUrl)) {
       /**
-       * If the URL is a "check and change" route
+       * If the URL is a "check and change" route,
        * and totalContractValue is over the threshold,
+       * or the application has been migrated from V1 to V2,
        * redirect to PRIVATE_MARKET with /check-and-change in URL.
        * This ensures that the next page can consume /check-and-change in the URL
        * and therefore correctly redirect on submission.
        * Otherwise, redirect to CHECK_AND_CHANGE_ROUTE.
        */
 
-      if (totalContractValueOverThreshold) {
+      if (totalContractValueOverThreshold || migratedV1toV2) {
         return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET_CHECK_AND_CHANGE}`);
       }
 
@@ -146,11 +148,12 @@ export const post = async (req: Request, res: Response) => {
     }
 
     /**
-     * if totalContractValue is over the threshold
-     * redirect to PRIVATE_MARKET
+     * if totalContractValue is over the threshold,
+     * or the application has been migrated from V1 to V2,
+     * redirect to PRIVATE_MARKET.
      * otherwise it should redirect to the AGENT page
      */
-    if (totalContractValueOverThreshold) {
+    if (totalContractValueOverThreshold || migratedV1toV2) {
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${PRIVATE_MARKET}`);
     }
 

--- a/src/ui/server/controllers/insurance/your-buyer/check-your-answers/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/check-your-answers/index.test.ts
@@ -42,6 +42,7 @@ describe('controllers/insurance/your-buyer/check-your-answers', () => {
         mockApplication.eligibility,
         referenceNumber,
         mockApplication.totalContractValueOverThreshold,
+        mockApplication.migratedV1toV2,
       );
 
       const expectedVariables = {

--- a/src/ui/server/controllers/insurance/your-buyer/check-your-answers/index.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/check-your-answers/index.ts
@@ -32,6 +32,7 @@ const get = (req: Request, res: Response) => {
       application.eligibility,
       application.referenceNumber,
       application.totalContractValueOverThreshold,
+      application.migratedV1toV2,
     );
 
     return res.render(TEMPLATE, {

--- a/src/ui/server/controllers/insurance/your-buyer/trading-history/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/trading-history/index.test.ts
@@ -257,9 +257,10 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
         expect(mapAndSave.buyerTradingHistory).toHaveBeenCalledWith(payload, mockApplication);
       });
 
-      describe('when application.totalContractValueOverThreshold is true', () => {
+      describe('when application.totalContractValueOverThreshold=true, migratedV1toV2=false', () => {
         it(`should redirect to ${CREDIT_INSURANCE_COVER}`, async () => {
           res.locals.application = mockApplicationTotalContractValueThresholdTrue;
+          res.locals.application.migratedV1toV2 = false;
 
           await post(req, res);
 
@@ -269,9 +270,10 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
         });
       });
 
-      describe('when application.totalContractValueOverThreshold is NOT true', () => {
+      describe('when application.totalContractValueOverThreshold=false, migratedV1toV2=true', () => {
         it('should redirect to the next page', async () => {
           res.locals.application = mockApplicationTotalContractValueThresholdFalse;
+          res.locals.application.migratedV1toV2 = true;
 
           await post(req, res);
           const expected = `${INSURANCE_ROOT}/${referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;

--- a/src/ui/server/controllers/insurance/your-buyer/trading-history/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/trading-history/index.test.ts
@@ -271,9 +271,21 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
       });
 
       describe('when application.totalContractValueOverThreshold=false, migratedV1toV2=true', () => {
-        it('should redirect to the next page', async () => {
+        it(`should redirect to ${CREDIT_INSURANCE_COVER}`, async () => {
           res.locals.application = mockApplicationTotalContractValueThresholdFalse;
           res.locals.application.migratedV1toV2 = true;
+
+          await post(req, res);
+          const expected = `${INSURANCE_ROOT}/${referenceNumber}${CREDIT_INSURANCE_COVER}`;
+
+          expect(res.redirect).toHaveBeenCalledWith(expected);
+        });
+      });
+
+      describe('when application.totalContractValueOverThreshold=false, migratedV1toV2=false', () => {
+        it(`should redirect to ${BUYER_FINANCIAL_INFORMATION}`, async () => {
+          res.locals.application = mockApplicationTotalContractValueThresholdFalse;
+          res.locals.application.migratedV1toV2 = false;
 
           await post(req, res);
           const expected = `${INSURANCE_ROOT}/${referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;

--- a/src/ui/server/controllers/insurance/your-buyer/trading-history/index.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/trading-history/index.ts
@@ -204,6 +204,8 @@ export const post = async (req: Request, res: Response) => {
     const {
       referenceNumber,
       buyer: { buyerTradingHistory },
+      migratedV1toV2,
+      totalContractValueOverThreshold,
     } = application;
 
     let isChange;
@@ -280,7 +282,7 @@ export const post = async (req: Request, res: Response) => {
      * redirect to CREDIT_INSURANCE_COVER
      * otherwise it should redirect to the BUYER_FINANCIAL_INFORMATION page
      */
-    if (application.totalContractValueOverThreshold) {
+    if (totalContractValueOverThreshold || migratedV1toV2) {
       return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${CREDIT_INSURANCE_COVER}`);
     }
 

--- a/src/ui/server/helpers/required-fields/export-contract/index.test.ts
+++ b/src/ui/server/helpers/required-fields/export-contract/index.test.ts
@@ -18,10 +18,6 @@ const {
   AGENT_CHARGES: { METHOD, PAYABLE_COUNTRY_CODE, FIXED_SUM_AMOUNT, FIXED_SUM_CURRENCY_CODE, PERCENTAGE_CHARGE },
 } = FIELD_IDS;
 
-const totalContractValueOverThresholdTrue = true;
-
-const mockMigratedV1toV2False = false;
-
 describe('server/helpers/required-fields/export-contract', () => {
   const {
     exportContract: {
@@ -187,20 +183,20 @@ describe('server/helpers/required-fields/export-contract', () => {
   describe('requiredFields', () => {
     it('should return array of required fields', () => {
       const result = requiredFields({
-        totalContractValueOverThreshold: totalContractValueOverThresholdTrue,
+        totalContractValueOverThreshold: true,
         finalDestinationKnown,
         attemptedPrivateMarketCover,
         isUsingAgent,
-        migratedV1toV2: mockMigratedV1toV2False,
+        migratedV1toV2: false,
       });
 
       const expected = [
         PAYMENT_TERMS_DESCRIPTION,
         ...getAboutGoodsOrServicesTasks(finalDestinationKnown),
         ...privateCoverTasks({
-          totalContractValueOverThreshold: totalContractValueOverThresholdTrue,
+          totalContractValueOverThreshold: true,
           attemptedPrivateMarketCover,
-          migratedV1toV2: mockMigratedV1toV2False,
+          migratedV1toV2: false,
         }),
         ...agentTasks({ isUsingAgent }),
         ...awardMethodTasks(awardMethodId),

--- a/src/ui/server/helpers/required-fields/export-contract/index.ts
+++ b/src/ui/server/helpers/required-fields/export-contract/index.ts
@@ -37,16 +37,18 @@ interface RequiredFields {
   agentIsCharging?: boolean;
   agentChargeMethod?: string;
   awardMethodId?: string;
+  migratedV1toV2?: boolean;
 }
 
 /**
  * privateCoverTasks
  * @param {Boolean} totalContractValueOverThreshold: If total contract value in eligibility should be over threshold.
  * @param {Boolean} attemptedPrivateMarketCover: "Attempted cover via the private market" flag
+ * @param {Boolean} migratedV1toV2: Application has been migrated from V1 to V2
  * @returns {Array} Array of tasks
  */
-export const privateCoverTasks = ({ totalContractValueOverThreshold, attemptedPrivateMarketCover }: RequiredFields): Array<string> => {
-  if (totalContractValueOverThreshold) {
+export const privateCoverTasks = ({ totalContractValueOverThreshold, attemptedPrivateMarketCover, migratedV1toV2 }: RequiredFields): Array<string> => {
+  if (totalContractValueOverThreshold || migratedV1toV2) {
     if (attemptedPrivateMarketCover) {
       return [DECLINED_DESCRIPTION];
     }
@@ -120,13 +122,15 @@ export const awardMethodTasks = (awardMethodId?: string): Array<string> => {
 
 /**
  * Required fields for the insurance - export contract section
- * * @param {Boolean} totalContractValueOverThreshold: If total contract value in eligibility should be over threshold.
+ * @param {Boolean} totalContractValueOverThreshold: If total contract value in eligibility should be over threshold.
  * @param {Boolean} finalDestinationKnown: "Final destination known"
  * @param {Boolean} attemptedPrivateMarketCover: "Attempted cover via the private market" flag
  * @param {Boolean} isUsingAgent: "Is using an agent to help win the export contract" flag
  * @param {Boolean} agentIsCharging: "Is the agent charging for their support in the export contract?" flag
  * @param {Boolean} agentChargeMethod: Agent charge method
  * @param {String} awardMethodId: Export contract award method ID
+ * @param {Boolean} agentChargeMethod: Agent charge method
+ * @param {Boolean} migratedV1toV2: Application has been migrated from V1 to V2
  * @returns {Array} Required field IDs
  */
 const requiredFields = ({
@@ -137,10 +141,11 @@ const requiredFields = ({
   agentIsCharging,
   agentChargeMethod,
   awardMethodId,
+  migratedV1toV2,
 }: RequiredFields): Array<string> => [
   PAYMENT_TERMS_DESCRIPTION,
   ...getAboutGoodsOrServicesTasks(finalDestinationKnown),
-  ...privateCoverTasks({ totalContractValueOverThreshold, attemptedPrivateMarketCover }),
+  ...privateCoverTasks({ totalContractValueOverThreshold, attemptedPrivateMarketCover, migratedV1toV2 }),
   ...agentTasks({ isUsingAgent, agentIsCharging, agentChargeMethod }),
   ...awardMethodTasks(awardMethodId),
 ];

--- a/src/ui/server/helpers/required-fields/prepare-application/index.test.ts
+++ b/src/ui/server/helpers/required-fields/prepare-application/index.test.ts
@@ -15,12 +15,13 @@ const {
     PRIVATE_MARKET: { ATTEMPTED },
     USING_AGENT,
   },
+  EXPORTER_BUSINESS: {
+    YOUR_COMPANY: { HAS_DIFFERENT_TRADING_NAME },
+  },
+  MIGRATED_FROM_V1_TO_V2,
   POLICY: {
     TYPE_OF_POLICY: { POLICY_TYPE },
     USING_BROKER,
-  },
-  EXPORTER_BUSINESS: {
-    YOUR_COMPANY: { HAS_DIFFERENT_TRADING_NAME },
   },
   YOUR_BUYER: { CONNECTION_WITH_BUYER, OUTSTANDING_PAYMENTS, TRADED_WITH_BUYER, HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER },
 } = INSURANCE_FIELD_IDS;
@@ -44,6 +45,7 @@ describe('server/helpers/required-fields/section-review', () => {
         attemptedPrivateMarketCover: flatApplicationData[ATTEMPTED],
         isUsingAgent: flatApplicationData[USING_AGENT],
         awardMethodId: flatApplicationData[AWARD_METHOD]?.id,
+        migratedV1toV2: flatApplicationData[MIGRATED_FROM_V1_TO_V2],
       }),
       ...requiredBusinessFields(flatApplicationData[HAS_DIFFERENT_TRADING_NAME]),
       ...requiredYourBuyerFields({

--- a/src/ui/server/helpers/required-fields/prepare-application/index.ts
+++ b/src/ui/server/helpers/required-fields/prepare-application/index.ts
@@ -13,12 +13,13 @@ const {
     PRIVATE_MARKET: { ATTEMPTED },
     USING_AGENT,
   },
+  EXPORTER_BUSINESS: {
+    YOUR_COMPANY: { HAS_DIFFERENT_TRADING_NAME },
+  },
+  MIGRATED_FROM_V1_TO_V2,
   POLICY: {
     TYPE_OF_POLICY: { POLICY_TYPE },
     USING_BROKER,
-  },
-  EXPORTER_BUSINESS: {
-    YOUR_COMPANY: { HAS_DIFFERENT_TRADING_NAME },
   },
   YOUR_BUYER: { CONNECTION_WITH_BUYER, OUTSTANDING_PAYMENTS, TRADED_WITH_BUYER, HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER },
 } = INSURANCE_FIELD_IDS;
@@ -39,6 +40,7 @@ const requiredFields = (application: ApplicationFlat): Array<string> => [
     attemptedPrivateMarketCover: application[ATTEMPTED],
     isUsingAgent: application[USING_AGENT],
     awardMethodId: application[AWARD_METHOD]?.id,
+    migratedV1toV2: application[MIGRATED_FROM_V1_TO_V2],
   }),
   ...requiredBusinessFields(application[HAS_DIFFERENT_TRADING_NAME]),
   ...requiredYourBuyerFields({

--- a/src/ui/server/helpers/summary-lists/export-contract/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/export-contract/index.test.ts
@@ -6,12 +6,6 @@ import generateGroupsOfSummaryLists from '../generate-groups-of-summary-lists';
 import { mockCountries } from '../../../test-mocks';
 import { referenceNumber, mockExportContract } from '../../../test-mocks/mock-application';
 
-const totalContractValueOverThresholdTrue = true;
-const totalContractValueOverThresholdFalse = false;
-
-const mockMigratedV1toV2True = true;
-const mockMigratedV1toV2False = false;
-
 describe('server/helpers/summary-lists/export-contract', () => {
   const mockAnswers = mockExportContract;
   const checkAndChange = true;
@@ -19,14 +13,7 @@ describe('server/helpers/summary-lists/export-contract', () => {
   describe('generateFields', () => {
     describe('when totalContractValueOverThreshold=false, migratedV1toV2=true', () => {
       it('should return all fields and values from the submitted data/answers', () => {
-        const result = generateFields(
-          mockAnswers,
-          totalContractValueOverThresholdFalse,
-          mockMigratedV1toV2True,
-          referenceNumber,
-          mockCountries,
-          checkAndChange,
-        );
+        const result = generateFields(mockAnswers, false, true, referenceNumber, mockCountries, checkAndChange);
 
         const expected = [
           generateAboutTheExportFields(mockAnswers, referenceNumber, mockCountries, checkAndChange),
@@ -40,14 +27,7 @@ describe('server/helpers/summary-lists/export-contract', () => {
 
     describe('when totalContractValueOverThreshold=true, migratedV1toV2=false', () => {
       it('should return all fields and values from the submitted data/answers', () => {
-        const result = generateFields(
-          mockAnswers,
-          totalContractValueOverThresholdTrue,
-          mockMigratedV1toV2False,
-          referenceNumber,
-          mockCountries,
-          checkAndChange,
-        );
+        const result = generateFields(mockAnswers, true, false, referenceNumber, mockCountries, checkAndChange);
 
         const expected = [
           generateAboutTheExportFields(mockAnswers, referenceNumber, mockCountries, checkAndChange),
@@ -61,14 +41,7 @@ describe('server/helpers/summary-lists/export-contract', () => {
 
     describe('when totalContractValueOverThreshold=false, migratedV1toV2=false', () => {
       it('should return some fields and values from the submitted data/answers', () => {
-        const result = generateFields(
-          mockAnswers,
-          totalContractValueOverThresholdFalse,
-          mockMigratedV1toV2False,
-          referenceNumber,
-          mockCountries,
-          checkAndChange,
-        );
+        const result = generateFields(mockAnswers, false, false, referenceNumber, mockCountries, checkAndChange);
 
         const expected = [
           generateAboutTheExportFields(mockAnswers, referenceNumber, mockCountries, checkAndChange),
@@ -82,16 +55,9 @@ describe('server/helpers/summary-lists/export-contract', () => {
 
   describe('exportContractSummaryLists', () => {
     it('should return an array of summary list rows', () => {
-      const result = exportContractSummaryLists(
-        mockAnswers,
-        totalContractValueOverThresholdFalse,
-        mockMigratedV1toV2True,
-        referenceNumber,
-        mockCountries,
-        checkAndChange,
-      );
+      const result = exportContractSummaryLists(mockAnswers, false, true, referenceNumber, mockCountries, checkAndChange);
 
-      const fields = generateFields(mockAnswers, totalContractValueOverThresholdFalse, mockMigratedV1toV2True, referenceNumber, mockCountries, checkAndChange);
+      const fields = generateFields(mockAnswers, false, true, referenceNumber, mockCountries, checkAndChange);
 
       const expected = generateGroupsOfSummaryLists(fields);
 

--- a/src/ui/server/helpers/summary-lists/export-contract/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/export-contract/index.test.ts
@@ -6,31 +6,27 @@ import generateGroupsOfSummaryLists from '../generate-groups-of-summary-lists';
 import { mockCountries } from '../../../test-mocks';
 import { referenceNumber, mockExportContract } from '../../../test-mocks/mock-application';
 
+const totalContractValueOverThresholdTrue = true;
+const totalContractValueOverThresholdFalse = false;
+
+const mockMigratedV1toV2True = true;
+const mockMigratedV1toV2False = false;
+
 describe('server/helpers/summary-lists/export-contract', () => {
   const mockAnswers = mockExportContract;
   const checkAndChange = true;
 
   describe('generateFields', () => {
-    describe('when totalContractValueOverThreshold is false', () => {
-      const totalContractValueOverThreshold = false;
-
-      it('should return some fields and values from the submitted data/answers', () => {
-        const result = generateFields(mockAnswers, totalContractValueOverThreshold, referenceNumber, mockCountries, checkAndChange);
-
-        const expected = [
-          generateAboutTheExportFields(mockAnswers, referenceNumber, mockCountries, checkAndChange),
-          generateAgentFields(mockAnswers.agent, referenceNumber, mockCountries, checkAndChange),
-        ];
-
-        expect(result).toEqual(expected);
-      });
-    });
-
-    describe('when totalContractValueOverThreshold is true', () => {
-      const totalContractValueOverThreshold = true;
-
+    describe('when totalContractValueOverThreshold=false, migratedV1toV2=true', () => {
       it('should return all fields and values from the submitted data/answers', () => {
-        const result = generateFields(mockAnswers, totalContractValueOverThreshold, referenceNumber, mockCountries, checkAndChange);
+        const result = generateFields(
+          mockAnswers,
+          totalContractValueOverThresholdFalse,
+          mockMigratedV1toV2True,
+          referenceNumber,
+          mockCountries,
+          checkAndChange,
+        );
 
         const expected = [
           generateAboutTheExportFields(mockAnswers, referenceNumber, mockCountries, checkAndChange),
@@ -41,15 +37,61 @@ describe('server/helpers/summary-lists/export-contract', () => {
         expect(result).toEqual(expected);
       });
     });
+
+    describe('when totalContractValueOverThreshold=true, migratedV1toV2=false', () => {
+      it('should return all fields and values from the submitted data/answers', () => {
+        const result = generateFields(
+          mockAnswers,
+          totalContractValueOverThresholdTrue,
+          mockMigratedV1toV2False,
+          referenceNumber,
+          mockCountries,
+          checkAndChange,
+        );
+
+        const expected = [
+          generateAboutTheExportFields(mockAnswers, referenceNumber, mockCountries, checkAndChange),
+          generatePrivateMarketFields(mockAnswers.privateMarket, referenceNumber, checkAndChange),
+          generateAgentFields(mockAnswers.agent, referenceNumber, mockCountries, checkAndChange),
+        ];
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('when totalContractValueOverThreshold=false, migratedV1toV2=false', () => {
+      it('should return some fields and values from the submitted data/answers', () => {
+        const result = generateFields(
+          mockAnswers,
+          totalContractValueOverThresholdFalse,
+          mockMigratedV1toV2False,
+          referenceNumber,
+          mockCountries,
+          checkAndChange,
+        );
+
+        const expected = [
+          generateAboutTheExportFields(mockAnswers, referenceNumber, mockCountries, checkAndChange),
+          generateAgentFields(mockAnswers.agent, referenceNumber, mockCountries, checkAndChange),
+        ];
+
+        expect(result).toEqual(expected);
+      });
+    });
   });
 
   describe('exportContractSummaryLists', () => {
     it('should return an array of summary list rows', () => {
-      const totalContractValueOverThreshold = false;
+      const result = exportContractSummaryLists(
+        mockAnswers,
+        totalContractValueOverThresholdFalse,
+        mockMigratedV1toV2True,
+        referenceNumber,
+        mockCountries,
+        checkAndChange,
+      );
 
-      const result = exportContractSummaryLists(mockAnswers, totalContractValueOverThreshold, referenceNumber, mockCountries, checkAndChange);
-
-      const fields = generateFields(mockAnswers, totalContractValueOverThreshold, referenceNumber, mockCountries, checkAndChange);
+      const fields = generateFields(mockAnswers, totalContractValueOverThresholdFalse, mockMigratedV1toV2True, referenceNumber, mockCountries, checkAndChange);
 
       const expected = generateGroupsOfSummaryLists(fields);
 

--- a/src/ui/server/helpers/summary-lists/export-contract/index.ts
+++ b/src/ui/server/helpers/summary-lists/export-contract/index.ts
@@ -39,6 +39,7 @@ export const generateFields = (
  * Create multiple groups with govukSummaryList data structure
  * @param {ApplicationExportContract} answers: export contract answers/submitted data in a simple object.text structure
  * @param {Boolean} totalContractValueOverThreshold: "Total contract value is over the threshold" flag
+ * @param {Boolean} migratedV1toV2: Application has been migrated from V1 to V2
  * @param {Number} referenceNumber: Application reference number
  * @param {Array<Country>} countries: Countries
  * @param {Boolean} checkAndChange: true if coming from check your answers section in submit application section. Defaults to false

--- a/src/ui/server/helpers/summary-lists/export-contract/index.ts
+++ b/src/ui/server/helpers/summary-lists/export-contract/index.ts
@@ -8,8 +8,9 @@ import { ApplicationExportContract, Country, SummaryListGroupData } from '../../
  * generateFields
  * Create all fields for the Insurance - "Export contract - about the export" govukSummaryList
  * @param {ApplicationExportContract} answers: All submitted export contract data
- * @param {Number} referenceNumber: Application reference number
  * @param {Boolean} totalContractValueOverThreshold: "Total contract value is over the threshold" flag
+ * @param {Boolean} migratedV1toV2: Application has been migrated from V1 to V2
+ * @param {Number} referenceNumber: Application reference number
  * @param {Array<Country>} countries: Countries
  * @param {Boolean} checkAndChange: True if coming from check your answers section in submit application section
  * @returns {Object} Fields and values in an object structure for GOVUK summary list structure
@@ -17,13 +18,14 @@ import { ApplicationExportContract, Country, SummaryListGroupData } from '../../
 export const generateFields = (
   answers: ApplicationExportContract,
   totalContractValueOverThreshold: boolean,
+  migratedV1toV2: boolean,
   referenceNumber: number,
   countries: Array<Country>,
   checkAndChange: boolean,
 ) => {
   const fields = [generateAboutTheExportFields(answers, referenceNumber, countries, checkAndChange)] as Array<SummaryListGroupData>;
 
-  if (totalContractValueOverThreshold) {
+  if (totalContractValueOverThreshold || migratedV1toV2) {
     fields.push(generatePrivateMarketFields(answers.privateMarket, referenceNumber, checkAndChange));
   }
 
@@ -45,11 +47,12 @@ export const generateFields = (
 export const exportContractSummaryLists = (
   answers: ApplicationExportContract,
   totalContractValueOverThreshold: boolean,
+  migratedV1toV2: boolean,
   referenceNumber: number,
   countries: Array<Country>,
   checkAndChange = false,
 ) => {
-  const fields = generateFields(answers, totalContractValueOverThreshold, referenceNumber, countries, checkAndChange);
+  const fields = generateFields(answers, totalContractValueOverThreshold, migratedV1toV2, referenceNumber, countries, checkAndChange);
 
   const summaryList = generateGroupsOfSummaryLists(fields);
 

--- a/src/ui/server/helpers/summary-lists/your-buyer/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-buyer/index.test.ts
@@ -9,19 +9,13 @@ import mockApplication, { mockApplicationBuyer, referenceNumber } from '../../..
 
 const { buyer } = mockApplication;
 
-const totalContractValueOverThresholdTrue = true;
-const totalContractValueOverThresholdFalse = false;
-
-const mockMigratedV1toV2True = true;
-const mockMigratedV1toV2False = false;
-
 const checkAndChange = false;
 
 describe('server/helpers/summary-lists/your-buyer', () => {
   describe('optionalFields', () => {
     describe('when totalContractValueOverThreshold=false, migratedV1toV2=true', () => {
       it('should return fields and values from creditInsuranceHistoryFields when totalContractValueOverThreshold is "true"', () => {
-        const result = optionalFields(mockApplicationBuyer, referenceNumber, totalContractValueOverThresholdFalse, mockMigratedV1toV2True, checkAndChange);
+        const result = optionalFields(mockApplicationBuyer, referenceNumber, false, true, checkAndChange);
 
         const expected = [creditInsuranceHistoryFields(mockApplicationBuyer.relationship, referenceNumber, checkAndChange)];
 
@@ -31,7 +25,7 @@ describe('server/helpers/summary-lists/your-buyer', () => {
 
     describe('when totalContractValueOverThreshold=true, migratedV1toV2=false', () => {
       it('should return fields and values from creditInsuranceHistoryFields when totalContractValueOverThreshold is "true"', () => {
-        const result = optionalFields(mockApplicationBuyer, referenceNumber, totalContractValueOverThresholdTrue, mockMigratedV1toV2False, checkAndChange);
+        const result = optionalFields(mockApplicationBuyer, referenceNumber, true, false, checkAndChange);
 
         const expected = [creditInsuranceHistoryFields(mockApplicationBuyer.relationship, referenceNumber, checkAndChange)];
 
@@ -41,7 +35,7 @@ describe('server/helpers/summary-lists/your-buyer', () => {
 
     describe('when totalContractValueOverThreshold=false, migratedV1toV2=false', () => {
       it('should return fields and values from creditInsuranceHistoryFields when totalContractValueOverThreshold is "false"', () => {
-        const result = optionalFields(mockApplicationBuyer, referenceNumber, totalContractValueOverThresholdFalse, mockMigratedV1toV2False, checkAndChange);
+        const result = optionalFields(mockApplicationBuyer, referenceNumber, false, false, checkAndChange);
 
         expect(result).toEqual([]);
       });
@@ -50,13 +44,13 @@ describe('server/helpers/summary-lists/your-buyer', () => {
 
   describe('generateFields', () => {
     it('should return fields and values from the submitted data/answers', () => {
-      const result = generateFields(mockApplicationBuyer, mockApplication.eligibility, referenceNumber, totalContractValueOverThresholdTrue, checkAndChange);
+      const result = generateFields(mockApplicationBuyer, mockApplication.eligibility, referenceNumber, true, checkAndChange);
 
       const expected = [
         generateCompanyOrOrganisationFields(buyer, mockApplication.eligibility, referenceNumber, checkAndChange),
         connectionWithBuyerFields(buyer.relationship, referenceNumber, checkAndChange),
         tradingHistoryFields(buyer.buyerTradingHistory, referenceNumber, checkAndChange),
-        ...optionalFields(buyer, referenceNumber, totalContractValueOverThresholdTrue, mockMigratedV1toV2False, checkAndChange),
+        ...optionalFields(buyer, referenceNumber, true, false, checkAndChange),
         financialAccountsFields(buyer.relationship, referenceNumber, checkAndChange),
       ];
 
@@ -66,22 +60,9 @@ describe('server/helpers/summary-lists/your-buyer', () => {
 
   describe('yourBuyerSummaryList', () => {
     it('should return an array of summary list rows', () => {
-      const result = yourBuyerSummaryList(
-        mockApplicationBuyer,
-        mockApplication.eligibility,
-        referenceNumber,
-        totalContractValueOverThresholdTrue,
-        mockMigratedV1toV2False,
-      );
+      const result = yourBuyerSummaryList(mockApplicationBuyer, mockApplication.eligibility, referenceNumber, true, false);
 
-      const fields = generateFields(
-        mockApplicationBuyer,
-        mockApplication.eligibility,
-        referenceNumber,
-        totalContractValueOverThresholdTrue,
-        mockMigratedV1toV2False,
-        checkAndChange,
-      );
+      const fields = generateFields(mockApplicationBuyer, mockApplication.eligibility, referenceNumber, true, false, checkAndChange);
 
       const expected = generateGroupsOfSummaryLists(fields);
 

--- a/src/ui/server/helpers/summary-lists/your-buyer/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/your-buyer/index.test.ts
@@ -7,37 +7,56 @@ import financialAccountsFields from './financial-accounts';
 import generateGroupsOfSummaryLists from '../generate-groups-of-summary-lists';
 import mockApplication, { mockApplicationBuyer, referenceNumber } from '../../../test-mocks/mock-application';
 
+const { buyer } = mockApplication;
+
+const totalContractValueOverThresholdTrue = true;
+const totalContractValueOverThresholdFalse = false;
+
+const mockMigratedV1toV2True = true;
+const mockMigratedV1toV2False = false;
+
+const checkAndChange = false;
+
 describe('server/helpers/summary-lists/your-buyer', () => {
-  const { buyer, totalContractValueOverThreshold } = mockApplication;
-  const checkAndChange = false;
-
   describe('optionalFields', () => {
-    it('should return fields and values from creditInsuranceHistoryFields when totalContractValueOverThreshold is "true"', () => {
-      const totalContractValueOverThresholdTrue = true;
-      const result = optionalFields(mockApplicationBuyer, referenceNumber, totalContractValueOverThresholdTrue, checkAndChange);
+    describe('when totalContractValueOverThreshold=false, migratedV1toV2=true', () => {
+      it('should return fields and values from creditInsuranceHistoryFields when totalContractValueOverThreshold is "true"', () => {
+        const result = optionalFields(mockApplicationBuyer, referenceNumber, totalContractValueOverThresholdFalse, mockMigratedV1toV2True, checkAndChange);
 
-      const expected = [creditInsuranceHistoryFields(mockApplicationBuyer.relationship, referenceNumber, checkAndChange)];
+        const expected = [creditInsuranceHistoryFields(mockApplicationBuyer.relationship, referenceNumber, checkAndChange)];
 
-      expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
+      });
     });
 
-    it('should return fields and values from creditInsuranceHistoryFields when totalContractValueOverThreshold is "false"', () => {
-      const totalContractValueOverThresholdFalse = false;
-      const result = optionalFields(mockApplicationBuyer, referenceNumber, totalContractValueOverThresholdFalse, checkAndChange);
+    describe('when totalContractValueOverThreshold=true, migratedV1toV2=false', () => {
+      it('should return fields and values from creditInsuranceHistoryFields when totalContractValueOverThreshold is "true"', () => {
+        const result = optionalFields(mockApplicationBuyer, referenceNumber, totalContractValueOverThresholdTrue, mockMigratedV1toV2False, checkAndChange);
 
-      expect(result).toEqual([]);
+        const expected = [creditInsuranceHistoryFields(mockApplicationBuyer.relationship, referenceNumber, checkAndChange)];
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('when totalContractValueOverThreshold=false, migratedV1toV2=false', () => {
+      it('should return fields and values from creditInsuranceHistoryFields when totalContractValueOverThreshold is "false"', () => {
+        const result = optionalFields(mockApplicationBuyer, referenceNumber, totalContractValueOverThresholdFalse, mockMigratedV1toV2False, checkAndChange);
+
+        expect(result).toEqual([]);
+      });
     });
   });
 
   describe('generateFields', () => {
     it('should return fields and values from the submitted data/answers', () => {
-      const result = generateFields(mockApplicationBuyer, mockApplication.eligibility, referenceNumber, totalContractValueOverThreshold, checkAndChange);
+      const result = generateFields(mockApplicationBuyer, mockApplication.eligibility, referenceNumber, totalContractValueOverThresholdTrue, checkAndChange);
 
       const expected = [
         generateCompanyOrOrganisationFields(buyer, mockApplication.eligibility, referenceNumber, checkAndChange),
         connectionWithBuyerFields(buyer.relationship, referenceNumber, checkAndChange),
         tradingHistoryFields(buyer.buyerTradingHistory, referenceNumber, checkAndChange),
-        ...optionalFields(buyer, referenceNumber, totalContractValueOverThreshold, checkAndChange),
+        ...optionalFields(buyer, referenceNumber, totalContractValueOverThresholdTrue, mockMigratedV1toV2False, checkAndChange),
         financialAccountsFields(buyer.relationship, referenceNumber, checkAndChange),
       ];
 
@@ -47,9 +66,22 @@ describe('server/helpers/summary-lists/your-buyer', () => {
 
   describe('yourBuyerSummaryList', () => {
     it('should return an array of summary list rows', () => {
-      const result = yourBuyerSummaryList(mockApplicationBuyer, mockApplication.eligibility, referenceNumber);
+      const result = yourBuyerSummaryList(
+        mockApplicationBuyer,
+        mockApplication.eligibility,
+        referenceNumber,
+        totalContractValueOverThresholdTrue,
+        mockMigratedV1toV2False,
+      );
 
-      const fields = generateFields(mockApplicationBuyer, mockApplication.eligibility, referenceNumber, checkAndChange);
+      const fields = generateFields(
+        mockApplicationBuyer,
+        mockApplication.eligibility,
+        referenceNumber,
+        totalContractValueOverThresholdTrue,
+        mockMigratedV1toV2False,
+        checkAndChange,
+      );
 
       const expected = generateGroupsOfSummaryLists(fields);
 

--- a/src/ui/server/helpers/summary-lists/your-buyer/index.ts
+++ b/src/ui/server/helpers/summary-lists/your-buyer/index.ts
@@ -16,18 +16,20 @@ import { SummaryListGroupData, ApplicationBuyer, InsuranceEligibility } from '..
  * @param {ApplicationBuyer} answersBuyer: Buyer answers
  * @param {Number} referenceNumber: Application reference number
  * @param {Boolean} totalContractValueOverThreshold: if total contract value in application is above threshold
+ * @param {Boolean} migratedV1toV2: Application has been migrated from V1 to V2
  * @param {Boolean} checkAndChange true if coming from check your answers section in submit application section
  * @returns {Array<SummaryListGroupData>} empty array or fields and values for credit insurance history
  */
 const optionalFields = (
   answersBuyer: ApplicationBuyer,
   referenceNumber: number,
-  totalContractValueOverThreshold?: boolean,
+  totalContractValueOverThreshold: boolean,
+  migratedV1toV2: boolean,
   checkAndChange?: boolean,
 ): Array<SummaryListGroupData> => {
   const fields = [] as Array<SummaryListGroupData>;
 
-  if (totalContractValueOverThreshold) {
+  if (totalContractValueOverThreshold || migratedV1toV2) {
     fields.push(creditInsuranceHistoryFields(answersBuyer.relationship, referenceNumber, checkAndChange));
   }
 
@@ -41,6 +43,7 @@ const optionalFields = (
  * @param {InsuranceEligibility} eligibilityAnswers: Eligibility answers
  * @param {Number} referenceNumber: Application reference number
  * @param {Boolean} totalContractValueOverThreshold: if total contract value in application is above threshold
+ * @param {Boolean} migratedV1toV2: Application has been migrated from V1 to V2
  * @param {Boolean} checkAndChange true if coming from check your answers section in submit application section
  * @returns {Object} All your buyer values in an object structure for GOVUK summary list structure
  */
@@ -48,14 +51,15 @@ const generateFields = (
   answers: ApplicationBuyer,
   eligibilityAnswers: InsuranceEligibility,
   referenceNumber: number,
-  totalContractValueOverThreshold?: boolean,
+  totalContractValueOverThreshold: boolean,
+  migratedV1toV2: boolean,
   checkAndChange?: boolean,
 ): Array<SummaryListGroupData> => {
   const fields = [
     generateCompanyOrOrganisationFields(answers, eligibilityAnswers, referenceNumber, checkAndChange),
     connectionWithBuyerFields(answers.relationship, referenceNumber, checkAndChange),
     tradingHistoryFields(answers.buyerTradingHistory, referenceNumber, checkAndChange),
-    ...optionalFields(answers, referenceNumber, totalContractValueOverThreshold, checkAndChange),
+    ...optionalFields(answers, referenceNumber, totalContractValueOverThreshold, migratedV1toV2, checkAndChange),
     financialAccountsFields(answers.relationship, referenceNumber, checkAndChange),
   ] as Array<SummaryListGroupData>;
 
@@ -69,6 +73,7 @@ const generateFields = (
  * @param {InsuranceEligibility} eligibilityAnswers: Eligibility answers
  * @param {Number} referenceNumber: Application reference number
  * @param {Boolean} totalContractValueOverThreshold: if total contract value in application is above threshold
+ * @param {Boolean} migratedV1toV2: Application has been migrated from V1 to V2
  * @param {Boolean} checkAndChange true if coming from check your answers section in submit application section
  * @returns {Object} Multiple groups with multiple fields/answers in govukSummaryList data structure
  */
@@ -76,7 +81,8 @@ const yourBuyerSummaryList = (
   answers: ApplicationBuyer,
   eligibilityAnswers: InsuranceEligibility,
   referenceNumber: number,
-  totalContractValueOverThreshold?: boolean,
+  totalContractValueOverThreshold: boolean,
+  migratedV1toV2: boolean,
   checkAndChange = false,
 ) => {
   const fields = generateFields(answers, eligibilityAnswers, referenceNumber, totalContractValueOverThreshold, checkAndChange);

--- a/src/ui/server/helpers/summary-lists/your-buyer/index.ts
+++ b/src/ui/server/helpers/summary-lists/your-buyer/index.ts
@@ -10,6 +10,7 @@ import { SummaryListGroupData, ApplicationBuyer, InsuranceEligibility } from '..
  * optionalFields
  * optional fields for the your buyer summary list
  * if totalContractValueOverThreshold is true,
+ * or the application has been migrated from V1 to V2,
  * then pushes fields and values for credit insurance history
  * if totalContractValueOverThreshold is false,
  * then returns an empty array
@@ -85,7 +86,7 @@ const yourBuyerSummaryList = (
   migratedV1toV2: boolean,
   checkAndChange = false,
 ) => {
-  const fields = generateFields(answers, eligibilityAnswers, referenceNumber, totalContractValueOverThreshold, checkAndChange);
+  const fields = generateFields(answers, eligibilityAnswers, referenceNumber, totalContractValueOverThreshold, migratedV1toV2, checkAndChange);
 
   const summaryList = generateGroupsOfSummaryLists(fields);
 

--- a/src/ui/types/application.ts
+++ b/src/ui/types/application.ts
@@ -279,13 +279,13 @@ interface Application extends ApplicationCore {
   sectionReview: ApplicationSectionReview;
   declaration: ApplicationDeclaration;
   totalContractValueOverThreshold: boolean;
-  migratedV1toV2?: boolean;
+  migratedV1toV2: boolean;
 }
 
 interface ApplicationFlatCore extends ApplicationCore, InsuranceEligibilityCore, ApplicationOwner {
   buyerCountry: string;
   totalContractValueOverThreshold?: boolean;
-  migratedV1toV2?: boolean;
+  migratedV1toV2: boolean;
 }
 
 type ApplicationFlat = ApplicationFlatCore & ApplicationPolicy & ApplicationBroker & ApplicationCompany & ApplicationDeclaration;


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates various conditions in the service so that any applications that have migrated from V1 to V2 (MVP to No-PDF) and have an "in progress" status, all conditional questions relating to the "contract value threshold" are required.

The reason for this change is:

- In MVP eligibility, we ask if the contract value is over £500k. A user can only proceed if the answer to this question is “no”.
- In No-PDF eligibility, we ask if the contract value is above or below £250k. A user can proceed with either option.
- If the contract value is above £250k, we ask more questions in the application.
- After data migration, it is not possible to determine if migrated MVP applications are specifically above £250k.
  - A user has only answered “it’s less than £500k” - it could be less than £250k.
  - Therefore, without these changes, migrated MVP applications do not ask the additional “above £250k” questions.

By enforcing the additional questions, we ensure that a complete data set is available if an MVP application's contract value is (or isn't) above £250k.

## TODO
- Manual test after running the migration script.

## Resolution :heavy_check_mark:
- Update all `totalContractValueOverThreshold` conditions to run the same execution if a new `migratedV1toV2` flag/param is true.
- Update unit tests.
- Update various summary list related functions to consume and pass `migratedV1toV2`.
- Update calls to the relevant summary lists to pass a `migratedV1toV2` flag.

## Miscellaneous :heavy_plus_sign:
- Update API types to include `migratedV1toV2`.
