### PR TITLE
chore(tests): add missing getCurrencies unit tests

### DIFF
--- a/src/ui/server/controllers/insurance/business/turnover-currency/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/turnover-currency/index.test.ts
@@ -204,6 +204,12 @@ describe('controllers/insurance/business/turnover-currency', () => {
         req.body = validBody;
       });
 
+      it('should NOT call api.keystone.APIM.getCurrencies', async () => {
+        await post(req, res);
+
+        expect(getCurrenciesSpy).toHaveBeenCalledTimes(0);
+      });
+
       it('should call mapAndSave.business once with the data from constructPayload function and application', async () => {
         await post(req, res);
 

--- a/src/ui/server/controllers/insurance/business/turnover/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/turnover/index.test.ts
@@ -180,6 +180,12 @@ describe('controllers/insurance/business/turnover', () => {
     };
 
     describe('when there are validation errors', () => {
+      it('should call api.keystone.APIM.getCurrencies', async () => {
+        await get(req, res);
+
+        expect(getCurrenciesSpy).toHaveBeenCalledTimes(1);
+      });
+
       it('should render template with validation errors and submitted values', async () => {
         req.body = {};
 
@@ -208,11 +214,10 @@ describe('controllers/insurance/business/turnover', () => {
         req.body = validBody;
       });
 
-      it('should redirect to next page', async () => {
+      it('should NOT call api.keystone.APIM.getCurrencies', async () => {
         await post(req, res);
 
-        const expected = `${INSURANCE_ROOT}/${referenceNumber}${CREDIT_CONTROL}`;
-        expect(res.redirect).toHaveBeenCalledWith(expected);
+        expect(getCurrenciesSpy).toHaveBeenCalledTimes(0);
       });
 
       it('should call mapAndSave.turnover once with data from constructPayload and application', async () => {
@@ -223,6 +228,13 @@ describe('controllers/insurance/business/turnover', () => {
         expect(mapAndSave.turnover).toHaveBeenCalledTimes(1);
 
         expect(mapAndSave.turnover).toHaveBeenCalledWith(payload, mockApplication);
+      });
+
+      it('should redirect to next page', async () => {
+        await post(req, res);
+
+        const expected = `${INSURANCE_ROOT}/${referenceNumber}${CREDIT_CONTROL}`;
+        expect(res.redirect).toHaveBeenCalledWith(expected);
       });
 
       describe("when the url's last substring is `change`", () => {

--- a/src/ui/server/controllers/insurance/policy/check-your-answers/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/check-your-answers/index.test.ts
@@ -69,6 +69,12 @@ describe('controllers/insurance/policy/check-your-answers', () => {
   });
 
   describe('get', () => {
+    it('should call api.keystone.countries.getAll', async () => {
+      await get(req, res);
+
+      expect(getCountriesSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('should call api.keystone.APIM.getCurrencies', async () => {
       await get(req, res);
 
@@ -105,18 +111,6 @@ describe('controllers/insurance/policy/check-your-answers', () => {
       };
 
       expect(res.render).toHaveBeenCalledWith(TEMPLATE, expectedVariables);
-    });
-
-    it('should call api.keystone.countries.getAll', async () => {
-      await get(req, res);
-
-      expect(getCountriesSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it('should call api.keystone.APIM.getCurrencies', async () => {
-      await get(req, res);
-
-      expect(getCurrenciesSpy).toHaveBeenCalledTimes(1);
     });
 
     describe('when there is no application', () => {

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/export-value/index.test.ts
@@ -197,6 +197,12 @@ describe('controllers/insurance/policy/multiple-contract-policy/export-value', (
         req.body = validBody;
       });
 
+      it('should NOT call api.keystone.APIM.getCurrencies', async () => {
+        await post(req, res);
+
+        expect(getCurrenciesSpy).toHaveBeenCalledTimes(0);
+      });
+
       it('should call mapAndSave.policy with data from constructPayload function and application', async () => {
         await post(req, res);
 

--- a/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/multiple-contract-policy/index.test.ts
@@ -233,6 +233,12 @@ describe('controllers/insurance/policy/multiple-contract-policy', () => {
         req.body = validBody;
       });
 
+      it('should NOT call api.keystone.APIM.getCurrencies', async () => {
+        await post(req, res);
+
+        expect(getCurrenciesSpy).toHaveBeenCalledTimes(0);
+      });
+
       it('should call mapAndSave.policy with data from constructPayload function and application', async () => {
         await post(req, res);
 

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/index.test.ts
@@ -234,6 +234,12 @@ describe('controllers/insurance/policy/single-contract-policy', () => {
         req.body = validBody;
       });
 
+      it('should NOT call api.keystone.APIM.getCurrencies', async () => {
+        await post(req, res);
+
+        expect(getCurrenciesSpy).toHaveBeenCalledTimes(0);
+      });
+
       it('should call mapAndSave.policy with data from constructPayload function and application', async () => {
         await post(req, res);
 

--- a/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/single-contract-policy/total-contract-value/index.test.ts
@@ -195,6 +195,12 @@ describe('controllers/insurance/policy/single-contract-policy/total-contract-val
         req.body = validBody;
       });
 
+      it('should NOT call api.keystone.APIM.getCurrencies', async () => {
+        await post(req, res);
+
+        expect(getCurrenciesSpy).toHaveBeenCalledTimes(0);
+      });
+
       it('should call mapAndSave.policy with data from constructPayload function and application', async () => {
         await post(req, res);
 

--- a/src/ui/server/controllers/insurance/your-buyer/currency-of-late-payments/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/currency-of-late-payments/index.test.ts
@@ -179,6 +179,12 @@ describe('controllers/insurance/your-buyer/currency-of-late-payments', () => {
         req.body = validBody;
       });
 
+      it('should NOT call api.keystone.APIM.getCurrencies', async () => {
+        await post(req, res);
+
+        expect(getCurrenciesSpy).toHaveBeenCalledTimes(0);
+      });
+
       it('should redirect to the next page', async () => {
         await post(req, res);
         const expected = `${INSURANCE_ROOT}/${referenceNumber}${OUTSTANDING_OR_OVERDUE_PAYMENTS}`;

--- a/src/ui/server/controllers/insurance/your-buyer/outstanding-or-overdue-payments/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/outstanding-or-overdue-payments/index.test.ts
@@ -188,6 +188,12 @@ describe('controllers/insurance/your-buyer/outstanding-or-overdue-payments', () 
         req.body = validBody;
       });
 
+      it('should NOT call api.keystone.APIM.getCurrencies', async () => {
+        await post(req, res);
+
+        expect(getCurrenciesSpy).toHaveBeenCalledTimes(0);
+      });
+
       it('should call mapAndSave.buyerTradingHistory once with data from constructPayload function and application', async () => {
         await post(req, res);
 
@@ -231,6 +237,12 @@ describe('controllers/insurance/your-buyer/outstanding-or-overdue-payments', () 
     });
 
     describe('when there are validation errors', () => {
+      it('should call api.keystone.APIM.getCurrencies', async () => {
+        await get(req, res);
+
+        expect(getCurrenciesSpy).toHaveBeenCalledTimes(1);
+      });
+
       it('should render template with validation errors', async () => {
         await post(req, res);
 
@@ -300,7 +312,7 @@ describe('controllers/insurance/your-buyer/outstanding-or-overdue-payments', () 
         });
 
         it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
-          await get(req, res);
+          await post(req, res);
 
           expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
         });
@@ -313,7 +325,7 @@ describe('controllers/insurance/your-buyer/outstanding-or-overdue-payments', () 
         });
 
         it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
-          await get(req, res);
+          await post(req, res);
 
           expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
         });

--- a/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
+++ b/src/ui/server/controllers/quote/tell-us-about-your-policy/index.test.ts
@@ -389,6 +389,12 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
         req.body = {};
       });
 
+      it('should call api.keystone.APIM.getCurrencies', async () => {
+        await get(req, res);
+
+        expect(getCurrenciesSpy).toHaveBeenCalledTimes(1);
+      });
+
       it('should render template with validation errors and submitted values from constructPayload function', async () => {
         await post(req, res);
 
@@ -559,6 +565,12 @@ describe('controllers/quote/tell-us-about-your-policy', () => {
 
       beforeEach(() => {
         req.body = validBody;
+      });
+
+      it('should call api.keystone.APIM.getCurrencies', async () => {
+        await get(req, res);
+
+        expect(getCurrenciesSpy).toHaveBeenCalledTimes(1);
       });
 
       it('should update the session with submitted data, populated with full currency object from constructPayload function', async () => {


### PR DESCRIPTION
## Introduction :pencil2:
Some UI unit tests had missing test coverage for some `api.keystone.APIM.getCurrencies` conditions - testing when it should or should not be called.

## Resolution :heavy_check_mark:
- Add missing unit tests.