### PR TITLE
chore(EMS-3830): improve field validation e2e test coverage

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-much-is-the-agent-charging/validation/how-much-is-the-agent-charging-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-much-is-the-agent-charging/validation/how-much-is-the-agent-charging-validation.spec.js
@@ -63,6 +63,14 @@ context('Insurance - Export contract - How much is the agent charging page - for
     });
   });
 
+  it(`should display validation errors when ${FIELD_ID} has letters`, () => {
+    cy.submitAndAssertFieldErrors({
+      ...assertions,
+      value: 'one',
+      expectedErrorMessage: ERROR_MESSAGES_OBJECT.INCORRECT_FORMAT,
+    });
+  });
+
   it(`should display validation errors when ${FIELD_ID} is below ${MINIMUM_CHARACTERS.ONE}`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
@@ -88,6 +88,16 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
       });
     });
 
+    describe(`when ${FIELD_ID} has letters`, () => {
+      it(`should display validation errors for ${FIELD_ID}`, () => {
+        cy.submitAndAssertFieldErrors({
+          ...assertions,
+          value: 'one',
+          expectedErrorMessage: NATURE_OF_BUSINESS_ERRORS[FIELD_ID].INCORRECT_FORMAT,
+        });
+      });
+    });
+
     describe(`when ${FIELD_ID} is below 0`, () => {
       it(`should display validation errors for ${FIELD_ID}`, () => {
         cy.submitAndAssertFieldErrors({

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
@@ -91,6 +91,20 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
         });
       });
     });
+
+    describe(`when ${FIELD_ID} has letters`, () => {
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+      });
+
+      it(`should display validation errors for ${FIELD_ID}`, () => {
+        cy.submitAndAssertFieldErrors({
+          ...assertions,
+          value: 'one',
+          expectedErrorMessage: NATURE_OF_BUSINESS_ERRORS[FIELD_ID].INCORRECT_FORMAT,
+        });
+      });
+    });
   });
 
   describe(`when ${FIELD_ID} is correctly entered as a whole number`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
@@ -63,6 +63,14 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
     });
   });
 
+  it(`should display validation errors when ${FIELD_ID} has letters`, () => {
+    cy.submitAndAssertFieldErrors({
+      ...assertions,
+      value: 'one',
+      expectedErrorMessage: ERROR_MESSAGE.INCORRECT_FORMAT,
+    });
+  });
+
   it(`should display validation errors when ${FIELD_ID} is negative but has a decimal place`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,

--- a/e2e-tests/shared-test-assertions/percentage-field-validation/index.js
+++ b/e2e-tests/shared-test-assertions/percentage-field-validation/index.js
@@ -56,6 +56,14 @@ export const percentageFieldValidation = ({
     });
   });
 
+  it(`should display validation errors when ${fieldId} percentage has letters`, () => {
+    cy.submitAndAssertFieldErrors({
+      ...assertions,
+      value: 'one',
+      expectedErrorMessage: errorMessages.INCORRECT_FORMAT,
+    });
+  });
+
   it(`should display validation errors when ${fieldId} percentage field is over 100`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,


### PR DESCRIPTION
## Introduction :pencil2:
- Some number related fields were missing tests for submitting with pure letters.

## Resolution :heavy_check_mark:
- Add E2E tests for submitting some number fields with pure letters.

## Miscellaneous :heavy_plus_sign:
- Note: We could create some DRY E2E assertions for number fields so that every number field uses the same E2E assertions, however this should be its own PR.
