### PR TITLE
chore(EMS-3850): update all e2e tests to use checkValue command

### DIFF
--- a/e2e-tests/commands/shared-commands/assertions/assert-empty-contract-completion-date-field-values.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-empty-contract-completion-date-field-values.js
@@ -12,9 +12,9 @@ const {
  * Assert all CONTRACT_COMPLETION_DATE field values are empty.
  */
 const assertEmptyContractCompletionDateFieldValues = () => {
-  field(CONTRACT_COMPLETION_DATE).dayInput().should('have.value', '');
-  field(CONTRACT_COMPLETION_DATE).monthInput().should('have.value', '');
-  field(CONTRACT_COMPLETION_DATE).yearInput().should('have.value', '');
+  cy.checkValue(field(CONTRACT_COMPLETION_DATE).dayInput(), '');
+  cy.checkValue(field(CONTRACT_COMPLETION_DATE).monthInput(), '');
+  cy.checkValue(field(CONTRACT_COMPLETION_DATE).yearInput(), '');
 };
 
 export default assertEmptyContractCompletionDateFieldValues;

--- a/e2e-tests/commands/shared-commands/assertions/assert-empty-requested-start-date-field-values.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-empty-requested-start-date-field-values.js
@@ -10,9 +10,9 @@ const {
  * Assert all REQUESTED_START_DATE field values are empty.
  */
 const assertEmptyRequestedStartDateFieldValues = () => {
-  field(REQUESTED_START_DATE).dayInput().should('have.value', '');
-  field(REQUESTED_START_DATE).monthInput().should('have.value', '');
-  field(REQUESTED_START_DATE).yearInput().should('have.value', '');
+  cy.checkValue(field(REQUESTED_START_DATE).dayInput(), '');
+  cy.checkValue(field(REQUESTED_START_DATE).monthInput(), '');
+  cy.checkValue(field(REQUESTED_START_DATE).yearInput(), '');
 };
 
 export default assertEmptyRequestedStartDateFieldValues;

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/enter-code/validation/account-sign-in-enter-code-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/enter-code/validation/account-sign-in-enter-code-validation.spec.js
@@ -72,7 +72,7 @@ context('Insurance - Account - Sign in - Enter code - validation', () => {
       expectedErrorMessage,
     });
 
-    field.input().should('have.value', invalidAccessCode);
+    cy.checkValue(field.input(), invalidAccessCode);
   });
 
   describe('when submitting a valid access code', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/pre-credit-period/change-your-answers-pre-credit-period-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/pre-credit-period/change-your-answers-pre-credit-period-yes-to-no.spec.js
@@ -136,7 +136,7 @@ context('Insurance - Change your answers - Policy - Pre-credit period - Change f
 
           cy.assertNoRadioOptionIsChecked();
 
-          field(CREDIT_PERIOD_WITH_BUYER).textarea().should('have.value', '');
+          cy.checkValue(field(CREDIT_PERIOD_WITH_BUYER).textarea(), '');
         });
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services-final-destination-not-known.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services-final-destination-not-known.spec.js
@@ -67,7 +67,7 @@ context(
         it('should have the submitted values', () => {
           cy.navigateToUrl(url);
 
-          aboutGoodsOrServicesPage[DESCRIPTION].textarea().should('have.value', application.EXPORT_CONTRACT[DESCRIPTION]);
+          cy.checkValue(aboutGoodsOrServicesPage[DESCRIPTION].textarea(), application.EXPORT_CONTRACT[DESCRIPTION]);
 
           cy.assertNoRadioOptionIsChecked();
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
@@ -170,7 +170,7 @@ context(
         it('should have the submitted values', () => {
           cy.navigateToUrl(url);
 
-          aboutGoodsOrServicesPage[DESCRIPTION].textarea().should('have.value', application.EXPORT_CONTRACT[DESCRIPTION]);
+          cy.checkValue(aboutGoodsOrServicesPage[DESCRIPTION].textarea(), application.EXPORT_CONTRACT[DESCRIPTION]);
 
           cy.assertYesRadioOptionIsChecked();
 
@@ -203,7 +203,7 @@ context(
         it('should retain the submitted value when going back to the page', () => {
           cy.clickBackLink();
 
-          descriptionField.textarea().should('have.value', submittedValue);
+          cy.checkValue(descriptionField.textarea(), submittedValue);
         });
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/validation/about-goods-or-services-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/validation/about-goods-or-services-validation.spec.js
@@ -124,7 +124,7 @@ context('Insurance - Export contract - About goods or services page - form valid
         includeFinalDestination: true,
       });
 
-      descriptionField.textarea().should('have.value', descriptionOverMaximum);
+      cy.checkValue(descriptionField.textarea(), descriptionOverMaximum);
 
       cy.assertYesRadioOptionIsChecked();
 
@@ -141,7 +141,7 @@ context('Insurance - Export contract - About goods or services page - form valid
         description: descriptionOverMaximum,
       });
 
-      descriptionField.textarea().should('have.value', descriptionOverMaximum);
+      cy.checkValue(descriptionField.textarea(), descriptionOverMaximum);
 
       cy.assertNoRadioOptionIsChecked();
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/multiple-policy/change-your-answers-change-policy-type-multiple-to-single-to-multiple.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/multiple-policy/change-your-answers-change-policy-type-multiple-to-single-to-multiple.spec.js
@@ -64,13 +64,13 @@ context('Insurance - Policy - Change your answers - Policy type - multiple to si
   it(`should have empty field values when going back to ${MULTIPLE_CONTRACT_POLICY} and ${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE}`, () => {
     cy.assertEmptyRequestedStartDateFieldValues();
 
-    field(TOTAL_MONTHS_OF_COVER).input().should('have.value', '');
+    cy.checkValue(field(TOTAL_MONTHS_OF_COVER).input(), '');
 
     cy.assertCurrencyFormFieldsAreEmpty();
 
     cy.navigateToUrl(exportValueUrl);
 
-    field(TOTAL_SALES_TO_BUYER).input().should('have.value', '');
-    field(MAXIMUM_BUYER_WILL_OWE).input().should('have.value', '');
+    cy.checkValue(field(TOTAL_SALES_TO_BUYER).input(), '');
+    cy.checkValue(field(MAXIMUM_BUYER_WILL_OWE).input(), '');
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/pre-credit-period/change-your-answers-pre-credit-period-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/pre-credit-period/change-your-answers-pre-credit-period-yes-to-no.spec.js
@@ -104,7 +104,7 @@ context('Insurance - Policy - Change your answers - Pre-credit period - As an ex
 
           cy.assertNoRadioOptionIsChecked();
 
-          field(CREDIT_PERIOD_WITH_BUYER).textarea().should('have.value', '');
+          cy.checkValue(field(CREDIT_PERIOD_WITH_BUYER).textarea(), '');
         });
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/single-policy/change-your-answers-change-policy-type-single-to-multiple-to-single.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/change-your-answers/single-policy/change-your-answers-change-policy-type-single-to-multiple-to-single.spec.js
@@ -66,7 +66,7 @@ context('Insurance - Policy - Change your answers - Policy type - single to mult
 
     cy.navigateToUrl(totalContractValueUrl);
 
-    field(TOTAL_CONTRACT_VALUE).input().should('have.value', '');
-    field(REQUESTED_CREDIT_LIMIT).input().should('have.value', '');
+    cy.checkValue(field(TOTAL_CONTRACT_VALUE).input(), '');
+    cy.checkValue(field(REQUESTED_CREDIT_LIMIT).input(), '');
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value.spec.js
@@ -127,8 +127,8 @@ context(
         it('should have the submitted values', () => {
           cy.navigateToUrl(url);
 
-          fieldSelector(TOTAL_SALES_TO_BUYER).input().should('have.value', application.POLICY[TOTAL_SALES_TO_BUYER]);
-          fieldSelector(MAXIMUM_BUYER_WILL_OWE).input().should('have.value', application.POLICY[MAXIMUM_BUYER_WILL_OWE]);
+          cy.checkValue(fieldSelector(TOTAL_SALES_TO_BUYER).input(), application.POLICY[TOTAL_SALES_TO_BUYER]);
+          cy.checkValue(fieldSelector(MAXIMUM_BUYER_WILL_OWE).input(), application.POLICY[MAXIMUM_BUYER_WILL_OWE]);
         });
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/save-and-back.spec.js
@@ -94,7 +94,7 @@ context('Insurance - Policy - Multiple contract policy Export value page - Save 
       });
 
       it('should NOT have saved the submitted value', () => {
-        field.input().should('have.value', '');
+        cy.checkValue(field.input(), '');
       });
     });
   });
@@ -124,7 +124,7 @@ context('Insurance - Policy - Multiple contract policy Export value page - Save 
       });
 
       it('should have the submitted value', () => {
-        fieldSelector(TOTAL_SALES_TO_BUYER).input().should('have.value', application.POLICY[TOTAL_SALES_TO_BUYER]);
+        cy.checkValue(fieldSelector(TOTAL_SALES_TO_BUYER).input(), application.POLICY[TOTAL_SALES_TO_BUYER]);
       });
     });
   });
