### PR TITLE
style(EMS-3835-3836): export contract - check your answers - currency code

### DIFF
--- a/e2e-tests/commands/insurance/check-export-contract-summary-list.js
+++ b/e2e-tests/commands/insurance/check-export-contract-summary-list.js
@@ -217,6 +217,19 @@ const checkExportContractSummaryList = {
       cy.assertSummaryListRowDoesNotExist(summaryList, fieldId);
     }
   },
+  [FIXED_SUM_CURRENCY_CODE]: ({ shouldRender = false }) => {
+    const fieldId = FIXED_SUM_CURRENCY_CODE;
+
+    if (shouldRender) {
+      const { expectedKey, expectedChangeLinkText } = getSummaryListField(fieldId, FIELDS.AGENT_CHARGES);
+
+      const expectedValue = application.EXPORT_CONTRACT.AGENT_CHARGES[fieldId];
+
+      cy.assertSummaryListRow(summaryList, fieldId, expectedKey, expectedValue, expectedChangeLinkText);
+    } else {
+      cy.assertSummaryListRowDoesNotExist(summaryList, fieldId);
+    }
+  },
   [FIXED_SUM_AMOUNT]: ({ shouldRender = false, agentChargeFixedSumAmount }) => {
     const fieldId = FIXED_SUM_AMOUNT;
 

--- a/e2e-tests/content-strings/fields/insurance/export-contract/index.js
+++ b/e2e-tests/content-strings/fields/insurance/export-contract/index.js
@@ -207,6 +207,10 @@ export const EXPORT_CONTRACT_FIELDS = {
     },
     [CURRENCY_CODE]: {
       LEGEND: 'What currency is the agent charging you in?',
+      SUMMARY: {
+        TITLE: "Currency of the agent's charge",
+        FORM_TITLE: EXPORT_CONTRACT_FORM_TITLES.AGENT,
+      },
     },
   },
 };

