### PR TITLE
style(EMS-3823): application submission - xlsx - credit limit row

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -6962,14 +6962,14 @@ var YOUR_BUYER_FIELDS = {
     }
   },
   [FAILED_PAYMENTS]: {
-    LABEL: "Has the buyer ever failed to pay you on time?",
+    HINT: "This is when an invoice has still not been paid 30 days or more after the agreed payment date.",
     SUMMARY: {
       TITLE: "Buyer failed to pay on time?",
       FORM_TITLE: TRADING_HISTORY
     }
   },
   [CURRENCY_CODE2]: {
-    LEGEND: "What currency are the outstanding or overdue payments in?"
+    LEGEND: "What is the currency the outstanding or overdue payments are in?"
   },
   [HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]: {
     LABEL: "Have you in the past held credit insurance cover on the buyer?",
@@ -6988,15 +6988,14 @@ var YOUR_BUYER_FIELDS = {
     MAXIMUM: MAXIMUM_CHARACTERS.BUYER.PREVIOUS_CREDIT_INSURANCE_COVER
   },
   [TOTAL_OUTSTANDING_PAYMENTS]: {
-    HEADING: "Tell us about the outstanding or overdue payments",
-    LABEL: "Total outstanding, including overdue",
+    LABEL: "Total outstanding, including overdue in",
     SUMMARY: {
       TITLE: "Total outstanding including overdue",
       FORM_TITLE: TRADING_HISTORY
     }
   },
   [TOTAL_AMOUNT_OVERDUE]: {
-    LABEL: "Amount overdue",
+    LABEL: "Amount overdue in",
     SUMMARY: {
       TITLE: "Amount overdue",
       FORM_TITLE: TRADING_HISTORY
@@ -7494,7 +7493,7 @@ var {
     CONTRACT_POLICY: {
       SINGLE: { CONTRACT_COMPLETION_DATE: CONTRACT_COMPLETION_DATE3 },
       POLICY_CURRENCY_CODE,
-      SINGLE: { TOTAL_CONTRACT_VALUE: TOTAL_CONTRACT_VALUE2 }
+      SINGLE: { REQUESTED_CREDIT_LIMIT, TOTAL_CONTRACT_VALUE: TOTAL_CONTRACT_VALUE2 }
     }
   }
 } = insurance_default;
@@ -7502,7 +7501,8 @@ var mapSingleContractPolicy = (policy) => {
   const mapped = [
     xlsx_row_default(String(FIELDS8[CONTRACT_COMPLETION_DATE3]), format_date_default(policy[CONTRACT_COMPLETION_DATE3], DATE_FORMAT.XLSX)),
     xlsx_row_default(String(CONTENT_STRINGS2[CURRENCY_CODE3].SUMMARY?.TITLE), policy[POLICY_CURRENCY_CODE]),
-    xlsx_row_default(String(FIELDS8[TOTAL_CONTRACT_VALUE2]), format_currency_default2(policy[TOTAL_CONTRACT_VALUE2], policy[POLICY_CURRENCY_CODE]))
+    xlsx_row_default(String(FIELDS8[TOTAL_CONTRACT_VALUE2]), format_currency_default2(policy[TOTAL_CONTRACT_VALUE2], policy[POLICY_CURRENCY_CODE])),
+    xlsx_row_default(String(CONTENT_STRINGS2[REQUESTED_CREDIT_LIMIT].SUMMARY?.TITLE), format_currency_default2(policy[REQUESTED_CREDIT_LIMIT], policy[POLICY_CURRENCY_CODE]))
   ];
   return mapped;
 };

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-policy/map-single-contract-policy/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-policy/map-single-contract-policy/index.test.ts
@@ -24,7 +24,7 @@ const {
     CONTRACT_POLICY: {
       SINGLE: { CONTRACT_COMPLETION_DATE },
       POLICY_CURRENCY_CODE,
-      SINGLE: { TOTAL_CONTRACT_VALUE },
+      SINGLE: { REQUESTED_CREDIT_LIMIT, TOTAL_CONTRACT_VALUE },
     },
   },
 } = FIELD_IDS;
@@ -50,6 +50,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-policy/map-single-contra
       xlsxRow(String(FIELDS[CONTRACT_COMPLETION_DATE]), formatDate(policy[CONTRACT_COMPLETION_DATE], DATE_FORMAT.XLSX)),
       xlsxRow(String(CONTENT_STRINGS[CURRENCY_CODE].SUMMARY?.TITLE), policy[POLICY_CURRENCY_CODE]),
       xlsxRow(String(FIELDS[TOTAL_CONTRACT_VALUE]), formatCurrency(policy[TOTAL_CONTRACT_VALUE], policy[POLICY_CURRENCY_CODE])),
+      xlsxRow(String(CONTENT_STRINGS[REQUESTED_CREDIT_LIMIT].SUMMARY?.TITLE), formatCurrency(policy[REQUESTED_CREDIT_LIMIT], policy[POLICY_CURRENCY_CODE])),
     ];
 
     expect(result).toEqual(expected);

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-policy/map-single-contract-policy/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-policy/map-single-contract-policy/index.ts
@@ -21,7 +21,7 @@ const {
     CONTRACT_POLICY: {
       SINGLE: { CONTRACT_COMPLETION_DATE },
       POLICY_CURRENCY_CODE,
-      SINGLE: { TOTAL_CONTRACT_VALUE },
+      SINGLE: { REQUESTED_CREDIT_LIMIT, TOTAL_CONTRACT_VALUE },
     },
   },
 } = FIELD_IDS;
@@ -37,6 +37,7 @@ const mapSingleContractPolicy = (policy: ApplicationPolicy) => {
     xlsxRow(String(FIELDS[CONTRACT_COMPLETION_DATE]), formatDate(policy[CONTRACT_COMPLETION_DATE], DATE_FORMAT.XLSX)),
     xlsxRow(String(CONTENT_STRINGS[CURRENCY_CODE].SUMMARY?.TITLE), policy[POLICY_CURRENCY_CODE]),
     xlsxRow(String(FIELDS[TOTAL_CONTRACT_VALUE]), formatCurrency(policy[TOTAL_CONTRACT_VALUE], policy[POLICY_CURRENCY_CODE])),
+    xlsxRow(String(CONTENT_STRINGS[REQUESTED_CREDIT_LIMIT].SUMMARY?.TITLE), formatCurrency(policy[REQUESTED_CREDIT_LIMIT], policy[POLICY_CURRENCY_CODE])),
   ];
 
   return mapped;

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint ./",
     "lint:fix": "eslint ./ --fix",
     "start": "keystone start --no-ui",
-    "test": "jest --runInBand --verbose --silent  --coverage --config=jest.config.js"
+    "test": "jest --runInBand --verbose --silent --coverage --config=jest.config.js"
   },
   "dependencies": {
     "@babel/core": "^7.25.2",

--- a/src/api/test-helpers/create-full-application.ts
+++ b/src/api/test-helpers/create-full-application.ts
@@ -61,6 +61,7 @@ export const createFullApplication = async (context: Context, policyType?: strin
    */
   const policyData = {
     policyType: POLICY_TYPE.SINGLE,
+    requestedCreditLimit: 100,
     totalSalesToBuyer: 123,
     totalValueOfContract: 456,
     maximumBuyerWillOwe: 789,


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the application submission XLSX mapping to include a new `REQUESTED_CREDIT_LIMIT` row in the "Policy" section.

This field was recently added to the user flow/data model.

## Resolution :heavy_check_mark:
- Update `mapSingleContractPolicy` XLSX mapping function