@@ -143,8 +143,8 @@ context('Insurance - Policy - Multiple contract policy Export value page - Save 
       });
 
       it('should render all submitted values', () => {
-        fieldSelector(TOTAL_SALES_TO_BUYER).input().should('have.value', application.POLICY[TOTAL_SALES_TO_BUYER]);
-        fieldSelector(MAXIMUM_BUYER_WILL_OWE).input().should('have.value', application.POLICY[MAXIMUM_BUYER_WILL_OWE]);
+        cy.checkValue(fieldSelector(TOTAL_SALES_TO_BUYER).input(), application.POLICY[TOTAL_SALES_TO_BUYER]);
+        cy.checkValue(fieldSelector(MAXIMUM_BUYER_WILL_OWE).input(), application.POLICY[MAXIMUM_BUYER_WILL_OWE]);
       });
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -147,11 +147,11 @@ context('Insurance - Policy - Multiple contract policy page - As an exporter, I 
       it('should have the submitted values', () => {
         cy.navigateToUrl(url);
 
-        fieldSelector(REQUESTED_START_DATE).dayInput().should('have.value', application.POLICY[REQUESTED_START_DATE].day);
-        fieldSelector(REQUESTED_START_DATE).monthInput().should('have.value', application.POLICY[REQUESTED_START_DATE].month);
-        fieldSelector(REQUESTED_START_DATE).yearInput().should('have.value', application.POLICY[REQUESTED_START_DATE].year);
+        cy.checkValue(fieldSelector(REQUESTED_START_DATE).dayInput(), application.POLICY[REQUESTED_START_DATE].day);
+        cy.checkValue(fieldSelector(REQUESTED_START_DATE).monthInput(), application.POLICY[REQUESTED_START_DATE].month);
+        cy.checkValue(fieldSelector(REQUESTED_START_DATE).yearInput(), application.POLICY[REQUESTED_START_DATE].year);
 
-        fieldSelector(TOTAL_MONTHS_OF_COVER).input().should('have.value', application.POLICY[TOTAL_MONTHS_OF_COVER]);
+        cy.checkValue(fieldSelector(TOTAL_MONTHS_OF_COVER).input(), application.POLICY[TOTAL_MONTHS_OF_COVER]);
 
         const isoCode = application.POLICY[POLICY_CURRENCY_CODE];
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
@@ -177,7 +177,7 @@ context(`Insurance - Policy - Pre-credit period page - ${story}`, () => {
 
           const expectedValue = mockApplication.POLICY[CREDIT_PERIOD_WITH_BUYER];
 
-          fieldSelector(CREDIT_PERIOD_WITH_BUYER).textarea().should('have.value', expectedValue);
+          cy.checkValue(fieldSelector(CREDIT_PERIOD_WITH_BUYER).textarea(), expectedValue);
         });
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/save-and-back.spec.js
@@ -109,7 +109,7 @@ context('Insurance - Policy - Pre-credit period page - Save and go back', () => 
       cy.clickSubmitButtonMultipleTimes({ count: 4 });
 
       cy.assertYesRadioOptionIsChecked();
-      descriptionField.textarea().should('have.value', '');
+      cy.checkValue(descriptionField.textarea(), '');
     });
   });
 
