### PR TITLE
chore(EMS-3899): dry completeDateFormFields cypress command

### DIFF
--- a/e2e-tests/commands/insurance/complete-multiple-contract-policy-form.js
+++ b/e2e-tests/commands/insurance/complete-multiple-contract-policy-form.js
@@ -14,6 +14,8 @@ const {
   },
 } = INSURANCE_FIELD_IDS;
 
+const { day, month, year } = application.POLICY[REQUESTED_START_DATE];
+
 /**
  * completeMultipleContractPolicyForm
  * Complete the "multiple contract policy" form
@@ -22,9 +24,7 @@ const {
  * @param {Boolean} chooseCurrency: Whether to choose a currency or not
  */
 const completeMultipleContractPolicyForm = ({ isoCode = application.POLICY[POLICY_CURRENCY_CODE], alternativeCurrency = false, chooseCurrency = true }) => {
-  cy.keyboardInput(field(REQUESTED_START_DATE).dayInput(), application.POLICY[REQUESTED_START_DATE].day);
-  cy.keyboardInput(field(REQUESTED_START_DATE).monthInput(), application.POLICY[REQUESTED_START_DATE].month);
-  cy.keyboardInput(field(REQUESTED_START_DATE).yearInput(), application.POLICY[REQUESTED_START_DATE].year);
+  cy.completeDateFormFields({ idPrefix: REQUESTED_START_DATE, day, month, year });
 
   cy.keyboardInput(field(TOTAL_MONTHS_OF_COVER).input(), application.POLICY[TOTAL_MONTHS_OF_COVER]);
 

--- a/e2e-tests/commands/insurance/complete-single-contract-policy-form.js
+++ b/e2e-tests/commands/insurance/complete-single-contract-policy-form.js
@@ -1,5 +1,5 @@
 import { INSURANCE_FIELD_IDS } from '../../constants/field-ids/insurance';
-import { radios, field } from '../../pages/shared';
+import { radios } from '../../pages/shared';
 import application from '../../fixtures/application';
 import { NON_STANDARD_CURRENCY_CODE } from '../../fixtures/currencies';
 
@@ -14,6 +14,8 @@ const {
   },
 } = INSURANCE_FIELD_IDS;
 