--- a/e2e-tests/shared-test-assertions/summary-lists/export-contract/fully-populated.js
+++ b/e2e-tests/shared-test-assertions/summary-lists/export-contract/fully-populated.js
@@ -9,7 +9,7 @@ const {
   USING_AGENT,
   AGENT_DETAILS: { NAME, FULL_ADDRESS, COUNTRY_CODE },
   AGENT_SERVICE: { IS_CHARGING, SERVICE_DESCRIPTION },
-  AGENT_CHARGES: { FIXED_SUM_AMOUNT, PERCENTAGE_CHARGE, PAYABLE_COUNTRY_CODE },
+  AGENT_CHARGES: { FIXED_SUM_AMOUNT, FIXED_SUM_CURRENCY_CODE, PERCENTAGE_CHARGE, PAYABLE_COUNTRY_CODE },
 } = FIELD_IDS;
 
 /**
@@ -68,6 +68,10 @@ const assertFullyPopulatedExportContractSummaryListRows = ({ agentChargeMethodFi
   });
 
   if (agentChargeMethodFixedSum) {
+    it(`should render a ${FIXED_SUM_CURRENCY_CODE} summary list row`, () => {
+      checkSummaryList[FIXED_SUM_CURRENCY_CODE]({ shouldRender: true });
+    });
+
     it(`should render a ${FIXED_SUM_AMOUNT} summary list row`, () => {
       checkSummaryList[FIXED_SUM_AMOUNT]({ shouldRender: true, agentChargeFixedSumAmount });
     });

--- a/e2e-tests/shared-test-assertions/summary-lists/export-contract/minimal.js
+++ b/e2e-tests/shared-test-assertions/summary-lists/export-contract/minimal.js
@@ -11,7 +11,7 @@ const {
   USING_AGENT,
   AGENT_DETAILS: { NAME, FULL_ADDRESS, COUNTRY_CODE },
   AGENT_SERVICE: { IS_CHARGING, SERVICE_DESCRIPTION },
-  AGENT_CHARGES: { FIXED_SUM_AMOUNT, PERCENTAGE_CHARGE, PAYABLE_COUNTRY_CODE },
+  AGENT_CHARGES: { FIXED_SUM_AMOUNT, FIXED_SUM_CURRENCY_CODE, PERCENTAGE_CHARGE, PAYABLE_COUNTRY_CODE },
 } = FIELD_IDS;
 
 const { OPEN_TENDER } = FIELDS.HOW_WAS_THE_CONTRACT_AWARDED[AWARD_METHOD].OPTIONS;
@@ -70,6 +70,10 @@ const assertMinimalExportContractSummaryListRows = ({ awardMethodValue = OPEN_TE
 
   it(`should NOT render an ${IS_CHARGING} summary list row`, () => {
     checkSummaryList[IS_CHARGING]({ shouldRender: false });
+  });
+
+  it(`should NOT render a ${FIXED_SUM_CURRENCY_CODE} summary list row`, () => {
+    checkSummaryList[FIXED_SUM_CURRENCY_CODE]({ shouldRender: false });
   });
 
   it(`should NOT render a ${FIXED_SUM_AMOUNT} summary list row`, () => {

--- a/src/ui/server/content-strings/fields/insurance/export-contract/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/export-contract/index.ts
@@ -204,6 +204,10 @@ export const EXPORT_CONTRACT_FIELDS = {
     },
     [CURRENCY_CODE]: {
       LEGEND: 'What currency is the agent charging you in?',
+      SUMMARY: {
+        TITLE: "Currency of the agent's charge",
+        FORM_TITLE: EXPORT_CONTRACT_FORM_TITLES.AGENT,
+      },
     },
   },
 };

--- a/src/ui/server/helpers/summary-lists/export-contract/agent-fields/agent-charges/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/export-contract/agent-fields/agent-charges/index.test.ts
@@ -1,6 +1,6 @@
 import agentChargesFields from '.';
 import { EXPORT_CONTRACT_FIELDS as FIELDS } from '../../../../../content-strings/fields/insurance';
-import FIELD_IDS from '../../../../../constants/field-ids/insurance/export-contract';
+import FIELD_IDS from '../../../../../constants/field-ids/insurance';
 import { EXPORT_CONTRACT as EXPORT_CONTRACT_ROUTES } from '../../../../../constants/routes/insurance/export-contract';
 import fieldGroupItem from '../../../generate-field-group-item';
 import getFieldById from '../../../../get-field-by-id';
@@ -13,12 +13,21 @@ import { transformEmptyDecimalsToWholeNumber } from '../../../../number';
 import { mockExportContractAgentService, mockCountries, referenceNumber } from '../../../../../test-mocks';
 
 const {
-  AGENT_SERVICE: { IS_CHARGING },
-  AGENT_CHARGES: { FIXED_SUM_AMOUNT, FIXED_SUM_CURRENCY_CODE, PERCENTAGE_CHARGE, PAYABLE_COUNTRY_CODE },
+  CURRENCY: { CURRENCY_CODE },
+  EXPORT_CONTRACT: {
+    AGENT_SERVICE: { IS_CHARGING },
+    AGENT_CHARGES: { FIXED_SUM_AMOUNT, FIXED_SUM_CURRENCY_CODE, PERCENTAGE_CHARGE, PAYABLE_COUNTRY_CODE },
+  },
 } = FIELD_IDS;
 
-const { AGENT_SERVICE_CHANGE, AGENT_SERVICE_CHECK_AND_CHANGE } = EXPORT_CONTRACT_ROUTES;
-const { AGENT_CHARGES_CHANGE, AGENT_CHARGES_CHECK_AND_CHANGE } = EXPORT_CONTRACT_ROUTES;
+const {
+  AGENT_CHARGES_CURRENCY_CHANGE,
+  AGENT_CHARGES_CURRENCY_CHECK_AND_CHANGE,
+  AGENT_CHARGES_CHANGE,
+  AGENT_CHARGES_CHECK_AND_CHANGE,
+  AGENT_SERVICE_CHANGE,
+  AGENT_SERVICE_CHECK_AND_CHANGE,
+} = EXPORT_CONTRACT_ROUTES;
 
 describe('server/helpers/summary-lists/export-contract/agent-fields/agent-charges', () => {
   const mockAnswersChargingTrue = {
@@ -53,7 +62,7 @@ describe('server/helpers/summary-lists/export-contract/agent-fields/agent-charge
     });
   });
 
-  describe(`when ${IS_CHARGING} is true and ${FIXED_SUM_AMOUNT} is provided`, () => {
+  describe.only(`when ${IS_CHARGING} is true and ${FIXED_SUM_AMOUNT} is provided`, () => {
     const mockAnswers = {
       ...mockAnswersChargingTrue,
       charge: {
@@ -77,6 +86,21 @@ describe('server/helpers/summary-lists/export-contract/agent-fields/agent-charge
             renderChangeLink: true,
           },
           mapYesNoField(mockAnswers[IS_CHARGING]),
+        ),
+        fieldGroupItem(
+          {
+            field: getFieldById(FIELDS.AGENT_CHARGES, CURRENCY_CODE),
+            data: mockAnswers.charge,
+            href: generateChangeLink(
+              AGENT_CHARGES_CURRENCY_CHANGE,
+              AGENT_CHARGES_CURRENCY_CHECK_AND_CHANGE,
+              `#${FIXED_SUM_CURRENCY_CODE}-label`,
+              referenceNumber,
+              checkAndChange,
+            ),
+            renderChangeLink: true,
+          },
+          mockAnswers.charge[FIXED_SUM_CURRENCY_CODE],
         ),
         fieldGroupItem(
           {
@@ -124,6 +148,21 @@ describe('server/helpers/summary-lists/export-contract/agent-fields/agent-charge
             renderChangeLink: true,
           },
           mapYesNoField(mockAnswers[IS_CHARGING]),
+        ),
+        fieldGroupItem(
+          {
+            field: getFieldById(FIELDS.AGENT_CHARGES, CURRENCY_CODE),
+            data: mockAnswers.charge,
+            href: generateChangeLink(
+              AGENT_CHARGES_CURRENCY_CHANGE,
+              AGENT_CHARGES_CURRENCY_CHECK_AND_CHANGE,
+              `#${FIXED_SUM_CURRENCY_CODE}-label`,
+              referenceNumber,
+              checkAndChange,
+            ),
+            renderChangeLink: true,
+          },
+          mockAnswers.charge[FIXED_SUM_CURRENCY_CODE],
         ),
         fieldGroupItem(
           {

--- a/src/ui/server/helpers/summary-lists/export-contract/agent-fields/agent-charges/index.test.ts
+++ b/src/ui/server/helpers/summary-lists/export-contract/agent-fields/agent-charges/index.test.ts
@@ -62,7 +62,7 @@ describe('server/helpers/summary-lists/export-contract/agent-fields/agent-charge
     });
   });
 
-  describe.only(`when ${IS_CHARGING} is true and ${FIXED_SUM_AMOUNT} is provided`, () => {
+  describe(`when ${IS_CHARGING} is true and ${FIXED_SUM_AMOUNT} is provided`, () => {
     const mockAnswers = {
       ...mockAnswersChargingTrue,
       charge: {

--- a/src/ui/server/helpers/summary-lists/export-contract/agent-fields/agent-charges/index.ts
+++ b/src/ui/server/helpers/summary-lists/export-contract/agent-fields/agent-charges/index.ts
@@ -1,5 +1,5 @@
 import { EXPORT_CONTRACT_FIELDS as FIELDS } from '../../../../../content-strings/fields/insurance';
-import FIELD_IDS from '../../../../../constants/field-ids/insurance/export-contract';
+import FIELD_IDS from '../../../../../constants/field-ids/insurance';
 import { EXPORT_CONTRACT as EXPORT_CONTRACT_ROUTES } from '../../../../../constants/routes/insurance/export-contract';
 import fieldGroupItem from '../../../generate-field-group-item';
 import getFieldById from '../../../../get-field-by-id';
@@ -12,12 +12,21 @@ import { transformEmptyDecimalsToWholeNumber, numberHasDecimalPlaces } from '../
 import { ApplicationExportContractAgentService, Country } from '../../../../../../types';
 
 const {
-  AGENT_SERVICE: { IS_CHARGING },
-  AGENT_CHARGES: { FIXED_SUM_AMOUNT, FIXED_SUM_CURRENCY_CODE, PERCENTAGE_CHARGE, PAYABLE_COUNTRY_CODE },
+  CURRENCY: { CURRENCY_CODE },
+  EXPORT_CONTRACT: {
+    AGENT_SERVICE: { IS_CHARGING },
+    AGENT_CHARGES: { FIXED_SUM_AMOUNT, FIXED_SUM_CURRENCY_CODE, PERCENTAGE_CHARGE, PAYABLE_COUNTRY_CODE },
+  },
 } = FIELD_IDS;
 
-const { AGENT_SERVICE_CHANGE, AGENT_SERVICE_CHECK_AND_CHANGE } = EXPORT_CONTRACT_ROUTES;
-const { AGENT_CHARGES_CHANGE, AGENT_CHARGES_CHECK_AND_CHANGE } = EXPORT_CONTRACT_ROUTES;
+const {
+  AGENT_CHARGES_CURRENCY_CHANGE,
+  AGENT_CHARGES_CURRENCY_CHECK_AND_CHANGE,
+  AGENT_CHARGES_CHANGE,
+  AGENT_CHARGES_CHECK_AND_CHANGE,
+  AGENT_SERVICE_CHANGE,
+  AGENT_SERVICE_CHECK_AND_CHANGE,
+} = EXPORT_CONTRACT_ROUTES;
 
 /**
  * agentChargesFields
@@ -29,7 +38,7 @@ const { AGENT_CHARGES_CHANGE, AGENT_CHARGES_CHECK_AND_CHANGE } = EXPORT_CONTRACT
  * @returns {Array<SummaryListItemData>} Agent charges fields
  */
 const agentChargesFields = (answers: ApplicationExportContractAgentService, referenceNumber: number, countries: Array<Country>, checkAndChange?: boolean) => {
-  const fields = [
+  let fields = [
     fieldGroupItem(
       {
         field: getFieldById(FIELDS.AGENT_SERVICE, IS_CHARGING),
@@ -54,7 +63,23 @@ const agentChargesFields = (answers: ApplicationExportContractAgentService, refe
        */
       const decimalPlaces = numberHasDecimalPlaces(answer) ? 2 : 0;
 
-      fields.push(
+      fields = [
+        ...fields,
+        fieldGroupItem(
+          {
+            field: getFieldById(FIELDS.AGENT_CHARGES, CURRENCY_CODE),
+            data: answers.charge,
+            href: generateChangeLink(
+              AGENT_CHARGES_CURRENCY_CHANGE,
+              AGENT_CHARGES_CURRENCY_CHECK_AND_CHANGE,
+              `#${FIXED_SUM_CURRENCY_CODE}-label`,
+              referenceNumber,
+              checkAndChange,
+            ),
+            renderChangeLink: true,
+          },
+          answers.charge[FIXED_SUM_CURRENCY_CODE],
+        ),
         fieldGroupItem(
           {
             field: getFieldById(FIELDS.AGENT_CHARGES, FIXED_SUM_AMOUNT),
@@ -64,7 +89,7 @@ const agentChargesFields = (answers: ApplicationExportContractAgentService, refe
           },
           formatCurrency(Number(answer), answers.charge[FIXED_SUM_CURRENCY_CODE], decimalPlaces),
         ),
-      );
+      ];
     }
 
     if (answers.charge[PERCENTAGE_CHARGE]) {


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the export contract's summary list to include a row for the "fixed sum currency code".

## Resolution :heavy_check_mark:
- Update DRY E2E assertions:
  - `checkExportContractSummaryList`
  - `assertFullyPopulatedExportContractSummaryListRows`
  - `assertMinimalExportContractSummaryListRows`
- Update field content strings.
- Update the UI's `agentChargesFields` function.