@@ -135,7 +135,7 @@ context('Insurance - Policy - Pre-credit period page - Save and go back', () => 
       cy.clickSubmitButtonMultipleTimes({ count: 4 });
 
       cy.assertYesRadioOptionIsChecked();
-      descriptionField.textarea().should('have.value', mockApplication.POLICY[CREDIT_PERIOD_WITH_BUYER]);
+      cy.checkValue(descriptionField.textarea(), mockApplication.POLICY[CREDIT_PERIOD_WITH_BUYER]);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
@@ -89,9 +89,9 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
       cy.startInsurancePolicySection({});
       cy.clickSubmitButton();
 
-      field.dayInput().should('have.value', '');
-      field.monthInput().should('have.value', '');
-      field.yearInput().should('have.value', '');
+      cy.checkValue(field.dayInput(), '');
+      cy.checkValue(field.monthInput(), '');
+      cy.checkValue(field.yearInput(), '');
     });
   });
 
@@ -121,9 +121,9 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
       cy.startInsurancePolicySection({});
       cy.clickSubmitButton();
 
-      field.dayInput().should('have.value', '1');
-      field.monthInput().should('have.value', month);
-      field.yearInput().should('have.value', new Date(futureDate).getFullYear());
+      cy.checkValue(field.dayInput(), '1');
+      cy.checkValue(field.monthInput(), month);
+      cy.checkValue(field.yearInput(), new Date(futureDate).getFullYear());
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
@@ -152,13 +152,13 @@ context('Insurance - Policy - Single contract policy page - As an exporter, I wa
 
         cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`);
 
-        fieldSelector(REQUESTED_START_DATE).dayInput().should('have.value', application.POLICY[REQUESTED_START_DATE].day);
-        fieldSelector(REQUESTED_START_DATE).monthInput().should('have.value', application.POLICY[REQUESTED_START_DATE].month);
-        fieldSelector(REQUESTED_START_DATE).yearInput().should('have.value', application.POLICY[REQUESTED_START_DATE].year);
+        cy.checkValue(fieldSelector(REQUESTED_START_DATE).dayInput(), application.POLICY[REQUESTED_START_DATE].day);
+        cy.checkValue(fieldSelector(REQUESTED_START_DATE).monthInput(), application.POLICY[REQUESTED_START_DATE].month);
+        cy.checkValue(fieldSelector(REQUESTED_START_DATE).yearInput(), application.POLICY[REQUESTED_START_DATE].year);
 
-        fieldSelector(CONTRACT_COMPLETION_DATE).dayInput().should('have.value', application.POLICY[CONTRACT_COMPLETION_DATE].day);
-        fieldSelector(CONTRACT_COMPLETION_DATE).monthInput().should('have.value', application.POLICY[CONTRACT_COMPLETION_DATE].month);
-        fieldSelector(CONTRACT_COMPLETION_DATE).yearInput().should('have.value', application.POLICY[CONTRACT_COMPLETION_DATE].year);
+        cy.checkValue(fieldSelector(CONTRACT_COMPLETION_DATE).dayInput(), application.POLICY[CONTRACT_COMPLETION_DATE].day);
+        cy.checkValue(fieldSelector(CONTRACT_COMPLETION_DATE).monthInput(), application.POLICY[CONTRACT_COMPLETION_DATE].month);
+        cy.checkValue(fieldSelector(CONTRACT_COMPLETION_DATE).yearInput(), application.POLICY[CONTRACT_COMPLETION_DATE].year);
 
         const isoCode = application.POLICY[POLICY_CURRENCY_CODE];
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/save-and-back.spec.js
@@ -72,8 +72,8 @@ context('Insurance - Policy - Single contract policy - Total contract value page
     it('should have the submitted values when going back to the page', () => {
       cy.navigateToUrl(url);
 
-      fieldSelector(TOTAL_CONTRACT_VALUE).input().should('have.value', application.POLICY[TOTAL_CONTRACT_VALUE]);
-      fieldSelector(REQUESTED_CREDIT_LIMIT).input().should('have.value', '');
+      cy.checkValue(fieldSelector(TOTAL_CONTRACT_VALUE).input(), application.POLICY[TOTAL_CONTRACT_VALUE]);
+      cy.checkValue(fieldSelector(REQUESTED_CREDIT_LIMIT).input(), '');
     });
   });
 
@@ -97,7 +97,7 @@ context('Insurance - Policy - Single contract policy - Total contract value page
     it('should have the submitted values when going back to the page', () => {
       cy.navigateToUrl(url);
 
-      fieldSelector(REQUESTED_CREDIT_LIMIT).input().should('have.value', application.POLICY[REQUESTED_CREDIT_LIMIT]);
+      cy.checkValue(fieldSelector(REQUESTED_CREDIT_LIMIT).input(), application.POLICY[REQUESTED_CREDIT_LIMIT]);
     });
   });
 
@@ -121,8 +121,8 @@ context('Insurance - Policy - Single contract policy - Total contract value page
     it('should have the submitted values when going back to the page', () => {
       cy.navigateToUrl(url);
 
-      fieldSelector(TOTAL_CONTRACT_VALUE).input().should('have.value', application.POLICY[TOTAL_CONTRACT_VALUE]);
-      fieldSelector(REQUESTED_CREDIT_LIMIT).input().should('have.value', application.POLICY[REQUESTED_CREDIT_LIMIT]);
+      cy.checkValue(fieldSelector(TOTAL_CONTRACT_VALUE).input(), application.POLICY[TOTAL_CONTRACT_VALUE]);
+      cy.checkValue(fieldSelector(REQUESTED_CREDIT_LIMIT).input(), application.POLICY[REQUESTED_CREDIT_LIMIT]);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value.spec.js
@@ -114,9 +114,9 @@ context(
         it('should have the submitted values', () => {
           cy.navigateToUrl(url);
 
-          fieldSelector(TOTAL_CONTRACT_VALUE).input().should('have.value', application.POLICY[TOTAL_CONTRACT_VALUE]);
+          cy.checkValue(fieldSelector(TOTAL_CONTRACT_VALUE).input(), application.POLICY[TOTAL_CONTRACT_VALUE]);
 
-          fieldSelector(REQUESTED_CREDIT_LIMIT).input().should('have.value', application.POLICY[REQUESTED_CREDIT_LIMIT]);
+          cy.checkValue(fieldSelector(REQUESTED_CREDIT_LIMIT).input(), application.POLICY[REQUESTED_CREDIT_LIMIT]);
         });
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/nature-of-business-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/nature-of-business-page.spec.js
@@ -115,9 +115,9 @@ context(
       it('should have the submitted values', () => {
         cy.navigateToUrl(natureOfBusinessUrl);
 
-        fieldSelector(GOODS_OR_SERVICES).textarea().should('have.value', application.EXPORTER_BUSINESS[GOODS_OR_SERVICES]);
-        fieldSelector(YEARS_EXPORTING).input().should('have.value', application.EXPORTER_BUSINESS[YEARS_EXPORTING]);
-        fieldSelector(EMPLOYEES_UK).input().should('have.value', application.EXPORTER_BUSINESS[EMPLOYEES_UK]);
+        cy.checkValue(fieldSelector(GOODS_OR_SERVICES).textarea(), application.EXPORTER_BUSINESS[GOODS_OR_SERVICES]);
+        cy.checkValue(fieldSelector(YEARS_EXPORTING).input(), application.EXPORTER_BUSINESS[YEARS_EXPORTING]);
+        cy.checkValue(fieldSelector(EMPLOYEES_UK).input(), application.EXPORTER_BUSINESS[EMPLOYEES_UK]);
       });
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/save-and-back.spec.js
@@ -76,9 +76,9 @@ context('Insurance - Your business - Nature of your business page - Save and bac
       // go through 2 business forms.
       cy.clickSubmitButtonMultipleTimes({ count: 2 });
 
-      field(GOODS_OR_SERVICES).textarea().should('have.value', application.EXPORTER_BUSINESS[GOODS_OR_SERVICES]);
-      field(YEARS_EXPORTING).input().should('have.value', '');
-      field(EMPLOYEES_UK).input().should('have.value', '');
+      cy.checkValue(field(GOODS_OR_SERVICES).textarea(), application.EXPORTER_BUSINESS[GOODS_OR_SERVICES]);
+      cy.checkValue(field(YEARS_EXPORTING).input(), '');
+      cy.checkValue(field(EMPLOYEES_UK).input(), '');
     });
   });
 
@@ -107,9 +107,9 @@ context('Insurance - Your business - Nature of your business page - Save and bac
       // company details submit
       cy.clickSubmitButton();
 
-      field(GOODS_OR_SERVICES).textarea().should('have.value', application.EXPORTER_BUSINESS[GOODS_OR_SERVICES]);
-      field(YEARS_EXPORTING).input().should('have.value', application.EXPORTER_BUSINESS[YEARS_EXPORTING]);
-      field(EMPLOYEES_UK).input().should('have.value', application.EXPORTER_BUSINESS[EMPLOYEES_UK]);
+      cy.checkValue(field(GOODS_OR_SERVICES).textarea(), application.EXPORTER_BUSINESS[GOODS_OR_SERVICES]);
+      cy.checkValue(field(YEARS_EXPORTING).input(), application.EXPORTER_BUSINESS[YEARS_EXPORTING]);
+      cy.checkValue(field(EMPLOYEES_UK).input(), application.EXPORTER_BUSINESS[EMPLOYEES_UK]);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/save-and-back.spec.js
@@ -76,8 +76,8 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
       // go through 3 business forms.
       cy.clickSubmitButtonMultipleTimes({ count: 3 });
 
-      field(ESTIMATED_ANNUAL_TURNOVER).input().should('have.value', application.EXPORTER_BUSINESS[ESTIMATED_ANNUAL_TURNOVER]);
-      field(PERCENTAGE_TURNOVER).input().should('have.value', '');
+      cy.checkValue(field(ESTIMATED_ANNUAL_TURNOVER).input(), application.EXPORTER_BUSINESS[ESTIMATED_ANNUAL_TURNOVER]);
+      cy.checkValue(field(PERCENTAGE_TURNOVER).input(), '');
     });
   });
 
@@ -105,8 +105,8 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
       // go through 2 business forms.
       cy.clickSubmitButtonMultipleTimes({ count: 3 });
 
-      field(ESTIMATED_ANNUAL_TURNOVER).input().should('have.value', application.EXPORTER_BUSINESS[ESTIMATED_ANNUAL_TURNOVER]);
-      field(PERCENTAGE_TURNOVER).input().should('have.value', application.EXPORTER_BUSINESS[PERCENTAGE_TURNOVER]);
+      cy.checkValue(field(ESTIMATED_ANNUAL_TURNOVER).input(), application.EXPORTER_BUSINESS[ESTIMATED_ANNUAL_TURNOVER]);
+      cy.checkValue(field(PERCENTAGE_TURNOVER).input(), application.EXPORTER_BUSINESS[PERCENTAGE_TURNOVER]);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
@@ -133,9 +133,9 @@ context(
 
         cy.checkText(turnoverPage[FINANCIAL_YEAR_END_DATE](), financialYearEnd.expectedValue);
 
-        fieldSelector(ESTIMATED_ANNUAL_TURNOVER).input().should('have.value', application.EXPORTER_BUSINESS[ESTIMATED_ANNUAL_TURNOVER]);
+        cy.checkValue(fieldSelector(ESTIMATED_ANNUAL_TURNOVER).input(), application.EXPORTER_BUSINESS[ESTIMATED_ANNUAL_TURNOVER]);
 
-        fieldSelector(PERCENTAGE_TURNOVER).input().should('have.value', application.EXPORTER_BUSINESS[PERCENTAGE_TURNOVER]);
+        cy.checkValue(fieldSelector(PERCENTAGE_TURNOVER).input(), application.EXPORTER_BUSINESS[PERCENTAGE_TURNOVER]);
       });
     });
   },

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
@@ -80,10 +80,10 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
 
       const field = fieldSelector(fieldId);
 
-      field.input().select(1).should('have.value', GBP.isoCode);
-      field.input().select(2).should('have.value', EUR.isoCode);
-      field.input().select(3).should('have.value', USD.isoCode);
-      field.input().select(4).should('have.value', JPY.isoCode);
+      cy.checkValue(field.input().select(1), GBP.isoCode);
+      cy.checkValue(field.input().select(2), EUR.isoCode);
+      cy.checkValue(field.input().select(3), USD.isoCode);
+      cy.checkValue(field.input().select(4), JPY.isoCode);
     });
 
     it('should render `max amount owed` label and input', () => {

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
@@ -86,10 +86,10 @@ context('Tell us about your single policy page - as an exporter, I want to provi
 
       const field = fieldSelector(fieldId);
 
-      field.input().select(1).should('have.value', GBP.isoCode);
-      field.input().select(2).should('have.value', EUR.isoCode);
-      field.input().select(3).should('have.value', USD.isoCode);
-      field.input().select(4).should('have.value', JPY.isoCode);
+      cy.checkValue(field.input().select(1), GBP.isoCode);
+      cy.checkValue(field.input().select(2), EUR.isoCode);
+      cy.checkValue(field.input().select(3), USD.isoCode);
+      cy.checkValue(field.input().select(4), JPY.isoCode);
     });
 
     it('should render `contract value` label and input', () => {


### PR DESCRIPTION
## Introduction :pencil2:
- Various E2E assertions were using `should('have.value', ...)` instead of an existing `cy.checkValue` command.

## Resolution :heavy_check_mark:
- Update all E2E tests to use `cy.checkValue`.
