### PR TITLE
style(EMS-3824-25-37-38-40-41): content iterations

### DIFF
--- a/e2e-tests/content-strings/fields/insurance/export-contract/index.js
+++ b/e2e-tests/content-strings/fields/insurance/export-contract/index.js
@@ -200,7 +200,7 @@ export const EXPORT_CONTRACT_FIELDS = {
     [PAYABLE_COUNTRY_CODE]: {
       LABEL: 'Country where charges are payable',
       SUMMARY: {
-        TITLE: 'Country that commission is payable',
+        TITLE: 'Country where commission is payable',
         FORM_TITLE: EXPORT_CONTRACT_FORM_TITLES.AGENT,
       },
     },

--- a/e2e-tests/content-strings/fields/insurance/your-buyer/index.js
+++ b/e2e-tests/content-strings/fields/insurance/your-buyer/index.js
@@ -100,7 +100,7 @@ export const YOUR_BUYER_FIELDS = {
     },
   },
   [FAILED_PAYMENTS]: {
-    LABEL: 'Has the buyer ever failed to pay you on time?',
+    HINT: 'This is when an invoice has still not been paid 30 days or more after the agreed payment date.',
     SUMMARY: {
       TITLE: 'Buyer failed to pay on time?',
       FORM_TITLE: TRADING_HISTORY,

--- a/e2e-tests/content-strings/pages/insurance/eligibility/index.js
+++ b/e2e-tests/content-strings/pages/insurance/eligibility/index.js
@@ -119,7 +119,7 @@ export const COMPANY_DETAILS = {
 };
 
 export const END_BUYER = {
-  PAGE_TITLE: "Does your export contract say you'll only get paid once you're buyer gets paid?",
+  PAGE_TITLE: "Does your export contract say you'll only get paid once your buyer gets paid?",
 };
 
 export const CANNOT_APPLY_MULTIPLE_RISKS_EXIT = {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/alternative-currency/alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/alternative-currency/alternative-currency.spec.js
@@ -56,7 +56,7 @@ context(
         pageTitle: FIELDS.AGENT_CHARGES[CURRENCY_CODE].LEGEND,
         currentHref: `${ROOT}/${referenceNumber}${AGENT_CHARGES_ALTERNATIVE_CURRENCY}`,
         backLink: `${ROOT}/${referenceNumber}${AGENT_CHARGES}`,
-        submitButtonCopy: BUTTONS.CONFIRM,
+        submitButtonCopy: BUTTONS.CONTINUE,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover-currency/turnover-currency-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover-currency/turnover-currency-page.spec.js
@@ -47,7 +47,7 @@ context(
         pageTitle: CONTENT_STRINGS.PAGE_TITLE,
         currentHref: `${ROOT}/${referenceNumber}${TURNOVER_CURRENCY_ROOT}`,
         backLink: `${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS_ROOT}`,
-        submitButtonCopy: BUTTONS.CONFIRM,
+        submitButtonCopy: BUTTONS.CONTINUE,
         assertSaveAndBackButtonDoesNotExist: true,
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/currency-of-late-payments/currency-of-late-payments.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/currency-of-late-payments/currency-of-late-payments.spec.js
@@ -54,7 +54,7 @@ context(
         pageTitle: YOUR_BUYER_FIELDS[CURRENCY_CODE].LEGEND,
         currentHref: `${ROOT}/${referenceNumber}${CURRENCY_OF_LATE_PAYMENTS}`,
         backLink: `${ROOT}/${referenceNumber}${TRADING_HISTORY}`,
-        submitButtonCopy: BUTTONS.CONFIRM,
+        submitButtonCopy: BUTTONS.CONTINUE,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/failed-to-pay/failed-to-pay.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/failed-to-pay/failed-to-pay.spec.js
@@ -1,5 +1,6 @@
-import { headingCaption, yesRadio, noRadio } from '../../../../../../pages/shared';
+import { headingCaption, yesRadio, yesNoRadioHint, noRadio } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
+import { YOUR_BUYER_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/your-buyer';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { YOUR_BUYER as FIELD_IDS } from '../../../../../../constants/field-ids/insurance/your-buyer';
@@ -11,7 +12,7 @@ const {
   YOUR_BUYER: { OUTSTANDING_OR_OVERDUE_PAYMENTS, FAILED_TO_PAY, BUYER_FINANCIAL_INFORMATION },
 } = INSURANCE_ROUTES;
 
-const { FAILED_PAYMENTS } = FIELD_IDS;
+const { FAILED_PAYMENTS: FIELD_ID } = FIELD_IDS;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -64,6 +65,8 @@ context(
         yesRadio().input().first().should('exist');
 
         cy.checkText(yesRadio().label().first(), FIELD_VALUES.YES);
+
+        cy.checkText(yesNoRadioHint(), FIELDS[FIELD_ID].HINT);
       });
 
       it('renders `no` radio button', () => {
@@ -79,7 +82,7 @@ context(
 
     describe('form submission', () => {
       describe('when submitting a fully filled form', () => {
-        describe(`when ${FAILED_PAYMENTS} is "no"`, () => {
+        describe(`when ${FIELD_ID} is "no"`, () => {
           it(`should redirect to ${FAILED_TO_PAY} page`, () => {
             cy.navigateToUrl(url);
 
@@ -97,8 +100,8 @@ context(
           });
         });
 
-        describe(`when ${FAILED_PAYMENTS} is "yes"`, () => {
-          it(`should redirect to ${FAILED_PAYMENTS} page`, () => {
+        describe(`when ${FIELD_ID} is "yes"`, () => {
+          it(`should redirect to ${FIELD_ID} page`, () => {
             cy.navigateToUrl(url);
 
             cy.completeAndSubmitFailedToPayForm({ failedToPay: true });

--- a/src/api/content-strings/fields/insurance/your-buyer/index.ts
+++ b/src/api/content-strings/fields/insurance/your-buyer/index.ts
@@ -99,7 +99,7 @@ export const YOUR_BUYER_FIELDS = {
     },
   },
   [FAILED_PAYMENTS]: {
-    LABEL: 'Has the buyer ever failed to pay you on time?',
+    HINT: 'This is when an invoice has still not been paid 30 days or more after the agreed payment date.',
     SUMMARY: {
       TITLE: 'Buyer failed to pay on time?',
       FORM_TITLE: TRADING_HISTORY,

--- a/src/ui/server/content-strings/fields/insurance/export-contract/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/export-contract/index.ts
@@ -197,7 +197,7 @@ export const EXPORT_CONTRACT_FIELDS = {
     [PAYABLE_COUNTRY_CODE]: {
       LABEL: 'Country where charges are payable',
       SUMMARY: {
-        TITLE: 'Country that commission is payable',
+        TITLE: 'Country where commission is payable',
         FORM_TITLE: EXPORT_CONTRACT_FORM_TITLES.AGENT,
       },
     },

--- a/src/ui/server/content-strings/fields/insurance/your-buyer/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/your-buyer/index.ts
@@ -85,7 +85,7 @@ export const YOUR_BUYER_FIELDS = {
     },
   },
   [FAILED_PAYMENTS]: {
-    LABEL: 'Has the buyer ever failed to pay you on time?',
+    HINT: 'This is when an invoice has still not been paid 30 days or more after the agreed payment date.',
     SUMMARY: {
       TITLE: 'Buyer failed to pay on time?',
     },

--- a/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
+++ b/src/ui/server/content-strings/pages/insurance/eligibility/index.ts
@@ -119,7 +119,7 @@ const COMPANY_DETAILS = {
 };
 
 const END_BUYER = {
-  PAGE_TITLE: "Does your export contract say you'll only get paid once you're buyer gets paid?",
+  PAGE_TITLE: "Does your export contract say you'll only get paid once your buyer gets paid?",
 };
 
 const CANNOT_APPLY_MULTIPLE_RISKS_EXIT = {

--- a/src/ui/templates/shared-pages/alternative-currency.njk
+++ b/src/ui/templates/shared-pages/alternative-currency.njk
@@ -59,7 +59,7 @@
       <div class="govuk-grid-column-three-quarters-from-desktop">
         <div class="govuk-button-group">
           {{ submitButton.render({
-            text: CONTENT_STRINGS.BUTTONS.CONFIRM
+            text: CONTENT_STRINGS.BUTTONS.CONTINUE
           }) }}
         </div>
       </div>


### PR DESCRIPTION
## Introduction :pencil2:
This PR introduces a series of minor content iterations throughout EXIPS.

This covers the following tickets:
- EMS-3824
- EMS-3825
- EMS-3837
- EMS-3838
- EMS-3840
- EMS-3841

## Resolution :heavy_check_mark:
- Update `PAYABLE_COUNTRY_CODE` summary list title.
- Add `FAILED_PAYMENTS` field hint.
- Update `END_BUYER` page title.
- Update "alternative currency" forms to have a submit button with "continue" copy, instead of "confirm".

## Miscellaneous :heavy_plus_sign:
- Remove unused `FAILED_PAYMENTS` content string label.
