### PR TITLE
chore(EMS-3789): dry cypress commands - task link clicks

### DIFF
--- a/e2e-tests/commands/insurance/check-your-answers/complete-and-submit-check-your-answers.js
+++ b/e2e-tests/commands/insurance/check-your-answers/complete-and-submit-check-your-answers.js
@@ -1,9 +1,3 @@
-import partials from '../../../partials';
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 /**
  * completeAndSubmitCheckYourAnswers
  * Complete and submit all "Application - Check your answers" forms:
@@ -13,7 +7,7 @@ const task = taskList.submitApplication.tasks.checkAnswers;
  * 4) Export contract
  */
 const completeAndSubmitCheckYourAnswers = () => {
-  task.link().click();
+  cy.clickTaskCheckAnswers();
 
   cy.completeAndSubmitMultipleCheckYourAnswers({ count: 4 });
 };

--- a/e2e-tests/commands/insurance/complete-declarations.js
+++ b/e2e-tests/commands/insurance/complete-declarations.js
@@ -1,9 +1,4 @@
-import partials from '../../partials';
 import { FIELD_VALUES } from '../../constants';
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.declarationsAndSubmit;
 
 /**
  * completeDeclarations
@@ -12,7 +7,7 @@ const task = taskList.submitApplication.tasks.declarationsAndSubmit;
  * - exportingWithCodeOfConduct: Should submit "yes" in the "exporting with code of conduct" form. Defaults to "yes".
  */
 const completeDeclarations = ({ hasAntiBriberyCodeOfConduct = true, exportingWithCodeOfConduct = true }) => {
-  task.link().click();
+  cy.clickTaskDeclarationsAndSubmit();
 
   cy.completeAndSubmitDeclarationConfidentiality();
 

--- a/e2e-tests/commands/insurance/declarations/complete-and-submit-declarations-forms.js
+++ b/e2e-tests/commands/insurance/declarations/complete-and-submit-declarations-forms.js
@@ -1,7 +1,3 @@
-import partials from '../../../partials';
-
-const { taskList } = partials.insurancePartials;
-
 /**
  * completeAndDeclarationsForms
  * completes declarations forms up to the specified form to stop at
@@ -15,7 +11,7 @@ const completeAndSubmitDeclarationsForms = ({ formToStopAt, referenceNumber }) =
   cy.completeAndSubmitCheckYourAnswers();
 
   // go to the page we want to test.
-  taskList.submitApplication.tasks.declarationsAndSubmit.link().click();
+  cy.clickTaskDeclarationsAndSubmit();
 
   const steps = [
     { name: 'confidentiality', action: () => cy.completeAndSubmitDeclarationConfidentiality() },

--- a/e2e-tests/commands/insurance/start-insurance-export-contract-section.js
+++ b/e2e-tests/commands/insurance/start-insurance-export-contract-section.js
@@ -1,9 +1,4 @@
-import partials from '../../partials';
 import { startNowLink } from '../../pages/shared';
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.prepareApplication.tasks.exportContract;
 
 /**
  * startInsuranceExportContractSection
@@ -14,7 +9,7 @@ const task = taskList.prepareApplication.tasks.exportContract;
  */
 const startInsuranceExportContractSection = ({ viaTaskList = true }) => {
   if (viaTaskList) {
-    task.link().click();
+    cy.clickTaskExportContract();
   }
 
   startNowLink().click();

--- a/e2e-tests/commands/insurance/start-insurance-policy-section.js
+++ b/e2e-tests/commands/insurance/start-insurance-policy-section.js
@@ -1,9 +1,4 @@
-import partials from '../../partials';
 import { startNowLink } from '../../pages/shared';
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.prepareApplication.tasks.policy;
 
 /**
  * startInsurancePolicySection
@@ -14,7 +9,7 @@ const task = taskList.prepareApplication.tasks.policy;
  */
 const startInsurancePolicySection = ({ viaTaskList = true }) => {
   if (viaTaskList) {
-    task.link().click();
+    cy.clickTaskPolicy();
   }
 
   startNowLink().click();

--- a/e2e-tests/commands/insurance/start-your-business-section.js
+++ b/e2e-tests/commands/insurance/start-your-business-section.js
@@ -1,9 +1,4 @@
-import partials from '../../partials';
 import { startNowLink } from '../../pages/shared';
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.prepareApplication.tasks.business;
 
 /**
  * startYourBusinessSection
@@ -14,7 +9,7 @@ const task = taskList.prepareApplication.tasks.business;
  */
 const startYourBusinessSection = ({ viaTaskList = true }) => {
   if (viaTaskList) {
-    task.link().click();
+    cy.clickTaskBusiness();
   }
 
   startNowLink().click();

--- a/e2e-tests/commands/insurance/start-your-buyer-section.js
+++ b/e2e-tests/commands/insurance/start-your-buyer-section.js
@@ -1,9 +1,4 @@
-import partials from '../../partials';
 import { startNowLink } from '../../pages/shared';
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.prepareApplication.tasks.buyer;
 
 /**
  * startInsuranceYourBuyerSection
@@ -14,7 +9,7 @@ const task = taskList.prepareApplication.tasks.buyer;
  */
 const startInsuranceYourBuyerSection = ({ viaTaskList = true }) => {
   if (viaTaskList) {
-    task.link().click();
+    cy.clickTaskBuyer();
   }
 
   startNowLink().click();

--- a/e2e-tests/commands/shared-commands/click-events/index.js
+++ b/e2e-tests/commands/shared-commands/click-events/index.js
@@ -19,6 +19,3 @@ Cypress.Commands.add('clickTaskCheckAnswers', require('./tasks/click-task-check-
 Cypress.Commands.add('clickTaskDeclarationsAndSubmit', require('./tasks/click-task-declarations-and-submit'));
 
 Cypress.Commands.add('rejectAnalyticsCookies', analytics.rejectAnalyticsCookies);
-
-// const task = taskList.submitApplication.tasks.checkAnswers;
-// cy.clickTaskCheckAnswers();

--- a/e2e-tests/commands/shared-commands/click-events/index.js
+++ b/e2e-tests/commands/shared-commands/click-events/index.js
@@ -11,4 +11,14 @@ Cypress.Commands.add('clickYesRadioInput', require('./click-yes-radio-input'));
 Cypress.Commands.add('clickProvideAlternativeCurrencyLink', require('./click-provide-alternative-currency-link'));
 Cypress.Commands.add('clickAlternativeCurrencyRadioOption', require('./click-alternative-currency-radio-option'));
 
+Cypress.Commands.add('clickTaskBusiness', require('./tasks/click-task-business'));
+Cypress.Commands.add('clickTaskBuyer', require('./tasks/click-task-buyer'));
+Cypress.Commands.add('clickTaskPolicy', require('./tasks/click-task-policy'));
+Cypress.Commands.add('clickTaskExportContract', require('./tasks/click-task-export-contract'));
+Cypress.Commands.add('clickTaskCheckAnswers', require('./tasks/click-task-check-answers'));
+Cypress.Commands.add('clickTaskDeclarationsAndSubmit', require('./tasks/click-task-declarations-and-submit'));
+
 Cypress.Commands.add('rejectAnalyticsCookies', analytics.rejectAnalyticsCookies);
+
+// const task = taskList.submitApplication.tasks.checkAnswers;
+// cy.clickTaskCheckAnswers();

--- a/e2e-tests/commands/shared-commands/click-events/tasks/click-task-business.js
+++ b/e2e-tests/commands/shared-commands/click-events/tasks/click-task-business.js
@@ -1,0 +1,13 @@
+import taskList from '../../../../partials/insurance/taskList';
+
+/**
+ * clickTaskBusiness
+ * Click the "Business" task link
+ */
+const clickTaskBusiness = () => {
+  const task = taskList.prepareApplication.tasks.business;
+
+  task.link().click();
+};
+
+export default clickTaskBusiness;

--- a/e2e-tests/commands/shared-commands/click-events/tasks/click-task-buyer.js
+++ b/e2e-tests/commands/shared-commands/click-events/tasks/click-task-buyer.js
@@ -1,0 +1,13 @@
+import taskList from '../../../../partials/insurance/taskList';
+
+/**
+ * clickTaskBuyer
+ * Click the "Buyer" task link
+ */
+const clickTaskBuyer = () => {
+  const task = taskList.prepareApplication.tasks.buyer;
+
+  task.link().click();
+};
+
+export default clickTaskBuyer;

--- a/e2e-tests/commands/shared-commands/click-events/tasks/click-task-check-answers.js
+++ b/e2e-tests/commands/shared-commands/click-events/tasks/click-task-check-answers.js
@@ -1,0 +1,13 @@
+import taskList from '../../../../partials/insurance/taskList';
+
+/**
+ * clickTaskCheckAnswers
+ * Click the "Check answers" task link
+ */
+const clickTaskCheckAnswers = () => {
+  const task = taskList.submitApplication.tasks.checkAnswers;
+
+  task.link().click();
+};
+
+export default clickTaskCheckAnswers;

--- a/e2e-tests/commands/shared-commands/click-events/tasks/click-task-declarations-and-submit.js
+++ b/e2e-tests/commands/shared-commands/click-events/tasks/click-task-declarations-and-submit.js
@@ -1,0 +1,13 @@
+import taskList from '../../../../partials/insurance/taskList';
+
+/**
+ * clickTaskDeclarationsAndSubmit
+ * Click the "Declarations and submit" task link
+ */
+const clickTaskDeclarationsAndSubmit = () => {
+  const task = taskList.submitApplication.tasks.declarationsAndSubmit;
+
+  task.link().click();
+};
+
+export default clickTaskDeclarationsAndSubmit;

--- a/e2e-tests/commands/shared-commands/click-events/tasks/click-task-export-contract.js
+++ b/e2e-tests/commands/shared-commands/click-events/tasks/click-task-export-contract.js
@@ -1,0 +1,13 @@
+import taskList from '../../../../partials/insurance/taskList';
+
+/**
+ * clickTaskExportContract
+ * Click the "Export contract" task link
+ */
+const clickTaskExportContract = () => {
+  const task = taskList.prepareApplication.tasks.exportContract;
+
+  task.link().click();
+};
+
+export default clickTaskExportContract;

--- a/e2e-tests/commands/shared-commands/click-events/tasks/click-task-policy.js
+++ b/e2e-tests/commands/shared-commands/click-events/tasks/click-task-policy.js
@@ -1,0 +1,13 @@
+import taskList from '../../../../partials/insurance/taskList';
+
+/**
+ * clickTaskPolicy
+ * Click the "Policy" task link
+ */
+const clickTaskPolicy = () => {
+  const task = taskList.prepareApplication.tasks.policy;
+
+  task.link().click();
+};
+
+export default clickTaskPolicy;

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/about-goods-or-services/change-your-answers-about-goods-or-services-final-destination-known-to-unknown.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/about-goods-or-services/change-your-answers-about-goods-or-services-final-destination-known-to-unknown.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import { DEFAULT } from '../../../../../../../../content-strings';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
@@ -13,10 +12,6 @@ const {
 const {
   ABOUT_GOODS_OR_SERVICES: { FINAL_DESTINATION: FIELD_ID },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const getFieldVariables = (referenceNumber) => ({
   route: ABOUT_GOODS_OR_SERVICES_CHECK_AND_CHANGE,
@@ -42,7 +37,7 @@ context(
 
         cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/about-goods-or-services/change-your-answers-about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/about-goods-or-services/change-your-answers-about-goods-or-services.spec.js
@@ -1,5 +1,4 @@
 import { field, status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import application from '../../../../../../../../fixtures/application';
@@ -14,10 +13,6 @@ const {
 const {
   ABOUT_GOODS_OR_SERVICES: { DESCRIPTION, FINAL_DESTINATION },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const getFieldVariables = (fieldId, referenceNumber) => ({
   changeLink: summaryList.field(fieldId).changeLink,
@@ -46,7 +41,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Abou
         finalDestinationKnown: true,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-fixed-sum-amount-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-fixed-sum-amount-alternative-currency.spec.js
@@ -1,5 +1,4 @@
 import { summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import application from '../../../../../../../../fixtures/application';
@@ -15,10 +14,6 @@ const {
 const {
   AGENT_CHARGES: { FIXED_SUM_AMOUNT, PAYABLE_COUNTRY_CODE },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const fieldId = FIXED_SUM_AMOUNT;
 
@@ -41,7 +36,7 @@ context(
           agentChargeMethodFixedSum: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-fixed-sum-amount.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-fixed-sum-amount.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import formatCurrency from '../../../../../../../../helpers/format-currency';
@@ -14,10 +13,6 @@ const {
 const {
   AGENT_CHARGES: { FIXED_SUM_AMOUNT },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const fieldId = FIXED_SUM_AMOUNT;
 
@@ -38,7 +33,7 @@ context(`Insurance - Change your answers - Export contract - Summary list - Agen
         agentChargeMethodFixedSum: true,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-fixed-sum-to-percentage.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-fixed-sum-to-percentage.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-export-contract-summary-list';
@@ -13,10 +12,6 @@ const {
 const {
   AGENT_CHARGES: { FIXED_SUM_AMOUNT, PERCENTAGE_CHARGE, PAYABLE_COUNTRY_CODE },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -35,7 +30,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
         agentChargeMethodFixedSum: true,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-payable-country.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-payable-country.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { XAD } from '../../../../../../../../fixtures/countries';
@@ -13,10 +12,6 @@ const {
 const {
   AGENT_CHARGES: { PAYABLE_COUNTRY_CODE },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const NEW_COUNTRY_INPUT = XAD.NAME;
 
@@ -39,7 +34,7 @@ context(`Insurance - Change your answers - Export contract - Summary list - Agen
         agentChargeMethodFixedSum: true,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-percentage-charge.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-percentage-charge.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import application from '../../../../../../../../fixtures/application';
@@ -13,10 +12,6 @@ const {
 const {
   AGENT_CHARGES: { PERCENTAGE_CHARGE },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const fieldId = PERCENTAGE_CHARGE;
 
@@ -37,7 +32,7 @@ context(`Insurance - Change your answers - Export contract - Summary list - Agen
         agentChargeMethodPercentage: true,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-percentage-to-fixed-sum.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-charges/change-your-answers-agent-charges-percentage-to-fixed-sum.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-export-contract-summary-list';
@@ -13,10 +12,6 @@ const {
 const {
   AGENT_CHARGES: { FIXED_SUM_AMOUNT, PERCENTAGE_CHARGE, PAYABLE_COUNTRY_CODE },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const fieldId = PERCENTAGE_CHARGE;
 
@@ -37,7 +32,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Perc
         agentChargeMethodPercentage: true,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-service/change-your-answers-agent-service-charging-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-service/change-your-answers-agent-service-charging-no-to-yes.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-export-contract-summary-list';
@@ -14,10 +13,6 @@ const {
   AGENT_SERVICE: { IS_CHARGING: FIELD_ID },
   AGENT_CHARGES: { FIXED_SUM_AMOUNT, PERCENTAGE_CHARGE, PAYABLE_COUNTRY_CODE },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -36,7 +31,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
         agentIsCharging: false,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-service/change-your-answers-agent-service-charging-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-service/change-your-answers-agent-service-charging-yes-to-no.spec.js
@@ -1,6 +1,5 @@
 import { autoCompleteField, field, status, summaryList } from '../../../../../../../../pages/shared';
 import { agentChargesPage } from '../../../../../../../../pages/insurance/export-contract';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-export-contract-summary-list';
@@ -15,10 +14,6 @@ const {
   AGENT_SERVICE: { IS_CHARGING: FIELD_ID },
   AGENT_CHARGES: { FIXED_SUM, FIXED_SUM_AMOUNT, PERCENTAGE_CHARGE, METHOD, PAYABLE_COUNTRY_CODE, PERCENTAGE },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -37,7 +32,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
         agentChargeMethodFixedSum: true,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-service/change-your-answers-agent-service-description.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-service/change-your-answers-agent-service-description.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 
@@ -12,10 +11,6 @@ const {
 const {
   AGENT_SERVICE: { SERVICE_DESCRIPTION: FIELD_ID },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -33,7 +28,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
         agentIsCharging: false,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent/change-your-answers-agent-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent/change-your-answers-agent-details.spec.js
@@ -1,5 +1,4 @@
 import { field, status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import application from '../../../../../../../../fixtures/application';
@@ -14,10 +13,6 @@ const {
 const {
   AGENT_DETAILS: { NAME, FULL_ADDRESS, COUNTRY_CODE },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const getFieldVariables = (fieldId, referenceNumber) => ({
   route: AGENT_DETAILS_CHECK_AND_CHANGE,
@@ -47,7 +42,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
         isUsingAgent: true,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent/change-your-answers-agent-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent/change-your-answers-agent-no-to-yes.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-export-contract-summary-list';
@@ -15,10 +14,6 @@ const {
   AGENT_DETAILS: { NAME, FULL_ADDRESS, COUNTRY_CODE },
   AGENT_SERVICE: { SERVICE_DESCRIPTION, IS_CHARGING },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -37,7 +32,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
         isUsingAgent: false,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent/change-your-answers-agent-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent/change-your-answers-agent-yes-to-no.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-export-contract-summary-list';
@@ -16,10 +15,6 @@ const {
   AGENT_SERVICE: { IS_CHARGING, SERVICE_DESCRIPTION },
 } = FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Change your answers - Export contract - Summary list - Agent - Yes to no', () => {
@@ -35,7 +30,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
         isUsingAgent: true,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/how-the-contract-was-awarded/change-your-answers-how-the-contract-was-awarded-from-other-method.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/how-the-contract-was-awarded/change-your-answers-how-the-contract-was-awarded-from-other-method.spec.js
@@ -1,5 +1,4 @@
 import { summaryList, radios, field } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { EXPORT_CONTRACT_FIELDS as FIELDS } from '../../../../../../../../content-strings/fields/insurance/export-contract';
@@ -17,10 +16,6 @@ const { DIRECT_AWARD, OTHER } = FIELDS.HOW_WAS_THE_CONTRACT_AWARDED[FIELD_ID].OP
 
 const baseUrl = Cypress.config('baseUrl');
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 context(
   `Insurance - Export contract - Change your answers - How the contract was awarded - Changing from ${OTHER.TEXT} to ${DIRECT_AWARD.TEXT} and back to ${OTHER.TEXT}`,
   () => {
@@ -36,7 +31,7 @@ context(
           contractAwardedOtherMethod: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/how-the-contract-was-awarded/change-your-answers-how-the-contract-was-awarded.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/how-the-contract-was-awarded/change-your-answers-how-the-contract-was-awarded.spec.js
@@ -1,5 +1,4 @@
 import { summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-export-contract-summary-list';
@@ -20,10 +19,6 @@ const { DIRECT_AWARD, NEGOTIATED_CONTRACT, COMPETITIVE_BIDDING, OPEN_TENDER, OTH
 
 const baseUrl = Cypress.config('baseUrl');
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 context(
   'Insurance - Change your answers - How the contract was awarded - As an Exporter, I want to be able to review my input regarding how the contract was awarded, So that I can be assured I am providing UKEF with the right information',
   () => {
@@ -38,7 +33,7 @@ context(
           referenceNumber,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/how-will-you-get-paid/change-your-answers-how-will-you-get-paid-total-contract-value-over-threshold.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/how-will-you-get-paid/change-your-answers-how-will-you-get-paid-total-contract-value-over-threshold.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 
@@ -12,10 +11,6 @@ const {
 const {
   HOW_WILL_YOU_GET_PAID: { PAYMENT_TERMS_DESCRIPTION: FIELD_ID },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const getFieldVariables = (referenceNumber) => ({
   route: HOW_WILL_YOU_GET_PAID_CHECK_AND_CHANGE,
@@ -42,7 +37,7 @@ context('Insurance - Change your answers - Export contract - Summary list - How 
         totalContractValueOverThreshold: true,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/how-will-you-get-paid/change-your-answers-how-will-you-get-paid.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/how-will-you-get-paid/change-your-answers-how-will-you-get-paid.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 
@@ -12,10 +11,6 @@ const {
 const {
   HOW_WILL_YOU_GET_PAID: { PAYMENT_TERMS_DESCRIPTION: FIELD_ID },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const getFieldVariables = (referenceNumber) => ({
   route: HOW_WILL_YOU_GET_PAID_CHECK_AND_CHANGE,
@@ -39,7 +34,7 @@ context('Insurance - Change your answers - Export contract - Summary list - How 
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/private-market/change-your-answers-declined-description.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/private-market/change-your-answers-declined-description.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 
@@ -12,10 +11,6 @@ const {
 const {
   PRIVATE_MARKET: { DECLINED_DESCRIPTION: FIELD_ID },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const getFieldVariables = (referenceNumber) => ({
   route: DECLINED_BY_PRIVATE_MARKET_CHECK_AND_CHANGE,
@@ -43,7 +38,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Decl
         attemptedPrivateMarketCover: true,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/private-market/change-your-answers-private-market-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/private-market/change-your-answers-private-market-no-to-yes.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-export-contract-summary-list';
@@ -13,10 +12,6 @@ const {
 const {
   PRIVATE_MARKET: { ATTEMPTED: FIELD_ID, DECLINED_DESCRIPTION },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -34,7 +29,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Priv
         attemptedPrivateMarketCover: false,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/private-market/change-your-answers-private-market-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/private-market/change-your-answers-private-market-yes-to-no.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import FIELD_IDS from '../../../../../../../../constants/field-ids/insurance/export-contract';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-export-contract-summary-list';
@@ -13,10 +12,6 @@ const {
 const {
   PRIVATE_MARKET: { ATTEMPTED: FIELD_ID, DECLINED_DESCRIPTION },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -34,7 +29,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Priv
         attemptedPrivateMarketCover: true,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/check-your-answers-export-contract-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/check-your-answers-export-contract-page.spec.js
@@ -1,5 +1,4 @@
 import { headingCaption } from '../../../../../../pages/shared';
-import partials from '../../../../../../partials';
 import { BUTTONS, PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
@@ -10,10 +9,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const CONTENT_STRINGS = PAGES.INSURANCE.CHECK_YOUR_ANSWERS.YOUR_EXPORT_CONTRACT;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -29,7 +24,7 @@ context(
 
         cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answer-summary-list-contract-awarded-competitive-bidding.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answer-summary-list-contract-awarded-competitive-bidding.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { assertMinimalExportContractSummaryListRows } from '../../../../../../../shared-test-assertions';
 import { EXPORT_CONTRACT_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/export-contract';
@@ -15,10 +14,6 @@ const {
 
 const { COMPETITIVE_BIDDING } = FIELDS.HOW_WAS_THE_CONTRACT_AWARDED[AWARD_METHOD].OPTIONS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context(`Insurance - Check your answers - Export contract - Summary list - Contract awarded with ${COMPETITIVE_BIDDING.TEXT}`, () => {
@@ -31,7 +26,7 @@ context(`Insurance - Check your answers - Export contract - Summary list - Contr
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber, contractAwardedCompetitiveBidding: true });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answer-summary-list-contract-awarded-direct-award.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answer-summary-list-contract-awarded-direct-award.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { assertMinimalExportContractSummaryListRows } from '../../../../../../../shared-test-assertions';
 import { EXPORT_CONTRACT_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/export-contract';
@@ -15,10 +14,6 @@ const {
 
 const { DIRECT_AWARD } = FIELDS.HOW_WAS_THE_CONTRACT_AWARDED[AWARD_METHOD].OPTIONS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context(`Insurance - Check your answers - Export contract - Summary list - Contract awarded with ${DIRECT_AWARD.TEXT}`, () => {
@@ -31,7 +26,7 @@ context(`Insurance - Check your answers - Export contract - Summary list - Contr
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber, contractAwardedDirectAward: true });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answer-summary-list-contract-awarded-negotiated-contract.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answer-summary-list-contract-awarded-negotiated-contract.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { assertMinimalExportContractSummaryListRows } from '../../../../../../../shared-test-assertions';
 import { EXPORT_CONTRACT_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/export-contract';
@@ -15,10 +14,6 @@ const {
 
 const { NEGOTIATED_CONTRACT } = FIELDS.HOW_WAS_THE_CONTRACT_AWARDED[AWARD_METHOD].OPTIONS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context(`Insurance - Check your answers - Export contract - Summary list - Contract awarded with ${NEGOTIATED_CONTRACT.TEXT}`, () => {
@@ -31,7 +26,7 @@ context(`Insurance - Check your answers - Export contract - Summary list - Contr
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber, contractAwardedNegotiatedContract: true });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answers-summary-list-contract-awarded-other-method.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answers-summary-list-contract-awarded-other-method.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { assertMinimalExportContractSummaryListRows } from '../../../../../../../shared-test-assertions';
 import application from '../../../../../../../fixtures/application';
@@ -16,10 +15,6 @@ const {
 
 const { OTHER } = FIELDS.HOW_WAS_THE_CONTRACT_AWARDED[AWARD_METHOD].OPTIONS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context(`Insurance - Check your answers - Export contract - Summary list - Contract awarded with ${OTHER.TEXT}`, () => {
@@ -32,7 +27,7 @@ context(`Insurance - Check your answers - Export contract - Summary list - Contr
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber, contractAwardedOtherMethod: true });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answers-summary-list-fully-populated-with-agent-charges-fixed-sum-decimals-multiple-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answers-summary-list-fully-populated-with-agent-charges-fixed-sum-decimals-multiple-policy.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { assertFullyPopulatedExportContractSummaryListRows } from '../../../../../../../shared-test-assertions';
 
@@ -6,10 +5,6 @@ const {
   ROOT: INSURANCE_ROOT,
   CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -36,7 +31,7 @@ context(
           agentChargeFixedSumAmount: fixedSumAmount,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answers-summary-list-fully-populated-with-agent-charges-fixed-sum-decimals.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answers-summary-list-fully-populated-with-agent-charges-fixed-sum-decimals.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { assertFullyPopulatedExportContractSummaryListRows } from '../../../../../../../shared-test-assertions';
 
@@ -6,10 +5,6 @@ const {
   ROOT: INSURANCE_ROOT,
   CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -36,7 +31,7 @@ context(
           agentChargeFixedSumAmount: fixedSumAmount,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answers-summary-list-fully-populated-with-agent-charges-fixed-sum.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answers-summary-list-fully-populated-with-agent-charges-fixed-sum.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { assertFullyPopulatedExportContractSummaryListRows } from '../../../../../../../shared-test-assertions';
 
@@ -6,10 +5,6 @@ const {
   ROOT: INSURANCE_ROOT,
   CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -33,7 +28,7 @@ context(
           finalDestinationKnown: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answers-summary-list-fully-populated-with-agent-charges-percentage.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answers-summary-list-fully-populated-with-agent-charges-percentage.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { assertFullyPopulatedExportContractSummaryListRows } from '../../../../../../../shared-test-assertions';
 
@@ -6,10 +5,6 @@ const {
   ROOT: INSURANCE_ROOT,
   CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -33,7 +28,7 @@ context(
           finalDestinationKnown: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answers-summary-list-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/summary-list/check-your-answers-summary-list-minimal.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { assertMinimalExportContractSummaryListRows } from '../../../../../../../shared-test-assertions';
 
@@ -6,10 +5,6 @@ const {
   ROOT: INSURANCE_ROOT,
   CHECK_YOUR_ANSWERS: { EXPORT_CONTRACT },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -25,7 +20,7 @@ context(
 
         cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/another-company/change-your-answers-change-another-company-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/another-company/change-your-answers-change-another-company-no-to-yes.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { summaryList } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
@@ -13,10 +12,6 @@ const {
   POLICY: { ANOTHER_COMPANY_CHECK_AND_CHANGE, OTHER_COMPANY_DETAILS_CHECK_AND_CHANGE },
   CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -35,7 +30,7 @@ context(
           otherCompanyInvolved: false,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/another-company/change-your-answers-change-another-company-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/another-company/change-your-answers-change-another-company-yes-to-no.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { summaryList } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
@@ -13,10 +12,6 @@ const {
   POLICY: { ANOTHER_COMPANY_CHECK_AND_CHANGE, OTHER_COMPANY_DETAILS },
   CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -35,7 +30,7 @@ context(
           otherCompanyInvolved: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker-no-to-yes.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -15,10 +14,6 @@ const {
   BROKER_DETAILS: { NAME, EMAIL, FULL_ADDRESS },
 } = POLICY_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Change your answers - Policy - Broker - No to yes - As an exporter, I want to change my answers to the broker section', () => {
@@ -31,7 +26,7 @@ context('Insurance - Change your answers - Policy - Broker - No to yes - As an e
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber, usingBroker: false });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker-yes-to-no.spec.js
@@ -1,5 +1,4 @@
 import { field, status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { FIELD_VALUES } from '../../../../../../../../constants';
@@ -15,10 +14,6 @@ const {
   BROKER_DETAILS: { NAME, EMAIL, FULL_ADDRESS },
 } = POLICY_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Change your answers - Policy - Broker - Yes to no - As an exporter, I want to change my answers to the broker section', () => {
@@ -31,7 +26,7 @@ context('Insurance - Change your answers - Policy - Broker - Yes to no - As an e
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber, usingBroker: true });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-change-broker.spec.js
@@ -1,5 +1,4 @@
 import { field, status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../../content-strings/fields/insurance/policy';
 import { FIELD_VALUES } from '../../../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
@@ -16,10 +15,6 @@ const {
   USING_BROKER,
   BROKER_DETAILS: { NAME, EMAIL, FULL_ADDRESS },
 } = INSURANCE_FIELD_IDS.POLICY;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -43,7 +38,7 @@ context('Insurance - Change your answers - Policy - Broker - As an exporter, I w
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber, usingBroker: true });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-international-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-international-name.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { field, summaryList } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
@@ -15,10 +14,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const fieldId = NAME;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -39,7 +34,7 @@ context(
           lossPayeeIsLocatedInUK: false,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-uk-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-uk-name.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { field, summaryList } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
@@ -15,10 +14,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const fieldId = NAME;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -39,7 +34,7 @@ context(
           lossPayeeIsLocatedInUK: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-international-to-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-international-to-uk.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { field, summaryList } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
@@ -16,10 +15,6 @@ const {
   POLICY: { LOSS_PAYEE_DETAILS_CHECK_AND_CHANGE, LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL, LOSS_PAYEE_FINANCIAL_DETAILS_UK_CHECK_AND_CHANGE },
   CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -41,7 +36,7 @@ context(
           lossPayeeIsLocatedInUK: false,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-international.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-international.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { field, summaryList } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
@@ -18,10 +17,6 @@ const {
   CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY },
 } = INSURANCE_ROUTES;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context(
@@ -40,7 +35,7 @@ context(
           lossPayeeIsLocatedInUK: false,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-uk-to-international.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-uk-to-international.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { field, summaryList } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
@@ -16,10 +15,6 @@ const {
   POLICY: { LOSS_PAYEE_DETAILS_CHECK_AND_CHANGE, LOSS_PAYEE_FINANCIAL_DETAILS_UK, LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_CHECK_AND_CHANGE },
   CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -41,7 +36,7 @@ context(
           lossPayeeIsLocatedInUK: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-uk.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { field, summaryList } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
@@ -19,10 +18,6 @@ const {
   CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY },
 } = INSURANCE_ROUTES;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context(
@@ -41,7 +36,7 @@ context(
           lossPayeeIsLocatedInUK: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/multiple-policy/change-your-answers-policy-multiple-policy-type.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/multiple-policy/change-your-answers-policy-multiple-policy-type.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { field, summaryList } from '../../../../../../../../pages/shared';
@@ -27,10 +26,6 @@ const {
   },
 } = INSURANCE_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const getFieldVariables = (fieldId, referenceNumber, route = MULTIPLE_CONTRACT_POLICY_CHECK_AND_CHANGE) => ({
   route,
   checkYourAnswersRoute: TYPE_OF_POLICY,
@@ -52,7 +47,7 @@ context('Insurance - Change your answers - Policy - Multiple contract policy - S
       referenceNumber = refNumber;
       cy.completePrepareApplicationMultiplePolicyType({});
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/multiple-policy/change-your-answers-policy-type-change-multiple-to-single-policy-type-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/multiple-policy/change-your-answers-policy-type-change-multiple-to-single-policy-type-summary-list.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
@@ -23,10 +22,6 @@ const {
   },
 } = INSURANCE_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Change your answers - Policy - Change multiple to single policy type - Summary List', () => {
@@ -39,7 +34,7 @@ context('Insurance - Change your answers - Policy - Change multiple to single po
       referenceNumber = refNumber;
       cy.completePrepareApplicationMultiplePolicyType({});
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-different-name-fields.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-different-name-fields.spec.js
@@ -1,5 +1,4 @@
 import { summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 
@@ -15,10 +14,6 @@ const {
   },
   ACCOUNT: { FIRST_NAME, LAST_NAME, EMAIL },
 } = INSURANCE_FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -38,7 +33,7 @@ context(
         referenceNumber = refNumber;
         cy.completePrepareApplicationMultiplePolicyType({ differentPolicyContact: true });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-different-name-to-same-name-then-back-to-different-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-different-name-to-same-name-then-back-to-different-name.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { POLICY as FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { summaryList } from '../../../../../../../../pages/shared';
@@ -12,10 +11,6 @@ const {
 const {
   NAME_ON_POLICY: { NAME, OTHER_NAME, SAME_NAME },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const getFieldVariables = (fieldId, referenceNumber) => ({
   route: NAME_ON_POLICY_CHECK_AND_CHANGE,
@@ -42,7 +37,7 @@ context(
         referenceNumber = refNumber;
         cy.completePrepareApplicationMultiplePolicyType({ differentPolicyContact: true });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-different-name-to-same-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-different-name-to-same-name.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { summaryList } from '../../../../../../../../pages/shared';
@@ -17,10 +16,6 @@ const {
   },
   ACCOUNT: { FIRST_NAME, LAST_NAME },
 } = INSURANCE_FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const { POLICY_CONTACT } = application;
 
@@ -47,7 +42,7 @@ context('Insurance - Change your answers - Policy - Change from different name t
       referenceNumber = refNumber;
       cy.completePrepareApplicationMultiplePolicyType({ differentPolicyContact: true });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-same-name-position.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-same-name-position.spec.js
@@ -1,5 +1,4 @@
 import { summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import { POLICY as FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 
@@ -12,10 +11,6 @@ const {
 const {
   NAME_ON_POLICY: { POSITION },
 } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const fieldId = POSITION;
 
@@ -32,7 +27,7 @@ context(
         referenceNumber = refNumber;
         cy.completePrepareApplicationMultiplePolicyType({ differentPolicyContact: false });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-same-name-to-different-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-same-name-to-different-name.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { summaryList } from '../../../../../../../../pages/shared';
@@ -16,10 +15,6 @@ const {
   },
   ACCOUNT: { FIRST_NAME, LAST_NAME, EMAIL },
 } = INSURANCE_FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const { POLICY_CONTACT } = application;
 
@@ -47,7 +42,7 @@ context('Insurance - Change your answers - Policy - Change from same name to dif
       referenceNumber = refNumber;
       cy.completePrepareApplicationMultiplePolicyType({});
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/other-company-details/change-your-answers-change-other-company-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/other-company-details/change-your-answers-change-other-company-details.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { autoCompleteField, field, summaryList } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
@@ -14,10 +13,6 @@ const {
   POLICY: { OTHER_COMPANY_DETAILS_CHECK_AND_CHANGE },
   CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -37,7 +32,7 @@ context(
           otherCompanyInvolved: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past previous "Check your answers" pages
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/pre-credit-period/change-your-answers-pre-credit-period-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/pre-credit-period/change-your-answers-pre-credit-period-yes-to-no.spec.js
@@ -1,5 +1,4 @@
 import { field, status, summaryList } from '../../../../../../../../pages/shared';
-import partials from '../../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../../constants';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
@@ -11,10 +10,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const { NEED_PRE_CREDIT_PERIOD, CREDIT_PERIOD_WITH_BUYER } = POLICY_FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const getFieldVariables = (fieldId, referenceNumber) => ({
   route: BROKER_CHECK_AND_CHANGE,
@@ -39,7 +34,7 @@ context('Insurance - Change your answers - Policy - Pre-credit period - Change f
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber, needPreCreditPeriod: true });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/single-policy/change-your-answers-policy-single-policy-type.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/single-policy/change-your-answers-policy-single-policy-type.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import { field, status, summaryList } from '../../../../../../../../pages/shared';
@@ -23,10 +22,6 @@ const {
   },
 } = INSURANCE_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const getFieldVariables = (fieldId, referenceNumber) => ({
   route: SINGLE_CONTRACT_POLICY_CHECK_AND_CHANGE,
   newValueInput: '',
@@ -47,7 +42,7 @@ context('Insurance - Change your answers - Policy - Single contract policy - Sum
       referenceNumber = refNumber;
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/single-policy/change-your-answers-policy-type-change-single-to-multiple-policy-type-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/single-policy/change-your-answers-policy-type-change-single-to-multiple-policy-type-summary-list.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
@@ -24,10 +23,6 @@ const {
   },
 } = INSURANCE_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Change your answers - Policy - Change single to multiple policy type - Summary List', () => {
@@ -40,7 +35,7 @@ context('Insurance - Change your answers - Policy - Change single to multiple po
       referenceNumber = refNumber;
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/check-your-answers-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/check-your-answers-policy-page.spec.js
@@ -1,5 +1,4 @@
 import { headingCaption, status } from '../../../../../../pages/shared';
-import partials from '../../../../../../partials';
 import { BUTTONS, PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
@@ -9,10 +8,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const CONTENT_STRINGS = PAGES.INSURANCE.CHECK_YOUR_ANSWERS.POLICY;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -26,7 +21,7 @@ context('Insurance - Check your answers - Policy - I want to confirm my selectio
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/save-and-back.spec.js
@@ -1,14 +1,9 @@
-import partials from '../../../../../../partials';
 import { ROUTES } from '../../../../../../constants';
 
 const {
   ROOT: INSURANCE_ROOT,
   CHECK_YOUR_ANSWERS: { TYPE_OF_POLICY },
 } = ROUTES.INSURANCE;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -22,7 +17,7 @@ context('Insurance - Check your answers - Policy page - Save and back', () => {
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-different-name-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-different-name-summary-list.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -15,10 +14,6 @@ const {
   USING_BROKER,
 } = POLICY_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Policy - Multiple contract policy - Different name - Summary List', () => {
@@ -30,7 +25,7 @@ context('Insurance - Check your answers - Policy - Multiple contract policy - Di
       referenceNumber = refNumber;
       cy.completePrepareApplicationMultiplePolicyType({ differentPolicyContact: true });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-other-company-no-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-other-company-no-summary-list.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -12,10 +11,6 @@ const {
   REQUESTED_JOINTLY_INSURED_PARTY: { REQUESTED, COMPANY_NAME, COMPANY_NUMBER, COUNTRY_CODE },
 } = POLICY_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Policy - Multiple contract policy - Other company no - Summary List', () => {
@@ -27,7 +22,7 @@ context('Insurance - Check your answers - Policy - Multiple contract policy - Ot
       referenceNumber = refNumber;
       cy.completePrepareApplicationMultiplePolicyType({});
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-other-company-yes-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-other-company-yes-summary-list.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -12,10 +11,6 @@ const {
   REQUESTED_JOINTLY_INSURED_PARTY: { REQUESTED, COMPANY_NAME, COMPANY_NUMBER, COUNTRY_CODE },
 } = POLICY_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Policy - Multiple contract policy - Other company Yes - Summary List', () => {
@@ -27,7 +22,7 @@ context('Insurance - Check your answers - Policy - Multiple contract policy - Ot
       referenceNumber = refNumber;
       cy.completePrepareApplicationMultiplePolicyType({ otherCompanyInvolved: true });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-same-name-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-same-name-summary-list.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
@@ -19,10 +18,6 @@ const {
   ACCOUNT: { EMAIL },
 } = INSURANCE_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Policy - Multiple contract policy - Same name - Summary List', () => {
@@ -34,7 +29,7 @@ context('Insurance - Check your answers - Policy - Multiple contract policy - Sa
       referenceNumber = refNumber;
       cy.completePrepareApplicationMultiplePolicyType({ usingBroker: false });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-with-broker-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-with-broker-summary-list.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -13,10 +12,6 @@ const {
   BROKER_DETAILS: { NAME, EMAIL, FULL_ADDRESS },
 } = POLICY_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Policy - Multiple contract policy - With broker - Summary List', () => {
@@ -28,7 +23,7 @@ context('Insurance - Check your answers - Policy - Multiple contract policy - Wi
       referenceNumber = refNumber;
       cy.completePrepareApplicationMultiplePolicyType({ usingBroker: true });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-different-name-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-different-name-summary-list.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
@@ -20,10 +19,6 @@ const {
   ACCOUNT: { EMAIL },
 } = INSURANCE_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Policy - Single contract policy - Different name - Summary List', () => {
@@ -35,7 +30,7 @@ context('Insurance - Check your answers - Policy - Single contract policy - Diff
       referenceNumber = refNumber;
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber, differentPolicyContact: true });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-other-company-no-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-other-company-no-summary-list.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -12,10 +11,6 @@ const {
   REQUESTED_JOINTLY_INSURED_PARTY: { REQUESTED, COMPANY_NAME, COMPANY_NUMBER, COUNTRY_CODE },
 } = POLICY_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Policy - Single contract policy - Other company no - Summary List', () => {
@@ -27,7 +22,7 @@ context('Insurance - Check your answers - Policy - Single contract policy - Othe
       referenceNumber = refNumber;
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-other-company-yes-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-other-company-yes-summary-list.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -12,10 +11,6 @@ const {
   REQUESTED_JOINTLY_INSURED_PARTY: { REQUESTED, COMPANY_NAME, COMPANY_NUMBER, COUNTRY_CODE },
 } = POLICY_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Policy - Single contract policy - Other company yes - Summary List', () => {
@@ -27,7 +22,7 @@ context('Insurance - Check your answers - Policy - Single contract policy - Othe
       referenceNumber = refNumber;
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber, otherCompanyInvolved: true });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-same-name-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-same-name-summary-list.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
@@ -19,10 +18,6 @@ const {
   ACCOUNT: { EMAIL },
 } = INSURANCE_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Policy - Single contract policy - Same name - Summary List', () => {
@@ -34,7 +29,7 @@ context('Insurance - Check your answers - Policy - Single contract policy - Same
       referenceNumber = refNumber;
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber, usingBroker: false });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-with-broker-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-with-broker-summary-list.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -13,10 +12,6 @@ const {
   BROKER_DETAILS: { NAME, EMAIL, FULL_ADDRESS },
 } = POLICY_FIELD_IDS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Policy - Single contract policy - With broker - Summary List', () => {
@@ -28,7 +23,7 @@ context('Insurance - Check your answers - Policy - Single contract policy - With
       referenceNumber = refNumber;
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber, usingBroker: true });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-company-details-trading-address-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-company-details-trading-address-yes-to-no.spec.js
@@ -1,5 +1,4 @@
 import { field, status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -16,10 +15,6 @@ const {
     ALTERNATIVE_TRADING_ADDRESS: { FULL_ADDRESS },
   },
 } = INSURANCE_FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const getFieldVariables = (fieldId, referenceNumber, route = COMPANY_DETAILS_CHECK_AND_CHANGE) => ({
   route,
@@ -43,7 +38,7 @@ context(`Insurance - Check your answers - Company details - Your business - ${FI
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
@@ -1,5 +1,4 @@
 import { field, status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { VALID_PHONE_NUMBERS, WEBSITE_EXAMPLES } from '../../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -17,10 +16,6 @@ const {
     ALTERNATIVE_TRADING_ADDRESS: { FULL_ADDRESS },
   },
 } = INSURANCE_FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -44,7 +39,7 @@ context('Insurance - Check your answers - Company details - Your business - Summ
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-credit-control-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-credit-control-no-to-yes.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { EXPORTER_BUSINESS as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/business';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -10,10 +9,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const { HAS_CREDIT_CONTROL: FIELD_ID } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -33,7 +28,7 @@ context(
           hasCreditControlProcess: false,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-credit-control-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-credit-control-yes-to-no.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { EXPORTER_BUSINESS as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/business';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -11,10 +10,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const { HAS_CREDIT_CONTROL: FIELD_ID } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -44,7 +39,7 @@ context(
           hasCreditControlProcess: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-nature-of-your-business.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-nature-of-your-business.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { field, summaryList } from '../../../../../../../pages/shared';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -12,10 +11,6 @@ const {
 const {
   NATURE_OF_YOUR_BUSINESS: { GOODS_OR_SERVICES, YEARS_EXPORTING, EMPLOYEES_UK },
 } = INSURANCE_FIELD_IDS.EXPORTER_BUSINESS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const getFieldVariables = (fieldId, referenceNumber) => ({
   route: NATURE_OF_BUSINESS_CHECK_AND_CHANGE,
@@ -39,7 +34,7 @@ context('Insurance - Check your answers - Nature of your Business - Your busines
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-trading-address.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -17,10 +16,6 @@ const {
     ALTERNATIVE_TRADING_ADDRESS: { FULL_ADDRESS },
   },
 } = INSURANCE_FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -44,7 +39,7 @@ context(`Insurance - Change your answers - ${TRADING_ADDRESS} and ${FULL_ADDRESS
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-turnover-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-turnover-currency.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { field as fieldSelector, summaryList, radios, autoCompleteField } from '../../../../../../../pages/shared';
 import { EXPORTER_BUSINESS_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/business';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
@@ -19,10 +18,6 @@ const {
 
 const { ALTERNATIVE_CURRENCY_CODE } = INSURANCE_FIELD_IDS.CURRENCY;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Turnover currency - Your business - Summary list', () => {
@@ -36,7 +31,7 @@ context('Insurance - Check your answers - Turnover currency - Your business - Su
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { field, summaryList } from '../../../../../../../pages/shared';
 import { GBP_CURRENCY_CODE } from '../../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
@@ -14,10 +13,6 @@ const {
 const {
   TURNOVER: { ESTIMATED_ANNUAL_TURNOVER, PERCENTAGE_TURNOVER },
 } = INSURANCE_FIELD_IDS.EXPORTER_BUSINESS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const getFieldVariables = (fieldId, referenceNumber) => ({
   route: TURNOVER_CHECK_AND_CHANGE,
@@ -41,7 +36,7 @@ context('Insurance - Check your answers - Turnover - Your business - Summary lis
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/check-your-answers-your-business-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/check-your-answers-your-business-page.spec.js
@@ -1,5 +1,4 @@
 import { headingCaption, status } from '../../../../../../pages/shared';
-import partials from '../../../../../../partials';
 import { BUTTONS, PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
@@ -10,10 +9,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const CONTENT_STRINGS = PAGES.INSURANCE.CHECK_YOUR_ANSWERS.YOUR_BUSINESS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -29,7 +24,7 @@ context(
 
         cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/save-and-back.spec.js
@@ -1,14 +1,9 @@
-import partials from '../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const {
   ROOT: INSURANCE_ROOT,
   CHECK_YOUR_ANSWERS: { YOUR_BUSINESS },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -22,7 +17,7 @@ context('Insurance - Check your answers - Your business page - Save and back', (
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/summary-list/check-your-answers-your-business-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/summary-list/check-your-answers-your-business-summary-list.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../commands/insurance/check-your-business-summary-list';
@@ -15,10 +14,6 @@ const {
   HAS_CREDIT_CONTROL,
 } = INSURANCE_FIELD_IDS.EXPORTER_BUSINESS;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Your business - Summary list', () => {
@@ -31,7 +26,7 @@ context('Insurance - Check your answers - Your business - Summary list', () => {
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUSINESS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-alternative-currency.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import application from '../../../../../../../fixtures/application';
@@ -17,10 +16,6 @@ const {
   YOUR_BUYER: { ALTERNATIVE_CURRENCY_CHECK_AND_CHANGE },
 } = INSURANCE_ROUTES;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Your buyer - Alternative currency - As an exporter, I want to change my answers to an alternative currency', () => {
@@ -37,7 +32,7 @@ context('Insurance - Check your answers - Your buyer - Alternative currency - As
         fullyPopulatedBuyerTradingHistory: true,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past "Your business" check your answers page
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-buyer-financial-accounts.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-buyer-financial-accounts.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { YOUR_BUYER as YOUR_BUYER_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -13,10 +12,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const fieldId = HAS_BUYER_FINANCIAL_ACCOUNTS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -32,7 +27,7 @@ context(
 
         cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past "Your business" check your answers page
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-company-or-organisation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-company-or-organisation.spec.js
@@ -1,5 +1,4 @@
 import { field as fieldSelector, status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { WEBSITE_EXAMPLES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
@@ -14,10 +13,6 @@ const {
 const {
   COMPANY_OR_ORGANISATION: { NAME, ADDRESS, REGISTRATION_NUMBER, WEBSITE },
 } = INSURANCE_FIELD_IDS.YOUR_BUYER;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const getFieldVariables = (fieldId, referenceNumber) => ({
   route: COMPANY_OR_ORGANISATION_CHECK_AND_CHANGE,
@@ -43,7 +38,7 @@ context(
 
         cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past "Your business" check your answers page
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-connection-with-buyer-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-connection-with-buyer-no-to-yes.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
 import checkSummaryList from '../../../../../../../commands/insurance/check-your-buyer-summary-list';
@@ -11,10 +10,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const { CONNECTION_WITH_BUYER: FIELD_ID, CONNECTION_WITH_BUYER_DESCRIPTION } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -30,7 +25,7 @@ context(
 
         cy.completePrepareApplicationSinglePolicyType({ referenceNumber, hasConnectionToBuyer: false });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past "Your business" check your answers page
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-connection-with-buyer-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-connection-with-buyer-yes-to-no.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
@@ -11,10 +10,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const { CONNECTION_WITH_BUYER: FIELD_ID, CONNECTION_WITH_BUYER_DESCRIPTION } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -30,7 +25,7 @@ context(
 
         cy.completePrepareApplicationSinglePolicyType({ referenceNumber, hasConnectionToBuyer: true });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past "Your business" check your answers page
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-credit-insurance-history.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-credit-insurance-history.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { YOUR_BUYER as YOUR_BUYER_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -14,10 +13,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const { BUYER } = application;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -36,7 +31,7 @@ context(
           totalContractValueOverThreshold: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past "Your business" check your answers page
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-trading-history-failed-payments.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-trading-history-failed-payments.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -11,10 +10,6 @@ const {
   CHECK_YOUR_ANSWERS: { YOUR_BUYER },
   YOUR_BUYER: { TRADING_HISTORY_CHECK_AND_CHANGE },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const fieldId = FAILED_PAYMENTS;
 
@@ -36,7 +31,7 @@ context(
           fullyPopulatedBuyerTradingHistory: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past "Your business" check your answers page
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-trading-history-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-trading-history-no-to-yes.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../commands/insurance/check-your-buyer-summary-list';
@@ -11,10 +10,6 @@ const {
   ROOT,
   CHECK_YOUR_ANSWERS: { YOUR_BUYER },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const fieldId = TRADED_WITH_BUYER;
 
@@ -36,7 +31,7 @@ context(
           fullyPopulatedBuyerTradingHistory: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past "Your business" check your answers page
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-trading-history-outstanding-payments-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-trading-history-outstanding-payments-no-to-yes.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -16,10 +15,6 @@ const {
   CHECK_YOUR_ANSWERS: { YOUR_BUYER },
   YOUR_BUYER: { TRADING_HISTORY_CHECK_AND_CHANGE },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const fieldId = OUTSTANDING_PAYMENTS;
 const currency = application.BUYER[CURRENCY_CODE];
@@ -42,7 +37,7 @@ context(
           fullyPopulatedBuyerTradingHistory: false,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past "Your business" check your answers page
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-trading-history-outstanding-payments-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-trading-history-outstanding-payments-yes-to-no.spec.js
@@ -1,5 +1,4 @@
 import { field, status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -11,10 +10,6 @@ const {
   CHECK_YOUR_ANSWERS: { YOUR_BUYER },
   YOUR_BUYER: { TRADING_HISTORY, TRADING_HISTORY_CHECK_AND_CHANGE },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const fieldId = OUTSTANDING_PAYMENTS;
 
@@ -37,7 +32,7 @@ context(
           fullyPopulatedBuyerTradingHistory: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past "Your business" check your answers page
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-trading-history-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-trading-history-yes-to-no.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
@@ -11,10 +10,6 @@ const {
   CHECK_YOUR_ANSWERS: { YOUR_BUYER },
   YOUR_BUYER: { TRADING_HISTORY },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const fieldId = TRADED_WITH_BUYER;
 
@@ -36,7 +31,7 @@ context(
           fullyPopulatedBuyerTradingHistory: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past "Your business" check your answers page
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer-no-to-yes.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
@@ -12,10 +11,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const { CONNECTION_WITH_BUYER: FIELD_ID, CONNECTION_WITH_BUYER_DESCRIPTION } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const { BUYER } = application;
 
@@ -44,7 +39,7 @@ context(
 
         cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past "Your business" check your answers page
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer-yes-to-no.spec.js
@@ -1,5 +1,4 @@
 import { status, summaryList } from '../../../../../../../pages/shared';
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/your-buyer';
@@ -11,10 +10,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const { CONNECTION_WITH_BUYER: FIELD_ID, CONNECTION_WITH_BUYER_DESCRIPTION } = FIELD_IDS;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const getFieldVariables = (fieldId, referenceNumber, route) => ({
   route,
@@ -45,7 +40,7 @@ context(
           hasConnectionToBuyer: true,
         });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past "Your business" check your answers page
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/check-your-answers-your-buyer-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/check-your-answers-your-buyer-page.spec.js
@@ -1,5 +1,4 @@
 import { headingCaption, status } from '../../../../../../pages/shared';
-import partials from '../../../../../../partials';
 import { BUTTONS, PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
@@ -9,10 +8,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const CONTENT_STRINGS = PAGES.INSURANCE.CHECK_YOUR_ANSWERS.YOUR_BUYER;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -28,7 +23,7 @@ context(
 
         cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-        task.link().click();
+        cy.clickTaskCheckAnswers();
 
         // To get past "Your business" check your answers page
         cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/save-and-back.spec.js
@@ -1,14 +1,9 @@
-import partials from '../../../../../../partials';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 
 const {
   ROOT: INSURANCE_ROOT,
   CHECK_YOUR_ANSWERS: { YOUR_BUYER },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -22,7 +17,7 @@ context('Insurance - Check your answers - Your buyer page - Save and back', () =
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past previous "Check your answers" pages
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/summary-list/check-your-answers-your-buyer-summary-list-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/summary-list/check-your-answers-your-buyer-summary-list-fully-populated.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import checkSummaryList from '../../../../../../../commands/insurance/check-your-buyer-summary-list';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
@@ -22,10 +21,6 @@ const {
   HAS_BUYER_FINANCIAL_ACCOUNTS,
 } = INSURANCE_FIELD_IDS.YOUR_BUYER;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Your buyer page - Summary list - application over total contract value threshold, all optional buyer fields', () => {
@@ -46,7 +41,7 @@ context('Insurance - Check your answers - Your buyer page - Summary list - appli
         totalContractValueOverThreshold: true,
       });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past "Your business" check your answers page
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/summary-list/check-your-answers-your-buyer-summary-list-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/summary-list/check-your-answers-your-buyer-summary-list-minimal.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../../partials';
 import checkSummaryList from '../../../../../../../commands/insurance/check-your-buyer-summary-list';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
@@ -22,10 +21,6 @@ const {
   HAS_BUYER_FINANCIAL_ACCOUNTS,
 } = INSURANCE_FIELD_IDS.YOUR_BUYER;
 
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.submitApplication.tasks.checkAnswers;
-
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Check your answers - Your buyer page - Summary list - application below total contract value threshold, no optional buyer fields', () => {
@@ -38,7 +33,7 @@ context('Insurance - Check your answers - Your buyer page - Summary list - appli
 
       cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
-      task.link().click();
+      cy.clickTaskCheckAnswers();
 
       // To get past "Your business" check your answers page
       cy.completeAndSubmitMultipleCheckYourAnswers({ count: 1 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/save-and-back.spec.js
@@ -1,8 +1,5 @@
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
-
-const { taskList } = partials.insurancePartials;
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -11,12 +8,10 @@ const {
   },
 } = INSURANCE_ROUTES;
 
-const task = taskList.submitApplication.tasks.declarationsAndSubmit;
-
 const baseUrl = Cypress.config('baseUrl');
 
 const navigateBackToPage = () => {
-  task.link().click();
+  cy.clickTaskDeclarationsAndSubmit();
 
   // go through the first 2 declaration forms.
   cy.clickSubmitButtonMultipleTimes({ count: 2 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/save-and-back.spec.js
@@ -1,8 +1,5 @@
-import partials from '../../../../../../../partials';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
-
-const { taskList } = partials.insurancePartials;
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -11,12 +8,10 @@ const {
   },
 } = INSURANCE_ROUTES;
 
-const task = taskList.submitApplication.tasks.declarationsAndSubmit;
-
 const baseUrl = Cypress.config('baseUrl');
 
 const navigateBackToPage = () => {
-  task.link().click();
+  cy.clickTaskDeclarationsAndSubmit();
 
   // go through the first 3 declaration forms.
   cy.clickSubmitButtonMultipleTimes({ count: 3 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/save-and-back.spec.js
@@ -1,9 +1,6 @@
 import { singleInputField } from '../../../../../../pages/shared';
-import partials from '../../../../../../partials';
 import { FIELD_IDS } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
-
-const { taskList } = partials.insurancePartials;
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -13,8 +10,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const FIELD_ID = FIELD_IDS.INSURANCE.DECLARATIONS.AGREE_ANTI_BRIBERY;
-
-const task = taskList.submitApplication.tasks.declarationsAndSubmit;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -82,7 +77,7 @@ context('Insurance - Declarations - Anti-bribery page - Save and go back', () =>
     });
 
     it('should have the originally submitted answer selected when going back to the page after submission', () => {
-      task.link().click();
+      cy.clickTaskDeclarationsAndSubmit();
 
       // go to the page
       cy.clickSubmitButton();

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/confidentiality/confidentiality.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/confidentiality/confidentiality.spec.js
@@ -1,10 +1,7 @@
 import { headingCaption, singleInputField, declarationPage } from '../../../../../../pages/shared';
-import partials from '../../../../../../partials';
 import { PAGES, ERROR_MESSAGES } from '../../../../../../content-strings';
 import { FIELD_IDS } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
-
-const { taskList } = partials.insurancePartials;
 
 const CONTENT_STRINGS = PAGES.INSURANCE.DECLARATIONS.CONFIDENTIALITY.VERSIONS[0];
 
@@ -37,7 +34,7 @@ context(
         cy.completeAndSubmitCheckYourAnswers();
 
         // go to the page we want to test.
-        taskList.submitApplication.tasks.declarationsAndSubmit.link().click();
+        cy.clickTaskDeclarationsAndSubmit();
 
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CONFIDENTIALITY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/confidentiality/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/confidentiality/save-and-back.spec.js
@@ -1,9 +1,6 @@
 import { singleInputField } from '../../../../../../pages/shared';
-import partials from '../../../../../../partials';
 import { FIELD_IDS } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
-
-const { taskList } = partials.insurancePartials;
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -11,8 +8,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const FIELD_ID = FIELD_IDS.INSURANCE.DECLARATIONS.AGREE_CONFIDENTIALITY;
-
-const task = taskList.submitApplication.tasks.declarationsAndSubmit;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -28,7 +23,7 @@ context('Insurance - Declarations - Confidentiality page - Save and go back', ()
       cy.completeAndSubmitCheckYourAnswers();
 
       // go to the page we want to test.
-      task.link().click();
+      cy.clickTaskDeclarationsAndSubmit();
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CONFIDENTIALITY}`;
 
@@ -82,7 +77,7 @@ context('Insurance - Declarations - Confidentiality page - Save and go back', ()
     });
 
     it('should have the originally submitted answer selected when going back to the page after submission', () => {
-      task.link().click();
+      cy.clickTaskDeclarationsAndSubmit();
 
       cy.assertRadioOptionIsChecked(singleInputField(FIELD_ID).input());
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/confirmation-and-acknowledgements/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/confirmation-and-acknowledgements/save-and-back.spec.js
@@ -1,9 +1,6 @@
 import { singleInputField } from '../../../../../../pages/shared';
-import partials from '../../../../../../partials';
 import { FIELD_IDS } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
-
-const { taskList } = partials.insurancePartials;
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -11,8 +8,6 @@ const {
 } = INSURANCE_ROUTES;
 
 const FIELD_ID = FIELD_IDS.INSURANCE.DECLARATIONS.AGREE_CONFIRMATION_ACKNOWLEDGEMENTS;
-
-const task = taskList.submitApplication.tasks.declarationsAndSubmit;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -78,7 +73,7 @@ context('Insurance - Declarations - Confirmation and acknowledgements page - Sav
     });
 
     it('should have the originally submitted answer selected when going back to the page after submission', () => {
-      task.link().click();
+      cy.clickTaskDeclarationsAndSubmit();
 
       // go through the first 4 declaration forms.
       cy.clickSubmitButtonMultipleTimes({ count: 4 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/root/export-contract-root.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/root/export-contract-root.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import assertSectionStartContent from '../../../../../../commands/shared-commands/assertions/assert-section-start-content';
@@ -10,10 +9,6 @@ const {
   ALL_SECTIONS,
   EXPORT_CONTRACT: { ROOT: EXPORT_CONTRACT_ROOT, HOW_WAS_THE_CONTRACT_AWARDED },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.prepareApplication.tasks.exportContract;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -28,7 +23,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        task.link().click();
+        cy.clickTaskExportContract();
 
         exportContractRootUrl = `${baseUrl}${ROOT}/${referenceNumber}${EXPORT_CONTRACT_ROOT}`;
         allSectionsUrl = `${ROOT}/${referenceNumber}${ALL_SECTIONS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/root/insurance-policy-root.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/root/insurance-policy-root.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import assertSectionStartContent from '../../../../../../commands/shared-commands/assertions/assert-section-start-content';
@@ -10,10 +9,6 @@ const {
   ALL_SECTIONS,
   POLICY: { ROOT: POLICY_ROOT, TYPE_OF_POLICY },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.prepareApplication.tasks.policy;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -29,7 +24,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        task.link().click();
+        cy.clickTaskPolicy();
 
         insurancePolicyRootUrl = `${baseUrl}${ROOT}/${referenceNumber}${POLICY_ROOT}`;
         typeOfPolicyUrl = `${ROOT}/${referenceNumber}${TYPE_OF_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/root/your-business-root.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/root/your-business-root.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import assertSectionStartContent from '../../../../../../commands/shared-commands/assertions/assert-section-start-content';
@@ -10,10 +9,6 @@ const {
   ALL_SECTIONS,
   EXPORTER_BUSINESS: { ROOT: EXPORTER_BUSINESS_ROOT, COMPANY_DETAILS },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.prepareApplication.tasks.business;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -29,7 +24,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        task.link().click();
+        cy.clickTaskBusiness();
 
         yourBusinessRootUrl = `${baseUrl}${ROOT}/${referenceNumber}${EXPORTER_BUSINESS_ROOT}`;
         companyDetailsUrl = `${ROOT}/${referenceNumber}${COMPANY_DETAILS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/root/your-buyer-root.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/root/your-buyer-root.spec.js
@@ -1,4 +1,3 @@
-import partials from '../../../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import assertSectionStartContent from '../../../../../../commands/shared-commands/assertions/assert-section-start-content';
@@ -10,10 +9,6 @@ const {
   ALL_SECTIONS,
   YOUR_BUYER: { ROOT: YOUR_BUYER_ROOT, COMPANY_OR_ORGANISATION },
 } = INSURANCE_ROUTES;
-
-const { taskList } = partials.insurancePartials;
-
-const task = taskList.prepareApplication.tasks.buyer;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -29,7 +24,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        task.link().click();
+        cy.clickTaskBuyer();
 
         yourBuyerRootUrl = `${baseUrl}${ROOT}/${referenceNumber}${YOUR_BUYER_ROOT}`;
         companyOrOrganisationUrl = `${ROOT}/${referenceNumber}${COMPANY_OR_ORGANISATION}`;


### PR DESCRIPTION
## Introduction :pencil2:
This PR introduces some new cypress commands to click the task links in the "All sections" task list.

## Resolution :heavy_check_mark:
- Create new cypress commands:
  - `cy.clickTaskBusiness();`
  - `cy.clickTaskBuyer();`
  - `cy.clickTaskPolicy();`
  - `cy.clickTaskExportContract();`
  - `cy.clickTaskCheckAnswers();`
  - `cy.clickTaskDeclarationsAndSubmit();`
- Update E2E tests.