### PR TITLE
fix(EMS-3831): buyer - outstanding/overdue payments - missing hint text

### DIFF
--- a/e2e-tests/content-strings/fields/insurance/your-buyer/index.js
+++ b/e2e-tests/content-strings/fields/insurance/your-buyer/index.js
@@ -131,6 +131,7 @@ export const YOUR_BUYER_FIELDS = {
   },
   [TOTAL_OUTSTANDING_PAYMENTS]: {
     LABEL: 'Total outstanding, including overdue in',
+    HINT: 'Enter a whole number. Do not enter decimals.',
     SUMMARY: {
       TITLE: 'Total outstanding including overdue',
       FORM_TITLE: TRADING_HISTORY,
@@ -138,6 +139,7 @@ export const YOUR_BUYER_FIELDS = {
   },
   [TOTAL_AMOUNT_OVERDUE]: {
     LABEL: 'Amount overdue in',
+    HINT: 'Enter a whole number. Do not enter decimals.',
     SUMMARY: {
       TITLE: 'Amount overdue',
       FORM_TITLE: TRADING_HISTORY,

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments.spec.js
@@ -69,7 +69,7 @@ context(
       });
 
       describe(TOTAL_OUTSTANDING_PAYMENTS, () => {
-        it(`should render a label for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
+        it('should render a label', () => {
           cy.assertCopyWithCurrencyName({
             expectedCopy: FIELDS[TOTAL_OUTSTANDING_PAYMENTS].LABEL,
             currencyName,
@@ -77,17 +77,21 @@ context(
           });
         });
 
-        it(`should render an input for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
+        it('should render a hint', () => {
+          cy.checkText(field(TOTAL_OUTSTANDING_PAYMENTS).hint(), FIELDS[TOTAL_OUTSTANDING_PAYMENTS].HINT);
+        });
+
+        it('should render an input', () => {
           field(TOTAL_OUTSTANDING_PAYMENTS).input().should('be.visible');
         });
 
-        it(`should render a prefix for ${TOTAL_OUTSTANDING_PAYMENTS}`, () => {
+        it('should render a prefix', () => {
           cy.checkText(field(TOTAL_OUTSTANDING_PAYMENTS).prefix(), SYMBOLS.GBP);
         });
       });
 
       describe(TOTAL_AMOUNT_OVERDUE, () => {
-        it(`should render a label for ${TOTAL_AMOUNT_OVERDUE}`, () => {
+        it('should render a label', () => {
           cy.assertCopyWithCurrencyName({
             expectedCopy: FIELDS[TOTAL_AMOUNT_OVERDUE].LABEL,
             currencyName,
@@ -95,11 +99,15 @@ context(
           });
         });
 
-        it(`should render an input for ${TOTAL_AMOUNT_OVERDUE}`, () => {
+        it('should render a hint', () => {
+          cy.checkText(field(TOTAL_AMOUNT_OVERDUE).hint(), FIELDS[TOTAL_AMOUNT_OVERDUE].HINT);
+        });
+
+        it('should render an input', () => {
           field(TOTAL_AMOUNT_OVERDUE).input().should('be.visible');
         });
 
-        it(`should render a prefix for ${TOTAL_AMOUNT_OVERDUE}`, () => {
+        it('should render a prefix', () => {
           cy.checkText(field(TOTAL_AMOUNT_OVERDUE).prefix(), SYMBOLS.GBP);
         });
       });

--- a/src/api/content-strings/fields/insurance/your-buyer/index.ts
+++ b/src/api/content-strings/fields/insurance/your-buyer/index.ts
@@ -130,6 +130,7 @@ export const YOUR_BUYER_FIELDS = {
   },
   [TOTAL_OUTSTANDING_PAYMENTS]: {
     LABEL: 'Total outstanding, including overdue in',
+    HINT: 'Enter a whole number. Do not enter decimals.',
     SUMMARY: {
       TITLE: 'Total outstanding including overdue',
       FORM_TITLE: TRADING_HISTORY,
@@ -137,6 +138,7 @@ export const YOUR_BUYER_FIELDS = {
   },
   [TOTAL_AMOUNT_OVERDUE]: {
     LABEL: 'Amount overdue in',
+    HINT: 'Enter a whole number. Do not enter decimals.',
     SUMMARY: {
       TITLE: 'Amount overdue',
       FORM_TITLE: TRADING_HISTORY,

--- a/src/ui/server/content-strings/fields/insurance/your-buyer/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/your-buyer/index.ts
@@ -112,12 +112,14 @@ export const YOUR_BUYER_FIELDS = {
   },
   [TOTAL_OUTSTANDING_PAYMENTS]: {
     LABEL: 'Total outstanding, including overdue in',
+    HINT: 'Enter a whole number. Do not enter decimals.',
     SUMMARY: {
       TITLE: 'Total outstanding including overdue',
     },
   },
   [TOTAL_AMOUNT_OVERDUE]: {
     LABEL: 'Amount overdue in',
+    HINT: 'Enter a whole number. Do not enter decimals.',
     SUMMARY: {
       TITLE: 'Amount overdue',
     },

--- a/src/ui/server/controllers/insurance/your-buyer/outstanding-or-overdue-payments/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/outstanding-or-overdue-payments/index.test.ts
@@ -74,10 +74,12 @@ describe('controllers/insurance/your-buyer/outstanding-or-overdue-payments', () 
         FIELDS: {
           TOTAL_OUTSTANDING_PAYMENTS: {
             ID: TOTAL_OUTSTANDING_PAYMENTS,
+            ...FIELDS[TOTAL_OUTSTANDING_PAYMENTS],
             LABEL: `${FIELDS[TOTAL_OUTSTANDING_PAYMENTS].LABEL} ${currency.name}`,
           },
           TOTAL_AMOUNT_OVERDUE: {
             ID: TOTAL_AMOUNT_OVERDUE,
+            ...FIELDS[TOTAL_AMOUNT_OVERDUE],
             LABEL: `${FIELDS[TOTAL_AMOUNT_OVERDUE].LABEL} ${currency.name}`,
           },
         },

--- a/src/ui/server/controllers/insurance/your-buyer/outstanding-or-overdue-payments/index.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/outstanding-or-overdue-payments/index.ts
@@ -58,10 +58,12 @@ export const pageVariables = (referenceNumber: number, currencies: Array<Currenc
     FIELDS: {
       TOTAL_OUTSTANDING_PAYMENTS: {
         ID: TOTAL_OUTSTANDING_PAYMENTS,
+        ...FIELDS[TOTAL_OUTSTANDING_PAYMENTS],
         LABEL: `${FIELDS[TOTAL_OUTSTANDING_PAYMENTS].LABEL} ${currency.name}`,
       },
       TOTAL_AMOUNT_OVERDUE: {
         ID: TOTAL_AMOUNT_OVERDUE,
+        ...FIELDS[TOTAL_AMOUNT_OVERDUE],
         LABEL: `${FIELDS[TOTAL_AMOUNT_OVERDUE].LABEL} ${currency.name}`,
       },
     },

--- a/src/ui/templates/insurance/your-buyer/outstanding-or-overdue-payments.njk
+++ b/src/ui/templates/insurance/your-buyer/outstanding-or-overdue-payments.njk
@@ -44,6 +44,7 @@
         {{ monetaryValueInput.render({
           fieldId: FIELDS.TOTAL_OUTSTANDING_PAYMENTS.ID,
           label: FIELDS.TOTAL_OUTSTANDING_PAYMENTS.LABEL,
+          hintText: FIELDS.TOTAL_OUTSTANDING_PAYMENTS.HINT,
           currencyPrefixSymbol: CURRENCY_PREFIX_SYMBOL,
           submittedValue: submittedValues[FIELDS.TOTAL_OUTSTANDING_PAYMENTS.ID] or application.buyer.buyerTradingHistory[FIELDS.TOTAL_OUTSTANDING_PAYMENTS.ID],
           validationError: validationErrors.errorList[FIELDS.TOTAL_OUTSTANDING_PAYMENTS.ID],
@@ -53,6 +54,7 @@
         {{ monetaryValueInput.render({
           fieldId: FIELDS.TOTAL_AMOUNT_OVERDUE.ID,
           label: FIELDS.TOTAL_AMOUNT_OVERDUE.LABEL,
+          hintText: FIELDS.TOTAL_AMOUNT_OVERDUE.HINT,
           currencyPrefixSymbol: CURRENCY_PREFIX_SYMBOL,
           submittedValue: submittedValues[FIELDS.TOTAL_AMOUNT_OVERDUE.ID] or application.buyer.buyerTradingHistory[FIELDS.TOTAL_AMOUNT_OVERDUE.ID],
           validationError: validationErrors.errorList[FIELDS.TOTAL_AMOUNT_OVERDUE.ID],


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where the "outstanding/overdue payments" form fields in the "your buyer" section had missing hint texts.

## Resolution :heavy_check_mark:
- Update field content strings.
- Update E2E tests.
- Update nunjucks template.

## Miscellaneous :heavy_plus_sign:
- Simplify some E2E descriptions.
