### PR TITLE
chore(EMS-3898): dry checkDateFieldValues cypress command

### DIFF
--- a/e2e-tests/commands/shared-commands/assertions/assert-empty-contract-completion-date-field-values.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-empty-contract-completion-date-field-values.js
@@ -12,9 +12,9 @@ const {
  * Assert all CONTRACT_COMPLETION_DATE field values are empty.
  */
 const assertEmptyContractCompletionDateFieldValues = () => {
-  field(CONTRACT_COMPLETION_DATE).dayInput().should('have.value', '');
-  field(CONTRACT_COMPLETION_DATE).monthInput().should('have.value', '');
-  field(CONTRACT_COMPLETION_DATE).yearInput().should('have.value', '');
+  const selector = field(CONTRACT_COMPLETION_DATE);
+
+  cy.checkDateFieldValues({ selector });
 };
 
 export default assertEmptyContractCompletionDateFieldValues;

--- a/e2e-tests/commands/shared-commands/assertions/assert-empty-requested-start-date-field-values.js
+++ b/e2e-tests/commands/shared-commands/assertions/assert-empty-requested-start-date-field-values.js
@@ -10,9 +10,9 @@ const {
  * Assert all REQUESTED_START_DATE field values are empty.
  */
 const assertEmptyRequestedStartDateFieldValues = () => {
-  field(REQUESTED_START_DATE).dayInput().should('have.value', '');
-  field(REQUESTED_START_DATE).monthInput().should('have.value', '');
-  field(REQUESTED_START_DATE).yearInput().should('have.value', '');
+  const selector = field(REQUESTED_START_DATE);
+
+  cy.checkDateFieldValues({ selector });
 };
 
 export default assertEmptyRequestedStartDateFieldValues;

--- a/e2e-tests/commands/shared-commands/assertions/check-date-field-values.js
+++ b/e2e-tests/commands/shared-commands/assertions/check-date-field-values.js
@@ -1,0 +1,15 @@
+/**
+ * checkDateFieldValues
+ * Check an date field's day, month and year input values
+ * @param {Function} selector: Cypress selector
+ * @param {String} day: Expected day value
+ * @param {String} month: Expected month value
+ * @param {String} year: Expected year value
+ */
+const checkDateFieldValues = ({ selector, day = '', month = '', year = '' }) => {
+  selector.dayInput().should('have.value', day);
+  selector.monthInput().should('have.value', month);
+  selector.yearInput().should('have.value', year);
+};
+
+export default checkDateFieldValues;

--- a/e2e-tests/commands/shared-commands/assertions/index.js
+++ b/e2e-tests/commands/shared-commands/assertions/index.js
@@ -41,6 +41,7 @@ Cypress.Commands.add('checkTextAndValue', require('./check-text-and-value'));
 Cypress.Commands.add('checkTextareaValue', require('./check-textarea-value'));
 Cypress.Commands.add('checkTypeAttribute', require('./check-type-attribute'));
 Cypress.Commands.add('checkValue', require('./check-value'));
+Cypress.Commands.add('checkDateFieldValues', require('./check-date-field-values'));
 
 Cypress.Commands.add('checkAuthenticatedHeader', require('./check-authenticated-header'));
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -147,9 +147,14 @@ context('Insurance - Policy - Multiple contract policy page - As an exporter, I 
       it('should have the submitted values', () => {
         cy.navigateToUrl(url);
 
-        fieldSelector(REQUESTED_START_DATE).dayInput().should('have.value', application.POLICY[REQUESTED_START_DATE].day);
-        fieldSelector(REQUESTED_START_DATE).monthInput().should('have.value', application.POLICY[REQUESTED_START_DATE].month);
-        fieldSelector(REQUESTED_START_DATE).yearInput().should('have.value', application.POLICY[REQUESTED_START_DATE].year);
+        const { day, month, year } = application.POLICY[REQUESTED_START_DATE];
+
+        cy.checkDateFieldValues({
+          selector: fieldSelector(REQUESTED_START_DATE),
+          day,
+          month,
+          year,
+        });
 
         cy.checkValue(fieldSelector(TOTAL_MONTHS_OF_COVER), application.POLICY[TOTAL_MONTHS_OF_COVER]);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
@@ -89,9 +89,7 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
       cy.startInsurancePolicySection({});
       cy.clickSubmitButton();
 
-      field.dayInput().should('have.value', '');
-      field.monthInput().should('have.value', '');
-      field.yearInput().should('have.value', '');
+      cy.assertEmptyRequestedStartDateFieldValues({});
     });
   });
 
@@ -121,9 +119,12 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
       cy.startInsurancePolicySection({});
       cy.clickSubmitButton();
 
-      field.dayInput().should('have.value', '1');
-      field.monthInput().should('have.value', month);
-      field.yearInput().should('have.value', new Date(futureDate).getFullYear());
+      cy.checkDateFieldValues({
+        selector: field,
+        day: '1',
+        month,
+        year: new Date(futureDate).getFullYear(),
+      });
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
@@ -152,13 +152,21 @@ context('Insurance - Policy - Single contract policy page - As an exporter, I wa
 
         cy.navigateToUrl(`${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`);
 
-        fieldSelector(REQUESTED_START_DATE).dayInput().should('have.value', application.POLICY[REQUESTED_START_DATE].day);
-        fieldSelector(REQUESTED_START_DATE).monthInput().should('have.value', application.POLICY[REQUESTED_START_DATE].month);
-        fieldSelector(REQUESTED_START_DATE).yearInput().should('have.value', application.POLICY[REQUESTED_START_DATE].year);
+        const { POLICY } = application;
 
-        fieldSelector(CONTRACT_COMPLETION_DATE).dayInput().should('have.value', application.POLICY[CONTRACT_COMPLETION_DATE].day);
-        fieldSelector(CONTRACT_COMPLETION_DATE).monthInput().should('have.value', application.POLICY[CONTRACT_COMPLETION_DATE].month);
-        fieldSelector(CONTRACT_COMPLETION_DATE).yearInput().should('have.value', application.POLICY[CONTRACT_COMPLETION_DATE].year);
+        cy.checkDateFieldValues({
+          selector: fieldSelector(REQUESTED_START_DATE),
+          day: POLICY[REQUESTED_START_DATE].day,
+          month: POLICY[REQUESTED_START_DATE].month,
+          year: POLICY[REQUESTED_START_DATE].year,
+        });
+
+        cy.checkDateFieldValues({
+          selector: fieldSelector(CONTRACT_COMPLETION_DATE),
+          day: POLICY[CONTRACT_COMPLETION_DATE].day,
+          month: POLICY[CONTRACT_COMPLETION_DATE].month,
+          year: POLICY[CONTRACT_COMPLETION_DATE].year,
+        });
 
         const isoCode = application.POLICY[POLICY_CURRENCY_CODE];
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR introduces a DRY `checkDateFieldValues` cypress command.

## Resolution :heavy_check_mark:
- Create `checkDateFieldValues` command.
- Update `assertEmptyContractCompletionDateFieldValues` command.
- Update `assertEmptyRequestedStartDateFieldValues` command.
- Update E2E tests.

## Miscellaneous :heavy_plus_sign:
List any additional fixes or improvements.