+const { POLICY } = application;
+
 /**
  * completeSingleContractPolicyForm
  * Complete the "single contract policy" form.
@@ -22,13 +24,19 @@ const {
  * @param {Boolean} chooseCurrency: Whether to choose a currency or not
  */
 const completeSingleContractPolicyForm = ({ isoCode = application.POLICY[POLICY_CURRENCY_CODE], alternativeCurrency = false, chooseCurrency = true }) => {
-  cy.keyboardInput(field(REQUESTED_START_DATE).dayInput(), application.POLICY[REQUESTED_START_DATE].day);
-  cy.keyboardInput(field(REQUESTED_START_DATE).monthInput(), application.POLICY[REQUESTED_START_DATE].month);
-  cy.keyboardInput(field(REQUESTED_START_DATE).yearInput(), application.POLICY[REQUESTED_START_DATE].year);
+  cy.completeDateFormFields({
+    idPrefix: REQUESTED_START_DATE,
+    day: POLICY[REQUESTED_START_DATE].day,
+    month: POLICY[REQUESTED_START_DATE].month,
+    year: POLICY[REQUESTED_START_DATE].year,
+  });
 
-  cy.keyboardInput(field(CONTRACT_COMPLETION_DATE).dayInput(), application.POLICY[CONTRACT_COMPLETION_DATE].day);
-  cy.keyboardInput(field(CONTRACT_COMPLETION_DATE).monthInput(), application.POLICY[CONTRACT_COMPLETION_DATE].month);
-  cy.keyboardInput(field(CONTRACT_COMPLETION_DATE).yearInput(), application.POLICY[CONTRACT_COMPLETION_DATE].year);
+  cy.completeDateFormFields({
+    idPrefix: CONTRACT_COMPLETION_DATE,
+    day: POLICY[CONTRACT_COMPLETION_DATE].day,
+    month: POLICY[CONTRACT_COMPLETION_DATE].month,
+    year: POLICY[CONTRACT_COMPLETION_DATE].year,
+  });
 
   if (chooseCurrency) {
     if (alternativeCurrency) {

--- a/e2e-tests/commands/insurance/date-field.js
+++ b/e2e-tests/commands/insurance/date-field.js
@@ -27,7 +27,7 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, e
   };
 
   return {
-    day: {
+    dayAssertions: {
       /**
        * Submit a date without a day.
        * Check validation errors.
@@ -105,7 +105,7 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, e
         });
       },
     },
-    month: {
+    monthAssertions: {
       /**
        * Submit a date without a month.
        * Check validation errors.
@@ -155,7 +155,7 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, e
         });
       },
     },
-    year: {
+    yearAssertions: {
       /**
        * Submit a date without a year.
        * Check validation errors.
@@ -299,8 +299,8 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, e
         const month = dateValue.getMonth() + 1;
         const year = dateValue.getFullYear();
 
-        cy.completeDateFormFields({ idPrefix: fieldA, day, month, year });
-        cy.completeDateFormFields({ idPrefix: fieldB, day, month, year });
+        cy.completeDateFormFields({ idPrefix: fieldA.id, day, month, year });
+        cy.completeDateFormFields({ idPrefix: fieldB.id, day, month, year });
 
         cy.clickSubmitButton();
 
@@ -322,7 +322,7 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, e
         const month = dateValue.getMonth() + 1;
         const year = dateValue.getFullYear();
 
-        cy.completeDateFormFields({ idPrefix: fieldB, day, month, year });
+        cy.completeDateFormFields({ idPrefix: fieldB.id, day, month, year });
 
         cy.clickSubmitButton();
 
@@ -344,7 +344,7 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, e
         const month = dateValue.getMonth() + 1;
         const year = dateValue.getFullYear();
 
-        cy.completeDateFormFields({ idPrefix: fieldB, day, month, year });
+        cy.completeDateFormFields({ idPrefix: fieldB.id, day, month, year });
 
         cy.clickSubmitButton();
 

--- a/e2e-tests/commands/insurance/date-field.js
+++ b/e2e-tests/commands/insurance/date-field.js
@@ -37,8 +37,6 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, e
         const month = date.getMonth() + 1;
         const year = date.getFullYear();
 
-        field.dayInput().clear();
-
         cy.completeDateFormFields({ idPrefix: fieldId, day: null, month, year });
 
         cy.clickSubmitButton();
@@ -55,9 +53,6 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, e
        * Check validation errors.
        */
       providedWithoutOtherFields: () => {
-        field.monthInput().clear();
-        field.yearInput().clear();
-
         cy.completeDateFormFields({ idPrefix: fieldId, day: '1', month: null, year: null });
 
         cy.clickSubmitButton();
@@ -116,8 +111,6 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, e
        * Check validation errors.
        */
       notProvided: () => {
-        field.monthInput().clear();
-
         cy.completeDateFormFields({ idPrefix: fieldId, day: '1', month: null, year: '2023' });
 
         cy.clickSubmitButton();
@@ -134,9 +127,6 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, e
        * Check validation errors.
        */
       providedWithoutOtherFields: () => {
-        field.dayInput().clear();
-        field.yearInput().clear();
-
         cy.completeDateFormFields({ idPrefix: fieldId, day: null, month: '1', year: null });
 
         cy.clickSubmitButton();
@@ -153,9 +143,6 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, e
        * Check validation errors.
        */
       notANumber: () => {
-        field.dayInput().clear();
-        field.yearInput().clear();
-
         cy.completeDateFormFields({ idPrefix: fieldId, day: null, month: 'One', year: null });
 
         cy.clickSubmitButton();
@@ -174,8 +161,6 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, e
        * Check validation errors.
        */
       notProvided: () => {
-        field.yearInput().clear();
-
         cy.completeDateFormFields({ idPrefix: fieldId, day: '1', month: '2', year: null });
 
         cy.clickSubmitButton();
@@ -192,9 +177,6 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, e
        * Check validation errors.
        */
       providedWithoutOtherFields: () => {
-        field.dayInput().clear();
-        field.monthInput().clear();
-
         cy.completeDateFormFields({ idPrefix: fieldId, day: null, month: null, year: '2023' });
 
         cy.clickSubmitButton();
@@ -227,9 +209,6 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, e
        * Check validation errors.
        */
       notANumber: () => {
-        field.dayInput().clear();
-        field.monthInput().clear();
-
         cy.completeDateFormFields({ idPrefix: fieldId, day: null, month: null, year: 'One' });
 
         cy.clickSubmitButton();

--- a/e2e-tests/commands/insurance/date-field.js
+++ b/e2e-tests/commands/insurance/date-field.js
@@ -15,9 +15,10 @@ import partials from '../../partials';
  * @param {Number} errorSummaryLength: The number of expected errors in the summary list
  * @param {Number} errorIndex: Index of summary list error
  * @param {String} field: Cypress field selector
+ * @param {String} fieldId: Field ID
  * @param {Object} errorMessages: Error messages
  */
-const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessages }) => {
+const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, fieldId, errorMessages }) => {
   const assertFieldErrorsParams = {
     field,
     errorIndex,
@@ -37,8 +38,8 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
         const year = date.getFullYear();
 
         field.dayInput().clear();
-        cy.keyboardInput(field.monthInput(), month);
-        cy.keyboardInput(field.yearInput(), year);
+
+        cy.completeDateFormFields({ idPrefix: fieldId, day: null, month, year });
 
         cy.clickSubmitButton();
 
@@ -54,9 +55,11 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
        * Check validation errors.
        */
       providedWithoutOtherFields: () => {
-        cy.keyboardInput(field.dayInput(), '1');
         field.monthInput().clear();
         field.yearInput().clear();
+
+        cy.completeDateFormFields({ idPrefix: fieldId, day: '1', month: null, year: null });
+
         cy.clickSubmitButton();
 
         const errorMessage = errorMessages.MISSING_MONTH_AND_YEAR;
@@ -71,7 +74,8 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
        * Check validation errors.
        */
       notANumber: () => {
-        cy.keyboardInput(field.dayInput().clear(), 'Test');
+        cy.completeDateFormFields({ idPrefix: fieldId, day: 'Test', month: null, year: null });
+
         cy.clickSubmitButton();
 
         const errorMessage = errorMessages.INCORRECT_FORMAT;
@@ -94,9 +98,7 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
 
         const invalidMonthDay = daysInMonth + 1;
 
-        cy.keyboardInput(field.dayInput().clear(), invalidMonthDay);
-        cy.keyboardInput(field.monthInput().clear(), month);
-        cy.keyboardInput(field.yearInput().clear(), year);
+        cy.completeDateFormFields({ idPrefix: fieldId, day: invalidMonthDay, month, year });
 
         cy.clickSubmitButton();
 
@@ -114,9 +116,10 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
        * Check validation errors.
        */
       notProvided: () => {
-        cy.keyboardInput(field.dayInput(), '1');
         field.monthInput().clear();
-        cy.keyboardInput(field.yearInput(), '2023');
+
+        cy.completeDateFormFields({ idPrefix: fieldId, day: '1', month: null, year: '2023' });
+
         cy.clickSubmitButton();
 
         const errorMessage = errorMessages.INVALID_MONTH;
@@ -132,8 +135,10 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
        */
       providedWithoutOtherFields: () => {
         field.dayInput().clear();
-        cy.keyboardInput(field.monthInput(), '1');
         field.yearInput().clear();
+
+        cy.completeDateFormFields({ idPrefix: fieldId, day: null, month: '1', year: null });
+
         cy.clickSubmitButton();
 
         const errorMessage = errorMessages.MISSING_DAY_AND_YEAR;
@@ -149,7 +154,10 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
        */
       notANumber: () => {
         field.dayInput().clear();
-        cy.keyboardInput(field.monthInput(), 'One');
+        field.yearInput().clear();
+
+        cy.completeDateFormFields({ idPrefix: fieldId, day: null, month: 'One', year: null });
+
         cy.clickSubmitButton();
 
         const errorMessage = errorMessages.INCORRECT_FORMAT;
@@ -166,9 +174,10 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
        * Check validation errors.
        */
       notProvided: () => {
-        cy.keyboardInput(field.dayInput(), '1');
-        cy.keyboardInput(field.monthInput(), '2');
         field.yearInput().clear();
+
+        cy.completeDateFormFields({ idPrefix: fieldId, day: '1', month: '2', year: null });
+
         cy.clickSubmitButton();
 
         const errorMessage = errorMessages.INVALID_YEAR;
@@ -185,7 +194,9 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
       providedWithoutOtherFields: () => {
         field.dayInput().clear();
         field.monthInput().clear();
-        cy.keyboardInput(field.yearInput(), '2023');
+
+        cy.completeDateFormFields({ idPrefix: fieldId, day: null, month: null, year: '2023' });
+
         cy.clickSubmitButton();
 
         const errorMessage = errorMessages.MISSING_DAY_AND_MONTH;
@@ -200,9 +211,8 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
        * Check validation errors.
        */
       notEnoughDigits: () => {
-        cy.keyboardInput(field.dayInput(), '1');
-        cy.keyboardInput(field.monthInput(), '2');
-        cy.keyboardInput(field.yearInput(), '202');
+        cy.completeDateFormFields({ idPrefix: fieldId, day: '1', month: '2', year: '202' });
+
         cy.clickSubmitButton();
 
         const errorMessage = errorMessages.INVALID_YEAR_DIGITS;
@@ -219,7 +229,9 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
       notANumber: () => {
         field.dayInput().clear();
         field.monthInput().clear();
-        cy.keyboardInput(field.yearInput(), 'One');
+
+        cy.completeDateFormFields({ idPrefix: fieldId, day: null, month: null, year: 'One' });
+
         cy.clickSubmitButton();
 
         const errorMessage = errorMessages.INCORRECT_FORMAT;
@@ -241,9 +253,8 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
       const yesterday = new Date(now.setDate(day - 1));
       const month = yesterday.getMonth() + 1;
 
-      cy.keyboardInput(field.dayInput(), yesterday.getDate());
-      cy.keyboardInput(field.monthInput(), month);
-      cy.keyboardInput(field.yearInput(), yesterday.getFullYear());
+      cy.completeDateFormFields({ idPrefix: fieldId, day: yesterday.getDate(), month, year: yesterday.getFullYear() });
+
       cy.clickSubmitButton();
 
       const errorMessage = errorMessages.BEFORE_EARLIEST;
@@ -263,9 +274,8 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
 
       const futureDate = new Date(now.setDate(day + 1));
 
-      cy.keyboardInput(field.dayInput(), day);
-      cy.keyboardInput(field.monthInput(), '24');
-      cy.keyboardInput(field.yearInput(), futureDate.getFullYear());
+      cy.completeDateFormFields({ idPrefix: fieldId, day, month: '24', year: futureDate.getFullYear() });
+
       cy.clickSubmitButton();
 
       const errorMessage = errorMessages.INVALID_DATE;
@@ -282,9 +292,7 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
     isToday: () => {
       const now = new Date();
 
-      cy.keyboardInput(field.dayInput(), now.getDate());
-      cy.keyboardInput(field.monthInput(), now.getMonth() + 1);
-      cy.keyboardInput(field.yearInput(), now.getFullYear());
+      cy.completeDateFormFields({ idPrefix: fieldId, day: now.getDate(), month: now.getMonth() + 1, year: now.getFullYear() });
 
       cy.clickSubmitButton();
 
@@ -312,13 +320,8 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
         const month = dateValue.getMonth() + 1;
         const year = dateValue.getFullYear();
 
-        cy.keyboardInput(fieldA.dayInput(), day);
-        cy.keyboardInput(fieldA.monthInput(), month);
-        cy.keyboardInput(fieldA.yearInput(), year);
-
-        cy.keyboardInput(fieldB.dayInput(), day);
-        cy.keyboardInput(fieldB.monthInput(), month);
-        cy.keyboardInput(fieldB.yearInput(), year);
+        cy.completeDateFormFields({ idPrefix: fieldA, day, month, year });
+        cy.completeDateFormFields({ idPrefix: fieldB, day, month, year });
 
         cy.clickSubmitButton();
 
@@ -340,9 +343,7 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
         const month = dateValue.getMonth() + 1;
         const year = dateValue.getFullYear();
 
-        cy.keyboardInput(fieldB.dayInput(), day);
-        cy.keyboardInput(fieldB.monthInput(), month);
-        cy.keyboardInput(fieldB.yearInput(), year);
+        cy.completeDateFormFields({ idPrefix: fieldB, day, month, year });
 
         cy.clickSubmitButton();
 
@@ -364,9 +365,7 @@ const checkValidation = ({ errorSummaryLength, errorIndex = 0, field, errorMessa
         const month = dateValue.getMonth() + 1;
         const year = dateValue.getFullYear();
 
-        cy.keyboardInput(fieldB.dayInput(), day);
-        cy.keyboardInput(fieldB.monthInput(), month);
-        cy.keyboardInput(fieldB.yearInput(), year);
+        cy.completeDateFormFields({ idPrefix: fieldB, day, month, year });
 
         cy.clickSubmitButton();
 

--- a/e2e-tests/commands/shared-commands/form/complete-date-form-fields.js
+++ b/e2e-tests/commands/shared-commands/form/complete-date-form-fields.js
@@ -11,15 +11,15 @@
  */
 const completeDateFormFields = ({ idPrefix, day, month, year }) => {
   if (day !== null) {
-    cy.keyboardInput(cy.get(`[data-cy="${idPrefix}-day"]`), day);
+    cy.keyboardInput(cy.get(`[data-cy="${idPrefix}-day-input"]`), day);
   }
 
   if (month !== null) {
-    cy.keyboardInput(cy.get(`[data-cy="${idPrefix}-month"]`), month);
+    cy.keyboardInput(cy.get(`[data-cy="${idPrefix}-month-input"]`), month);
   }
 
   if (year !== null) {
-    cy.keyboardInput(cy.get(`[data-cy="${idPrefix}-year"]`), year);
+    cy.keyboardInput(cy.get(`[data-cy="${idPrefix}-year-input"]`), year);
   }
 };
 

--- a/e2e-tests/commands/shared-commands/form/complete-date-form-fields.js
+++ b/e2e-tests/commands/shared-commands/form/complete-date-form-fields.js
@@ -1,0 +1,26 @@
+/**
+ * completeDateFormFields
+ * Complete day, month and year date fields.
+ * For each date field, check that a null value is NOT provided.
+ * In some tests, only 1x date fields is changed, for validation testing.
+ * Therefore, only enter something into each field if the field is NOT provided as null.
+ * @param {string} idPrefix: ID prefix of the date fields
+ * @param {string} day: Optional day string
+ * @param {string} month: Optional month string
+ * @param {string} year: Optional year string
+ */
+const completeDateFormFields = ({ idPrefix, day, month, year }) => {
+  if (day !== null) {
+    cy.keyboardInput(cy.get(`[data-cy="${idPrefix}-day"]`), day);
+  }
+
+  if (month !== null) {
+    cy.keyboardInput(cy.get(`[data-cy="${idPrefix}-month"]`), month);
+  }
+
+  if (year !== null) {
+    cy.keyboardInput(cy.get(`[data-cy="${idPrefix}-year"]`), year);
+  }
+};
+
+export default completeDateFormFields;

--- a/e2e-tests/commands/shared-commands/form/index.js
+++ b/e2e-tests/commands/shared-commands/form/index.js
@@ -2,6 +2,8 @@ Cypress.Commands.add('changeAnswerField', require('./change-answer-field'));
 Cypress.Commands.add('changeAnswerSelectField', require('./change-answer-select-field'));
 Cypress.Commands.add('changeAnswerRadioField', require('./change-answer-radio-field'));
 
+Cypress.Commands.add('completeDateFormFields', require('./complete-date-form-fields'));
+
 Cypress.Commands.add('completeAlternativeCurrencyField', require('./complete-alternative-currency-field'));
 Cypress.Commands.add('clickAlternativeCurrencyRadioAndCompleteCurrency', require('./click-alternative-currency-radio-and-complete-currency'));
 Cypress.Commands.add('clickAlternativeCurrencyRadioAndSubmitCurrency', require('./click-alternative-currency-radio-and-submit-currency'));

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-requested-start-date.spec.js
@@ -30,7 +30,7 @@ context('Insurance - Policy - Multiple contract policy page - form validation - 
 
   const field = fieldSelector(REQUESTED_START_DATE);
 
-  const { day, month, year, notInTheFuture, invalidFormat, isToday } = dateField.checkValidation({
+  const { dayAssertions, monthAssertions, yearAssertions, notInTheFuture, invalidFormat, isToday } = dateField.checkValidation({
     errorSummaryLength: 3,
     errorIndex: 0,
     field,
@@ -61,47 +61,47 @@ context('Insurance - Policy - Multiple contract policy page - form validation - 
   });
 
   it('when the day is not provided', () => {
-    day.notProvided();
+    dayAssertions.notProvided();
   });
 
   it('when the month is not provided', () => {
-    month.notProvided();
+    monthAssertions.notProvided();
   });
 
   it('when the year is not provided', () => {
-    year.notProvided();
+    yearAssertions.notProvided();
   });
 
   it('when the day is provided, but month and year are not', () => {
-    day.providedWithoutOtherFields();
+    dayAssertions.providedWithoutOtherFields();
   });
 
   it('when the month is provided, but day and year are not', () => {
-    month.providedWithoutOtherFields();
+    monthAssertions.providedWithoutOtherFields();
   });
 
   it('when the year is provided, but day and month are not', () => {
-    year.providedWithoutOtherFields();
+    yearAssertions.providedWithoutOtherFields();
   });
 
   it('when the day is not a number', () => {
-    day.notANumber();
+    dayAssertions.notANumber();
   });
 
   it('when the month is not a number', () => {
-    month.notANumber();
+    monthAssertions.notANumber();
   });
 
   it('when the year is not a number', () => {
-    year.notANumber();
+    yearAssertions.notANumber();
   });
 
   it('when the day is greater than the last day of month', () => {
-    day.isGreaterThanLastDayOfMonth();
+    dayAssertions.isGreaterThanLastDayOfMonth();
   });
 
   it('when the year does not have enough digits', () => {
-    year.notEnoughDigits();
+    yearAssertions.notEnoughDigits();
   });
 
   it('when the the date is not in the future', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
@@ -33,7 +33,7 @@ context('Insurance - Policy - Single contract policy page - form validation - co
 
   const field = fieldSelector(CONTRACT_COMPLETION_DATE);
 
-  const { day, month, year, notInTheFuture, invalidFormat, isToday, withTwoDateFields } = dateField.checkValidation({
+  const { dayAssertions, monthAssertions, yearAssertions, notInTheFuture, invalidFormat, isToday, withTwoDateFields } = dateField.checkValidation({
     errorSummaryLength: 3,
     errorIndex: 1,
     field,
@@ -64,47 +64,47 @@ context('Insurance - Policy - Single contract policy page - form validation - co
   });
 
   it('when the day is not provided', () => {
-    day.notProvided();
+    dayAssertions.notProvided();
   });
 
   it('when the month is not provided', () => {
-    month.notProvided();
+    monthAssertions.notProvided();
   });
 
   it('when the year is not provided', () => {
-    year.notProvided();
+    yearAssertions.notProvided();
   });
 
   it('when the day is provided, but month and year are not', () => {
-    day.providedWithoutOtherFields();
+    dayAssertions.providedWithoutOtherFields();
   });
 
   it('when the month is provided, but day and year are not', () => {
-    month.providedWithoutOtherFields();
+    monthAssertions.providedWithoutOtherFields();
   });
 
   it('when the year is provided, but day and month are not', () => {
-    year.providedWithoutOtherFields();
+    yearAssertions.providedWithoutOtherFields();
   });
 
   it('when the day is not a number', () => {
-    day.notANumber();
+    dayAssertions.notANumber();
   });
 
   it('when the month is not a number', () => {
-    month.notANumber();
+    monthAssertions.notANumber();
   });
 
   it('when the year is not a number', () => {
-    year.notANumber();
+    yearAssertions.notANumber();
   });
 
   it('when the day is greater than the last day of month', () => {
-    day.isGreaterThanLastDayOfMonth();
+    dayAssertions.isGreaterThanLastDayOfMonth();
   });
 
   it('when the year does not have enough digits', () => {
-    year.notEnoughDigits();
+    yearAssertions.notEnoughDigits();
   });
 
   it('when the the date is not in the future', () => {
@@ -124,14 +124,21 @@ context('Insurance - Policy - Single contract policy page - form validation - co
     const initYear = date.getFullYear();
     const startDate = new Date(date.setFullYear(initYear + 1));
 
-    const startDateObj = {
+    const { day, month, year } = {
       day: startDate.getDate(),
       month: startDate.getMonth() + 1,
       year: startDate.getFullYear(),
     };
 
-    const fieldA = fieldSelector(REQUESTED_START_DATE);
-    const fieldB = fieldSelector(CONTRACT_COMPLETION_DATE);
+    const fieldA = {
+      ...fieldSelector(REQUESTED_START_DATE),
+      id: REQUESTED_START_DATE,
+    };
+
+    const fieldB = {
+      ...fieldSelector(CONTRACT_COMPLETION_DATE),
+      id: CONTRACT_COMPLETION_DATE,
+    };
 
     const { cannotBeTheSame, cannotBeBefore, cannotBeAfter } = withTwoDateFields({
       fieldA,
@@ -143,9 +150,7 @@ context('Insurance - Policy - Single contract policy page - form validation - co
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.keyboardInput(fieldSelector(REQUESTED_START_DATE).dayInput(), startDateObj.day);
-      cy.keyboardInput(fieldSelector(REQUESTED_START_DATE).monthInput(), startDateObj.month);
-      cy.keyboardInput(fieldSelector(REQUESTED_START_DATE).yearInput(), startDateObj.year);
+      cy.completeDateFormFields({ idPrefix: REQUESTED_START_DATE, day, month, year });
     });
 
     it(`should render a validation error when the date is the same as ${REQUESTED_START_DATE}`, () => {
@@ -153,13 +158,13 @@ context('Insurance - Policy - Single contract policy page - form validation - co
     });
 
     it(`should render a validation error when the date is before the ${REQUESTED_START_DATE}`, () => {
-      const yesterday = new Date(date.setDate(startDateObj.day - 1));
+      const yesterday = new Date(date.setDate(day - 1));
 
       cannotBeBefore(yesterday);
     });
 
     it(`should render a validation error when the date is over the maximum years allowed after ${REQUESTED_START_DATE}`, () => {
-      const additionalYears = startDateObj.year + ELIGIBILITY.MAX_COVER_PERIOD_YEARS;
+      const additionalYears = year + ELIGIBILITY.MAX_COVER_PERIOD_YEARS;
 
       const futureDate = new Date(startDate.setFullYear(additionalYears));
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
@@ -27,7 +27,7 @@ context('Insurance - Policy - Single contract policy page - form validation - re
 
   const field = fieldSelector(REQUESTED_START_DATE);
 
-  const { day, month, year, notInTheFuture, invalidFormat, isToday } = dateField.checkValidation({
+  const { dayAssertions, monthAssertions, yearAssertions, notInTheFuture, invalidFormat, isToday } = dateField.checkValidation({
     errorSummaryLength: 3,
     errorIndex: 0,
     field,
@@ -58,47 +58,47 @@ context('Insurance - Policy - Single contract policy page - form validation - re
   });
 
   it('when the day is not provided', () => {
-    day.notProvided();
+    dayAssertions.notProvided();
   });
 
   it('when the month is not provided', () => {
-    month.notProvided();
+    monthAssertions.notProvided();
   });
 
   it('when the year is not provided', () => {
-    year.notProvided();
+    yearAssertions.notProvided();
   });
 
   it('when the day is provided, but month and year are not', () => {
-    day.providedWithoutOtherFields();
+    dayAssertions.providedWithoutOtherFields();
   });
 
   it('when the month is provided, but day and year are not', () => {
-    month.providedWithoutOtherFields();
+    monthAssertions.providedWithoutOtherFields();
   });
 
   it('when the year is provided, but day and month are not', () => {
-    year.providedWithoutOtherFields();
+    yearAssertions.providedWithoutOtherFields();
   });
 
   it('when the day is not a number', () => {
-    day.notANumber();
+    dayAssertions.notANumber();
   });
 
   it('when the month is not a number', () => {
-    month.notANumber();
+    monthAssertions.notANumber();
   });
 
   it('when the year is not a number', () => {
-    year.notANumber();
+    yearAssertions.notANumber();
   });
 
   it('when the day is greater than the last day of month', () => {
-    day.isGreaterThanLastDayOfMonth();
+    dayAssertions.isGreaterThanLastDayOfMonth();
   });
 
   it('when the year does not have enough digits', () => {
-    year.notEnoughDigits();
+    yearAssertions.notEnoughDigits();
   });
 
   it('when the the date is not in the future', () => {


### PR DESCRIPTION
## Introduction :pencil2:
This PR creates a new `completeDateFormFields` cypress command so that instead of this:

```js
cy.keyboardInput(field.dayInput(), '1');
cy.keyboardInput(field.monthInput(), '2');
cy.keyboardInput(field.yearInput(), '2022');
```

We can just do this:

```js
cy.completeDateFormFields({ idPrefix: REQUESTED_START_DATE, day: '1', month: '2', year: '2022' });
```

## Resolution :heavy_check_mark:
- Create new command.
- Update E2E tests.
- Rename DRY date validation assertions to return day/month/year with an assertion suffix.
