### PR TITLE
fix(EMS-3822): your buyer - outstanding/overdue payments - label currencies

### DIFF
--- a/e2e-tests/commands/insurance/complete-and-submit-alternative-currency-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-alternative-currency-form.js
@@ -5,11 +5,12 @@ const { CURRENCY_CODE } = INSURANCE_FIELD_IDS.CURRENCY;
 
 /**
  * completeAndSubmitAlternativeCurrencyForm
- * presses hyperlink and completes the alternative currency form
+ * conditionally clicks "alternative currency" hyperlink and completes the alternative currency form
  * if isoCode provided - clicks the radio for currency and submits alternative currency form
  * if alternativeCurrency true, then enters alternative currency and submits alternative currency form
- * @param {String} isoCode: isoCode provided for radio selection
- * @param {Boolean} alternativeCurrency: if alternative currency should be entered
+ * @param {String} isoCode: isoCode for radio selection.
+ * @param {Boolean} alternativeCurrency: If alternative currency should be entered.
+ * @param {Boolean} clickAlternativeCurrencyLink: if the "Alternative currency" link should be clicked.
  */
 const completeAndSubmitAlternativeCurrencyForm = ({ isoCode, alternativeCurrency, clickAlternativeCurrencyLink = true }) => {
   if (isoCode) {
@@ -26,7 +27,7 @@ const completeAndSubmitAlternativeCurrencyForm = ({ isoCode, alternativeCurrency
       cy.clickProvideAlternativeCurrencyLink();
     }
 
-    cy.clickAlternativeCurrencyRadioAndSubmitCurrency({});
+    cy.clickAlternativeCurrencyRadioAndSubmitCurrency({ currency: isoCode });
   }
 
   if (!isoCode && !alternativeCurrency) {

--- a/e2e-tests/commands/insurance/your-buyer/complete-and-submit-your-buyer-forms.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-and-submit-your-buyer-forms.js
@@ -2,34 +2,30 @@
  * completeAndSubmitYourBuyerForms
  * completes your buyer forms up to the specified form to stop at
  * eg, when 'connectionWithTheBuyer' is passed, it will complete all forms up to and including 'connectionWithTheBuyer'
- * @param {String} formToStopAt: the form to stop at
- * @param {Boolean} viaTaskList: whether to complete the section via the task list
- * @param {Boolean} hasConnectionToBuyer: whether the exporter has a connection with the buyer
- * @param {Boolean} exporterHasTradedWithBuyer: whether the exporter has traded with the buyer
- * @param {Boolean} outstandingPayments: whether the exporter has outstanding payments with the buyer
- * @param {Boolean} failedToPay: whether the buyer has failed to pay the exporter
- * @param {Boolean} fullyPopulatedBuyerTradingHistory: whether to fully populate the buyer trading history form
- * @param {Boolean} exporterHasBuyerFinancialAccounts: whether the exporter has buyer financial accounts
- * @param {String} isoCode: Policy currency ISO code
  * @param {Boolean} alternativeCurrency: If alternative currency should be entered.
  * @param {Boolean} clickAlternativeCurrencyLink: if the "Alternative currency" link should be clicked.
+ * @param {Boolean} exporterHasTradedWithBuyer: whether the exporter has traded with the buyer
+ * @param {Boolean} failedToPay: whether the buyer has failed to pay the exporter
+ * @param {String} formToStopAt: the form to stop at
+ * @param {Boolean} fullyPopulatedBuyerTradingHistory: whether to fully populate the buyer trading history form
+ * @param {Boolean} hasConnectionToBuyer: whether the exporter has a connection with the buyer
+ * @param {Boolean} exporterHasBuyerFinancialAccounts: whether the exporter has buyer financial accounts
+ * @param {String} isoCode: Policy currency ISO code
+ * @param {Boolean} outstandingPayments: whether the exporter has outstanding payments with the buyer
+ * @param {Boolean} viaTaskList: whether to complete the section via the task list
  */
-
-// TODO
-// TODO - alphabetical ordered documentation
-// TODO - alphabetical ordered documentation
 const completeAndSubmitYourBuyerForms = ({
-  formToStopAt,
-  viaTaskList,
-  hasConnectionToBuyer,
-  exporterHasTradedWithBuyer,
-  outstandingPayments,
-  failedToPay,
-  fullyPopulatedBuyerTradingHistory,
-  exporterHasBuyerFinancialAccounts,
-  isoCode,
   alternativeCurrency,
   clickAlternativeCurrencyLink,
+  exporterHasTradedWithBuyer,
+  failedToPay,
+  formToStopAt,
+  fullyPopulatedBuyerTradingHistory,
+  exporterHasBuyerFinancialAccounts,
+  hasConnectionToBuyer,
+  isoCode,
+  outstandingPayments,
+  viaTaskList,
 }) => {
   cy.startInsuranceYourBuyerSection({ viaTaskList });
 

--- a/e2e-tests/commands/insurance/your-buyer/complete-and-submit-your-buyer-forms.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-and-submit-your-buyer-forms.js
@@ -10,7 +10,14 @@
  * @param {Boolean} failedToPay: whether the buyer has failed to pay the exporter
  * @param {Boolean} fullyPopulatedBuyerTradingHistory: whether to fully populate the buyer trading history form
  * @param {Boolean} exporterHasBuyerFinancialAccounts: whether the exporter has buyer financial accounts
+ * @param {String} isoCode: Policy currency ISO code
+ * @param {Boolean} alternativeCurrency: If alternative currency should be entered.
+ * @param {Boolean} clickAlternativeCurrencyLink: if the "Alternative currency" link should be clicked.
  */
+
+// TODO
+// TODO - alphabetical ordered documentation
+// TODO - alphabetical ordered documentation
 const completeAndSubmitYourBuyerForms = ({
   formToStopAt,
   viaTaskList,
@@ -20,6 +27,9 @@ const completeAndSubmitYourBuyerForms = ({
   failedToPay,
   fullyPopulatedBuyerTradingHistory,
   exporterHasBuyerFinancialAccounts,
+  isoCode,
+  alternativeCurrency,
+  clickAlternativeCurrencyLink,
 }) => {
   cy.startInsuranceYourBuyerSection({ viaTaskList });
 
@@ -40,7 +50,10 @@ const completeAndSubmitYourBuyerForms = ({
     });
 
     if (outstandingPayments) {
-      steps.push({ name: 'currencyOfLatePayments', action: () => cy.completeAndSubmitAlternativeCurrencyForm({}) });
+      steps.push({
+        name: 'currencyOfLatePayments',
+        action: () => cy.completeAndSubmitAlternativeCurrencyForm({ isoCode, alternativeCurrency, clickAlternativeCurrencyLink }),
+      });
       steps.push({ name: 'outstandingOrOverduePayments', action: () => cy.completeAndSubmitOutstandingOrOverduePaymentsForm({ outstandingPayments }) });
     }
 

--- a/e2e-tests/content-strings/fields/insurance/your-buyer/index.js
+++ b/e2e-tests/content-strings/fields/insurance/your-buyer/index.js
@@ -130,15 +130,14 @@ export const YOUR_BUYER_FIELDS = {
     MAXIMUM: MAXIMUM_CHARACTERS.BUYER.PREVIOUS_CREDIT_INSURANCE_COVER,
   },
   [TOTAL_OUTSTANDING_PAYMENTS]: {
-    HEADING: 'Tell us about the outstanding or overdue payments',
-    LABEL: 'Total outstanding, including overdue',
+    LABEL: 'Total outstanding, including overdue in',
     SUMMARY: {
       TITLE: 'Total outstanding including overdue',
       FORM_TITLE: TRADING_HISTORY,
     },
   },
   [TOTAL_AMOUNT_OVERDUE]: {
-    LABEL: 'Amount overdue',
+    LABEL: 'Amount overdue in',
     SUMMARY: {
       TITLE: 'Amount overdue',
       FORM_TITLE: TRADING_HISTORY,

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-alternative-currency.spec.js
@@ -1,0 +1,79 @@
+import { field } from '../../../../../../pages/shared';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { YOUR_BUYER as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/your-buyer';
+import { YOUR_BUYER_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/your-buyer';
+import { NON_STANDARD_CURRENCY_NAME } from '../../../../../../fixtures/currencies';
+
+const {
+  ROOT,
+  YOUR_BUYER: { OUTSTANDING_OR_OVERDUE_PAYMENTS },
+} = INSURANCE_ROUTES;
+
+const { TOTAL_AMOUNT_OVERDUE, TOTAL_OUTSTANDING_PAYMENTS } = FIELD_IDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Your buyer - Outstanding or overdue payments - Alternative currency', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${OUTSTANDING_OR_OVERDUE_PAYMENTS}`;
+
+      cy.completeAndSubmitYourBuyerForms({
+        formToStopAt: 'currencyOfLatePayments',
+        outstandingPayments: true,
+        exporterHasTradedWithBuyer: true,
+        alternativeCurrency: true,
+        clickAlternativeCurrencyLink: false,
+      });
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('page tests', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    describe(TOTAL_OUTSTANDING_PAYMENTS, () => {
+      it('should render a label with the alternative currency', () => {
+        cy.assertCopyWithCurrencyName({
+          expectedCopy: FIELDS[TOTAL_OUTSTANDING_PAYMENTS].LABEL,
+          currencyName: NON_STANDARD_CURRENCY_NAME,
+          selector: field(TOTAL_OUTSTANDING_PAYMENTS).label(),
+        });
+      });
+
+      it('should NOT render a prefix', () => {
+        field(TOTAL_OUTSTANDING_PAYMENTS).prefix().should('not.exist');
+      });
+    });
+
+    describe(TOTAL_AMOUNT_OVERDUE, () => {
+      it('should render a label with the alternative currency', () => {
+        cy.assertCopyWithCurrencyName({
+          expectedCopy: FIELDS[TOTAL_AMOUNT_OVERDUE].LABEL,
+          currencyName: NON_STANDARD_CURRENCY_NAME,
+          selector: field(TOTAL_AMOUNT_OVERDUE).label(),
+        });
+      });
+
+      it('should NOT render a prefix', () => {
+        field(TOTAL_AMOUNT_OVERDUE).prefix().should('not.exist');
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-alternative-currency.spec.js
@@ -11,6 +11,8 @@ const {
 
 const { TOTAL_AMOUNT_OVERDUE, TOTAL_OUTSTANDING_PAYMENTS } = FIELD_IDS;
 
+const currencyName = NON_STANDARD_CURRENCY_NAME;
+
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Your buyer - Outstanding or overdue payments - Alternative currency', () => {
@@ -52,7 +54,7 @@ context('Insurance - Your buyer - Outstanding or overdue payments - Alternative 
       it('should render a label with the alternative currency', () => {
         cy.assertCopyWithCurrencyName({
           expectedCopy: FIELDS[TOTAL_OUTSTANDING_PAYMENTS].LABEL,
-          currencyName: NON_STANDARD_CURRENCY_NAME,
+          currencyName,
           selector: field(TOTAL_OUTSTANDING_PAYMENTS).label(),
         });
       });
@@ -66,7 +68,7 @@ context('Insurance - Your buyer - Outstanding or overdue payments - Alternative 
       it('should render a label with the alternative currency', () => {
         cy.assertCopyWithCurrencyName({
           expectedCopy: FIELDS[TOTAL_AMOUNT_OVERDUE].LABEL,
-          currencyName: NON_STANDARD_CURRENCY_NAME,
+          currencyName,
           selector: field(TOTAL_AMOUNT_OVERDUE).label(),
         });
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-non-gbp-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-non-gbp-currency.spec.js
@@ -11,6 +11,8 @@ const {
 
 const { TOTAL_AMOUNT_OVERDUE, TOTAL_OUTSTANDING_PAYMENTS } = FIELD_IDS;
 
+const currencyName = USD.name;
+
 const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Your buyer - Outstanding or overdue payments - Non-GBP (supported) currency', () => {
@@ -52,7 +54,7 @@ context('Insurance - Your buyer - Outstanding or overdue payments - Non-GBP (sup
       it('should render a label with the non-GBP currency', () => {
         cy.assertCopyWithCurrencyName({
           expectedCopy: FIELDS[TOTAL_OUTSTANDING_PAYMENTS].LABEL,
-          currencyName: USD.name,
+          currencyName,
           selector: field(TOTAL_OUTSTANDING_PAYMENTS).label(),
         });
       });
@@ -66,7 +68,7 @@ context('Insurance - Your buyer - Outstanding or overdue payments - Non-GBP (sup
       it('should render a label with the non-GBP currency', () => {
         cy.assertCopyWithCurrencyName({
           expectedCopy: FIELDS[TOTAL_AMOUNT_OVERDUE].LABEL,
-          currencyName: USD.name,
+          currencyName,
           selector: field(TOTAL_AMOUNT_OVERDUE).label(),
         });
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-non-gbp-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-non-gbp-currency.spec.js
@@ -1,0 +1,79 @@
+import { field } from '../../../../../../pages/shared';
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { YOUR_BUYER as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/your-buyer';
+import { YOUR_BUYER_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/your-buyer';
+import { SYMBOLS, USD } from '../../../../../../fixtures/currencies';
+
+const {
+  ROOT,
+  YOUR_BUYER: { OUTSTANDING_OR_OVERDUE_PAYMENTS },
+} = INSURANCE_ROUTES;
+
+const { TOTAL_AMOUNT_OVERDUE, TOTAL_OUTSTANDING_PAYMENTS } = FIELD_IDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Your buyer - Outstanding or overdue payments - Non-GBP (supported) currency', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      url = `${baseUrl}${ROOT}/${referenceNumber}${OUTSTANDING_OR_OVERDUE_PAYMENTS}`;
+
+      cy.completeAndSubmitYourBuyerForms({
+        formToStopAt: 'currencyOfLatePayments',
+        outstandingPayments: true,
+        exporterHasTradedWithBuyer: true,
+        isoCode: USD.isoCode,
+        clickAlternativeCurrencyLink: false,
+      });
+
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('page tests', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+    });
+
+    describe(TOTAL_OUTSTANDING_PAYMENTS, () => {
+      it('should render a label with the non-GBP currency', () => {
+        cy.assertCopyWithCurrencyName({
+          expectedCopy: FIELDS[TOTAL_OUTSTANDING_PAYMENTS].LABEL,
+          currencyName: USD.name,
+          selector: field(TOTAL_OUTSTANDING_PAYMENTS).label(),
+        });
+      });
+
+      it('should render a prefix', () => {
+        cy.checkText(field(TOTAL_OUTSTANDING_PAYMENTS).prefix(), SYMBOLS.USD);
+      });
+    });
+
+    describe(TOTAL_AMOUNT_OVERDUE, () => {
+      it('should render a label with the non-GBP currency', () => {
+        cy.assertCopyWithCurrencyName({
+          expectedCopy: FIELDS[TOTAL_AMOUNT_OVERDUE].LABEL,
+          currencyName: USD.name,
+          selector: field(TOTAL_AMOUNT_OVERDUE).label(),
+        });
+      });
+
+      it('should render a prefix', () => {
+        cy.checkText(field(TOTAL_AMOUNT_OVERDUE).prefix(), SYMBOLS.USD);
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments.spec.js
@@ -4,6 +4,7 @@ import { YOUR_BUYER_FIELDS as FIELDS } from '../../../../../../content-strings/f
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/your-buyer';
 import application from '../../../../../../fixtures/application';
+import { GBP, SYMBOLS } from '../../../../../../fixtures/currencies';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.YOUR_BUYER.OUTSTANDING_OR_OVERDUE_PAYMENTS;
 
@@ -67,21 +68,37 @@ context(
 
       describe(TOTAL_OUTSTANDING_PAYMENTS, () => {
         it(`should render a label for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
-          cy.checkText(field(TOTAL_OUTSTANDING_PAYMENTS).label(), FIELDS[TOTAL_OUTSTANDING_PAYMENTS].LABEL);
+          cy.assertCopyWithCurrencyName({
+            expectedCopy: FIELDS[TOTAL_OUTSTANDING_PAYMENTS].LABEL,
+            currencyName: GBP.name,
+            selector: field(TOTAL_OUTSTANDING_PAYMENTS).label(),
+          });
         });
 
         it(`should render an input for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
           field(TOTAL_OUTSTANDING_PAYMENTS).input().should('be.visible');
         });
+
+        it(`should render a prefix for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
+          cy.checkText(field(TOTAL_OUTSTANDING_PAYMENTS).prefix(), SYMBOLS.GBP);
+        });
       });
 
       describe(TOTAL_AMOUNT_OVERDUE, () => {
         it(`should render a label for ${TOTAL_AMOUNT_OVERDUE}`, () => {
-          cy.checkText(field(TOTAL_AMOUNT_OVERDUE).label(), FIELDS[TOTAL_AMOUNT_OVERDUE].LABEL);
+          cy.assertCopyWithCurrencyName({
+            expectedCopy: FIELDS[TOTAL_AMOUNT_OVERDUE].LABEL,
+            currencyName: GBP.name,
+            selector: field(TOTAL_AMOUNT_OVERDUE).label(),
+          });
         });
 
         it(`should render an input for ${TOTAL_AMOUNT_OVERDUE}`, () => {
           field(TOTAL_AMOUNT_OVERDUE).input().should('be.visible');
+        });
+
+        it(`should render a prefix for ${TOTAL_AMOUNT_OVERDUE}`, () => {
+          cy.checkText(field(TOTAL_AMOUNT_OVERDUE).prefix(), SYMBOLS.GBP);
         });
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments.spec.js
@@ -15,9 +15,11 @@ const {
 
 const { TOTAL_AMOUNT_OVERDUE, TOTAL_OUTSTANDING_PAYMENTS, OUTSTANDING_PAYMENTS } = FIELD_IDS;
 
-const baseUrl = Cypress.config('baseUrl');
-
 const { BUYER } = application;
+
+const currencyName = GBP.name;
+
+const baseUrl = Cypress.config('baseUrl');
 
 context(
   'Insurance - Your buyer - Outstanding or overdue payments - As an Underwriter, I want to know about any outstanding and/or overdue payments the buyer owes the exporter, So that I can better understand the level of risk when assessing the application',
@@ -70,7 +72,7 @@ context(
         it(`should render a label for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
           cy.assertCopyWithCurrencyName({
             expectedCopy: FIELDS[TOTAL_OUTSTANDING_PAYMENTS].LABEL,
-            currencyName: GBP.name,
+            currencyName,
             selector: field(TOTAL_OUTSTANDING_PAYMENTS).label(),
           });
         });
@@ -88,7 +90,7 @@ context(
         it(`should render a label for ${TOTAL_AMOUNT_OVERDUE}`, () => {
           cy.assertCopyWithCurrencyName({
             expectedCopy: FIELDS[TOTAL_AMOUNT_OVERDUE].LABEL,
-            currencyName: GBP.name,
+            currencyName,
             selector: field(TOTAL_AMOUNT_OVERDUE).label(),
           });
         });

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -6980,7 +6980,7 @@ var YOUR_BUYER_FIELDS = {
     },
   },
   [CURRENCY_CODE2]: {
-    LEGEND: 'Select the currency the outstanding or overdue payments are in?',
+    LEGEND: 'What is the currency the outstanding or overdue payments are in?',
   },
   [HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]: {
     LABEL: 'Have you in the past held credit insurance cover on the buyer?',
@@ -6999,15 +6999,14 @@ var YOUR_BUYER_FIELDS = {
     MAXIMUM: MAXIMUM_CHARACTERS.BUYER.PREVIOUS_CREDIT_INSURANCE_COVER,
   },
   [TOTAL_OUTSTANDING_PAYMENTS]: {
-    HEADING: 'Tell us about the outstanding or overdue payments',
-    LABEL: 'Total outstanding, including overdue',
+    LABEL: 'Total outstanding, including overdue in',
     SUMMARY: {
       TITLE: 'Total outstanding including overdue',
       FORM_TITLE: TRADING_HISTORY,
     },
   },
   [TOTAL_AMOUNT_OVERDUE]: {
-    LABEL: 'Amount overdue',
+    LABEL: 'Amount overdue in',
     SUMMARY: {
       TITLE: 'Amount overdue',
       FORM_TITLE: TRADING_HISTORY,

--- a/src/api/content-strings/fields/insurance/your-buyer/index.ts
+++ b/src/api/content-strings/fields/insurance/your-buyer/index.ts
@@ -125,15 +125,14 @@ export const YOUR_BUYER_FIELDS = {
     MAXIMUM: MAXIMUM_CHARACTERS.BUYER.PREVIOUS_CREDIT_INSURANCE_COVER,
   },
   [TOTAL_OUTSTANDING_PAYMENTS]: {
-    HEADING: 'Tell us about the outstanding or overdue payments',
-    LABEL: 'Total outstanding, including overdue',
+    LABEL: 'Total outstanding, including overdue in',
     SUMMARY: {
       TITLE: 'Total outstanding including overdue',
       FORM_TITLE: TRADING_HISTORY,
     },
   },
   [TOTAL_AMOUNT_OVERDUE]: {
-    LABEL: 'Amount overdue',
+    LABEL: 'Amount overdue in',
     SUMMARY: {
       TITLE: 'Amount overdue',
       FORM_TITLE: TRADING_HISTORY,

--- a/src/ui/server/content-strings/fields/insurance/your-buyer/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/your-buyer/index.ts
@@ -111,14 +111,13 @@ export const YOUR_BUYER_FIELDS = {
     MAXIMUM: MAXIMUM_CHARACTERS.BUYER.PREVIOUS_CREDIT_INSURANCE_COVER,
   },
   [TOTAL_OUTSTANDING_PAYMENTS]: {
-    HEADING: 'Tell us about the outstanding or overdue payments',
-    LABEL: 'Total outstanding, including overdue',
+    LABEL: 'Total outstanding, including overdue in',
     SUMMARY: {
       TITLE: 'Total outstanding including overdue',
     },
   },
   [TOTAL_AMOUNT_OVERDUE]: {
-    LABEL: 'Amount overdue',
+    LABEL: 'Amount overdue in',
     SUMMARY: {
       TITLE: 'Amount overdue',
     },

--- a/src/ui/server/controllers/insurance/your-buyer/outstanding-or-overdue-payments/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/outstanding-or-overdue-payments/index.test.ts
@@ -74,11 +74,11 @@ describe('controllers/insurance/your-buyer/outstanding-or-overdue-payments', () 
         FIELDS: {
           TOTAL_OUTSTANDING_PAYMENTS: {
             ID: TOTAL_OUTSTANDING_PAYMENTS,
-            ...FIELDS[TOTAL_OUTSTANDING_PAYMENTS],
+            LABEL: `${FIELDS[TOTAL_OUTSTANDING_PAYMENTS].LABEL} ${currency.name}`,
           },
           TOTAL_AMOUNT_OVERDUE: {
             ID: TOTAL_AMOUNT_OVERDUE,
-            ...FIELDS[TOTAL_AMOUNT_OVERDUE],
+            LABEL: `${FIELDS[TOTAL_AMOUNT_OVERDUE].LABEL} ${currency.name}`,
           },
         },
         PAGE_CONTENT_STRINGS,

--- a/src/ui/server/controllers/insurance/your-buyer/outstanding-or-overdue-payments/index.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/outstanding-or-overdue-payments/index.ts
@@ -58,11 +58,11 @@ export const pageVariables = (referenceNumber: number, currencies: Array<Currenc
     FIELDS: {
       TOTAL_OUTSTANDING_PAYMENTS: {
         ID: TOTAL_OUTSTANDING_PAYMENTS,
-        ...FIELDS[TOTAL_OUTSTANDING_PAYMENTS],
+        LABEL: `${FIELDS[TOTAL_OUTSTANDING_PAYMENTS].LABEL} ${currency.name}`,
       },
       TOTAL_AMOUNT_OVERDUE: {
         ID: TOTAL_AMOUNT_OVERDUE,
-        ...FIELDS[TOTAL_AMOUNT_OVERDUE],
+        LABEL: `${FIELDS[TOTAL_AMOUNT_OVERDUE].LABEL} ${currency.name}`,
       },
     },
     PAGE_CONTENT_STRINGS,
@@ -91,13 +91,13 @@ export const get = async (req: Request, res: Response) => {
       buyer: { buyerTradingHistory },
     } = application;
 
-    const { supportedCurrencies } = await api.keystone.APIM.getCurrencies();
+    const { allCurrencies } = await api.keystone.APIM.getCurrencies();
 
-    if (!isPopulatedArray(supportedCurrencies)) {
+    if (!isPopulatedArray(allCurrencies)) {
       return res.redirect(PROBLEM_WITH_SERVICE);
     }
 
-    const generatedPageVariables = pageVariables(referenceNumber, supportedCurrencies, String(buyerTradingHistory[CURRENCY_CODE]));
+    const generatedPageVariables = pageVariables(referenceNumber, allCurrencies, String(buyerTradingHistory[CURRENCY_CODE]));
 
     return res.render(TEMPLATE, {
       ...insuranceCorePageVariables({

--- a/src/ui/templates/insurance/your-buyer/outstanding-or-overdue-payments.njk
+++ b/src/ui/templates/insurance/your-buyer/outstanding-or-overdue-payments.njk
@@ -29,44 +29,43 @@
     }) }}
   {% endif %}
 
-  <div class="govuk-grid-row">
-    <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
-      <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+  <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
+    <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters-from-desktop">
+
         <span class="govuk-caption-xl" data-cy="heading-caption">
           {{ CONTENT_STRINGS.HEADING_CAPTION }}
         </span>
 
         <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 
-        <div class="govuk-grid-row">
-          {{ monetaryValueInput.render({
-            fieldId: FIELDS.TOTAL_OUTSTANDING_PAYMENTS.ID,
-            label: FIELDS.TOTAL_OUTSTANDING_PAYMENTS.LABEL,
-            currencyPrefixSymbol: CURRENCY_PREFIX_SYMBOL,
-            submittedValue: submittedValues[FIELDS.TOTAL_OUTSTANDING_PAYMENTS.ID] or application.buyer.buyerTradingHistory[FIELDS.TOTAL_OUTSTANDING_PAYMENTS.ID],
-            validationError: validationErrors.errorList[FIELDS.TOTAL_OUTSTANDING_PAYMENTS.ID],
-            legendClass: LEGEND_CLASS
-          }) }}
+        {{ monetaryValueInput.render({
+          fieldId: FIELDS.TOTAL_OUTSTANDING_PAYMENTS.ID,
+          label: FIELDS.TOTAL_OUTSTANDING_PAYMENTS.LABEL,
+          currencyPrefixSymbol: CURRENCY_PREFIX_SYMBOL,
+          submittedValue: submittedValues[FIELDS.TOTAL_OUTSTANDING_PAYMENTS.ID] or application.buyer.buyerTradingHistory[FIELDS.TOTAL_OUTSTANDING_PAYMENTS.ID],
+          validationError: validationErrors.errorList[FIELDS.TOTAL_OUTSTANDING_PAYMENTS.ID],
+          legendClass: LEGEND_CLASS
+        }) }}
 
-          {{ monetaryValueInput.render({
-            fieldId: FIELDS.TOTAL_AMOUNT_OVERDUE.ID,
-            label: FIELDS.TOTAL_AMOUNT_OVERDUE.LABEL,
-            currencyPrefixSymbol: CURRENCY_PREFIX_SYMBOL,
-            submittedValue: submittedValues[FIELDS.TOTAL_AMOUNT_OVERDUE.ID] or application.buyer.buyerTradingHistory[FIELDS.TOTAL_AMOUNT_OVERDUE.ID],
-            validationError: validationErrors.errorList[FIELDS.TOTAL_AMOUNT_OVERDUE.ID],
-            legendClass: LEGEND_CLASS
-          }) }}
-        <div>
+        {{ monetaryValueInput.render({
+          fieldId: FIELDS.TOTAL_AMOUNT_OVERDUE.ID,
+          label: FIELDS.TOTAL_AMOUNT_OVERDUE.LABEL,
+          currencyPrefixSymbol: CURRENCY_PREFIX_SYMBOL,
+          submittedValue: submittedValues[FIELDS.TOTAL_AMOUNT_OVERDUE.ID] or application.buyer.buyerTradingHistory[FIELDS.TOTAL_AMOUNT_OVERDUE.ID],
+          validationError: validationErrors.errorList[FIELDS.TOTAL_AMOUNT_OVERDUE.ID],
+          legendClass: LEGEND_CLASS
+        }) }}
       </div>
+    </div>
 
-      {{ formButtons.render({
-        contentStrings: CONTENT_STRINGS.BUTTONS,
-        saveAndBackUrl: SAVE_AND_BACK_URL
-      }) }}
+    {{ formButtons.render({
+      contentStrings: CONTENT_STRINGS.BUTTONS,
+      saveAndBackUrl: SAVE_AND_BACK_URL
+    }) }}
 
-    </form>
-  </div>
+  </form.
 
 {% endblock %}


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where the "outstanding and overdue payments" field labels in the "your buyer" section would not render the previously submitted currency.

## Resolution :heavy_check_mark:
- Update `completeAndSubmitAlternativeCurrencyForm` cypress command to consume and pass a `currency` param.
- Update `completeAndSubmitYourBuyerForms` cypress command.
- Update field content strings.
- Add E2E test coverage for:
  - Viewing the "outstanding/overdue payments" form with an "alternative" currency.
  - Viewing the "outstanding/overdue payments" form with a non-GBP currency.
- Update the GET controller to:
  - Add the currency to each form field.
  - Consume`allCurrencies` instead of only `supportedCurrencies`.

## Miscellaneous :heavy_plus_sign:
- Fix a nunjucks column layout issue.
