### PR TITLE
style(EMS-3821): application submission - xlsx - payments currency

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -6992,6 +6992,10 @@ var YOUR_BUYER_FIELDS = {
   },
   [CURRENCY_CODE2]: {
     LEGEND: 'What is the currency the outstanding or overdue payments are in?',
+    SUMMARY: {
+      TITLE: 'Outstanding payments currency',
+      FORM_TITLE: TRADING_HISTORY,
+    },
   },
   [HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]: {
     LABEL: 'Have you in the past held credit insurance cover on the buyer?',
@@ -7888,11 +7892,13 @@ var { FIELDS: FIELDS21 } = XLSX;
 var mapOutstandingPayments = (tradingHistory) => {
   if (tradingHistory[OUTSTANDING_PAYMENTS3]) {
     const values = {
+      currency: tradingHistory[CURRENCY_CODE5],
       totalOutstanding: format_currency_default(tradingHistory[TOTAL_OUTSTANDING_PAYMENTS3], tradingHistory[CURRENCY_CODE5]),
       totalAmountOverdue: format_currency_default(tradingHistory[TOTAL_AMOUNT_OVERDUE2], tradingHistory[CURRENCY_CODE5]),
     };
     const mapped = [
       xlsx_row_default(String(FIELDS21[TOTAL_OUTSTANDING_PAYMENTS3]), values.totalOutstanding),
+      xlsx_row_default(String(YOUR_BUYER_FIELDS[CURRENCY_CODE5].SUMMARY?.TITLE), values.currency),
       xlsx_row_default(String(YOUR_BUYER_FIELDS[TOTAL_AMOUNT_OVERDUE2].SUMMARY?.TITLE), values.totalAmountOverdue),
     ];
     return mapped;

--- a/src/api/content-strings/fields/insurance/your-buyer/index.ts
+++ b/src/api/content-strings/fields/insurance/your-buyer/index.ts
@@ -107,6 +107,10 @@ export const YOUR_BUYER_FIELDS = {
   },
   [CURRENCY_CODE]: {
     LEGEND: 'What is the currency the outstanding or overdue payments are in?',
+    SUMMARY: {
+      TITLE: 'Outstanding payments currency',
+      FORM_TITLE: TRADING_HISTORY,
+    },
   },
   [HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER]: {
     LABEL: 'Have you in the past held credit insurance cover on the buyer?',

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/map-outstanding-payments/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/map-outstanding-payments/index.test.ts
@@ -24,12 +24,14 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-outstanding-payments', (
       const result = mapOutstandingPayments(mockTradingHistory);
 
       const expectedValues = {
+        currency: mockTradingHistory[CURRENCY_CODE],
         totalOutstanding: formatCurrency(mockTradingHistory[TOTAL_OUTSTANDING_PAYMENTS], mockTradingHistory[CURRENCY_CODE]),
         totalAmountOverdue: formatCurrency(mockTradingHistory[TOTAL_AMOUNT_OVERDUE], mockTradingHistory[CURRENCY_CODE]),
       };
 
       const expected = [
         xlsxRow(String(FIELDS[TOTAL_OUTSTANDING_PAYMENTS]), expectedValues.totalOutstanding),
+        xlsxRow(String(CONTENT_STRINGS[CURRENCY_CODE].SUMMARY?.TITLE), expectedValues.currency),
         xlsxRow(String(CONTENT_STRINGS[TOTAL_AMOUNT_OVERDUE].SUMMARY?.TITLE), expectedValues.totalAmountOverdue),
       ];
 

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/map-outstanding-payments/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-buyer/map-outstanding-payments/index.ts
@@ -21,12 +21,14 @@ const { FIELDS } = XLSX;
 const mapOutstandingPayments = (tradingHistory: BuyerTradingHistory) => {
   if (tradingHistory[OUTSTANDING_PAYMENTS]) {
     const values = {
+      currency: tradingHistory[CURRENCY_CODE],
       totalOutstanding: formatCurrency(tradingHistory[TOTAL_OUTSTANDING_PAYMENTS], tradingHistory[CURRENCY_CODE]),
       totalAmountOverdue: formatCurrency(tradingHistory[TOTAL_AMOUNT_OVERDUE], tradingHistory[CURRENCY_CODE]),
     };
 
     const mapped = [
       xlsxRow(String(FIELDS[TOTAL_OUTSTANDING_PAYMENTS]), values.totalOutstanding),
+      xlsxRow(String(CONTENT_STRINGS[CURRENCY_CODE].SUMMARY?.TITLE), values.currency),
       xlsxRow(String(CONTENT_STRINGS[TOTAL_AMOUNT_OVERDUE].SUMMARY?.TITLE), values.totalAmountOverdue),
     ];
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds a new currency code row to the XLSX's "Your buyer" sheet, sent to underwriters during application submission.

## Resolution :heavy_check_mark:
- Update content strings.
- Update `mapOutstandingPayments` function.

## Miscellaneous :heavy_plus_sign:
List any additional fixes or improvements.
