### PR TITLE
chore(EMS-3600): dry mock promise rejection functions

### DIFF
--- a/src/api/custom-resolvers/mutations/account-sign-in-new-code/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in-new-code/index.test.ts
@@ -3,7 +3,7 @@ import generate from '../../../helpers/generate-otp';
 import getFullNameString from '../../../helpers/get-full-name-string';
 import sendEmail from '../../../emails';
 import accounts from '../../../test-helpers/accounts';
-import { mockOTP, mockSendEmailResponse, mockErrorMessage } from '../../../test-mocks';
+import { mockOTP, mockSendEmailResponse, mockErrorMessage, mockSpyPromiseRejection } from '../../../test-mocks';
 import { Account, AccountSignInSendNewCodeVariables, AccountSignInResponse } from '../../../types';
 import getKeystoneContext from '../../../test-helpers/get-keystone-context';
 
@@ -88,7 +88,7 @@ describe('custom-resolvers/account-sign-in-new-code', () => {
 
   describe('error handling', () => {
     beforeEach(() => {
-      sendEmail.accessCodeEmail = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      sendEmail.accessCodeEmail = mockSpyPromiseRejection;
     });
 
     test('should throw an error', async () => {

--- a/src/api/custom-resolvers/mutations/account-sign-in/account-sign-in-checks/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/account-sign-in-checks/index.test.ts
@@ -7,7 +7,7 @@ import sendEmail from '../../../../emails';
 import accounts from '../../../../test-helpers/accounts';
 import accountStatusHelper from '../../../../test-helpers/account-status';
 import getKeystoneContext from '../../../../test-helpers/get-keystone-context';
-import { mockAccount, mockOTP, mockSendEmailResponse, mockUrlOrigin, mockErrorMessage } from '../../../../test-mocks';
+import { mockAccount, mockOTP, mockSendEmailResponse, mockUrlOrigin, mockErrorMessage, mockSpyPromiseRejection } from '../../../../test-mocks';
 import { Account, AccountSignInResponse, Context } from '../../../../types';
 
 dotenv.config();
@@ -135,7 +135,7 @@ describe('custom-resolvers/account-sign-in/account-sign-in-checks', () => {
 
   describe('error handling', () => {
     beforeEach(() => {
-      sendEmail.accessCodeEmail = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      sendEmail.accessCodeEmail = mockSpyPromiseRejection;
     });
 
     test('should throw an error', async () => {

--- a/src/api/custom-resolvers/mutations/account-sign-in/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/index.test.ts
@@ -7,7 +7,7 @@ import accountChecks from './account-sign-in-checks';
 import accounts from '../../../test-helpers/accounts';
 import accountStatusHelper from '../../../test-helpers/account-status';
 import authRetries from '../../../test-helpers/auth-retries';
-import { mockAccount, mockOTP, mockUrlOrigin, mockErrorMessage } from '../../../test-mocks';
+import { mockAccount, mockOTP, mockUrlOrigin, mockErrorMessage, mockSpyPromiseRejection } from '../../../test-mocks';
 import { Account, AccountSignInResponse, Context } from '../../../types';
 import getKeystoneContext from '../../../test-helpers/get-keystone-context';
 
@@ -197,7 +197,7 @@ describe('custom-resolvers/account-sign-in', () => {
 
   describe('error handling', () => {
     beforeEach(() => {
-      sendEmail.accessCodeEmail = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      sendEmail.accessCodeEmail = mockSpyPromiseRejection;
     });
 
     test('should throw an error', async () => {

--- a/src/api/custom-resolvers/mutations/create-an-account/account-exists-blocked.test.ts
+++ b/src/api/custom-resolvers/mutations/create-an-account/account-exists-blocked.test.ts
@@ -4,7 +4,7 @@ import sendEmail from '../../../emails';
 import confirmEmailAddressEmail from '../../../helpers/send-email-confirm-email-address';
 import accounts from '../../../test-helpers/accounts';
 import accountStatus from '../../../test-helpers/account-status';
-import { mockAccount, mockSendEmailResponse } from '../../../test-mocks';
+import { mockAccount, mockSendEmailResponse, mockSpyPromiseRejection } from '../../../test-mocks';
 import { Account, Context } from '../../../types';
 import getKeystoneContext from '../../../test-helpers/get-keystone-context';
 import sendEmailReactivateAccountLinkHelper from '../../../helpers/send-email-reactivate-account-link';
@@ -206,8 +206,6 @@ describe('custom-resolvers/create-an-account - account exists and blocked', () =
   });
 
   describe('when sendEmailReactivateAccountLinkHelper.send errors', () => {
-    const mockError = 'mock error';
-
     beforeEach(async () => {
       jest.resetAllMocks();
 
@@ -241,7 +239,7 @@ describe('custom-resolvers/create-an-account - account exists and blocked', () =
       sendConfirmEmailAddressEmailSpy = jest.fn(() => Promise.resolve(mockSendEmailResponse));
       confirmEmailAddressEmail.send = sendConfirmEmailAddressEmailSpy;
 
-      sendEmailReactivateAccountLinkSpy = jest.fn(() => Promise.reject(new Error(mockError)));
+      sendEmailReactivateAccountLinkSpy = mockSpyPromiseRejection;
       sendEmailReactivateAccountLinkHelper.send = sendEmailReactivateAccountLinkSpy;
     });
 

--- a/src/api/custom-resolvers/mutations/create-feedback/index.test.ts
+++ b/src/api/custom-resolvers/mutations/create-feedback/index.test.ts
@@ -1,7 +1,7 @@
 import { format } from 'date-fns';
 import createInsuranceFeedbackAndEmail from '.';
 import sendEmail from '../../../emails';
-import { mockInsuranceFeedback, mockSendEmailResponse, mockSpyPromise, mockErrorMessage } from '../../../test-mocks';
+import { mockInsuranceFeedback, mockSendEmailResponse, mockSpyPromise, mockErrorMessage, mockSpyPromiseRejection } from '../../../test-mocks';
 import { Context, Feedback } from '../../../types';
 import getKeystoneContext from '../../../test-helpers/get-keystone-context';
 
@@ -74,7 +74,7 @@ describe('custom-resolvers/create-feedback', () => {
   describe('when the feedback email call fails', () => {
     beforeEach(async () => {
       jest.resetAllMocks();
-      sendInsuranceFeedbackEmailSpy = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      sendInsuranceFeedbackEmailSpy = mockSpyPromiseRejection;
 
       sendEmail.insuranceFeedbackEmail = sendInsuranceFeedbackEmailSpy;
     });

--- a/src/api/custom-resolvers/mutations/send-email-insurance-feedback/index.test.ts
+++ b/src/api/custom-resolvers/mutations/send-email-insurance-feedback/index.test.ts
@@ -1,6 +1,6 @@
 import sendEmailInsuranceFeedback from '.';
 import sendEmail from '../../../emails';
-import { mockInsuranceFeedbackEmail, mockSendEmailResponse, mockAccount, mockErrorMessage } from '../../../test-mocks';
+import { mockInsuranceFeedbackEmail, mockSendEmailResponse, mockAccount, mockErrorMessage, mockSpyPromiseRejection } from '../../../test-mocks';
 import { InsuranceFeedbackVariables } from '../../../types';
 
 describe('custom-resolvers/send-email-insurance-feedback', () => {
@@ -38,7 +38,7 @@ describe('custom-resolvers/send-email-insurance-feedback', () => {
 
   describe('error handling', () => {
     beforeEach(() => {
-      sendEmail.insuranceFeedbackEmail = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      sendEmail.insuranceFeedbackEmail = mockSpyPromiseRejection;
     });
 
     test('should throw an error', async () => {

--- a/src/api/custom-resolvers/mutations/send-email-password-reset-link/index.test.ts
+++ b/src/api/custom-resolvers/mutations/send-email-password-reset-link/index.test.ts
@@ -6,7 +6,7 @@ import { ACCOUNT } from '../../../constants';
 import accounts from '../../../test-helpers/accounts';
 import authRetries from '../../../test-helpers/auth-retries';
 import { get30minutesFromNow } from '../../../helpers/date';
-import { mockAccount, mockUrlOrigin, mockSendEmailResponse, mockErrorMessage } from '../../../test-mocks';
+import { mockAccount, mockUrlOrigin, mockSendEmailResponse, mockErrorMessage, mockSpyPromiseRejection } from '../../../test-mocks';
 import { Account, Context, SuccessResponse } from '../../../types';
 import getKeystoneContext from '../../../test-helpers/get-keystone-context';
 
@@ -178,7 +178,7 @@ describe('custom-resolvers/send-email-password-reset-link', () => {
 
   describe('error handling', () => {
     beforeEach(() => {
-      sendEmail.passwordResetLink = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      sendEmail.passwordResetLink = mockSpyPromiseRejection;
     });
 
     test('should throw an error', async () => {

--- a/src/api/custom-resolvers/mutations/send-email-reactivate-account-link/index.test.ts
+++ b/src/api/custom-resolvers/mutations/send-email-reactivate-account-link/index.test.ts
@@ -2,7 +2,7 @@ import sendEmailReactivateAccountLink from '.';
 import sendEmailReactivateAccountLinkHelper from '../../../helpers/send-email-reactivate-account-link';
 import accounts from '../../../test-helpers/accounts';
 import accountStatus from '../../../test-helpers/account-status';
-import { mockAccount, mockUrlOrigin, mockSendEmailResponse } from '../../../test-mocks';
+import { mockAccount, mockUrlOrigin, mockSendEmailResponse, mockSpyPromiseRejection } from '../../../test-mocks';
 import { Account, Context, SuccessResponse, AccountSendEmailReactivateLinkVariables } from '../../../types';
 import getKeystoneContext from '../../../test-helpers/get-keystone-context';
 
@@ -63,7 +63,7 @@ describe('custom-resolvers/send-email-reactivate-account-link', () => {
 
   describe('when sendEmailReactivateAccountLinkHelper.send errors', () => {
     beforeEach(() => {
-      sendEmailReactivateAccountLinkHelper.send = jest.fn(() => Promise.reject(new Error('mock error')));
+      sendEmailReactivateAccountLinkHelper.send = mockSpyPromiseRejection;
     });
 
     it('should throw an error', async () => {

--- a/src/api/custom-resolvers/queries/get-APIM-CIS-countries/index.test.ts
+++ b/src/api/custom-resolvers/queries/get-APIM-CIS-countries/index.test.ts
@@ -2,7 +2,7 @@ import getApimCisCountries from '.';
 import APIM from '../../../integrations/APIM';
 import mapCisCountries from '../../../helpers/map-CIS-countries';
 import mockCisCountriesResponse from '../../../test-mocks/mock-APIM-CIS-countries-response';
-import { mockCisCountries, mockErrorMessage } from '../../../test-mocks';
+import { mockCisCountries, mockErrorMessage, mockSpyPromiseRejection } from '../../../test-mocks';
 
 describe('custom-resolvers/get-APIM-CIS-countries', () => {
   jest.mock('../../../integrations/APIM');
@@ -55,7 +55,7 @@ describe('custom-resolvers/get-APIM-CIS-countries', () => {
 
   describe('when APIM CIS API is down', () => {
     beforeEach(() => {
-      APIM.getCisCountries = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      APIM.getCisCountries = mockSpyPromiseRejection;
     });
 
     it('should throw an error', async () => {

--- a/src/api/custom-resolvers/queries/get-APIM-currencies/index.test.ts
+++ b/src/api/custom-resolvers/queries/get-APIM-currencies/index.test.ts
@@ -2,7 +2,7 @@ import getApimCurrencies from '.';
 import APIM from '../../../integrations/APIM';
 import mapCurrencies from '../../../helpers/map-currencies';
 import mockApimCurrenciesResponse from '../../../test-mocks/mock-APIM-currencies-response';
-import { mockCurrencies, mockErrorMessage } from '../../../test-mocks';
+import { mockCurrencies, mockErrorMessage, mockSpyPromiseRejection } from '../../../test-mocks';
 
 describe('custom-resolvers/get-APIM-currencies', () => {
   jest.mock('../../../integrations/APIM');
@@ -62,7 +62,7 @@ describe('custom-resolvers/get-APIM-currencies', () => {
 
   describe('when APIM currencies API is down', () => {
     beforeEach(() => {
-      APIM.getCurrencies = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      APIM.getCurrencies = mockSpyPromiseRejection;
     });
 
     it('should throw an error', async () => {

--- a/src/api/custom-resolvers/queries/get-companies-house-information/index.test.ts
+++ b/src/api/custom-resolvers/queries/get-companies-house-information/index.test.ts
@@ -3,6 +3,7 @@ import sanitiseCompaniesHouseNumber from '../../../helpers/sanitise-companies-ho
 import companiesHouse from '../../../integrations/companies-house';
 import { mapCompaniesHouseFields } from '../../../helpers/map-companies-house-fields';
 import industrySectorNames from '../../../integrations/industry-sector';
+import { mockSpyPromiseRejection } from '../../../test-mocks';
 import mockCompanyAPIResponse from '../../../test-mocks/mock-companies-house-api-response';
 import mockIndustrySectors from '../../../test-mocks/mock-industry-sectors';
 
@@ -61,7 +62,7 @@ describe('custom-resolvers/get-companies-house-information', () => {
 
   describe('when companies house API is down', () => {
     beforeEach(() => {
-      companiesHouse.get = jest.fn(() => Promise.reject(new Error('mock')));
+      companiesHouse.get = mockSpyPromiseRejection;
     });
 
     it('should return object containing success as false and apiError as true', async () => {
@@ -106,7 +107,7 @@ describe('custom-resolvers/get-companies-house-information', () => {
   describe('when companies house returns a response but industry sector errors', () => {
     beforeEach(() => {
       companiesHouse.get = jest.fn(() => Promise.resolve({ success: true, data: mockCompanyAPIResponse }));
-      industrySectorNames.get = jest.fn(() => Promise.reject(new Error('mock')));
+      industrySectorNames.get = mockSpyPromiseRejection;
     });
 
     it('should return object containing success as false and apiError as true', async () => {

--- a/src/api/custom-resolvers/queries/get-ordnance-survey-address/index.test.ts
+++ b/src/api/custom-resolvers/queries/get-ordnance-survey-address/index.test.ts
@@ -4,7 +4,7 @@ import mapAndFilterAddress from '../../../helpers/map-and-filter-address';
 import mockOrdnanceSurveyResponse from '../../../test-mocks/mock-ordnance-survey-response';
 import { MOCK_OS_ADDRESS_INPUT } from '../../../test-mocks/mock-os-address-input';
 import { OrdnanceSurveyResponse } from '../../../types';
-import { mockErrorMessage } from '../../../test-mocks';
+import { mockSpyPromiseRejection } from '../../../test-mocks';
 
 describe('getOrdnanceSurveyAddress', () => {
   jest.mock('../../../integrations/ordnance-survey');
@@ -45,7 +45,7 @@ describe('getOrdnanceSurveyAddress', () => {
 
   describe('when ordnanceSurvey API is down', () => {
     beforeEach(() => {
-      ordnanceSurvey.get = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      ordnanceSurvey.get = mockSpyPromiseRejection;
     });
 
     it('should return object containing success as false and apiError as true', async () => {

--- a/src/api/emails/access-code-email/index.test.ts
+++ b/src/api/emails/access-code-email/index.test.ts
@@ -2,7 +2,7 @@ import { accessCodeEmail } from '.';
 import notify from '../../integrations/notify';
 import { EMAIL_TEMPLATE_IDS } from '../../constants';
 import getFullNameString from '../../helpers/get-full-name-string';
-import { mockAccount, mockSendEmailResponse, mockErrorMessage } from '../../test-mocks';
+import { mockAccount, mockSendEmailResponse, mockErrorMessage, mockSpyPromiseRejection } from '../../test-mocks';
 
 describe('emails/access-code-email', () => {
   const sendEmailSpy = jest.fn(() => Promise.resolve(mockSendEmailResponse));
@@ -38,7 +38,7 @@ describe('emails/access-code-email', () => {
 
   describe('error handling', () => {
     beforeAll(async () => {
-      notify.sendEmail = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      notify.sendEmail = mockSpyPromiseRejection;
     });
 
     test('should throw an error', async () => {

--- a/src/api/emails/application/index.test.ts
+++ b/src/api/emails/application/index.test.ts
@@ -3,7 +3,7 @@ import notify from '../../integrations/notify';
 import { EMAIL_TEMPLATE_IDS } from '../../constants';
 import getFullNameString from '../../helpers/get-full-name-string';
 import fileSystem from '../../file-system';
-import { mockAccount, mockApplication, mockCompany, mockBuyer, mockSendEmailResponse, mockErrorMessage } from '../../test-mocks';
+import { mockAccount, mockApplication, mockCompany, mockBuyer, mockSendEmailResponse, mockErrorMessage, mockSpyPromiseRejection } from '../../test-mocks';
 
 describe('emails/application', () => {
   const sendEmailSpy = jest.fn(() => Promise.resolve(mockSendEmailResponse));
@@ -58,7 +58,7 @@ describe('emails/application', () => {
 
     describe('error handling', () => {
       beforeAll(async () => {
-        notify.sendEmail = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+        notify.sendEmail = mockSpyPromiseRejection;
       });
 
       test('should throw an error', async () => {
@@ -106,7 +106,7 @@ describe('emails/application', () => {
 
     describe('error handling', () => {
       beforeAll(async () => {
-        notify.sendEmail = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+        notify.sendEmail = mockSpyPromiseRejection;
       });
 
       test('should throw an error', async () => {

--- a/src/api/emails/confirm-email-address/index.test.ts
+++ b/src/api/emails/confirm-email-address/index.test.ts
@@ -2,7 +2,7 @@ import { confirmEmailAddress } from '.';
 import notify from '../../integrations/notify';
 import { EMAIL_TEMPLATE_IDS } from '../../constants';
 import getFullNameString from '../../helpers/get-full-name-string';
-import { mockAccount, mockSendEmailResponse, mockUrlOrigin, mockErrorMessage } from '../../test-mocks';
+import { mockAccount, mockSendEmailResponse, mockUrlOrigin, mockErrorMessage, mockSpyPromiseRejection } from '../../test-mocks';
 
 describe('emails/confirm-email-address', () => {
   const sendEmailSpy = jest.fn(() => Promise.resolve(mockSendEmailResponse));
@@ -37,7 +37,7 @@ describe('emails/confirm-email-address', () => {
 
   describe('error handling', () => {
     beforeAll(async () => {
-      notify.sendEmail = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      notify.sendEmail = mockSpyPromiseRejection;
     });
 
     test('should throw an error', async () => {

--- a/src/api/emails/documents/index.test.ts
+++ b/src/api/emails/documents/index.test.ts
@@ -2,7 +2,7 @@ import { documentsEmail } from '.';
 import notify from '../../integrations/notify';
 import { EMAIL_TEMPLATE_IDS } from '../../constants';
 import getFullNameString from '../../helpers/get-full-name-string';
-import { mockAccount, mockApplication, mockSendEmailResponse, mockErrorMessage } from '../../test-mocks';
+import { mockAccount, mockApplication, mockSendEmailResponse, mockErrorMessage, mockSpyPromiseRejection } from '../../test-mocks';
 
 describe('emails/documents', () => {
   const sendEmailSpy = jest.fn(() => Promise.resolve(mockSendEmailResponse));
@@ -44,7 +44,7 @@ describe('emails/documents', () => {
 
   describe('error handling', () => {
     beforeAll(async () => {
-      notify.sendEmail = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      notify.sendEmail = mockSpyPromiseRejection;
     });
 
     test('should throw an error', async () => {

--- a/src/api/emails/insurance-feedback-email/index.test.ts
+++ b/src/api/emails/insurance-feedback-email/index.test.ts
@@ -3,7 +3,7 @@ import notify from '../../integrations/notify';
 import { EMAIL_TEMPLATE_IDS } from '../../constants';
 import formatDate from '../../helpers/format-date';
 import mapFeedbackSatisfaction from '../../helpers/map-feedback-satisfaction';
-import { mockAccount, mockInsuranceFeedback, mockSendEmailResponse, mockErrorMessage } from '../../test-mocks';
+import { mockAccount, mockInsuranceFeedback, mockSendEmailResponse, mockErrorMessage, mockSpyPromiseRejection } from '../../test-mocks';
 
 describe('emails/insurance-feedback-email', () => {
   const sendEmailSpy = jest.fn(() => Promise.resolve(mockSendEmailResponse));
@@ -73,7 +73,7 @@ describe('emails/insurance-feedback-email', () => {
 
   describe('error handling', () => {
     beforeAll(async () => {
-      notify.sendEmail = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      notify.sendEmail = mockSpyPromiseRejection;
     });
 
     test('should throw an error', async () => {

--- a/src/api/emails/password-reset-link/index.test.ts
+++ b/src/api/emails/password-reset-link/index.test.ts
@@ -2,7 +2,7 @@ import { passwordResetLink } from '.';
 import notify from '../../integrations/notify';
 import { EMAIL_TEMPLATE_IDS } from '../../constants';
 import getFullNameString from '../../helpers/get-full-name-string';
-import { mockAccount, mockUrlOrigin, mockSendEmailResponse, mockErrorMessage } from '../../test-mocks';
+import { mockAccount, mockUrlOrigin, mockSendEmailResponse, mockErrorMessage, mockSpyPromiseRejection } from '../../test-mocks';
 
 describe('emails/password-reset-link', () => {
   const sendEmailSpy = jest.fn(() => Promise.resolve(mockSendEmailResponse));
@@ -40,7 +40,7 @@ describe('emails/password-reset-link', () => {
 
   describe('error handling', () => {
     beforeAll(async () => {
-      notify.sendEmail = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      notify.sendEmail = mockSpyPromiseRejection;
     });
 
     test('should throw an error', async () => {

--- a/src/api/emails/reactivate-account-link/index.test.ts
+++ b/src/api/emails/reactivate-account-link/index.test.ts
@@ -2,7 +2,7 @@ import { reactivateAccountLink } from '.';
 import notify from '../../integrations/notify';
 import { EMAIL_TEMPLATE_IDS } from '../../constants';
 import getFullNameString from '../../helpers/get-full-name-string';
-import { mockAccount, mockUrlOrigin, mockSendEmailResponse, mockErrorMessage } from '../../test-mocks';
+import { mockAccount, mockUrlOrigin, mockSendEmailResponse, mockErrorMessage, mockSpyPromiseRejection } from '../../test-mocks';
 
 describe('emails/reactivate-account-link', () => {
   const sendEmailSpy = jest.fn(() => Promise.resolve(mockSendEmailResponse));
@@ -40,7 +40,7 @@ describe('emails/reactivate-account-link', () => {
 
   describe('error handling', () => {
     beforeAll(async () => {
-      notify.sendEmail = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      notify.sendEmail = mockSpyPromiseRejection;
     });
 
     test('should throw an error', async () => {

--- a/src/api/emails/send-application-submitted-emails/index.test.ts
+++ b/src/api/emails/send-application-submitted-emails/index.test.ts
@@ -7,7 +7,7 @@ import getApplicationSubmittedEmailTemplateIds from '../../helpers/get-applicati
 import formatDate from '../../helpers/format-date';
 import { createFullApplication, getKeystoneContext } from '../../test-helpers';
 import { Application, ApplicationSubmissionEmailVariables, Context } from '../../types';
-import { mockSendEmailResponse, mockErrorMessage } from '../../test-mocks';
+import { mockSendEmailResponse, mockErrorMessage, mockSpyPromiseRejection } from '../../test-mocks';
 
 dotenv.config();
 
@@ -289,7 +289,7 @@ describe('emails/send-email-application-submitted', () => {
 
     describe('when sendEmail.application.submittedEmail fails', () => {
       beforeEach(() => {
-        sendEmail.application.submittedEmail = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+        sendEmail.application.submittedEmail = mockSpyPromiseRejection;
       });
 
       test('should throw an error', async () => {

--- a/src/api/emails/submission-deadline/index.test.ts
+++ b/src/api/emails/submission-deadline/index.test.ts
@@ -1,7 +1,7 @@
 import { submissionDeadlineEmail } from '.';
 import notify from '../../integrations/notify';
 import { EMAIL_TEMPLATE_IDS } from '../../constants';
-import { mockApplication, mockSendEmailResponse } from '../../test-mocks';
+import { mockApplication, mockSendEmailResponse, mockSpyPromiseRejection } from '../../test-mocks';
 import { SubmissionDeadlineEmailVariables } from '../../types';
 
 describe('emails/submission-deadline', () => {
@@ -17,8 +17,6 @@ describe('emails/submission-deadline', () => {
     buyerName: String(mockApplication.buyer.companyOrOrganisationName),
     submissionDeadline: new Date(mockApplication.submissionDeadline).toString(),
   } as SubmissionDeadlineEmailVariables;
-
-  const mockErrorMessage = 'Mock error';
 
   beforeAll(async () => {
     notify.sendEmail = sendEmailSpy;
@@ -38,7 +36,7 @@ describe('emails/submission-deadline', () => {
 
   describe('error handling', () => {
     beforeAll(async () => {
-      notify.sendEmail = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      notify.sendEmail = mockSpyPromiseRejection;
     });
 
     test('should throw an error', async () => {

--- a/src/api/helpers/create-an-application/index.api-error.test.ts
+++ b/src/api/helpers/create-an-application/index.api-error.test.ts
@@ -4,7 +4,7 @@ import applicationRelationships from './create-application-relationships';
 import applicationColumns from './update-application-columns';
 import getKeystoneContext from '../../test-helpers/get-keystone-context';
 import applications from '../../test-helpers/applications';
-import { mockCountries } from '../../test-mocks';
+import { mockCountries, mockSpyPromiseRejection } from '../../test-mocks';
 import mockCompany from '../../test-mocks/mock-company';
 import { APPLICATION } from '../../constants';
 import { Context, Application } from '../../types';
@@ -73,7 +73,7 @@ describe('helpers/create-an-application - error handling', () => {
 
   describe('when initialApplication.create fails', () => {
     beforeEach(() => {
-      initialApplication.create = jest.fn(() => Promise.reject(new Error(mockError)));
+      initialApplication.create = mockSpyPromiseRejection;
     });
 
     it('should throw an error', async () => {
@@ -85,7 +85,7 @@ describe('helpers/create-an-application - error handling', () => {
 
   describe('when applicationRelationships.create fails', () => {
     beforeEach(() => {
-      applicationRelationships.create = jest.fn(() => Promise.reject(new Error(mockError)));
+      applicationRelationships.create = mockSpyPromiseRejection;
     });
 
     it('should throw an error', async () => {
@@ -97,7 +97,7 @@ describe('helpers/create-an-application - error handling', () => {
 
   describe('when applicationColumns.update fails', () => {
     beforeEach(() => {
-      applicationColumns.update = jest.fn(() => Promise.reject(new Error(mockError)));
+      applicationColumns.update = mockSpyPromiseRejection;
     });
 
     it('should throw an error', async () => {

--- a/src/api/helpers/send-email-application-submission-deadline/send-email/index.test.ts
+++ b/src/api/helpers/send-email-application-submission-deadline/send-email/index.test.ts
@@ -5,6 +5,7 @@ import { createFullApplication } from '../../../test-helpers';
 import { dateInTheFutureByDays } from '../../date';
 import mapApplicationSubmissionDeadlineVariables from '../../map-application-submission-deadline-variables';
 import applications from '../../../test-helpers/applications';
+import { mockSpyPromiseRejection } from '../../../test-mocks';
 import { Application, Context } from '../../../types';
 
 describe('helpers/send-email-application-submission-deadline/send-email', () => {
@@ -58,7 +59,7 @@ describe('helpers/send-email-application-submission-deadline/send-email', () => 
   describe('error handling', () => {
     describe('sendEmail.submissionDeadlineEmail fails', () => {
       beforeEach(async () => {
-        sendEmail.submissionDeadlineEmail = jest.fn(() => Promise.reject(new Error('Mock error')));
+        sendEmail.submissionDeadlineEmail = mockSpyPromiseRejection;
       });
 
       test('should return success as false', async () => {

--- a/src/api/helpers/send-email-confirm-email-address/index.test.ts
+++ b/src/api/helpers/send-email-confirm-email-address/index.test.ts
@@ -1,10 +1,10 @@
 import confirmEmailAddressEmail from '.';
 import getFullNameString from '../get-full-name-string';
 import sendEmail from '../../emails';
+import { DATE_24_HOURS_IN_THE_PAST, DATE_24_HOURS_FROM_NOW } from '../../constants';
 import accounts from '../../test-helpers/accounts';
 import getKeystoneContext from '../../test-helpers/get-keystone-context';
-import { mockAccount, mockUrlOrigin, mockSendEmailResponse, mockErrorMessage } from '../../test-mocks';
-import { DATE_24_HOURS_IN_THE_PAST, DATE_24_HOURS_FROM_NOW } from '../../constants';
+import { mockAccount, mockUrlOrigin, mockSendEmailResponse, mockErrorMessage, mockSpyPromiseRejection } from '../../test-mocks';
 import { Account, Context } from '../../types';
 
 describe('helpers/send-email-confirm-email-address', () => {
@@ -116,7 +116,7 @@ describe('helpers/send-email-confirm-email-address', () => {
 
   describe('error handling', () => {
     beforeEach(() => {
-      sendEmail.confirmEmailAddress = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      sendEmail.confirmEmailAddress = mockSpyPromiseRejection;
     });
 
     test('should throw an error', async () => {

--- a/src/api/integrations/notify/index.test.ts
+++ b/src/api/integrations/notify/index.test.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import notificationsClient from 'notifications-node-client';
 import notify from '.';
+import { mockSpyPromiseRejection } from '../../test-mocks';
 
 jest.mock('notifications-node-client');
 
@@ -33,7 +34,7 @@ describe('integrations/notify', () => {
     beforeEach(() => {
       notificationsClient.NotifyClient = () => ({
         prepareUpload: jest.fn(),
-        sendEmail: jest.fn(() => Promise.reject(new Error('mock'))),
+        sendEmail: mockSpyPromiseRejection,
       });
     });
 

--- a/src/api/test-mocks/index.ts
+++ b/src/api/test-mocks/index.ts
@@ -199,8 +199,10 @@ export const mockRes = () => {
   return res;
 };
 
-export const mockSpyPromise = () => jest.fn().mockResolvedValue({});
-
 export const mockErrorMessage = 'Mock error';
 
 export const mockInvalidId = 'invalid-id';
+
+export const mockSpyPromise = () => jest.fn().mockResolvedValue({});
+
+export const mockSpyPromiseRejection = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));

--- a/src/ui/server/controllers/insurance/account/create/confirm-email-resent/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/confirm-email-resent/index.test.ts
@@ -6,7 +6,7 @@ import getUserNameFromSession from '../../../../../helpers/get-user-name-from-se
 import { sanitiseValue } from '../../../../../helpers/sanitise-data';
 import { Request, Response } from '../../../../../../types';
 import api from '../../../../../api';
-import { mockReq, mockRes, mockAccount } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockAccount, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
 
@@ -131,7 +131,7 @@ describe('controllers/insurance/account/create/confirm-email-resent', () => {
       beforeAll(() => {
         req.query.id = mockAccount.id;
 
-        getAccountSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        getAccountSpy = mockSpyPromiseRejection;
         api.keystone.account.get = getAccountSpy;
       });
 

--- a/src/ui/server/controllers/insurance/account/create/confirm-email/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/confirm-email/index.test.ts
@@ -6,7 +6,7 @@ import { sanitiseValue } from '../../../../../helpers/sanitise-data';
 import getUserNameFromSession from '../../../../../helpers/get-user-name-from-session';
 import { Request, Response } from '../../../../../../types';
 import api from '../../../../../api';
-import { mockReq, mockRes, mockAccount } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockAccount, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
 
@@ -100,7 +100,7 @@ describe('controllers/insurance/account/create/confirm-email', () => {
 
     describe('when there is an error calling the API', () => {
       beforeAll(() => {
-        getAccountSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        getAccountSpy = mockSpyPromiseRejection;
         api.keystone.account.get = getAccountSpy;
       });
 

--- a/src/ui/server/controllers/insurance/account/create/resend-confirm-email/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/resend-confirm-email/index.test.ts
@@ -4,7 +4,7 @@ import { ROUTES } from '../../../../../constants';
 import { sanitiseValue } from '../../../../../helpers/sanitise-data';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockAccount } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockAccount, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 dotenv.config();
 
@@ -88,7 +88,7 @@ describe('controllers/insurance/account/create/resend-confirm-email', () => {
 
     describe('when there is an error calling the API', () => {
       beforeAll(() => {
-        sendEmailConfirmEmailAddressSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        sendEmailConfirmEmailAddressSpy = mockSpyPromiseRejection;
         api.keystone.account.sendEmailConfirmEmailAddress = sendEmailConfirmEmailAddressSpy;
       });
 

--- a/src/ui/server/controllers/insurance/account/create/verify-email-expired-link/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/verify-email-expired-link/index.test.ts
@@ -6,7 +6,7 @@ import { sanitiseValue } from '../../../../../helpers/sanitise-data';
 import getUserNameFromSession from '../../../../../helpers/get-user-name-from-session';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
-import { mockAccount, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockAccount, mockReq, mockRes, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   INSURANCE: {
@@ -136,7 +136,7 @@ describe('controllers/insurance/account/create/verify-email-expired-link', () =>
 
     describe('when there is an error calling the API', () => {
       beforeAll(() => {
-        sendEmailConfirmEmailAddressSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        sendEmailConfirmEmailAddressSpy = mockSpyPromiseRejection;
         api.keystone.account.sendEmailConfirmEmailAddress = sendEmailConfirmEmailAddressSpy;
       });
 

--- a/src/ui/server/controllers/insurance/account/create/verify-email/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/verify-email/index.test.ts
@@ -3,7 +3,7 @@ import { ROUTES } from '../../../../../constants';
 import { sanitiseValue } from '../../../../../helpers/sanitise-data';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
-import { mockAccount, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockAccount, mockReq, mockRes, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   INSURANCE: {
@@ -157,7 +157,7 @@ describe('controllers/insurance/account/create/verify-email', () => {
         req.query.token = mockToken;
         req.query.id = mockAccount.id;
 
-        verifyEmailAddressSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        verifyEmailAddressSpy = mockSpyPromiseRejection;
 
         api.keystone.account.verifyEmailAddress = verifyEmailAddressSpy;
       });

--- a/src/ui/server/controllers/insurance/account/create/your-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/index.test.ts
@@ -13,7 +13,7 @@ import accountAlreadyExistsAlreadyVerifiedValidation from './validation/account-
 import saveData from './save-data';
 import application from '../../../../../helpers/create-an-application';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockAccount, mockSession, mockCreateApplicationResponse } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockAccount, mockSession, mockCreateApplicationResponse, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { FIRST_NAME, LAST_NAME, EMAIL, PASSWORD } = ACCOUNT_FIELD_IDS;
 
@@ -328,7 +328,7 @@ describe('controllers/insurance/account/create/your-details', () => {
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const saveDataSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const saveDataSpy = mockSpyPromiseRejection;
 
             saveData.account = saveDataSpy;
           });
@@ -353,7 +353,7 @@ describe('controllers/insurance/account/create/your-details', () => {
 
           req.body = validBody;
 
-          createApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          createApplicationSpy = mockSpyPromiseRejection;
           application.create = createApplicationSpy;
         });
 

--- a/src/ui/server/controllers/insurance/account/create/your-details/save-data/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/create/your-details/save-data/index.test.ts
@@ -1,7 +1,7 @@
 import save from '.';
 import api from '../../../../../../api';
 import { sanitiseData } from '../../../../../../helpers/sanitise-data';
-import { mockAccount, mockUrlOrigin } from '../../../../../../test-mocks';
+import { mockAccount, mockUrlOrigin, mockSpyPromiseRejection } from '../../../../../../test-mocks';
 
 describe('controllers/account/create/your-details/save-data', () => {
   const mockCreateAccountResponse = mockAccount;
@@ -32,7 +32,7 @@ describe('controllers/account/create/your-details/save-data', () => {
   describe('api error handling', () => {
     describe('when there is an error', () => {
       beforeEach(() => {
-        accountCreateSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        accountCreateSpy = mockSpyPromiseRejection;
         api.keystone.account.create = accountCreateSpy;
       });
 

--- a/src/ui/server/controllers/insurance/account/password-reset/expired-link/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/password-reset/expired-link/index.test.ts
@@ -5,7 +5,7 @@ import insuranceCorePageVariables from '../../../../../helpers/page-variables/co
 import { sanitiseValue } from '../../../../../helpers/sanitise-data';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
-import { mockAccount, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockAccount, mockReq, mockRes, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   ACCOUNT: {
@@ -114,7 +114,7 @@ describe('controllers/insurance/account/password-reset/expired-link', () => {
     describe('api error handling', () => {
       describe('when the get account API call fails', () => {
         beforeEach(() => {
-          getAccountSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getAccountSpy = mockSpyPromiseRejection;
           api.keystone.account.get = sendEmailPasswordResetLinkSpy;
         });
 
@@ -127,7 +127,7 @@ describe('controllers/insurance/account/password-reset/expired-link', () => {
 
       describe('when the password reset link API call fails', () => {
         beforeEach(() => {
-          sendEmailPasswordResetLinkSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          sendEmailPasswordResetLinkSpy = mockSpyPromiseRejection;
           api.keystone.account.sendEmailPasswordResetLink = sendEmailPasswordResetLinkSpy;
         });
 

--- a/src/ui/server/controllers/insurance/account/password-reset/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/password-reset/index.test.ts
@@ -9,7 +9,7 @@ import generateValidationErrors from './validation';
 import api from '../../../../api';
 import accountDoesNotExistValidation from './validation/account-does-not-exist';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockAccount } from '../../../../test-mocks';
+import { mockReq, mockRes, mockAccount, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const {
   ACCOUNT: { EMAIL },
@@ -183,7 +183,7 @@ describe('controllers/insurance/account/password-reset', () => {
           beforeEach(() => {
             req.body = validBody;
 
-            sendEmailPasswordResetLinkSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            sendEmailPasswordResetLinkSpy = mockSpyPromiseRejection;
             api.keystone.account.sendEmailPasswordResetLink = sendEmailPasswordResetLinkSpy;
           });
 

--- a/src/ui/server/controllers/insurance/account/password-reset/new-password/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/password-reset/new-password/index.test.ts
@@ -9,7 +9,7 @@ import generateValidationErrors from './validation';
 import api from '../../../../../api';
 import cannotUseNewPasswordValidation from './validation/cannot-use-new-password';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockAccount } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockAccount, mockSpyPromiseRejection } from '../../../../../test-mocks';
 const {
   INSURANCE: {
     ACCOUNT: {
@@ -163,7 +163,7 @@ describe('controllers/insurance/account/password-reset/new-password', () => {
     describe('api error handling', () => {
       describe('when the verify account password reset token API call fails', () => {
         beforeEach(() => {
-          verifyAccountPasswordResetTokenSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          verifyAccountPasswordResetTokenSpy = mockSpyPromiseRejection;
           api.keystone.account.verifyPasswordResetToken = verifyAccountPasswordResetTokenSpy;
         });
 
@@ -279,7 +279,7 @@ describe('controllers/insurance/account/password-reset/new-password', () => {
       describe('api error handling', () => {
         describe('when the password reset API call fails', () => {
           beforeEach(() => {
-            passwordResetSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            passwordResetSpy = mockSpyPromiseRejection;
             api.keystone.account.passwordReset = passwordResetSpy;
           });
 

--- a/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/enter-code/index.test.ts
@@ -12,7 +12,15 @@ import accessCodeValidationErrors from './validation/rules/access-code';
 import application from '../../../../../helpers/create-an-application';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockAccount, mockSession, mockApplications, mockCreateApplicationResponse } from '../../../../../test-mocks';
+import {
+  mockReq,
+  mockRes,
+  mockAccount,
+  mockSession,
+  mockApplications,
+  mockCreateApplicationResponse,
+  mockSpyPromiseRejection,
+} from '../../../../../test-mocks';
 
 const {
   ACCOUNT: { ACCESS_CODE },
@@ -364,7 +372,7 @@ describe('controllers/insurance/account/sign-in/enter-code', () => {
         beforeEach(() => {
           req.body = validBody;
 
-          verifyAccountSignInCodeSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          verifyAccountSignInCodeSpy = mockSpyPromiseRejection;
           api.keystone.account.verifyAccountSignInCode = verifyAccountSignInCodeSpy;
         });
 
@@ -387,7 +395,7 @@ describe('controllers/insurance/account/sign-in/enter-code', () => {
 
           req.body = validBody;
 
-          createApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          createApplicationSpy = mockSpyPromiseRejection;
           application.create = createApplicationSpy;
         });
 

--- a/src/ui/server/controllers/insurance/account/sign-in/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/index.test.ts
@@ -11,7 +11,7 @@ import emailAndPasswordIncorrectValidationErrors from '../../../../shared-valida
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import api from '../../../../api';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockAccount } from '../../../../test-mocks';
+import { mockReq, mockRes, mockAccount, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const { EMAIL, PASSWORD } = ACCOUNT_FIELD_IDS;
 
@@ -324,7 +324,7 @@ describe('controllers/insurance/account/sign-in', () => {
       beforeEach(() => {
         req.body = validBody;
 
-        accountSignInSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        accountSignInSpy = mockSpyPromiseRejection;
         api.keystone.account.signIn = accountSignInSpy;
       });
 

--- a/src/ui/server/controllers/insurance/account/sign-in/request-new-code/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/sign-in/request-new-code/index.test.ts
@@ -5,7 +5,7 @@ import insuranceCorePageVariables from '../../../../../helpers/page-variables/co
 import getUserNameFromSession from '../../../../../helpers/get-user-name-from-session';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockAccount } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockAccount, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   INSURANCE: {
@@ -125,7 +125,7 @@ describe('controllers/insurance/account/sign-in/request-new-code', () => {
 
     describe('when there is an error calling the API', () => {
       beforeAll(() => {
-        signInSendNewCodeSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        signInSendNewCodeSpy = mockSpyPromiseRejection;
         api.keystone.account.signInSendNewCode = signInSendNewCodeSpy;
       });
 

--- a/src/ui/server/controllers/insurance/account/suspended/expired-link/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/suspended/expired-link/index.test.ts
@@ -6,7 +6,7 @@ import insuranceCorePageVariables from '../../../../../helpers/page-variables/co
 import { sanitiseValue } from '../../../../../helpers/sanitise-data';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockAccount } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockAccount, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   ACCOUNT: {
@@ -100,7 +100,7 @@ describe('controllers/insurance/account/suspended/expired-link', () => {
     describe('api error handling', () => {
       describe('when the send email reactivate account link API call fails', () => {
         beforeEach(() => {
-          sendEmailReactivateAccountLinkResponseSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          sendEmailReactivateAccountLinkResponseSpy = mockSpyPromiseRejection;
           api.keystone.account.sendEmailReactivateAccountLink = sendEmailReactivateAccountLinkResponseSpy;
         });
 

--- a/src/ui/server/controllers/insurance/account/suspended/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/suspended/index.test.ts
@@ -5,7 +5,7 @@ import insuranceCorePageVariables from '../../../../helpers/page-variables/core/
 import { sanitiseValue } from '../../../../helpers/sanitise-data';
 import api from '../../../../api';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockAccount } from '../../../../test-mocks';
+import { mockReq, mockRes, mockAccount, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const {
   PROBLEM_WITH_SERVICE,
@@ -99,7 +99,7 @@ describe('controllers/insurance/account/suspended', () => {
     describe('api error handling', () => {
       describe('when the send email reactivate account link API call fails', () => {
         beforeEach(() => {
-          sendEmailReactivateAccountLinkResponseSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          sendEmailReactivateAccountLinkResponseSpy = mockSpyPromiseRejection;
           api.keystone.account.sendEmailReactivateAccountLink = sendEmailReactivateAccountLinkResponseSpy;
         });
 

--- a/src/ui/server/controllers/insurance/account/suspended/verify-email/index.test.ts
+++ b/src/ui/server/controllers/insurance/account/suspended/verify-email/index.test.ts
@@ -3,7 +3,7 @@ import { ROUTES } from '../../../../../constants';
 import { sanitiseValue } from '../../../../../helpers/sanitise-data';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
-import { mockAccount, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockAccount, mockReq, mockRes, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   INSURANCE: {
@@ -110,7 +110,7 @@ describe('controllers/insurance/account/suspended/verify-email', () => {
   describe('api error handling', () => {
     describe('when the verify reactivate account token API call fails', () => {
       beforeEach(() => {
-        verifyAccountReactivationTokenSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        verifyAccountReactivationTokenSpy = mockSpyPromiseRejection;
 
         api.keystone.account.verifyAccountReactivationToken = verifyAccountReactivationTokenSpy;
       });

--- a/src/ui/server/controllers/insurance/business/alternative-trading-address/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/alternative-trading-address/save-and-back/index.test.ts
@@ -3,8 +3,8 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import { FIELD_IDS } from '..';
 import { ROUTES } from '../../../../../constants';
 import BUSINESS_FIELD_IDS from '../../../../../constants/field-ids/insurance/business';
-import { mockReq, mockRes, mockApplication } from '../../../../../test-mocks';
 import mapAndSave from '../../map-and-save/company-different-trading-address';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 import { Request, Response } from '../../../../../../types';
 
 const {
@@ -110,7 +110,7 @@ describe('controllers/insurance/business/alternative-trading-address/save-and-ba
       beforeEach(() => {
         res.locals = mockRes().locals;
         req.body = validBody;
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.companyDifferentTradingAddress = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/business/companies-house-search/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/companies-house-search/index.test.ts
@@ -13,7 +13,7 @@ import companiesHouse from '../../../../helpers/companies-house-search';
 import mapCompaniesHouseData from '../../../../helpers/mappings/map-companies-house-data';
 import saveData from '../save-data/companies-house-search-data';
 import { CompaniesHouseResponse, Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockCompaniesHouseResponse, mockCompany, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockCompaniesHouseResponse, mockCompany, referenceNumber, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const {
   ELIGIBILITY: {
@@ -227,7 +227,7 @@ describe('controllers/insurance/business/companies-house-search', () => {
 
       describe('when there is an error with companiesHouse.search', () => {
         beforeEach(() => {
-          companiesHouse.search = jest.fn(() => Promise.reject(new Error('mock')));
+          companiesHouse.search = mockSpyPromiseRejection;
         });
 
         it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
@@ -242,7 +242,7 @@ describe('controllers/insurance/business/companies-house-search', () => {
       describe('when there is an error with saveData.companyDetailsPostMigration', () => {
         beforeEach(() => {
           companiesHouse.search = jest.fn(() => Promise.resolve(mockCompaniesHouseResponse));
-          saveData.companyDetailsPostMigration = jest.fn(() => Promise.reject(new Error('mock')));
+          saveData.companyDetailsPostMigration = mockSpyPromiseRejection;
         });
 
         it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {

--- a/src/ui/server/controllers/insurance/business/company-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/index.test.ts
@@ -11,7 +11,7 @@ import mapAndSave from '../map-and-save/company-details';
 import { companiesHouseSummaryList } from '../../../../helpers/summary-lists/companies-house';
 import companyDetailsValidation from './validation/company-details';
 import { Application, Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockPhoneNumbers, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockPhoneNumbers, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   YOUR_COMPANY: { HAS_DIFFERENT_TRADING_NAME, TRADING_ADDRESS, WEBSITE, PHONE_NUMBER, DIFFERENT_TRADING_NAME },
@@ -319,7 +319,7 @@ describe('controllers/insurance/business/companies-details', () => {
         it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
           req.body = validBody;
 
-          mapAndSave.companyDetails = jest.fn(() => Promise.reject(new Error('mock')));
+          mapAndSave.companyDetails = mockSpyPromiseRejection;
 
           await post(req, res);
 

--- a/src/ui/server/controllers/insurance/business/company-details/save-and-back/index.POST-save-and-back.test.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/save-and-back/index.POST-save-and-back.test.ts
@@ -6,7 +6,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/company-details';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockApplication, mockPhoneNumbers, mockCompany } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockCompany, mockPhoneNumbers, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   YOUR_COMPANY: { HAS_DIFFERENT_TRADING_NAME, TRADING_ADDRESS, PHONE_NUMBER },
@@ -120,7 +120,7 @@ describe('controllers/insurance/business/companies-details', () => {
         beforeEach(() => {
           req.body = validBody;
           res.locals = mockRes().locals;
-          updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+          updateMapAndSave = mockSpyPromiseRejection;
           mapAndSave.companyDetails = updateMapAndSave;
         });
 

--- a/src/ui/server/controllers/insurance/business/credit-control/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/credit-control/save-and-back/index.test.ts
@@ -2,9 +2,9 @@ import { post } from '.';
 import constructPayload from '../../../../../helpers/construct-payload';
 import { FIELD_ID } from '..';
 import { ROUTES } from '../../../../../constants';
-import { mockReq, mockRes, mockApplication } from '../../../../../test-mocks';
 import mapAndSave from '../../map-and-save/business';
 import { Request, Response } from '../../../../../../types';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
 
@@ -105,7 +105,7 @@ describe('controllers/insurance/business/credit-control/save-and-back', () => {
         req.body = validBody;
         res.locals = mockRes().locals;
 
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.business = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/business/map-and-save/business/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/business/map-and-save/business/index.api-error.test.ts
@@ -1,7 +1,7 @@
 import mapAndSave from '.';
 import save from '../../save-data/business';
 import { FIELD_IDS } from '../../../../../constants';
-import { mockApplication, mockSpyPromise } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromise, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   EXPORTER_BUSINESS: {
@@ -36,7 +36,7 @@ describe('controllers/insurance/business/map-and-save/business - API error', () 
 
   describe('when save application business call fails', () => {
     beforeEach(() => {
-      save.business = jest.fn(() => Promise.reject(new Error('mock')));
+      save.business = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/business/map-and-save/company-details/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/business/map-and-save/company-details/index.api-error.test.ts
@@ -2,7 +2,7 @@ import mapAndSave from '.';
 import saveCompany from '../../save-data/company-details';
 import nullify from '../nullify-company-different-address';
 import { FIELD_IDS } from '../../../../../constants';
-import { mockApplication, mockSpyPromise } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromise, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   COMPANIES_HOUSE: { COMPANY_NUMBER },
@@ -46,7 +46,7 @@ describe('controllers/insurance/business/map-and-save/company-details - API erro
 
   describe('when saveCompany.companyDetails fails', () => {
     beforeEach(() => {
-      saveCompany.companyDetails = jest.fn(() => Promise.reject(new Error('mock')));
+      saveCompany.companyDetails = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {
@@ -70,7 +70,7 @@ describe('controllers/insurance/business/map-and-save/company-details - API erro
 
   describe('when nullify.companyDifferentTradingAddress fails', () => {
     beforeEach(() => {
-      nullify.companyDifferentTradingAddress = jest.fn(() => Promise.reject(new Error('mock')));
+      nullify.companyDifferentTradingAddress = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/business/map-and-save/company-different-trading-address/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/business/map-and-save/company-different-trading-address/index.api-error.test.ts
@@ -1,7 +1,7 @@
 import mapAndSave from '.';
 import save from '../../save-data/company-different-trading-address';
 import { FIELD_IDS } from '../../../../../constants';
-import { mockApplication, mockSpyPromise } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromise, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   ALTERNATIVE_TRADING_ADDRESS: { FULL_ADDRESS },
@@ -32,7 +32,7 @@ describe('controllers/insurance/business/map-and-save/company-different-trading-
 
   describe('when save application differentTradingAddress call fails', () => {
     beforeEach(() => {
-      save.companyDifferentTradingAddress = jest.fn(() => Promise.reject(new Error('mock')));
+      save.companyDifferentTradingAddress = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/business/map-and-save/nullify-company-different-address/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/map-and-save/nullify-company-different-address/index.test.ts
@@ -1,7 +1,7 @@
 import nullify from '.';
 import saveAddress from '../../save-data/company-different-trading-address';
 import nullifyCompanyDifferentTradingAddress from '../../../../../helpers/nullify-company-different-trading-address-data';
-import { mockApplication, mockSpyPromise } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromise, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/business/map-and-save/nullify-company-different-address', () => {
   jest.mock('../../save-data/company-different-trading-address');
@@ -37,7 +37,7 @@ describe('controllers/insurance/business/map-and-save/nullify-company-different-
 
   describe('when save saveAddress.companyDifferentTradingAddress call fails', () => {
     beforeEach(() => {
-      saveAddress.companyDifferentTradingAddress = jest.fn(() => Promise.reject(new Error('mock')));
+      saveAddress.companyDifferentTradingAddress = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/business/map-and-save/turnover/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/business/map-and-save/turnover/index.api-error.test.ts
@@ -1,7 +1,7 @@
 import mapAndSave from '.';
 import save from '../../save-data/business';
 import { FIELD_IDS } from '../../../../../constants';
-import { mockApplication, mockSpyPromise } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromise, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   EXPORTER_BUSINESS: {
@@ -35,7 +35,7 @@ describe('controllers/insurance/business/map-and-save/turnover - API error', () 
 
   describe('when save application business call fails', () => {
     beforeEach(() => {
-      save.business = jest.fn(() => Promise.reject(new Error('mock')));
+      save.business = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/business/nature-of-business/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/nature-of-business/save-and-back/index.test.ts
@@ -3,9 +3,9 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import { FIELD_IDS } from '..';
 import { ROUTES } from '../../../../../constants';
 import BUSINESS_FIELD_IDS from '../../../../../constants/field-ids/insurance/business';
-import { mockReq, mockRes, mockApplication, mockBusinessNatureOfBusiness } from '../../../../../test-mocks';
 import mapAndSave from '../../map-and-save/business';
 import { Request, Response } from '../../../../../../types';
+import { mockReq, mockRes, mockApplication, mockBusinessNatureOfBusiness, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   NATURE_OF_YOUR_BUSINESS: { YEARS_EXPORTING, EMPLOYEES_UK },
@@ -112,7 +112,7 @@ describe('controllers/insurance/business/nature-of-business/save-and-back', () =
     describe('when mapAndSave.business fails', () => {
       beforeEach(() => {
         res.locals = mockRes().locals;
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.business = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/business/save-data/business/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/business/save-data/business/index.api-error.test.ts
@@ -1,7 +1,7 @@
 import save from '.';
 import api from '../../../../../api';
 import { FIELD_IDS } from '../../../../../constants';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   EXPORTER_BUSINESS: {
@@ -25,7 +25,7 @@ describe('controllers/insurance/business/save-data/business - API error', () => 
 
   describe('when there is an error', () => {
     beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.business = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/business/save-data/companies-house-search-data/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/business/save-data/companies-house-search-data/index.api-error.test.ts
@@ -1,6 +1,6 @@
 import save from '.';
 import api from '../../../../../api';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/business/save-data/companies-house-search-data - API error', () => {
   let updateSpy = jest.fn(() => Promise.resolve(true));
@@ -15,7 +15,7 @@ describe('controllers/insurance/business/save-data/companies-house-search-data -
 
   describe('when there is an error', () => {
     beforeEach(() => {
-      updateSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateSpy = mockSpyPromiseRejection;
 
       api.keystone.application.update.companyPostDataMigration = updateSpy;
     });

--- a/src/ui/server/controllers/insurance/business/save-data/company-details/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/business/save-data/company-details/index.api-error.test.ts
@@ -1,7 +1,7 @@
 import save from '.';
 import api from '../../../../../api';
 import { FIELD_IDS } from '../../../../../constants';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   EXPORTER_BUSINESS: {
@@ -25,7 +25,7 @@ describe('controllers/insurance/business/save-data/company-details - API error',
 
   describe('when there is an error', () => {
     beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.company = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/business/save-data/company-different-trading-address/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/business/save-data/company-different-trading-address/index.api-error.test.ts
@@ -1,6 +1,6 @@
 import save from '.';
 import api from '../../../../../api';
-import { mockApplication, mockCompanyDifferentTradingAddress } from '../../../../../test-mocks';
+import { mockApplication, mockCompanyDifferentTradingAddress, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/business/save-data/company-different-trading-address - API error', () => {
   const mockUpdateApplicationResponse = mockApplication;
@@ -13,7 +13,7 @@ describe('controllers/insurance/business/save-data/company-different-trading-add
 
   describe('when there is an error', () => {
     beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.companyDifferentTradingAddress = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/business/turnover/alternative-currency/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/alternative-currency/index.test.ts
@@ -12,7 +12,16 @@ import getUserNameFromSession from '../../../../../helpers/get-user-name-from-se
 import generateValidationErrors from './validation';
 import mapAndSave from '../../map-and-save/turnover';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockCurrenciesResponse, mockCurrenciesEmptyResponse, mockApplication, referenceNumber, GBP } from '../../../../../test-mocks';
+import {
+  mockReq,
+  mockRes,
+  mockApplication,
+  mockCurrenciesResponse,
+  mockCurrenciesEmptyResponse,
+  mockSpyPromiseRejection,
+  referenceNumber,
+  GBP,
+} from '../../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -122,7 +131,7 @@ describe('controllers/insurance/business/turnover/alternative-currency', () => {
     describe('api error handling', () => {
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -253,7 +262,7 @@ describe('controllers/insurance/business/turnover/alternative-currency', () => {
     describe('api error handling', () => {
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 

--- a/src/ui/server/controllers/insurance/business/turnover/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/index.test.ts
@@ -21,6 +21,7 @@ import {
   mockCurrencies,
   mockCurrenciesResponse,
   mockCurrenciesEmptyResponse,
+  mockSpyPromiseRejection,
 } from '../../../../test-mocks';
 
 const { FINANCIAL_YEAR_END_DATE, ESTIMATED_ANNUAL_TURNOVER, PERCENTAGE_TURNOVER, TURNOVER_CURRENCY_CODE } = BUSINESS_FIELD_IDS.TURNOVER;
@@ -173,7 +174,7 @@ describe('controllers/insurance/business/turnover', () => {
     describe('api error handling', () => {
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -296,7 +297,7 @@ describe('controllers/insurance/business/turnover', () => {
     describe('api error handling', () => {
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 

--- a/src/ui/server/controllers/insurance/business/turnover/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/save-and-back/index.test.ts
@@ -4,7 +4,7 @@ import { ROUTES } from '../../../../../constants';
 import BUSINESS_FIELD_IDS from '../../../../../constants/field-ids/insurance/business';
 import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/turnover';
-import { mockReq, mockRes, mockApplication, mockBusinessTurnover } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockBusinessTurnover, mockSpyPromiseRejection } from '../../../../../test-mocks';
 import { Request, Response } from '../../../../../../types';
 
 const {
@@ -112,7 +112,7 @@ describe('controllers/insurance/business/turnover/save-and-back', () => {
       beforeEach(() => {
         req.body = validBody;
         res.locals = mockRes().locals;
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.turnover = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/check-your-answers/export-contract/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/export-contract/index.test.ts
@@ -12,7 +12,7 @@ import sectionStatus from '../../../../helpers/section-status';
 import constructPayload from '../../../../helpers/construct-payload';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, referenceNumber, mockApplication, mockCountries, mockSpyPromise } from '../../../../test-mocks';
+import { mockReq, mockRes, referenceNumber, mockApplication, mockCountries, mockSpyPromise, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const CHECK_YOUR_ANSWERS_TEMPLATE = TEMPLATES.INSURANCE.CHECK_YOUR_ANSWERS;
 
@@ -136,7 +136,7 @@ describe('controllers/insurance/check-your-answers/export-contract', () => {
 
     describe('when the get countries API call fails', () => {
       beforeEach(() => {
-        getCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        getCountriesSpy = mockSpyPromiseRejection;
         api.keystone.countries.getAll = getCountriesSpy;
       });
 
@@ -217,7 +217,7 @@ describe('controllers/insurance/check-your-answers/export-contract', () => {
 
       describe('when the save data API call fails', () => {
         beforeEach(() => {
-          mockSaveSectionReview = jest.fn(() => Promise.reject(new Error('mock')));
+          mockSaveSectionReview = mockSpyPromiseRejection;
           save.sectionReview = mockSaveSectionReview;
 
           req.body = mockBody;

--- a/src/ui/server/controllers/insurance/check-your-answers/policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/policy/index.test.ts
@@ -24,6 +24,7 @@ import {
   mockNominatedLossPayee,
   referenceNumber,
   mockSpyPromise,
+  mockSpyPromiseRejection,
 } from '../../../../test-mocks';
 import { mockBroker } from '../../../../test-mocks/mock-application';
 
@@ -162,7 +163,7 @@ describe('controllers/insurance/check-your-answers/policy', () => {
     describe('api error handling', () => {
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -188,7 +189,7 @@ describe('controllers/insurance/check-your-answers/policy', () => {
 
       describe('when the get countries API call fails', () => {
         beforeEach(() => {
-          getCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCountriesSpy = mockSpyPromiseRejection;
           api.keystone.countries.getAll = getCountriesSpy;
         });
 
@@ -270,7 +271,7 @@ describe('controllers/insurance/check-your-answers/policy', () => {
 
       describe('when the save data API call fails', () => {
         beforeEach(() => {
-          mockSaveSectionReview = jest.fn(() => Promise.reject(new Error('mock')));
+          mockSaveSectionReview = mockSpyPromiseRejection;
           save.sectionReview = mockSaveSectionReview;
 
           req.body = mockBody;

--- a/src/ui/server/controllers/insurance/check-your-answers/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import stripEmptyFormFields from '../../../../helpers/strip-empty-form-fields';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -80,7 +80,7 @@ describe('controllers/insurance/check-your-answers/save-and-back', () => {
 
     describe('when the save data API call fails', () => {
       beforeEach(() => {
-        mockSaveData = jest.fn(() => Promise.reject(new Error('mock')));
+        mockSaveData = mockSpyPromiseRejection;
         save.sectionReview = mockSaveData;
       });
 

--- a/src/ui/server/controllers/insurance/check-your-answers/save-data/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/save-data/index.test.ts
@@ -2,7 +2,7 @@ import save from '.';
 import api from '../../../../api';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import { FIELD_IDS } from '../../../../constants';
-import { mockApplication } from '../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const {
   CHECK_YOUR_ANSWERS: { POLICY },
@@ -43,7 +43,7 @@ describe('controllers/insurance/check-your-answers/save-data', () => {
 
   describe('when there is an error calling the API', () => {
     beforeAll(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.declarations = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/check-your-answers/your-business/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/your-business/index.test.ts
@@ -11,7 +11,7 @@ import sectionStatus from '../../../../helpers/section-status';
 import constructPayload from '../../../../helpers/construct-payload';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockSpyPromise, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromise, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const { company, business } = mockApplication;
 
@@ -163,7 +163,7 @@ describe('controllers/insurance/check-your-answers/your-business', () => {
 
       describe('when the save data API call fails', () => {
         beforeEach(() => {
-          mockSaveSectionReview = jest.fn(() => Promise.reject(new Error('mock')));
+          mockSaveSectionReview = mockSpyPromiseRejection;
           save.sectionReview = mockSaveSectionReview;
 
           req.body = mockBody;

--- a/src/ui/server/controllers/insurance/check-your-answers/your-buyer/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/your-buyer/index.test.ts
@@ -11,7 +11,7 @@ import sectionStatus from '../../../../helpers/section-status';
 import constructPayload from '../../../../helpers/construct-payload';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockSpyPromise, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromise, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const CHECK_YOUR_ANSWERS_TEMPLATE = TEMPLATES.INSURANCE.CHECK_YOUR_ANSWERS;
 
@@ -167,7 +167,7 @@ describe('controllers/insurance/check-your-answers/your-buyer', () => {
 
       describe('when the save data API call fails', () => {
         beforeEach(() => {
-          mockSaveSectionReview = jest.fn(() => Promise.reject(new Error('mock')));
+          mockSaveSectionReview = mockSpyPromiseRejection;
           save.sectionReview = mockSaveSectionReview;
 
           req.body = mockBody;

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/code-of-conduct/index.test.ts
@@ -8,7 +8,7 @@ import mapApplicationToFormFields from '../../../../../helpers/mappings/map-appl
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import save from '../../save-data';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockApplication, mockSpyPromise, referenceNumber } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromise, mockSpyPromiseRejection, referenceNumber } from '../../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -209,7 +209,7 @@ describe('controllers/insurance/declarations/anti-bribery/code-of-conduct', () =
 
         describe('when the save data API call fails', () => {
           beforeEach(() => {
-            mockSaveDeclaration = jest.fn(() => Promise.reject(new Error('mock')));
+            mockSaveDeclaration = mockSpyPromiseRejection;
             save.declaration = mockSaveDeclaration;
 
             req.body = validBody;

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/exporting-with-code-of-conduct/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/exporting-with-code-of-conduct/index.test.ts
@@ -7,7 +7,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import save from '../../save-data';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockApplication, mockSpyPromise, referenceNumber } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromise, mockSpyPromiseRejection, referenceNumber } from '../../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -168,7 +168,7 @@ describe('controllers/insurance/declarations/anti-bribery/exporting-with-a-code-
 
         describe('when the save data API call fails', () => {
           beforeEach(() => {
-            mockSaveDeclaration = jest.fn(() => Promise.reject(new Error('mock')));
+            mockSaveDeclaration = mockSpyPromiseRejection;
             save.declaration = mockSaveDeclaration;
 
             req.body = validBody;

--- a/src/ui/server/controllers/insurance/declarations/anti-bribery/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/anti-bribery/index.test.ts
@@ -8,7 +8,7 @@ import mapApplicationToFormFields from '../../../../helpers/mappings/map-applica
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockSpyPromise, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromise, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -173,7 +173,7 @@ describe('controllers/insurance/declarations/anti-bribery', () => {
 
       describe('when the save data API call fails', () => {
         beforeEach(() => {
-          mockSaveDeclaration = jest.fn(() => Promise.reject(new Error('mock')));
+          mockSaveDeclaration = mockSpyPromiseRejection;
           save.declaration = mockSaveDeclaration;
 
           req.body = validBody;

--- a/src/ui/server/controllers/insurance/declarations/confidentiality/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/confidentiality/index.test.ts
@@ -8,7 +8,7 @@ import mapApplicationToFormFields from '../../../../helpers/mappings/map-applica
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockSpyPromise, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromise, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -175,7 +175,7 @@ describe('controllers/insurance/declarations/confidentiality', () => {
 
         describe('when the save data API call fails', () => {
           beforeEach(() => {
-            mockSaveDeclaration = jest.fn(() => Promise.reject(new Error('mock')));
+            mockSaveDeclaration = mockSpyPromiseRejection;
             save.declaration = mockSaveDeclaration;
 
             req.body = validBody;

--- a/src/ui/server/controllers/insurance/declarations/confirmation-and-acknowledgements/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/confirmation-and-acknowledgements/index.test.ts
@@ -9,7 +9,7 @@ import mapApplicationToFormFields from '../../../../helpers/mappings/map-applica
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockSpyPromise, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromise, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -200,7 +200,7 @@ describe('controllers/insurance/declarations/confirmation-and-acknowledgements',
 
         describe('when the save data API call fails', () => {
           beforeEach(() => {
-            mockSaveDeclaration = jest.fn(() => Promise.reject(new Error('mock')));
+            mockSaveDeclaration = mockSpyPromiseRejection;
             save.declaration = mockSaveDeclaration;
 
             req.body = validBody;
@@ -232,7 +232,7 @@ describe('controllers/insurance/declarations/confirmation-and-acknowledgements',
 
         describe('when the submit application API call fails', () => {
           beforeEach(() => {
-            submitApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            submitApplicationSpy = mockSpyPromiseRejection;
             api.keystone.application.submit = submitApplicationSpy;
 
             req.body = validBody;

--- a/src/ui/server/controllers/insurance/declarations/confirmation-and-acknowledgements/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/confirmation-and-acknowledgements/index.ts
@@ -59,6 +59,7 @@ export const get = async (req: Request, res: Response) => {
     ...pageVariables(application.referenceNumber),
     userName: getUserNameFromSession(req.session.user),
     application: mapApplicationToFormFields(res.locals.application),
+    SUBMIT_BUTTON_COPY: 'Tony testing',
   });
 };
 

--- a/src/ui/server/controllers/insurance/declarations/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/save-and-back/index.test.ts
@@ -4,7 +4,7 @@ import DECLARATIONS_FIELD_IDS from '../../../../constants/field-ids/insurance/de
 import constructPayload from '../../../../helpers/construct-payload';
 import save from '../save-data';
 import { Request, Response } from '../../../../../types';
-import { referenceNumber, mockReq, mockRes } from '../../../../test-mocks';
+import { mockReq, mockRes, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE },
@@ -98,7 +98,7 @@ describe('controllers/insurance/declarations/confidentiality/save-and-back', () 
 
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mockSaveData = jest.fn(() => Promise.reject(new Error('mock')));
+        mockSaveData = mockSpyPromiseRejection;
         save.declaration = mockSaveData;
       });
 

--- a/src/ui/server/controllers/insurance/declarations/save-data/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/save-data/index.test.ts
@@ -3,7 +3,7 @@ import api from '../../../../api';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import stripEmptyFormFields from '../../../../helpers/strip-empty-form-fields';
 import { FIELD_IDS } from '../../../../constants';
-import { mockApplication } from '../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const {
   DECLARATIONS: { AGREE_CONFIDENTIALITY },
@@ -47,7 +47,7 @@ describe('controllers/insurance/declarations/save-data', () => {
 
   describe('when there is an error calling the API', () => {
     beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.declarations = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/buyer-country/index.test.ts
@@ -9,7 +9,7 @@ import { validation as generateValidationErrors } from '../../../../shared-valid
 import api from '../../../../api';
 import mapCountries from '../../../../helpers/mappings/map-countries';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockCountries } from '../../../../test-mocks';
+import { mockReq, mockRes, mockCountries, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const {
   PROBLEM_WITH_SERVICE,
@@ -89,7 +89,7 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
 
     describe('when the get CIS countries API call fails', () => {
       beforeEach(() => {
-        getCisCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        getCisCountriesSpy = mockSpyPromiseRejection;
         api.keystone.APIM.getCisCountries = getCisCountriesSpy;
       });
 
@@ -149,7 +149,7 @@ describe('controllers/insurance/eligibility/buyer-country', () => {
 
     describe('when the get CIS countries API call fails', () => {
       beforeEach(() => {
-        getCisCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        getCisCountriesSpy = mockSpyPromiseRejection;
         api.keystone.APIM.getCisCountries = getCisCountriesSpy;
       });
 

--- a/src/ui/server/controllers/insurance/eligibility/companies-house-search/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/companies-house-search/index.test.ts
@@ -13,7 +13,7 @@ import companiesHouse from '../../../../helpers/companies-house-search';
 import mapCompaniesHouseData from '../../../../helpers/mappings/map-companies-house-data';
 import { updateSubmittedData } from '../../../../helpers/update-submitted-data/insurance';
 import { CompaniesHouseResponse, Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockCompaniesHouseResponse, mockCompany } from '../../../../test-mocks';
+import { mockReq, mockRes, mockCompaniesHouseResponse, mockCompany, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const {
   ELIGIBILITY: { COMPANIES_HOUSE_NUMBER },
@@ -245,7 +245,7 @@ describe('controllers/insurance/eligibility/companies-house-search', () => {
 
       describe('when there is an error', () => {
         beforeEach(() => {
-          companiesHouse.search = jest.fn(() => Promise.reject(new Error('mock')));
+          companiesHouse.search = mockSpyPromiseRejection;
         });
 
         it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {

--- a/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.test.ts
+++ b/src/ui/server/controllers/insurance/eligibility/eligible-to-apply-online/index.test.ts
@@ -5,7 +5,7 @@ import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
 import corePageVariables from '../../../../helpers/page-variables/core/insurance';
 import getUserNameFromSession from '../../../../helpers/get-user-name-from-session';
 import application from '../../../../helpers/create-an-application';
-import { mockAccount, referenceNumber, mockSession, mockReq, mockRes, mockCreateApplicationResponse } from '../../../../test-mocks';
+import { mockAccount, mockSession, mockReq, mockRes, mockCreateApplicationResponse, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 import { Request, Response } from '../../../../../types';
 
 const {
@@ -104,7 +104,7 @@ describe('controllers/insurance/eligibility/eligible-to-apply-online', () => {
             },
           };
 
-          createApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          createApplicationSpy = mockSpyPromiseRejection;
           application.create = createApplicationSpy;
         });
 

--- a/src/ui/server/controllers/insurance/export-contract/about-goods-or-services/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/about-goods-or-services/index.test.ts
@@ -15,7 +15,7 @@ import mapCountries from '../../../../helpers/mappings/map-countries';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import mapAndSave from '../map-and-save/export-contract';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockCountries, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockCountries, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -158,7 +158,7 @@ describe('controllers/insurance/export-contract/about-goods-or-services', () => 
     describe('api error handling', () => {
       describe('when the get countries API call fails', () => {
         beforeEach(() => {
-          getCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCountriesSpy = mockSpyPromiseRejection;
           api.keystone.countries.getAll = getCountriesSpy;
         });
 
@@ -294,7 +294,7 @@ describe('controllers/insurance/export-contract/about-goods-or-services', () => 
       describe('get countries call', () => {
         describe('when the get countries API call fails', () => {
           beforeEach(() => {
-            getCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            getCountriesSpy = mockSpyPromiseRejection;
             api.keystone.countries.getAll = getCountriesSpy;
           });
 
@@ -340,7 +340,7 @@ describe('controllers/insurance/export-contract/about-goods-or-services', () => 
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const mapAndSaveSpy = mockSpyPromiseRejection;
 
             mapAndSave.exportContract = mapAndSaveSpy;
           });

--- a/src/ui/server/controllers/insurance/export-contract/about-goods-or-services/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/about-goods-or-services/save-and-back/index.test.ts
@@ -7,7 +7,7 @@ import mapAndSave from '../../map-and-save/export-contract';
 import generateValidationErrors from '../validation';
 import api from '../../../../../api';
 import { Request, Response } from '../../../../../../types';
-import { mockCountries, mockReq, mockRes, referenceNumber } from '../../../../../test-mocks';
+import { mockCountries, mockReq, mockRes, mockSpyPromiseRejection, referenceNumber } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -160,7 +160,7 @@ describe('controllers/insurance/export-contract/about-goods-or-services/save-and
 
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        mapAndSaveSpy = mockSpyPromiseRejection;
 
         mapAndSave.exportContract = mapAndSaveSpy;
       });

--- a/src/ui/server/controllers/insurance/export-contract/agent-charges/alternative-currency/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-charges/alternative-currency/index.test.ts
@@ -19,6 +19,7 @@ import {
   mockCurrencies,
   mockCurrenciesResponse,
   mockCurrenciesEmptyResponse,
+  mockSpyPromiseRejection,
   referenceNumber,
 } from '../../../../../test-mocks';
 
@@ -146,7 +147,7 @@ describe('controllers/insurance/export-contract/agent-charges/alternative-curren
 
     describe('when the get currencies API call fails', () => {
       beforeEach(() => {
-        getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        getCurrenciesSpy = mockSpyPromiseRejection;
         api.keystone.APIM.getCurrencies = getCurrenciesSpy;
       });
 
@@ -211,7 +212,7 @@ describe('controllers/insurance/export-contract/agent-charges/alternative-curren
 
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -326,7 +327,7 @@ describe('controllers/insurance/export-contract/agent-charges/alternative-curren
     describe('when mapAndSave.exportContractAgentServiceCharge returns an error', () => {
       beforeEach(() => {
         req.body = validBody;
-        const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        const mapAndSaveSpy = mockSpyPromiseRejection;
 
         mapAndSave.exportContractAgentServiceCharge = mapAndSaveSpy;
       });

--- a/src/ui/server/controllers/insurance/export-contract/agent-charges/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-charges/index.test.ts
@@ -24,6 +24,7 @@ import {
   mockCurrencies,
   mockCurrenciesResponse,
   mockExportContractAgentServiceCharge,
+  mockSpyPromiseRejection,
   referenceNumber,
 } from '../../../../test-mocks';
 
@@ -243,7 +244,7 @@ describe('controllers/insurance/export-contract/agent-charges', () => {
 
     describe('when the get countries API call fails', () => {
       beforeEach(() => {
-        getCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        getCountriesSpy = mockSpyPromiseRejection;
         api.keystone.countries.getAll = getCountriesSpy;
       });
 
@@ -269,7 +270,7 @@ describe('controllers/insurance/export-contract/agent-charges', () => {
 
     describe('when the get currencies API call fails', () => {
       beforeEach(() => {
-        getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        getCurrenciesSpy = mockSpyPromiseRejection;
         api.keystone.APIM.getCurrencies = getCurrenciesSpy;
       });
 
@@ -342,7 +343,7 @@ describe('controllers/insurance/export-contract/agent-charges', () => {
 
       describe('when the get countries API call fails', () => {
         beforeEach(() => {
-          getCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCountriesSpy = mockSpyPromiseRejection;
           api.keystone.countries.getAll = getCountriesSpy;
         });
 
@@ -368,7 +369,7 @@ describe('controllers/insurance/export-contract/agent-charges', () => {
 
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -475,7 +476,7 @@ describe('controllers/insurance/export-contract/agent-charges', () => {
     describe('when mapAndSave.exportContractAgentServiceCharge returns an error', () => {
       beforeEach(() => {
         req.body = validBody;
-        const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        const mapAndSaveSpy = mockSpyPromiseRejection;
 
         mapAndSave.exportContractAgentServiceCharge = mapAndSaveSpy;
       });

--- a/src/ui/server/controllers/insurance/export-contract/agent-charges/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-charges/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/export-contract-agent-service-charge';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockApplication, mockReq, mockRes, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -88,7 +88,7 @@ describe('controllers/insurance/export-contract/agent-charges/save-and-back', ()
 
   describe('when there is an error calling the API', () => {
     beforeAll(() => {
-      mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      mapAndSaveSpy = mockSpyPromiseRejection;
 
       mapAndSave.exportContractAgentServiceCharge = mapAndSaveSpy;
     });

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/index.test.ts
@@ -13,7 +13,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/export-contract-agent';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockCountries, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockCountries, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -136,7 +136,7 @@ describe('controllers/insurance/export-contract/agent-details', () => {
 
     describe('when the get countries API call fails', () => {
       beforeEach(() => {
-        getCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        getCountriesSpy = mockSpyPromiseRejection;
         api.keystone.countries.getAll = getCountriesSpy;
       });
 
@@ -205,7 +205,7 @@ describe('controllers/insurance/export-contract/agent-details', () => {
 
       describe('when the get countries API call fails', () => {
         beforeEach(() => {
-          getCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCountriesSpy = mockSpyPromiseRejection;
           api.keystone.countries.getAll = getCountriesSpy;
         });
 
@@ -320,7 +320,7 @@ describe('controllers/insurance/export-contract/agent-details', () => {
     describe('when mapAndSave.exportContractAgent returns an error', () => {
       beforeEach(() => {
         req.body = validBody;
-        const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        const mapAndSaveSpy = mockSpyPromiseRejection;
 
         mapAndSave.exportContractAgent = mapAndSaveSpy;
       });

--- a/src/ui/server/controllers/insurance/export-contract/agent-details/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-details/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/export-contract-agent';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockApplication, mockReq, mockRes, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -86,7 +86,7 @@ describe('controllers/insurance/export-contract/agent-details/save-and-back', ()
 
   describe('when there is an error calling the API', () => {
     beforeAll(() => {
-      mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      mapAndSaveSpy = mockSpyPromiseRejection;
 
       mapAndSave.exportContractAgent = mapAndSaveSpy;
     });

--- a/src/ui/server/controllers/insurance/export-contract/agent-service/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-service/index.test.ts
@@ -12,7 +12,7 @@ import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/export-contract-agent-service';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -325,7 +325,7 @@ describe('controllers/insurance/export-contract/agent-service', () => {
     describe('when mapAndSave.exportContractAgentService returns an error', () => {
       beforeEach(() => {
         req.body = validBody;
-        const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        const mapAndSaveSpy = mockSpyPromiseRejection;
 
         mapAndSave.exportContractAgentService = mapAndSaveSpy;
       });

--- a/src/ui/server/controllers/insurance/export-contract/agent-service/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent-service/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/export-contract-agent-service';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockApplication, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockApplication, mockReq, mockRes, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -88,7 +88,7 @@ describe('controllers/insurance/export-contract/agent-service/save-and-back', ()
 
   describe('when there is an error calling the API', () => {
     beforeAll(() => {
-      mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      mapAndSaveSpy = mockSpyPromiseRejection;
 
       mapAndSave.exportContractAgentService = mapAndSaveSpy;
     });

--- a/src/ui/server/controllers/insurance/export-contract/agent/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent/index.test.ts
@@ -10,7 +10,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../map-and-save/export-contract-agent';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -288,7 +288,7 @@ describe('controllers/insurance/export-contract/agent', () => {
     describe('when mapAndSave.exportContractAgent returns an error', () => {
       beforeEach(() => {
         req.body = validBody;
-        const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        const mapAndSaveSpy = mockSpyPromiseRejection;
 
         mapAndSave.exportContractAgent = mapAndSaveSpy;
       });

--- a/src/ui/server/controllers/insurance/export-contract/agent/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/agent/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/export-contract-agent';
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import { Request, Response } from '../../../../../../types';
-import { referenceNumber, mockCountries, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockCountries, mockReq, mockRes, mockSpyPromiseRejection, referenceNumber } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -88,7 +88,7 @@ describe('controllers/insurance/export-contract/agent/save-and-back', () => {
 
   describe('when there is an error calling the API', () => {
     beforeAll(() => {
-      mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      mapAndSaveSpy = mockSpyPromiseRejection;
 
       mapAndSave.exportContractAgent = mapAndSaveSpy;
     });

--- a/src/ui/server/controllers/insurance/export-contract/check-your-answers/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/check-your-answers/index.test.ts
@@ -8,7 +8,7 @@ import getUserNameFromSession from '../../../../helpers/get-user-name-from-sessi
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import { exportContractSummaryLists } from '../../../../helpers/summary-lists/export-contract';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockCountries } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockCountries, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -77,7 +77,7 @@ describe('controllers/insurance/export-contract/check-your-answers', () => {
     describe('api error handling', () => {
       describe('when the get countries API call fails', () => {
         beforeEach(() => {
-          getCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCountriesSpy = mockSpyPromiseRejection;
           api.keystone.countries.getAll = getCountriesSpy;
         });
 

--- a/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/index.test.ts
@@ -11,7 +11,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/private-market';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -230,7 +230,7 @@ describe('controllers/insurance/export-contract/declined-by-private-market', () 
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const mapAndSaveSpy = mockSpyPromiseRejection;
 
             mapAndSave.privateMarket = mapAndSaveSpy;
           });

--- a/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/declined-by-private-market/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/private-market';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockCountries, referenceNumber, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockCountries, mockReq, mockRes, mockSpyPromiseRejection, referenceNumber } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -89,7 +89,7 @@ describe('controllers/insurance/export-contract/declined-by-private-market/save-
   describe('api error handling', () => {
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        mapAndSaveSpy = mockSpyPromiseRejection;
 
         mapAndSave.privateMarket = mapAndSaveSpy;
       });

--- a/src/ui/server/controllers/insurance/export-contract/how-was-the-contract-awarded/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/how-was-the-contract-awarded/index.test.ts
@@ -12,7 +12,7 @@ import generateValidationErrors from './validation';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import mapAndSave from '../map-and-save/export-contract';
 import { ObjectType, Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockExportContract, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockExportContract, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -243,7 +243,7 @@ describe('controllers/insurance/export-contract/how-was-the-contract-awarded', (
     describe('when mapAndSave.exportContract returns an error', () => {
       beforeEach(() => {
         req.body = validBody;
-        const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        const mapAndSaveSpy = mockSpyPromiseRejection;
 
         mapAndSave.exportContract = mapAndSaveSpy;
       });

--- a/src/ui/server/controllers/insurance/export-contract/how-was-the-contract-awarded/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/how-was-the-contract-awarded/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/export-contract';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, referenceNumber } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockSpyPromiseRejection, referenceNumber } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -106,7 +106,7 @@ describe('controllers/insurance/export-contract/how-was-the-contract-awarded/sav
 
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        mapAndSaveSpy = mockSpyPromiseRejection;
 
         mapAndSave.exportContract = mapAndSaveSpy;
       });

--- a/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/index.test.ts
@@ -17,6 +17,7 @@ import {
   mockApplication,
   mockApplicationTotalContractValueThresholdTrue,
   mockApplicationTotalContractValueThresholdFalse,
+  mockSpyPromiseRejection,
   referenceNumber,
 } from '../../../../test-mocks';
 
@@ -274,7 +275,7 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid', () => {
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const mapAndSaveSpy = mockSpyPromiseRejection;
 
             mapAndSave.exportContract = mapAndSaveSpy;
           });

--- a/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/how-will-you-get-paid/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/export-contract';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { referenceNumber, mockCountries, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockCountries, mockReq, mockRes, mockSpyPromiseRejection, referenceNumber } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -89,7 +89,7 @@ describe('controllers/insurance/export-contract/how-will-you-get-paid/save-and-b
   describe('api error handling', () => {
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        mapAndSaveSpy = mockSpyPromiseRejection;
 
         mapAndSave.exportContract = mapAndSaveSpy;
       });

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service-charge/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service-charge/index.api-error.test.ts
@@ -1,6 +1,6 @@
 import mapAndSave from '.';
 import save from '../../save-data/export-contract-agent-service-charge';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/export-contract/map-and-save/export-contract-agent-service-charge - api errors', () => {
   jest.mock('../../save-data/export-contract-agent-service');
@@ -24,7 +24,7 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
 
   describe('when save application exportContractAgentServiceCharge call fails', () => {
     beforeEach(() => {
-      save.exportContractAgentServiceCharge = jest.fn(() => Promise.reject(new Error('mock')));
+      save.exportContractAgentServiceCharge = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent-service/index.api-error.test.ts
@@ -2,7 +2,7 @@ import mapAndSave from '.';
 import FIELD_IDS from '../../../../../constants/field-ids/insurance/export-contract';
 import saveService from '../../save-data/export-contract-agent-service';
 import saveCharge from '../../save-data/export-contract-agent-service-charge';
-import { mockApplication, mockApplicationAgentServiceChargeEmpty } from '../../../../../test-mocks';
+import { mockApplication, mockApplicationAgentServiceChargeEmpty, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   AGENT_SERVICE: { IS_CHARGING },
@@ -39,7 +39,7 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
 
   describe('when saveService.exportContractAgentService call fails', () => {
     beforeEach(() => {
-      saveService.exportContractAgentService = jest.fn(() => Promise.reject(new Error('mock')));
+      saveService.exportContractAgentService = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {
@@ -64,7 +64,7 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
 
     describe('when saveCharge.exportContractAgentServiceCharge call fails', () => {
       beforeEach(() => {
-        saveCharge.exportContractAgentServiceCharge = jest.fn(() => Promise.reject(new Error('mock')));
+        saveCharge.exportContractAgentServiceCharge = mockSpyPromiseRejection;
       });
 
       it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract-agent/index.api-error.test.ts
@@ -3,7 +3,7 @@ import saveAgent from '../../save-data/export-contract-agent';
 import saveAgentServiceCharge from '../../save-data/export-contract-agent-service-charge';
 import nullify from '../nullify-export-contract-agent-service';
 import EXPORT_CONTRACT_FIELD_IDS from '../../../../../constants/field-ids/insurance/export-contract';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { USING_AGENT } = EXPORT_CONTRACT_FIELD_IDS;
 
@@ -30,7 +30,7 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
 
   describe('when saveAgent.exportContractAgent call fails', () => {
     beforeEach(() => {
-      saveAgent.exportContractAgent = jest.fn(() => Promise.reject(new Error('mock')));
+      saveAgent.exportContractAgent = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {
@@ -54,7 +54,7 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
 
   describe('when save saveAgentServiceCharge.exportContractAgentServiceCharge call fails', () => {
     beforeEach(() => {
-      saveAgentServiceCharge.exportContractAgentServiceCharge = jest.fn(() => Promise.reject(new Error('mock')));
+      saveAgentServiceCharge.exportContractAgentServiceCharge = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {
@@ -78,7 +78,7 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
 
   describe('when save nullify.exportContractAgentServiceAndCharge call fails', () => {
     beforeEach(() => {
-      nullify.exportContractAgentServiceAndCharge = jest.fn(() => Promise.reject(new Error('mock')));
+      nullify.exportContractAgentServiceAndCharge = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/export-contract/index.api-error.test.ts
@@ -1,6 +1,6 @@
 import mapAndSave from '.';
 import save from '../../save-data/export-contract';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/export-contract/map-and-save/export-contract - api errors', () => {
   jest.mock('../../save-data/export-contract');
@@ -24,7 +24,7 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract - a
 
   describe('when save application exportContract call fails', () => {
     beforeEach(() => {
-      save.exportContract = jest.fn(() => Promise.reject(new Error('mock')));
+      save.exportContract = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/nullify-export-contract-agent-service/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/nullify-export-contract-agent-service/index.test.ts
@@ -3,7 +3,7 @@ import saveAgentService from '../../save-data/export-contract-agent-service';
 import saveAgentServiceCharge from '../../save-data/export-contract-agent-service-charge';
 import nullifyAgentServiceData from '../../../../../helpers/nullify-agent-service-data';
 import nullifyAgentServiceChargeData from '../../../../../helpers/nullify-agent-service-charge-data';
-import { mockApplication, mockSpyPromise } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromise, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/export-contract/map-and-save/export-contract-agent', () => {
   jest.mock('../../save-data/export-contract-agent-service');
@@ -49,7 +49,7 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
 
   describe('when save saveAgentServiceCharge.exportContractAgentServiceCharge call fails', () => {
     beforeEach(() => {
-      saveAgentServiceCharge.exportContractAgentServiceCharge = jest.fn(() => Promise.reject(new Error('mock')));
+      saveAgentServiceCharge.exportContractAgentServiceCharge = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {
@@ -73,7 +73,7 @@ describe('controllers/insurance/export-contract/map-and-save/export-contract-age
 
   describe('when save saveAgentService.exportContractAgentService call fails', () => {
     beforeEach(() => {
-      saveAgentService.exportContractAgentService = jest.fn(() => Promise.reject(new Error('mock')));
+      saveAgentService.exportContractAgentService = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/export-contract/map-and-save/private-market/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/map-and-save/private-market/index.api-error.test.ts
@@ -1,6 +1,6 @@
 import mapAndSave from '.';
 import save from '../../save-data/private-market';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/export-contract/map-and-save/private-market - api errors', () => {
   jest.mock('../../save-data/private-market');
@@ -24,7 +24,7 @@ describe('controllers/insurance/export-contract/map-and-save/private-market - ap
 
   describe('when save application privateMarket call fails', () => {
     beforeEach(() => {
-      save.privateMarket = jest.fn(() => Promise.reject(new Error('mock')));
+      save.privateMarket = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/export-contract/private-market/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/private-market/index.test.ts
@@ -9,7 +9,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../map-and-save/private-market';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -295,7 +295,7 @@ describe('controllers/insurance/export-contract/private-market', () => {
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const mapAndSaveSpy = mockSpyPromiseRejection;
 
             mapAndSave.privateMarket = mapAndSaveSpy;
           });

--- a/src/ui/server/controllers/insurance/export-contract/private-market/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/private-market/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/private-market';
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import { Request, Response } from '../../../../../../types';
-import { referenceNumber, mockCountries, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockCountries, mockReq, mockRes, mockSpyPromiseRejection, referenceNumber } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -89,7 +89,7 @@ describe('controllers/insurance/export-contract/private-market/save-and-back', (
   describe('api error handling', () => {
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        mapAndSaveSpy = mockSpyPromiseRejection;
 
         mapAndSave.privateMarket = mapAndSaveSpy;
       });

--- a/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent-service-charge/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent-service-charge/index.test.ts
@@ -3,7 +3,7 @@ import FIELD_IDS from '../../../../../constants/field-ids/insurance/export-contr
 import api from '../../../../../api';
 import generateValidationErrors from '../../../policy/type-of-policy/validation';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   AGENT_CHARGES: { PERCENTAGE_CHARGE, FIXED_SUM_AMOUNT, METHOD, PAYABLE_COUNTRY_CODE },
@@ -72,7 +72,7 @@ describe('controllers/insurance/export-contract/save-data/export-contract-agent-
 
   describe('when there is an error calling the API', () => {
     beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.exportContractAgentServiceCharge = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent-service/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent-service/index.test.ts
@@ -3,7 +3,7 @@ import api from '../../../../../api';
 import generateValidationErrors from '../../../policy/type-of-policy/validation';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import INSURANCE_FIELD_IDS from '../../../../../constants/field-ids/insurance';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   EXPORT_CONTRACT: {
@@ -68,7 +68,7 @@ describe('controllers/insurance/export-contract/save-data/export-contract-agent-
 
   describe('when there is an error calling the API', () => {
     beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.exportContractAgentService = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent/index.test.ts
@@ -3,7 +3,7 @@ import api from '../../../../../api';
 import generateValidationErrors from '../../../policy/type-of-policy/validation';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import INSURANCE_FIELD_IDS from '../../../../../constants/field-ids/insurance';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   EXPORT_CONTRACT: {
@@ -68,7 +68,7 @@ describe('controllers/insurance/export-contract/save-data/export-contract-agent'
 
   describe('when there is an error calling the API', () => {
     beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.exportContractAgent = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/export-contract/save-data/export-contract/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/export-contract/index.test.ts
@@ -3,7 +3,7 @@ import api from '../../../../../api';
 import generateValidationErrors from '../../../policy/type-of-policy/validation';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import INSURANCE_FIELD_IDS from '../../../../../constants/field-ids/insurance';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   EXPORT_CONTRACT: {
@@ -68,7 +68,7 @@ describe('controllers/insurance/export-contract/save-data/export-contract', () =
 
   describe('api error handling', () => {
     beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.exportContract = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/export-contract/save-data/private-market/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/private-market/index.test.ts
@@ -3,7 +3,7 @@ import api from '../../../../../api';
 import generateValidationErrors from '../../../policy/type-of-policy/validation';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import INSURANCE_FIELD_IDS from '../../../../../constants/field-ids/insurance';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   EXPORT_CONTRACT: {
@@ -68,7 +68,7 @@ describe('controllers/insurance/export-contract/save-data/private-market', () =>
 
   describe('when there is an error calling the API', () => {
     beforeAll(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.privateMarket = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/policy/another-company/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/another-company/index.test.ts
@@ -11,7 +11,7 @@ import { sanitiseData } from '../../../../helpers/sanitise-data';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../map-and-save/jointly-insured-party';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -326,7 +326,7 @@ describe('controllers/insurance/policy/another-company', () => {
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const mapAndSaveSpy = mockSpyPromiseRejection;
 
             mapAndSave.jointlyInsuredParty = mapAndSaveSpy;
           });

--- a/src/ui/server/controllers/insurance/policy/another-company/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/another-company/save-and-back/index.test.ts
@@ -3,8 +3,8 @@ import { FIELD_ID } from '..';
 import { ROUTES } from '../../../../../constants';
 import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/jointly-insured-party';
-import { mockReq, mockRes, mockApplication } from '../../../../../test-mocks';
 import { Request, Response } from '../../../../../../types';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
 
@@ -106,7 +106,7 @@ describe('controllers/insurance/policy/another-company/save-and-back', () => {
       beforeEach(() => {
         req.body = validBody;
         res.locals = mockRes().locals;
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.jointlyInsuredParty = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/policy/broker-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-details/index.test.ts
@@ -12,7 +12,7 @@ import { sanitiseData } from '../../../../helpers/sanitise-data';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/broker';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const { NAME, EMAIL, FULL_ADDRESS } = POLICY_FIELD_IDS.BROKER_DETAILS;
 
@@ -228,7 +228,7 @@ describe('controllers/insurance/policy/broker-details', () => {
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const mapAndSaveSpy = mockSpyPromiseRejection;
 
             mapAndSave.broker = mapAndSaveSpy;
           });

--- a/src/ui/server/controllers/insurance/policy/broker-details/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-details/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save/broker';
 import { FIELD_IDS } from '..';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { USING_BROKER } = POLICY_FIELD_IDS;
 
@@ -114,7 +114,7 @@ describe('controllers/insurance/policy/broker-details/save-and-back', () => {
       beforeEach(() => {
         req.body = validBody;
         res.locals = mockRes().locals;
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.broker = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/policy/broker/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/broker/index.test.ts
@@ -11,7 +11,7 @@ import mapApplicationToFormFields from '../../../../helpers/mappings/map-applica
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../map-and-save/broker';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const { USING_BROKER } = POLICY_FIELD_IDS;
 
@@ -292,7 +292,7 @@ describe('controllers/insurance/policy/broker', () => {
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const mapAndSaveSpy = mockSpyPromiseRejection;
 
             mapAndSave.broker = mapAndSaveSpy;
           });

--- a/src/ui/server/controllers/insurance/policy/broker/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/broker/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../../map-and-save/broker';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { USING_BROKER } = POLICY_FIELD_IDS;
 
@@ -114,7 +114,7 @@ describe('controllers/insurance/policy/broker/save-and-back', () => {
       beforeEach(() => {
         req.body = validBody;
         res.locals = mockRes().locals;
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.broker = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/policy/call-map-and-save/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/call-map-and-save/index.test.ts
@@ -3,7 +3,7 @@ import { FIELD_IDS, FIELD_VALUES } from '../../../../constants';
 import { Request, Response } from '../../../../../types';
 import generateValidationErrors from '../type-of-policy/validation';
 import mapAndSave from '../map-and-save/policy';
-import { mockApplication, mockReq, mockRes } from '../../../../test-mocks';
+import { mockApplication, mockReq, mockRes, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const { POLICY_TYPE } = FIELD_IDS;
 
@@ -73,7 +73,7 @@ describe('controllers/insurance/policy/call-map-and-save', () => {
 
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mockMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        mockMapAndSave = mockSpyPromiseRejection;
         mapAndSave.policy = mockMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/policy/check-your-answers/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/check-your-answers/index.test.ts
@@ -19,6 +19,7 @@ import {
   mockCurrenciesResponse,
   mockCurrenciesEmptyResponse,
   mockNominatedLossPayee,
+  mockSpyPromiseRejection,
   referenceNumber,
 } from '../../../../test-mocks';
 import { mockBroker } from '../../../../test-mocks/mock-application';
@@ -125,7 +126,7 @@ describe('controllers/insurance/policy/check-your-answers', () => {
     describe('api error handling', () => {
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -151,7 +152,7 @@ describe('controllers/insurance/policy/check-your-answers', () => {
 
       describe('when the get countries API call fails', () => {
         beforeEach(() => {
-          getCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCountriesSpy = mockSpyPromiseRejection;
           api.keystone.countries.getAll = getCountriesSpy;
         });
 

--- a/src/ui/server/controllers/insurance/policy/different-name-on-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/different-name-on-policy/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/policy-contact';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockContact, referenceNumber } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockContact, mockSpyPromiseRejection, referenceNumber } from '../../../../../test-mocks';
 
 const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE },
@@ -96,7 +96,7 @@ describe('controllers/insurance/policy/different-name-on-policy/save-and-back', 
 
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mockMapAndSave = jest.fn(() => Promise.reject(new Error('Mock error')));
+        mockMapAndSave = mockSpyPromiseRejection;
 
         mapAndSave.policyContact = mockMapAndSave;
       });

--- a/src/ui/server/controllers/insurance/policy/loss-payee-details/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/loss-payee-details/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save/loss-payee';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   LOSS_PAYEE_DETAILS: { NAME },
@@ -116,7 +116,7 @@ describe('controllers/insurance/policy/loss-payee-details/save-and-back', () => 
       beforeEach(() => {
         req.body = validBody;
         res.locals = mockRes().locals;
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.lossPayee = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/policy/loss-payee-financial-details-international/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/loss-payee-financial-details-international/index.test.ts
@@ -11,7 +11,14 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/loss-payee-financial-details-international';
 import { Application, Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockLossPayeeFinancialDetailsInternational, referenceNumber, mockApplication } from '../../../../test-mocks';
+import {
+  mockReq,
+  mockRes,
+  mockApplication,
+  mockLossPayeeFinancialDetailsInternational,
+  mockSpyPromiseRejection,
+  referenceNumber,
+} from '../../../../test-mocks';
 
 const { BIC_SWIFT_CODE, IBAN } = POLICY_FIELD_IDS.LOSS_PAYEE_FINANCIAL_INTERNATIONAL;
 const { FINANCIAL_ADDRESS } = POLICY_FIELD_IDS;
@@ -210,7 +217,7 @@ describe('controllers/insurance/policy/loss-payee-financial-details-internationa
     describe('when mapAndSave.exportContractAgentServiceCharge returns an error', () => {
       beforeEach(() => {
         req.body = validBody;
-        const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+        const mapAndSaveSpy = mockSpyPromiseRejection;
 
         mapAndSave.lossPayeeFinancialDetailsInternational = mapAndSaveSpy;
       });

--- a/src/ui/server/controllers/insurance/policy/loss-payee-financial-details-international/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/loss-payee-financial-details-international/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save/loss-payee-financial-details-international';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockApplication, mockLossPayeeFinancialDetailsInternational } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockLossPayeeFinancialDetailsInternational, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
 
@@ -109,7 +109,7 @@ describe('controllers/insurance/policy/loss-payee-financial-details-internationa
       beforeEach(() => {
         req.body = validBody;
         res.locals = mockRes().locals;
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.lossPayeeFinancialDetailsInternational = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/policy/loss-payee-financial-details-uk/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/loss-payee-financial-details-uk/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save/loss-payee-financial-details-uk';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockApplication, mockLossPayeeFinancialDetailsUk } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockLossPayeeFinancialDetailsUk, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
 
@@ -109,7 +109,7 @@ describe('controllers/insurance/policy/loss-payee-financial-details-uk/save-and-
       beforeEach(() => {
         req.body = validBody;
         res.locals = mockRes().locals;
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.lossPayeeFinancialDetailsUk = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/policy/loss-payee/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/loss-payee/index.test.ts
@@ -10,7 +10,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from '../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../map-and-save/loss-payee';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   LOSS_PAYEE: { IS_APPOINTED },
@@ -282,7 +282,7 @@ describe('controllers/insurance/policy/loss-payee', () => {
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const mapAndSaveSpy = mockSpyPromiseRejection;
 
             mapAndSave.lossPayee = mapAndSaveSpy;
           });

--- a/src/ui/server/controllers/insurance/policy/loss-payee/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/loss-payee/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../../../../../shared-validation/yes-no-radios-form';
 import mapAndSave from '../../map-and-save/loss-payee';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockApplication } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   LOSS_PAYEE: { IS_APPOINTED },
@@ -116,7 +116,7 @@ describe('controllers/insurance/policy/loss-payee/save-and-back', () => {
       beforeEach(() => {
         req.body = validBody;
         res.locals = mockRes().locals;
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.lossPayee = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/policy/map-and-save/broker/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/policy/map-and-save/broker/index.api-error.test.ts
@@ -1,6 +1,6 @@
 import mapAndSave from '.';
 import save from '../../save-data/broker';
-import { mockApplication, mockBroker, mockSpyPromise } from '../../../../../test-mocks';
+import { mockApplication, mockBroker, mockSpyPromise, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/policy/map-and-save/broker - API error', () => {
   jest.mock('../../save-data/broker');
@@ -27,7 +27,7 @@ describe('controllers/insurance/policy/map-and-save/broker - API error', () => {
 
   describe('when save application broker call fails', () => {
     beforeEach(() => {
-      save.broker = jest.fn(() => Promise.reject(new Error('mock')));
+      save.broker = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/policy/map-and-save/loss-payee/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/policy/map-and-save/loss-payee/index.api-error.test.ts
@@ -3,7 +3,7 @@ import FIELD_IDS from '../../../../../constants/field-ids/insurance/policy';
 import saveLossPayee from '../../save-data/nominated-loss-payee';
 import saveUk from '../../save-data/loss-payee-financial-details-uk';
 import saveInternational from '../../save-data/loss-payee-financial-details-international';
-import { mockApplication, mockNominatedLossPayee } from '../../../../../test-mocks';
+import { mockApplication, mockNominatedLossPayee, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   LOSS_PAYEE: { IS_APPOINTED },
@@ -42,7 +42,7 @@ describe('controllers/insurance/policy/map-and-save/loss-payee - API error', () 
 
   describe('when saveLossPayee.nominatedLossPayee call fails', () => {
     beforeEach(() => {
-      saveLossPayee.nominatedLossPayee = jest.fn(() => Promise.reject(new Error('mock')));
+      saveLossPayee.nominatedLossPayee = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {
@@ -66,7 +66,7 @@ describe('controllers/insurance/policy/map-and-save/loss-payee - API error', () 
 
   describe('when saveUk.lossPayeeFinancialDetailsUk call fails', () => {
     beforeEach(() => {
-      saveUk.lossPayeeFinancialDetailsUk = jest.fn(() => Promise.reject(new Error('mock')));
+      saveUk.lossPayeeFinancialDetailsUk = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {
@@ -90,7 +90,7 @@ describe('controllers/insurance/policy/map-and-save/loss-payee - API error', () 
 
   describe('when saveInternational.lossPayeeFinancialDetailsInternational call fails', () => {
     beforeEach(() => {
-      saveInternational.lossPayeeFinancialDetailsInternational = jest.fn(() => Promise.reject(new Error('mock')));
+      saveInternational.lossPayeeFinancialDetailsInternational = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/policy/map-and-save/policy-contact/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/policy/map-and-save/policy-contact/index.api-error.test.ts
@@ -1,7 +1,7 @@
 import mapAndSave from '.';
 import POLICY_FIELD_IDS from '../../../../../constants/field-ids/insurance/policy';
 import save from '../../save-data/policy-contact';
-import { mockApplication, mockSpyPromise } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromise, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   NAME_ON_POLICY: { NAME, SAME_NAME },
@@ -32,7 +32,7 @@ describe('controllers/insurance/policy/map-and-save/policy-contact', () => {
 
   describe('when save application policy call fails', () => {
     beforeEach(() => {
-      save.policyContact = jest.fn(() => Promise.reject(new Error('mock')));
+      save.policyContact = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/policy/map-and-save/policy/index-api-errors.test.ts
+++ b/src/ui/server/controllers/insurance/policy/map-and-save/policy/index-api-errors.test.ts
@@ -1,6 +1,6 @@
 import mapAndSave from '.';
 import save from '../../save-data/policy';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/policy/map-and-save/policy - api errors', () => {
   jest.mock('../../save-data/policy');
@@ -24,7 +24,7 @@ describe('controllers/insurance/policy/map-and-save/policy - api errors', () => 
 
   describe('when save application policy call fails', () => {
     beforeEach(() => {
-      save.policy = jest.fn(() => Promise.reject(new Error('mock')));
+      save.policy = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.test.ts
@@ -13,7 +13,7 @@ import mapApplicationToFormFields from '../../../../../helpers/mappings/map-appl
 import generateValidationErrors from './validation';
 import mapAndSave from '../../map-and-save/policy';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockCurrencies, mockCurrenciesResponse, mockCurrenciesEmptyResponse } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockCurrencies, mockCurrenciesResponse, mockCurrenciesEmptyResponse, mockSpyPromiseRejection } from '../../../../../test-mocks';
 import { mockApplicationMultiplePolicy as mockApplication } from '../../../../../test-mocks/mock-application';
 
 const {
@@ -155,7 +155,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
     describe('api error handling', () => {
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -293,7 +293,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
       describe('get currencies call', () => {
         describe('when the get currencies API call fails', () => {
           beforeEach(() => {
-            getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            getCurrenciesSpy = mockSpyPromiseRejection;
             api.keystone.APIM.getCurrencies = getCurrenciesSpy;
           });
 
@@ -339,7 +339,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const mapAndSaveSpy = mockSpyPromiseRejection;
 
             mapAndSave.policy = mapAndSaveSpy;
           });

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../../helpers/construct-payload';
 import mapAndSave from '../../../map-and-save/policy';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../../types';
-import { referenceNumber, mockReq, mockRes } from '../../../../../../test-mocks';
+import { referenceNumber, mockReq, mockRes, mockSpyPromiseRejection } from '../../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -91,7 +91,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value/sav
 
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mockMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        mockMapAndSave = mockSpyPromiseRejection;
         mapAndSave.policy = mockMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.test.ts
@@ -13,7 +13,7 @@ import mapApplicationToFormFields from '../../../../helpers/mappings/map-applica
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/policy';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockCurrenciesResponse, mockCurrenciesEmptyResponse } from '../../../../test-mocks';
+import { mockReq, mockRes, mockCurrenciesResponse, mockCurrenciesEmptyResponse, mockSpyPromiseRejection } from '../../../../test-mocks';
 import {
   mockApplicationMultiplePolicy as mockApplication,
   mockApplicationMultiplePolicyWithoutCurrencyCode,
@@ -194,7 +194,7 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
     describe('api error handling', () => {
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -394,7 +394,7 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
       describe('get currencies call', () => {
         describe('when the get currencies API call fails', () => {
           beforeEach(() => {
-            getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            getCurrenciesSpy = mockSpyPromiseRejection;
             api.keystone.APIM.getCurrencies = getCurrenciesSpy;
           });
 
@@ -440,7 +440,7 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const mapAndSaveSpy = mockSpyPromiseRejection;
 
             mapAndSave.policy = mapAndSaveSpy;
           });

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/policy';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { referenceNumber, mockReq, mockRes } from '../../../../../test-mocks';
+import { referenceNumber, mockReq, mockRes, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -91,7 +91,7 @@ describe('controllers/insurance/policy/multiple-contract-policy/save-and-back', 
 
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mockMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        mockMapAndSave = mockSpyPromiseRejection;
         mapAndSave.policy = mockMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/policy/name-on-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/name-on-policy/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/policy-contact';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { referenceNumber, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockSpyPromiseRejection, referenceNumber } from '../../../../../test-mocks';
 
 const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE },
@@ -98,7 +98,7 @@ describe('controllers/insurance/policy/name-on-policy/save-and-back', () => {
 
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mockMapAndSave = jest.fn(() => Promise.reject(new Error('Mock error')));
+        mockMapAndSave = mockSpyPromiseRejection;
 
         mapAndSave.policyContact = mockMapAndSave;
       });

--- a/src/ui/server/controllers/insurance/policy/other-company-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/index.test.ts
@@ -13,7 +13,7 @@ import { sanitiseData } from '../../../../helpers/sanitise-data';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/jointly-insured-party';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockCountries } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockCountries, mockSpyPromiseRejection } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -137,7 +137,7 @@ describe('controllers/insurance/policy/other-company-details', () => {
     describe('api error handling', () => {
       describe('when the get countries API call fails', () => {
         beforeEach(() => {
-          getCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCountriesSpy = mockSpyPromiseRejection;
           api.keystone.countries.getAll = getCountriesSpy;
         });
 
@@ -279,7 +279,7 @@ describe('controllers/insurance/policy/other-company-details', () => {
     describe('api error handling', () => {
       describe('when the get countries API call fails', () => {
         beforeEach(() => {
-          getCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCountriesSpy = mockSpyPromiseRejection;
           api.keystone.countries.getAll = getCountriesSpy;
         });
 
@@ -324,7 +324,7 @@ describe('controllers/insurance/policy/other-company-details', () => {
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const mapAndSaveSpy = mockSpyPromiseRejection;
 
             mapAndSave.jointlyInsuredParty = mapAndSaveSpy;
           });

--- a/src/ui/server/controllers/insurance/policy/other-company-details/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/save-and-back/index.test.ts
@@ -4,7 +4,7 @@ import { ROUTES } from '../../../../../constants/routes';
 import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/jointly-insured-party';
 import generateValidationErrors from '../validation';
-import { mockReq, mockRes, mockApplication } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 import { Request, Response } from '../../../../../../types';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
@@ -17,7 +17,7 @@ describe('controllers/insurance/policy/other-company-details/save-and-back', () 
 
   const updateMapAndSaveSuccess = jest.fn(() => Promise.resolve(true));
   const updateMapAndSaveFalse = jest.fn(() => Promise.resolve(false));
-  const updateMapAndSaveError = jest.fn(() => Promise.reject(new Error('mock')));
+  const updateMapAndSaveError = mockSpyPromiseRejection;
 
   beforeEach(() => {
     req = mockReq();

--- a/src/ui/server/controllers/insurance/policy/pre-credit-period/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/pre-credit-period/index.test.ts
@@ -12,7 +12,7 @@ import { sanitiseData } from '../../../../helpers/sanitise-data';
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/policy';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -261,7 +261,7 @@ describe('controllers/insurance/policy/pre-credit-period', () => {
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const mapAndSaveSpy = mockSpyPromiseRejection;
 
             mapAndSave.policy = mapAndSaveSpy;
           });

--- a/src/ui/server/controllers/insurance/policy/pre-credit-period/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/pre-credit-period/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/policy';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { referenceNumber, mockReq, mockRes } from '../../../../../test-mocks';
+import { referenceNumber, mockReq, mockRes, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -91,7 +91,7 @@ describe('controllers/insurance/policy/pre-credit-period/save-and-back', () => {
 
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mockMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        mockMapAndSave = mockSpyPromiseRejection;
         mapAndSave.policy = mockMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/policy/save-data/broker/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/broker/index.api-error.test.ts
@@ -1,12 +1,12 @@
 import save from '.';
 import api from '../../../../../api';
-import { mockApplication, mockBroker } from '../../../../../test-mocks';
+import { mockApplication, mockBroker, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/policy/save-data/broker - API error', () => {
   const mockFormBody = mockBroker;
 
   beforeEach(() => {
-    const updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+    const updateApplicationSpy = mockSpyPromiseRejection;
     api.keystone.application.update.broker = updateApplicationSpy;
   });
 

--- a/src/ui/server/controllers/insurance/policy/save-data/jointly-insured-party/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/jointly-insured-party/index.api-error.test.ts
@@ -1,12 +1,12 @@
 import save from '.';
 import api from '../../../../../api';
-import { mockApplication, mockJointlyInsuredParty } from '../../../../../test-mocks';
+import { mockApplication, mockJointlyInsuredParty, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/policy/save-data/jointly-insured-policy - API error', () => {
   const mockFormBody = mockJointlyInsuredParty;
 
   beforeEach(() => {
-    const updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+    const updateApplicationSpy = mockSpyPromiseRejection;
     api.keystone.application.update.jointlyInsuredParty = updateApplicationSpy;
   });
 

--- a/src/ui/server/controllers/insurance/policy/save-data/loss-payee-financial-details-international/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/loss-payee-financial-details-international/index.api-error.test.ts
@@ -1,6 +1,6 @@
 import save from '.';
 import api from '../../../../../api';
-import { mockApplication, mockLossPayeeFinancialDetailsInternational } from '../../../../../test-mocks';
+import { mockApplication, mockLossPayeeFinancialDetailsInternational, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/policy/save-data/loss-payee-financial-details-international - API error', () => {
   const mockUpdateApplicationResponse = mockApplication;
@@ -13,7 +13,7 @@ describe('controllers/insurance/policy/save-data/loss-payee-financial-details-in
 
   describe('when there is an error', () => {
     beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.updateLossPayeeFinancialDetailsInternational = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/policy/save-data/loss-payee-financial-details-uk/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/loss-payee-financial-details-uk/index.api-error.test.ts
@@ -1,6 +1,6 @@
 import save from '.';
 import api from '../../../../../api';
-import { mockApplication, mockLossPayeeFinancialDetailsUk } from '../../../../../test-mocks';
+import { mockApplication, mockLossPayeeFinancialDetailsUk, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/policy/save-data/loss-payee-financial-details-uk - API error', () => {
   const mockUpdateApplicationResponse = mockApplication;
@@ -13,7 +13,7 @@ describe('controllers/insurance/policy/save-data/loss-payee-financial-details-uk
 
   describe('when there is an error', () => {
     beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.lossPayeeFinancialDetailsUk = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/policy/save-data/nominated-loss-payee/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/nominated-loss-payee/index.api-error.test.ts
@@ -1,12 +1,12 @@
 import save from '.';
 import api from '../../../../../api';
-import { mockApplication, mockNominatedLossPayee } from '../../../../../test-mocks';
+import { mockApplication, mockNominatedLossPayee, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/policy/save-data/nominated-loss-payee - API error', () => {
   const mockFormBody = mockNominatedLossPayee;
 
   beforeEach(() => {
-    const updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+    const updateApplicationSpy = mockSpyPromiseRejection;
     api.keystone.application.update.nominatedLossPayee = updateApplicationSpy;
   });
 

--- a/src/ui/server/controllers/insurance/policy/save-data/policy-contact/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/policy-contact/index.test.ts
@@ -3,7 +3,7 @@ import api from '../../../../../api';
 import generateValidationErrors from '../../name-on-policy/validation';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import POLICY_FIELD_IDS from '../../../../../constants/field-ids/insurance/policy';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   NAME_ON_POLICY: { POSITION, IS_SAME_AS_OWNER },
@@ -66,7 +66,7 @@ describe('controllers/insurance/policy/save-data/policy-contact', () => {
 
   describe('when there is an error calling the API', () => {
     beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.policyContact = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/policy/save-data/policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/policy/index.test.ts
@@ -1,11 +1,11 @@
 import save from '.';
 import api from '../../../../../api';
+import { FIELD_VALUES } from '../../../../../constants';
+import POLICY_FIELD_IDS from '../../../../../constants/field-ids/insurance/policy';
 import getDataToSave from '../../../../../helpers/get-data-to-save';
 import generateValidationErrors from '../../type-of-policy/validation';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
-import { FIELD_VALUES } from '../../../../../constants';
-import { mockApplication } from '../../../../../test-mocks';
-import POLICY_FIELD_IDS from '../../../../../constants/field-ids/insurance/policy';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { POLICY_TYPE } = POLICY_FIELD_IDS;
 
@@ -69,7 +69,7 @@ describe('controllers/insurance/policy/save-data/policy', () => {
 
   describe('when there is an error calling the API', () => {
     beforeEach(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.policy = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/index.test.ts
@@ -13,7 +13,7 @@ import mapApplicationToFormFields from '../../../../helpers/mappings/map-applica
 import generateValidationErrors from './validation';
 import mapAndSave from '../map-and-save/policy';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockCurrencies, mockCurrenciesResponse, mockCurrenciesEmptyResponse } from '../../../../test-mocks';
+import { mockReq, mockRes, mockCurrencies, mockCurrenciesResponse, mockCurrenciesEmptyResponse, mockSpyPromiseRejection } from '../../../../test-mocks';
 import mockApplication, { referenceNumber, mockApplicationSinglePolicyWithoutCurrencyCode } from '../../../../test-mocks/mock-application';
 
 const {
@@ -177,7 +177,7 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
     describe('api error handling', () => {
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -385,7 +385,7 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
       describe('get currencies call', () => {
         describe('when the get currencies API call fails', () => {
           beforeEach(() => {
-            getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            getCurrenciesSpy = mockSpyPromiseRejection;
             api.keystone.APIM.getCurrencies = getCurrenciesSpy;
           });
 
@@ -431,7 +431,7 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const savePolicyDataSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const savePolicyDataSpy = mockSpyPromiseRejection;
 
             mapAndSave.policy = savePolicyDataSpy;
           });

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import mapAndSave from '../../map-and-save/policy';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { referenceNumber, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockSpyPromiseRejection, referenceNumber } from '../../../../../test-mocks';
 
 const {
   INSURANCE: { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE },
@@ -93,7 +93,7 @@ describe('controllers/insurance/policy/single-contract-policy/save-and-back', ()
 
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mockMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        mockMapAndSave = mockSpyPromiseRejection;
         mapAndSave.policy = mockMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
@@ -13,7 +13,7 @@ import mapApplicationToFormFields from '../../../../../helpers/mappings/map-appl
 import generateValidationErrors from './validation';
 import mapAndSave from '../../map-and-save/policy';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockCurrencies, mockCurrenciesResponse, mockCurrenciesEmptyResponse } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockCurrencies, mockCurrenciesResponse, mockCurrenciesEmptyResponse, mockSpyPromiseRejection } from '../../../../../test-mocks';
 import { mockApplicationMultiplePolicy as mockApplication } from '../../../../../test-mocks/mock-application';
 
 const {
@@ -147,7 +147,7 @@ describe('controllers/insurance/policy/single-contract-policy/total-contract-val
     describe('api error handling', () => {
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -284,7 +284,7 @@ describe('controllers/insurance/policy/single-contract-policy/total-contract-val
       describe('get currencies call', () => {
         describe('when the get currencies API call fails', () => {
           beforeEach(() => {
-            getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            getCurrenciesSpy = mockSpyPromiseRejection;
             api.keystone.APIM.getCurrencies = getCurrenciesSpy;
           });
 
@@ -330,7 +330,7 @@ describe('controllers/insurance/policy/single-contract-policy/total-contract-val
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const mapAndSaveSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const mapAndSaveSpy = mockSpyPromiseRejection;
 
             mapAndSave.policy = mapAndSaveSpy;
           });

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../../helpers/construct-payload';
 import mapAndSave from '../../../map-and-save/policy';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../../types';
-import { referenceNumber, mockReq, mockRes } from '../../../../../../test-mocks';
+import { mockReq, mockRes, mockSpyPromiseRejection, referenceNumber } from '../../../../../../test-mocks';
 
 const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
 
@@ -91,7 +91,7 @@ describe('controllers/insurance/policy/single-contract-policy/total-contract-val
 
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mockMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        mockMapAndSave = mockSpyPromiseRejection;
         mapAndSave.policy = mockMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/policy/type-of-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/type-of-policy/index.test.ts
@@ -11,7 +11,7 @@ import generateValidationErrors from './validation';
 import constructPayload from '../../../../helpers/construct-payload';
 import mapAndSave from '../map-and-save/policy';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -291,7 +291,7 @@ describe('controllers/insurance/policy/type-of-policy', () => {
 
         describe('when there is an error', () => {
           beforeEach(() => {
-            const savePolicyDataSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            const savePolicyDataSpy = mockSpyPromiseRejection;
 
             mapAndSave.policy = savePolicyDataSpy;
           });

--- a/src/ui/server/controllers/insurance/policy/type-of-policy/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/type-of-policy/save-and-back/index.test.ts
@@ -5,7 +5,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save/policy';
 import { Request, Response } from '../../../../../../types';
-import { referenceNumber, mockReq, mockRes } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockSpyPromiseRejection, referenceNumber } from '../../../../../test-mocks';
 
 const {
   INSURANCE: { INSURANCE_ROOT, PROBLEM_WITH_SERVICE },
@@ -93,7 +93,7 @@ describe('controllers/insurance/policy/type-of-policy/save-and-back', () => {
 
     describe('when the mapAndSave call fails', () => {
       beforeEach(() => {
-        mockMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        mockMapAndSave = mockSpyPromiseRejection;
         mapAndSave.policy = mockMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/your-buyer/alternative-currency/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/alternative-currency/index.test.ts
@@ -20,6 +20,7 @@ import {
   mockCurrenciesResponse,
   mockCurrenciesEmptyResponse,
   mockBuyerTradingHistory,
+  mockSpyPromiseRejection,
   referenceNumber,
 } from '../../../../test-mocks';
 import mapAndSave from '../map-and-save/buyer-trading-history';
@@ -130,7 +131,7 @@ describe('controllers/insurance/your-buyer/alternative-currency', () => {
     describe('api error handling', () => {
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -258,7 +259,7 @@ describe('controllers/insurance/your-buyer/alternative-currency', () => {
       describe('get currencies call', () => {
         describe('when the get currencies API call fails', () => {
           beforeEach(() => {
-            getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+            getCurrenciesSpy = mockSpyPromiseRejection;
             api.keystone.APIM.getCurrencies = getCurrenciesSpy;
           });
 
@@ -302,7 +303,7 @@ describe('controllers/insurance/your-buyer/alternative-currency', () => {
         beforeEach(() => {
           req.body = validBody;
           res.locals = mockRes().locals;
-          mapAndSave.buyerTradingHistory = jest.fn(() => Promise.reject(new Error('mock')));
+          mapAndSave.buyerTradingHistory = mockSpyPromiseRejection;
           getCurrenciesSpy = jest.fn(() => Promise.resolve(mockCurrenciesResponse));
         });
 

--- a/src/ui/server/controllers/insurance/your-buyer/buyer-financial-information/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/buyer-financial-information/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import BUYER_FIELD_IDS from '../../../../../constants/field-ids/insurance/your-b
 import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { HAS_BUYER_FINANCIAL_ACCOUNTS } = BUYER_FIELD_IDS;
 
@@ -114,7 +114,7 @@ describe('controllers/insurance/your-buyer/buyer-financial-information/save-and-
         req.body = validBody;
 
         res.locals = mockRes().locals;
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.buyerRelationship = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/index.test.ts
@@ -10,7 +10,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import mapAndSave from '../map-and-save/buyer';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockBuyer, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockBuyer, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const { COMPANY_OR_ORGANISATION } = BUYER_FIELD_IDS;
 
@@ -236,7 +236,7 @@ describe('controllers/insurance/your-buyer/company-or-organisation', () => {
         beforeEach(() => {
           req.body = validBody;
           res.locals = mockRes().locals;
-          mapAndSave.yourBuyer = jest.fn(() => Promise.reject(new Error('mock')));
+          mapAndSave.yourBuyer = mockSpyPromiseRejection;
         });
 
         it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {

--- a/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import INSURANCE_FIELD_IDS from '../../../../../constants/field-ids/insurance';
 import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockBuyer } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockBuyer, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const {
   COMPANY_OR_ORGANISATION: { NAME },
@@ -114,7 +114,7 @@ describe('controllers/insurance/your-buyer/company-or-organisation/save-and-back
     describe('when mapAndSave.yourBuyer fails', () => {
       beforeEach(() => {
         res.locals = mockRes().locals;
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.yourBuyer = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/your-buyer/connection-with-buyer/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/connection-with-buyer/index.test.ts
@@ -9,10 +9,10 @@ import getUserNameFromSession from '../../../../helpers/get-user-name-from-sessi
 import generateValidationErrors from './validation';
 import constructPayload from '../../../../helpers/construct-payload';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
-import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, mockBuyer, referenceNumber } from '../../../../test-mocks';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import mapAndSave from '../map-and-save/buyer-relationship';
+import { Request, Response } from '../../../../../types';
+import { mockReq, mockRes, mockApplication, mockBuyer, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -255,7 +255,7 @@ describe('controllers/insurance/your-buyer/connection-with-buyer', () => {
         beforeEach(() => {
           req.body = validBody;
           res.locals = mockRes().locals;
-          mapAndSave.buyerRelationship = jest.fn(() => Promise.reject(new Error('mock')));
+          mapAndSave.buyerRelationship = mockSpyPromiseRejection;
         });
 
         it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {

--- a/src/ui/server/controllers/insurance/your-buyer/connection-with-buyer/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/connection-with-buyer/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import INSURANCE_FIELD_IDS from '../../../../../constants/field-ids/insurance';
 import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockBuyer } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockBuyer, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { CONNECTION_WITH_BUYER, CONNECTION_WITH_BUYER_DESCRIPTION } = INSURANCE_FIELD_IDS.YOUR_BUYER;
 
@@ -117,7 +117,7 @@ describe('controllers/insurance/your-buyer/connection-with-buyer/save-and-back',
         req.body = validBody;
 
         res.locals = mockRes().locals;
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.buyerRelationship = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/your-buyer/credit-insurance-cover/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/credit-insurance-cover/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import BUYER_FIELD_IDS from '../../../../../constants/field-ids/insurance/your-b
 import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../validation';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER, PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER } = BUYER_FIELD_IDS;
 
@@ -115,7 +115,7 @@ describe('controllers/insurance/your-buyer/credit-insurance-information/save-and
         req.body = validBody;
 
         res.locals = mockRes().locals;
-        updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+        updateMapAndSave = mockSpyPromiseRejection;
         mapAndSave.buyerRelationship = updateMapAndSave;
       });
 

--- a/src/ui/server/controllers/insurance/your-buyer/map-and-save/buyer-relationship/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/map-and-save/buyer-relationship/index.api-error.test.ts
@@ -1,6 +1,6 @@
 import mapAndSave from '.';
 import save from '../../save-data/buyer-relationship';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/business/map-and-save/buyer-relationship - api errors', () => {
   jest.mock('../../save-data/buyer-relationship');
@@ -24,7 +24,7 @@ describe('controllers/insurance/business/map-and-save/buyer-relationship - api e
 
   describe('when save application buyerRelationship call fails', () => {
     beforeEach(() => {
-      save.buyerRelationship = jest.fn(() => Promise.reject(new Error('mock')));
+      save.buyerRelationship = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/your-buyer/map-and-save/buyer-trading-history/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/map-and-save/buyer-trading-history/index.api-error.test.ts
@@ -1,6 +1,6 @@
 import mapAndSave from '.';
 import save from '../../save-data/buyer-trading-history';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/business/map-and-save/buyer-trading-history - api errors', () => {
   jest.mock('../../save-data/buyer-trading-history');
@@ -24,7 +24,7 @@ describe('controllers/insurance/business/map-and-save/buyer-trading-history - ap
 
   describe('when save application buyer call fails', () => {
     beforeEach(() => {
-      save.buyerTradingHistory = jest.fn(() => Promise.reject(new Error('mock')));
+      save.buyerTradingHistory = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/your-buyer/map-and-save/buyer/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/map-and-save/buyer/index.api-error.test.ts
@@ -1,6 +1,6 @@
 import mapAndSave from '.';
 import save from '../../save-data/buyer';
-import { mockApplication } from '../../../../../test-mocks';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 describe('controllers/insurance/business/map-and-save/buyer - api errors', () => {
   jest.mock('../../save-data/buyer');
@@ -24,7 +24,7 @@ describe('controllers/insurance/business/map-and-save/buyer - api errors', () =>
 
   describe('when save application buyer call fails', () => {
     beforeEach(() => {
-      save.buyer = jest.fn(() => Promise.reject(new Error('mock')));
+      save.buyer = mockSpyPromiseRejection;
     });
 
     it('should return false', async () => {

--- a/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-relationship/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-relationship/index.test.ts
@@ -1,11 +1,11 @@
 import save, { NULL_OR_EMPTY_STRING_FIELDS } from '.';
 import api from '../../../../../api';
+import YOUR_BUYER_FIELD_IDS from '../../../../../constants/field-ids/insurance/your-buyer';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import stripEmptyFormFields from '../../../../../helpers/strip-empty-form-fields';
 import getDataToSave from '../../../../../helpers/get-data-to-save';
-import { mockApplication, mockBuyerRelationship } from '../../../../../test-mocks';
 import generateValidationErrors from '../../../../../helpers/validation';
-import YOUR_BUYER_FIELD_IDS from '../../../../../constants/field-ids/insurance/your-buyer';
+import { mockApplication, mockBuyerRelationship, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { CONNECTION_WITH_BUYER_DESCRIPTION, PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER } = YOUR_BUYER_FIELD_IDS;
 
@@ -67,7 +67,7 @@ describe('controllers/insurance/your-buyer/save-data/buyer-relationship', () => 
 
   describe('when there is an error calling the API', () => {
     beforeAll(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.buyerRelationship = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-trading-history/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-trading-history/index.test.ts
@@ -1,12 +1,12 @@
 import save, { NULL_OR_EMPTY_STRING_FIELDS } from '.';
 import api from '../../../../../api';
 import INSURANCE_FIELD_IDS from '../../../../../constants/field-ids/insurance';
+import YOUR_BUYER_FIELD_IDS from '../../../../../constants/field-ids/insurance/your-buyer';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import stripEmptyFormFields from '../../../../../helpers/strip-empty-form-fields';
 import getDataToSave from '../../../../../helpers/get-data-to-save';
-import { mockApplication, mockBuyerTradingHistory } from '../../../../../test-mocks';
 import generateValidationErrors from '../../../../../helpers/validation';
-import YOUR_BUYER_FIELD_IDS from '../../../../../constants/field-ids/insurance/your-buyer';
+import { mockApplication, mockBuyerTradingHistory, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { TOTAL_OUTSTANDING_PAYMENTS, TOTAL_AMOUNT_OVERDUE, FAILED_PAYMENTS, OUTSTANDING_PAYMENTS } = YOUR_BUYER_FIELD_IDS;
 
@@ -72,7 +72,7 @@ describe('controllers/insurance/your-buyer/save-data/buyer-trading-history', () 
 
   describe('when there is an error calling the API', () => {
     beforeAll(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.buyerTradingHistory = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/your-buyer/save-data/buyer/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/save-data/buyer/index.test.ts
@@ -3,7 +3,7 @@ import api from '../../../../../api';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import getDataToSave from '../../../../../helpers/get-data-to-save';
 import { FIELD_IDS } from '../../../../../constants';
-import { mockApplication, mockBuyer } from '../../../../../test-mocks';
+import { mockApplication, mockBuyer, mockSpyPromiseRejection } from '../../../../../test-mocks';
 import generateValidationErrors from '../../../../../helpers/validation';
 
 const {
@@ -62,7 +62,7 @@ describe('controllers/insurance/your-buyer/save-data/buyer', () => {
 
   describe('when there is an error calling the API', () => {
     beforeAll(() => {
-      updateApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      updateApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.update.buyer = updateApplicationSpy;
     });
 

--- a/src/ui/server/controllers/insurance/your-buyer/traded-with-buyer/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/traded-with-buyer/index.test.ts
@@ -9,7 +9,7 @@ import constructPayload from '../../../../helpers/construct-payload';
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import mapAndSave from '../map-and-save/buyer-trading-history';
 import { Request, Response } from '../../../../../types';
-import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
 
 const {
   INSURANCE_ROOT,
@@ -312,7 +312,7 @@ describe('controllers/insurance/your-buyer/traded-with-buyer', () => {
         beforeEach(() => {
           req.body = validBody;
           res.locals = mockRes().locals;
-          mapAndSave.buyerTradingHistory = jest.fn(() => Promise.reject(new Error('mock')));
+          mapAndSave.buyerTradingHistory = mockSpyPromiseRejection;
         });
 
         it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {

--- a/src/ui/server/controllers/insurance/your-buyer/traded-with-buyer/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/traded-with-buyer/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save/buyer-trading-history';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes, mockBuyer } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockBuyer, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { CONNECTION_WITH_BUYER, TRADED_WITH_BUYER } = INSURANCE_FIELD_IDS.YOUR_BUYER;
 
@@ -113,7 +113,7 @@ describe('controllers/insurance/your-buyer/working-with-buyer/save-and-back', ()
   describe('when mapAndSave.yourBuyer fails', () => {
     beforeEach(() => {
       res.locals = mockRes().locals;
-      updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+      updateMapAndSave = mockSpyPromiseRejection;
       mapAndSave.buyerTradingHistory = updateMapAndSave;
     });
 

--- a/src/ui/server/controllers/insurance/your-buyer/trading-history/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/trading-history/index.test.ts
@@ -22,6 +22,7 @@ import {
   mockApplicationTotalContractValueThresholdFalse,
   mockCurrencies,
   mockCurrenciesResponse,
+  mockSpyPromiseRejection,
   referenceNumber,
 } from '../../../../test-mocks';
 
@@ -359,7 +360,7 @@ describe('controllers/insurance/your-buyer/trading-history', () => {
         beforeEach(() => {
           req.body = validBody;
           res.locals = mockRes().locals;
-          mapAndSave.buyerTradingHistory = jest.fn(() => Promise.reject(new Error('mock')));
+          mapAndSave.buyerTradingHistory = mockSpyPromiseRejection;
         });
 
         it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {

--- a/src/ui/server/controllers/insurance/your-buyer/trading-history/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/trading-history/save-and-back/index.test.ts
@@ -6,7 +6,7 @@ import constructPayload from '../../../../../helpers/construct-payload';
 import generateValidationErrors from '../validation';
 import mapAndSave from '../../map-and-save/buyer-trading-history';
 import { Request, Response } from '../../../../../../types';
-import { mockReq, mockRes } from '../../../../../test-mocks';
+import { mockReq, mockRes, mockSpyPromiseRejection } from '../../../../../test-mocks';
 
 const { OUTSTANDING_PAYMENTS, FAILED_PAYMENTS, TOTAL_AMOUNT_OVERDUE } = INSURANCE_FIELD_IDS.YOUR_BUYER;
 
@@ -112,7 +112,7 @@ describe('controllers/insurance/your-buyer/trading-history/save-and-back', () =>
   describe('when mapAndSave.buyerTradingHistory fails', () => {
     beforeEach(() => {
       res.locals = mockRes().locals;
-      updateMapAndSave = jest.fn(() => Promise.reject(new Error('mock')));
+      updateMapAndSave = mockSpyPromiseRejection;
       mapAndSave.buyerTradingHistory = updateMapAndSave;
     });
 

--- a/src/ui/server/controllers/quote/buyer-country/index.test.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.test.ts
@@ -11,7 +11,7 @@ import mapSubmittedEligibilityCountry from '../../../helpers/mappings/map-submit
 import api from '../../../api';
 import mapCountries from '../../../helpers/mappings/map-countries';
 import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
-import { mockReq, mockRes, mockCountries } from '../../../test-mocks';
+import { mockReq, mockRes, mockCountries, mockSpyPromiseRejection } from '../../../test-mocks';
 import { Request, Response } from '../../../../types';
 
 describe('controllers/quote/buyer-country', () => {
@@ -171,7 +171,7 @@ describe('controllers/quote/buyer-country', () => {
     describe('api error handling', () => {
       describe('when the get CIS countries API call fails', () => {
         beforeEach(() => {
-          getCisCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCisCountriesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCisCountries = getCisCountriesSpy;
         });
 
@@ -372,7 +372,7 @@ describe('controllers/quote/buyer-country', () => {
     describe('api error handling', () => {
       describe('when the get CIS countries API call fails', () => {
         beforeEach(() => {
-          getCisCountriesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCisCountriesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCisCountries = getCisCountriesSpy;
         });
 

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
@@ -12,7 +12,16 @@ import mapPercentageOfCover from '../../../helpers/mappings/map-percentage-of-co
 import mapCreditPeriod from '../../../helpers/mappings/map-credit-period';
 import { updateSubmittedData } from '../../../helpers/update-submitted-data/quote';
 import { isSinglePolicyType, isMultiplePolicyType } from '../../../helpers/policy-type';
-import { mockReq, mockRes, mockAnswers, mockCurrencies, mockCurrenciesResponse, mockCurrenciesEmptyResponse, mockSession } from '../../../test-mocks';
+import {
+  mockReq,
+  mockRes,
+  mockAnswers,
+  mockCurrencies,
+  mockCurrenciesResponse,
+  mockCurrenciesEmptyResponse,
+  mockSession,
+  mockSpyPromiseRejection,
+} from '../../../test-mocks';
 import { Request, Response, SelectOption } from '../../../../types';
 
 const {
@@ -331,7 +340,7 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
     describe('api error handling', () => {
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 
@@ -587,7 +596,7 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
     describe('api error handling', () => {
       describe('when the get currencies API call fails', () => {
         beforeEach(() => {
-          getCurrenciesSpy = jest.fn(() => Promise.reject(new Error('mock')));
+          getCurrenciesSpy = mockSpyPromiseRejection;
           api.keystone.APIM.getCurrencies = getCurrenciesSpy;
         });
 

--- a/src/ui/server/helpers/create-an-application/index.test.ts
+++ b/src/ui/server/helpers/create-an-application/index.test.ts
@@ -2,7 +2,7 @@ import application from '.';
 import { sanitiseData } from '../sanitise-data';
 import mapEligibilityAnswers from '../map-eligibility-answers';
 import api from '../../api';
-import { mockEligibility, mockAccount, mockCreateApplicationResponse } from '../../test-mocks';
+import { mockEligibility, mockAccount, mockCreateApplicationResponse, mockSpyPromiseRejection } from '../../test-mocks';
 
 describe('helpers/create-an-application', () => {
   let createApplicationSpy = jest.fn(() => Promise.resolve(mockCreateApplicationResponse));
@@ -25,7 +25,7 @@ describe('helpers/create-an-application', () => {
 
   describe('when the create application API call fails', () => {
     beforeEach(() => {
-      createApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      createApplicationSpy = mockSpyPromiseRejection;
 
       api.keystone.application.create = createApplicationSpy;
     });

--- a/src/ui/server/helpers/get-application-by-reference-number/index.test.ts
+++ b/src/ui/server/helpers/get-application-by-reference-number/index.test.ts
@@ -1,7 +1,7 @@
 import getApplicationByReferenceNumber from '.';
 import getApplicationByReferenceNumberVariables from '../get-application-by-reference-number-variables';
 import api from '../../api';
-import { mockApplication, mockSpyPromise, referenceNumber } from '../../test-mocks';
+import { mockApplication, mockSpyPromise, mockSpyPromiseRejection, mockErrorMessage, referenceNumber } from '../../test-mocks';
 import LOSS_PAYEE_ROUTES from '../../constants/routes/insurance/policy/loss-payee';
 
 const { LOSS_PAYEE_FINANCIAL_DETAILS_UK_ROOT } = LOSS_PAYEE_ROUTES;
@@ -45,8 +45,7 @@ describe('helpers/get-application-by-reference-number', () => {
 
   describe('when the api call fails', () => {
     it('should return false', async () => {
-      const mockErrorMessage = 'Mock error';
-      getApplicationSpy = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+      getApplicationSpy = mockSpyPromiseRejection;
       api.keystone.application.getByReferenceNumber = getApplicationSpy;
 
       await expect(getApplicationByReferenceNumber(variables)).rejects.toThrow(

--- a/src/ui/server/middleware/insurance/get-application-by-reference-number/index.test.ts
+++ b/src/ui/server/middleware/insurance/get-application-by-reference-number/index.test.ts
@@ -1,7 +1,7 @@
 import getApplicationByReferenceNumberMiddleware, { RELEVANT_ROUTES } from '.';
 import { INSURANCE_ROUTES } from '../../../constants/routes/insurance';
 import api from '../../../api';
-import { mockReq, mockRes, mockApplication, referenceNumber } from '../../../test-mocks';
+import { mockReq, mockRes, mockApplication, mockSpyPromiseRejection, referenceNumber } from '../../../test-mocks';
 import { Next, Request, Response } from '../../../../types';
 
 const {
@@ -110,7 +110,7 @@ describe('middleware/insurance/get-application-by-reference-number', () => {
     });
 
     describe('when the API call fails', () => {
-      const getApplicationSpy = jest.fn(() => Promise.reject(new Error('mock')));
+      const getApplicationSpy = mockSpyPromiseRejection;
 
       beforeEach(() => {
         api.keystone.application.getByReferenceNumber = getApplicationSpy;

--- a/src/ui/server/test-mocks/index.ts
+++ b/src/ui/server/test-mocks/index.ts
@@ -119,6 +119,10 @@ const mockRes = () => {
 
 const mockSpyPromise = () => jest.fn().mockResolvedValue({});
 
+const mockErrorMessage = 'Mock error';
+
+const mockSpyPromiseRejection = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
+
 export {
   EUR,
   HKD,
@@ -159,6 +163,7 @@ export {
   mockCurrenciesEmptyResponse,
   mockCompanyDifferentTradingAddress,
   mockEligibility,
+  mockErrorMessage,
   mockErrorMessagesObject,
   mockErrors,
   mockExportContractAgentService,
@@ -178,6 +183,7 @@ export {
   mockReq,
   mockRes,
   mockSpyPromise,
+  mockSpyPromiseRejection,
   mockValidEmail,
   referenceNumber,
 };

--- a/src/ui/server/test-mocks/index.ts
+++ b/src/ui/server/test-mocks/index.ts
@@ -117,9 +117,9 @@ const mockRes = () => {
   return res;
 };
 
-const mockSpyPromise = () => jest.fn().mockResolvedValue({});
-
 const mockErrorMessage = 'Mock error';
+
+const mockSpyPromise = () => jest.fn().mockResolvedValue({});
 
 const mockSpyPromiseRejection = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the API and UI unit tests to use a DRY mock promise rejection function.

Now, instead of having this in individual unit tests: 

```ts
someSpy = jest.fn(() => Promise.reject(new Error(mockErrorMessage)));
```

We can now just import a mock and do:

```ts
someSpy = mockSpyPromiseRejection;
```

## Resolution :heavy_check_mark:
- Create new `mockSpyPromiseRejection` test mocks.
- Update all unit tests.
- Change the ordering of some unit test imports.
