### PR TITLE
chore(EMS-3900): corePageChecks - assert 'save and back' by default

### DIFF
--- a/e2e-tests/commands/core-page-checks.js
+++ b/e2e-tests/commands/core-page-checks.js
@@ -128,6 +128,8 @@ const corePageChecks = ({
 
   if (assertSaveAndBackButtonDoesNotExist) {
     cy.assertSaveAndBackButtonDoesNotExist();
+  } else {
+    cy.assertSaveAndBackButton();
   }
 };
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/accessibility-statement-signed-in.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/accessibility-statement-signed-in.spec.js
@@ -29,6 +29,7 @@ context('Accessibility statement page - Insurance - Signed in', () => {
       backLink: dashboardUrl,
       hasAForm: false,
       assertAuthenticatedHeader: true,
+      assertSaveAndBackButtonDoesNotExist: true,
       isInsurancePage: true,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/accessibility-statement.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/accessibility-statement.spec.js
@@ -50,6 +50,7 @@ context('Accessibility statement page - Insurance', () => {
       backLink: checkIfEligibleUrl,
       hasAForm: false,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
       isInsurancePage: true,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/confirm-email/confirm-email.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/confirm-email/confirm-email.spec.js
@@ -59,6 +59,7 @@ context(
           backLink: YOUR_DETAILS,
           hasAForm: false,
           assertAuthenticatedHeader: false,
+          assertSaveAndBackButtonDoesNotExist: true,
           lightHouseThresholds: {
             performance: 69,
           },

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/resend-confirm-email/resend-confirm-email.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/resend-confirm-email/resend-confirm-email.spec.js
@@ -58,6 +58,7 @@ context(
           backLink: `${CONFIRM_EMAIL}?id=${account.id}`,
           hasAForm: false,
           assertAuthenticatedHeader: false,
+          assertSaveAndBackButtonDoesNotExist: true,
         });
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/create/your-details/account-create-your-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/create/your-details/account-create-your-details.spec.js
@@ -50,6 +50,7 @@ context(
         currentHref: YOUR_DETAILS,
         backLink: HAVE_AN_ACCOUNT,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
         lightHouseThresholds: {
           performance: 70,
         },

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/manage/account-manage.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/manage/account-manage.spec.js
@@ -87,6 +87,7 @@ context(
             assertBackLink: true,
             hasAForm: false,
             assertAuthenticatedHeader: true,
+            assertSaveAndBackButtonDoesNotExist: true,
           });
         });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/account-password-reset.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/account-password-reset.spec.js
@@ -58,6 +58,7 @@ context(
         currentHref: PASSWORD_RESET_ROOT,
         backLink: SIGN_IN_ROOT,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
         submitButtonCopy: BUTTONS.SUBMIT,
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/expired-link/account-password-reset-expired-link.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/expired-link/account-password-reset-expired-link.spec.js
@@ -88,6 +88,7 @@ context('Insurance - Account - Password reset - expired link page', () => {
         currentHref: EXPIRED_LINK,
         assertBackLink: false,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
         hasAForm: false,
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/link-sent/account-password-reset-link-sent.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/link-sent/account-password-reset-link-sent.spec.js
@@ -58,6 +58,7 @@ context(
           currentHref: LINK_SENT,
           backLink: PASSWORD_RESET_ROOT,
           assertAuthenticatedHeader: false,
+          assertSaveAndBackButtonDoesNotExist: true,
           hasAForm: false,
         });
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/new-password/account-password-reset-new-password.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/new-password/account-password-reset-new-password.spec.js
@@ -67,6 +67,7 @@ context(
             currentHref: url,
             assertBackLink: false,
             assertAuthenticatedHeader: false,
+            assertSaveAndBackButtonDoesNotExist: true,
             submitButtonCopy: BUTTONS.SUBMIT,
           });
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/success/account-password-reset-success.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/password-reset/success/account-password-reset-success.spec.js
@@ -66,6 +66,7 @@ context(
             currentHref: successUrl,
             assertBackLink: false,
             assertAuthenticatedHeader: false,
+            assertSaveAndBackButtonDoesNotExist: true,
             hasAForm: false,
           });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/reactivated/account-reactivated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/reactivated/account-reactivated.spec.js
@@ -52,6 +52,7 @@ context('Insurance - Account - Reactivated page', () => {
         currentHref: REACTIVATED_ROOT,
         assertBackLink: false,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
         hasAForm: false,
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/account-sign-in.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/account-sign-in.spec.js
@@ -56,6 +56,7 @@ context(
         currentHref: SIGN_IN_ROOT,
         backLink: YOUR_DETAILS,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
         lightHouseThresholds: {
           performance: 70,
         },

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/enter-code/account-sign-in-enter-code.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/enter-code/account-sign-in-enter-code.spec.js
@@ -54,6 +54,7 @@ context(
           currentHref: ENTER_CODE,
           backLink: SIGN_IN_ROOT,
           assertAuthenticatedHeader: false,
+          assertSaveAndBackButtonDoesNotExist: true,
         });
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/request-new-code/account-sign-in-request-new-code.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/request-new-code/account-sign-in-request-new-code.spec.js
@@ -44,6 +44,7 @@ context(
         backLink: ENTER_CODE,
         submitButtonCopy: BUTTONS.SEND_NEW_ACCESS_CODE,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-out/account-signed-out.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-out/account-signed-out.spec.js
@@ -35,6 +35,7 @@ context(
         assertBackLink: false,
         hasAForm: false,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/suspended/account-suspended.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/suspended/account-suspended.spec.js
@@ -50,6 +50,7 @@ context(
           currentHref: accountSuspendedUrl,
           assertBackLink: false,
           assertAuthenticatedHeader: false,
+          assertSaveAndBackButtonDoesNotExist: true,
           hasAForm: false,
         });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/suspended/email-sent/account-suspended-email-sent.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/suspended/email-sent/account-suspended-email-sent.spec.js
@@ -59,6 +59,7 @@ context(
             currentHref: EMAIL_SENT,
             backLink: `${SUSPENDED_ROOT}?id=${account.id}`,
             assertAuthenticatedHeader: false,
+            assertSaveAndBackButtonDoesNotExist: true,
             hasAForm: false,
           });
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/suspended/expired-link/account-suspended-expired-link.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/suspended/expired-link/account-suspended-expired-link.spec.js
@@ -70,6 +70,7 @@ context('Insurance - Account - Suspended - Verify email - Visit with an expired 
         currentHref: verifyEmailUrl,
         assertBackLink: false,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
         submitButtonCopy: BUTTONS.REACTIVATE_ACCOUNT,
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/suspended/link-invalid/account-suspended-invalid-link.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/suspended/link-invalid/account-suspended-invalid-link.spec.js
@@ -36,6 +36,7 @@ context('Insurance - Account - Suspended - Verify email - Visit with an invalid 
         currentHref: verifyEmailUrl,
         assertBackLink: false,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
         hasAForm: false,
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/all-sections.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/all-sections.spec.js
@@ -42,6 +42,7 @@ context('Insurance - All sections - new application', () => {
       backLink: ELIGIBILITY.ELIGIBLE_TO_APPLY_ONLINE,
       hasAForm: false,
       assertBackLink: false,
+      assertSaveAndBackButtonDoesNotExist: true,
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/application-submitted.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/application-submitted.spec.js
@@ -44,6 +44,7 @@ context('Insurance - application submitted page', () => {
       currentHref: `${INSURANCE_ROOT}/${referenceNumber}${APPLICATION_SUBMITTED}`,
       backLink: `${INSURANCE_ROOT}/${referenceNumber}${CONFIRMATION_AND_ACKNOWLEDGEMENTS}`,
       assertBackLink: false,
+      assertSaveAndBackButtonDoesNotExist: true,
       hasAForm: false,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/check-your-answers-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/check-your-answers-policy-page.spec.js
@@ -61,10 +61,6 @@ context('Insurance - Check your answers - Policy - I want to confirm my selectio
     it('renders a `completed` status tag', () => {
       cy.checkTaskStatusCompleted(status);
     });
-
-    it('renders a `save and back` button', () => {
-      cy.assertSaveAndBackButton();
-    });
   });
 
   describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/check-your-answers-your-business-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/check-your-answers-your-business-page.spec.js
@@ -62,10 +62,6 @@ context(
         cy.checkTaskStatusCompleted(status);
       });
 
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
-
       describe('form submission', () => {
         it(`should redirect to ${YOUR_BUYER}`, () => {
           cy.navigateToUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/check-your-answers-your-buyer-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/check-your-answers-your-buyer-page.spec.js
@@ -64,10 +64,6 @@ context(
         cy.checkTaskStatusCompleted(status);
       });
 
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
-
       describe('form submission', () => {
         it(`should redirect to ${TYPE_OF_POLICY}`, () => {
           cy.navigateToUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/contact-us.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/contact-us.spec.js
@@ -34,6 +34,7 @@ context('Contact us page - Insurance', () => {
       backLink: ROUTES.INSURANCE.ELIGIBILITY.CHECK_IF_ELIGIBLE,
       hasAForm: false,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
       isInsurancePage: true,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/cookies-saved.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/cookies-saved.spec.js
@@ -42,6 +42,7 @@ context('Cookies saved page - Insurance', () => {
       backLink: COOKIES,
       hasAForm: false,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
       isInsurancePage: true,
       assertCookies: false,
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/cookies.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/cookies.spec.js
@@ -43,6 +43,7 @@ context('Cookies page - Insurance', () => {
       backLink: CHECK_IF_ELIGIBLE,
       submitButtonCopy: BUTTONS.SAVE_CHANGES,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
       isInsurancePage: true,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/buyer-country/buyer-country.spec.js
@@ -32,6 +32,7 @@ context('Insurance - Buyer country page - as an exporter, I want to check if UKE
       currentHref: BUYER_COUNTRY,
       backLink: COMPANY_DETAILS,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
       lightHouseThresholds: {
         performance: 70,
       },

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-page.spec.js
@@ -38,6 +38,7 @@ context('Insurance Eligibility - Cannot apply exit page', () => {
       backLink: BUYER_COUNTRY,
       hasAForm: false,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/check-if-eligible.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/check-if-eligible.spec.js
@@ -29,6 +29,7 @@ context('Insurance Eligibility - check if eligible page', () => {
       currentHref: CHECK_IF_ELIGIBLE,
       backLink: `${CHECK_IF_ELIGIBLE}#`,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-number/companies-house-number.spec.js
@@ -32,6 +32,7 @@ context(
         currentHref: ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER,
         backLink: ROUTES.INSURANCE.ELIGIBILITY.EXPORTER_LOCATION,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-search/companies-house-search.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-search/companies-house-search.spec.js
@@ -49,6 +49,7 @@ context('Insurance - Eligibility - Companies house search page - I want to check
       currentHref: ENTER_COMPANIES_HOUSE_NUMBER,
       backLink: COMPANIES_HOUSE_NUMBER,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-unavailable/companies-house-unavailable.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-unavailable/companies-house-unavailable.spec.js
@@ -31,6 +31,7 @@ context(
         currentHref: url,
         assertBackLink: false,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
         hasAForm: false,
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-details/company-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-details/company-details.spec.js
@@ -31,6 +31,7 @@ context('Insurance - Eligibility - Companies details page - I want to check if I
       currentHref: COMPANY_DETAILS,
       backLink: ENTER_COMPANIES_HOUSE_NUMBER,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-not-active/company-not-active.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-not-active/company-not-active.spec.js
@@ -33,6 +33,7 @@ context('Insurance - Eligibility - Company not active - I want to check if I can
       currentHref: COMPANY_NOT_ACTIVE_EXIT,
       backLink: ENTER_COMPANIES_HOUSE_NUMBER,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
       hasAForm: false,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/contract-too-short/contract-too-short.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/contract-too-short/contract-too-short.spec.js
@@ -31,6 +31,7 @@ context('Insurance - Eligibility - Contract too short page', () => {
       backLink: `${CONTRACT_TOO_SHORT_EXIT}#`,
       currentHref: CONTRACT_TOO_SHORT_EXIT,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
       hasAForm: false,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cover-period/cover-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cover-period/cover-period.spec.js
@@ -42,6 +42,7 @@ context(
         currentHref: COVER_PERIOD_ROUTE,
         backLink: TOTAL_VALUE_INSURED,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/eligible-to-apply-online/eligible-to-apply-online.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/eligible-to-apply-online/eligible-to-apply-online.spec.js
@@ -41,6 +41,7 @@ context(
         backLink: CHECK_YOUR_ANSWERS,
         submitButtonCopy: CONTENT_STRINGS.SUBMIT_BUTTON,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/end-buyer/end-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/end-buyer/end-buyer.spec.js
@@ -39,6 +39,7 @@ context(
         currentHref: END_BUYER,
         backLink: UK_GOODS_OR_SERVICES,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
@@ -32,6 +32,7 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
       currentHref: EXPORTER_LOCATION,
       backLink: CHECK_IF_ELIGIBLE,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/have-an-account/have-an-account.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/have-an-account/have-an-account.spec.js
@@ -40,6 +40,7 @@ context(
         currentHref: HAVE_AN_ACCOUNT,
         backLink: ELIGIBLE_TO_APPLY_ONLINE,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/long-term-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/long-term-cover.spec.js
@@ -33,6 +33,7 @@ context(
         backLink: COVER_PERIOD,
         hasAForm: false,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/member-of-a-group-exit-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/member-of-a-group-exit-page.spec.js
@@ -33,6 +33,7 @@ context(
         backLink: MEMBER_OF_A_GROUP,
         hasAForm: false,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/member-of-a-group/member-of-a-group.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/member-of-a-group/member-of-a-group.spec.js
@@ -40,6 +40,7 @@ context(
         currentHref: MEMBER_OF_A_GROUP,
         backLink: PARTY_TO_CONSORTIUM,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/need-to-start-again.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/need-to-start-again.spec.js
@@ -37,6 +37,7 @@ context('Insurance Eligibility - Need to start again exit page', () => {
       assertBackLink: false,
       submitButtonCopy: LINKS.START_AGAIN.TEXT,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/no-companies-house-number/no-companies-house-number.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/no-companies-house-number/no-companies-house-number.spec.js
@@ -31,6 +31,7 @@ context('Insurance - Eligibility - You cannot apply for credit insurance page (n
       currentHref: NO_COMPANIES_HOUSE_NUMBER_EXIT,
       assertBackLink: false,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
       hasAForm: false,
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/party-to-consortium-exit-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/party-to-consortium-exit-page.spec.js
@@ -33,6 +33,7 @@ context(
         backLink: PARTY_TO_CONSORTIUM,
         hasAForm: false,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/party-to-consortium/party-to-consortium.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/party-to-consortium/party-to-consortium.spec.js
@@ -37,6 +37,7 @@ context(
         currentHref: PARTY_TO_CONSORTIUM,
         backLink: END_BUYER,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/total-value-insured/total-value-insured.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/total-value-insured/total-value-insured.spec.js
@@ -42,6 +42,7 @@ context(
         currentHref: TOTAL_VALUE_INSURED,
         backLink: BUYER_COUNTRY,
         assertAuthenticatedHeader: false,
+        assertSaveAndBackButtonDoesNotExist: true,
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -44,6 +44,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
       currentHref: UK_GOODS_OR_SERVICES,
       backLink: COVER_PERIOD,
       assertAuthenticatedHeader: false,
+      assertSaveAndBackButtonDoesNotExist: true,
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
@@ -138,10 +138,6 @@ context(
           assertCountryAutocompleteInput({ fieldId });
         });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges.spec.js
@@ -106,10 +106,6 @@ context(
       describe(`searchable autocomplete input (${PAYABLE_COUNTRY_CODE})`, () => {
         assertCountryAutocompleteInput({ fieldId: PAYABLE_COUNTRY_CODE });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-details/agent-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-details/agent-details.spec.js
@@ -88,10 +88,6 @@ context(
       describe(`searchable autocomplete input (${COUNTRY_CODE})`, () => {
         assertCountryAutocompleteInput({ fieldId: COUNTRY_CODE });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-service/agent-service.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-service/agent-service.spec.js
@@ -98,10 +98,6 @@ context(
           cy.checkRadioInputYesAriaLabel(FIELDS.AGENT_SERVICE[fieldId].LABEL);
         });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent/agent.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent/agent.spec.js
@@ -88,10 +88,6 @@ context(
           cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
         });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/currency-of-agent-charges/currency-of-agent-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/currency-of-agent-charges/currency-of-agent-charges.spec.js
@@ -67,10 +67,6 @@ context(
       it('renders a heading caption', () => {
         cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('currency form fields', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/declined-by-private-market/declined-by-private-market.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/declined-by-private-market/declined-by-private-market.spec.js
@@ -82,10 +82,6 @@ context(
           expectedHint: fieldStrings.HINT,
         });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form validation', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-much-the-agent-is-charging/how-much-the-agent-is-charging.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-much-the-agent-is-charging/how-much-the-agent-is-charging.spec.js
@@ -72,10 +72,6 @@ context(
 
         field.input().should('exist');
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-was-the-contract-awarded/how-was-the-contract-awarded.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-was-the-contract-awarded/how-was-the-contract-awarded.spec.js
@@ -112,10 +112,6 @@ context(
 
         fieldSelector(OTHER_AWARD_METHOD).input().should('be.visible');
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/how-will-you-get-paid.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/how-will-you-get-paid.spec.js
@@ -86,10 +86,6 @@ context(
           maximumCharacters: MAXIMUM_CHARACTERS.PAYMENT_TERMS_DESCRIPTION,
         });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form validation', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/private-market.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/private-market.spec.js
@@ -104,10 +104,6 @@ context(
           });
         });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/page-not-found.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/page-not-found.spec.js
@@ -22,6 +22,7 @@ context('Insurance - page not found', () => {
       hasAForm: false,
       assertBackLink: false,
       assertAuthenticatedHeader: true,
+      assertSaveAndBackButtonDoesNotExist: true,
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/another-company.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/another-company.spec.js
@@ -77,10 +77,6 @@ context(`Insurance - Policy - Another company page - ${story}`, () => {
       cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
     });
 
-    it('renders a `save and back` button', () => {
-      cy.assertSaveAndBackButton();
-    });
-
     describe(`renders ${FIELD_ID}`, () => {
       it('renders a hint', () => {
         cy.checkText(yesNoRadioHint(), FIELDS.REQUESTED_JOINTLY_INSURED_PARTY[FIELD_ID].HINT);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-confirm-address/broker-confirm-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-confirm-address/broker-confirm-address.spec.js
@@ -96,10 +96,6 @@ context(
           cy.assertUrl(brokerDetailsUrl);
         });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
@@ -97,10 +97,6 @@ context(
           maximumCharacters: fieldStrings.MAXIMUM,
         });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
@@ -115,10 +115,6 @@ context(
           cy.checkLink(brokerPage.link(), APPROVED_BROKER_LIST, CONTENT_STRINGS.LINK_TEXT);
         });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
@@ -107,10 +107,6 @@ context(
 
         cy.checkText(field.label(), FIELDS.DIFFERENT_NAME_ON_POLICY[fieldId].LABEL);
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/loss-payee-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/loss-payee-details.spec.js
@@ -100,10 +100,6 @@ context(
         const expectedLabel = FIELD_STRINGS[LOCATION].OPTIONS.INTERNATIONAL.TEXT;
         cy.checkText(field.label(), expectedLabel);
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/loss-payee-financial-details-international.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/loss-payee-financial-details-international.spec.js
@@ -98,10 +98,6 @@ context(
           maximumCharacters: fieldStrings.MAXIMUM,
         });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/loss-payee-financial-details-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/loss-payee-financial-details-uk.spec.js
@@ -98,10 +98,6 @@ context(
           maximumCharacters: fieldStrings.MAXIMUM,
         });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee/loss-payee.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee/loss-payee.spec.js
@@ -100,10 +100,6 @@ context(
       it('renders `yes` and `no` radio buttons in the correct order', () => {
         cy.assertYesNoRadiosOrder({ noRadioFirst: true });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value.spec.js
@@ -99,10 +99,6 @@ context(
 
         field.input().should('exist');
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -100,10 +100,6 @@ context('Insurance - Policy - Multiple contract policy page - As an exporter, I 
       cy.checkText(field.hint(), CONTRACT_POLICY.MULTIPLE[fieldId].HINT);
       field.input().should('exist');
     });
-
-    it('renders a `save and back` button', () => {
-      cy.assertSaveAndBackButton();
-    });
   });
 
   describe('currency form fields', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/name-on-policy-page.spec.js
@@ -93,10 +93,6 @@ context(
 
         cy.checkText(field(OTHER_NAME).label(), FIELDS.NAME_ON_POLICY.OPTIONS.OTHER_NAME.TEXT);
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/other-company-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/other-company-details.spec.js
@@ -87,10 +87,6 @@ context(`Insurance - Policy - Other company details page - ${story}`, () => {
       cy.checkText(field.label(), FIELD_STRINGS[fieldId].LABEL);
       field.input().should('exist');
     });
-
-    it('renders a `save and back` button', () => {
-      cy.assertSaveAndBackButton();
-    });
   });
 
   describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
@@ -68,10 +68,6 @@ context(`Insurance - Policy - Pre-credit period page - ${story}`, () => {
       cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
     });
 
-    it('renders a `save and back` button', () => {
-      cy.assertSaveAndBackButton();
-    });
-
     describe(`renders ${NEED_PRE_CREDIT_PERIOD} label and inputs`, () => {
       it('renders `yes` and `no` radio buttons in the correct order', () => {
         cy.assertYesNoRadiosOrder({ noRadioFirst: true });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
@@ -101,10 +101,6 @@ context('Insurance - Policy - Single contract policy page - As an exporter, I wa
       field.monthInput().should('exist');
       field.yearInput().should('exist');
     });
-
-    it('renders a `save and back` button', () => {
-      cy.assertSaveAndBackButton();
-    });
   });
 
   describe('currency form fields', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value.spec.js
@@ -86,10 +86,6 @@ context(
 
         field.input().should('exist');
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/type-of-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/type-of-policy.spec.js
@@ -88,10 +88,6 @@ context('Insurance - Policy - Type of policy page - As an exporter, I want to en
 
       cy.checkText(multiplePolicyField.hintList.item3(), FIELDS[FIELD_ID].OPTIONS.MULTIPLE.HINT_LIST[2]);
     });
-
-    it('renders a `save and back` button', () => {
-      cy.assertSaveAndBackButton();
-    });
   });
 
   describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/problem-with-service.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/problem-with-service.spec.js
@@ -26,6 +26,7 @@ context('Problem with service page - Insurance', () => {
       hasAForm: false,
       assertAuthenticatedHeader: false,
       assertBackLink: false,
+      assertSaveAndBackButtonDoesNotExist: true,
       isInsurancePage: true,
       assertCookies: false,
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/alternative-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/alternative-trading-address.spec.js
@@ -102,10 +102,6 @@ context(
           maximumCharacters: fieldStrings.MAXIMUM,
         });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form validation', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-page.spec.js
@@ -52,10 +52,6 @@ context('Insurance - Your Business - Check your answers - As an exporter, I want
     it('renders a heading caption', () => {
       cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
     });
-
-    it('renders a `save and back` button', () => {
-      cy.assertSaveAndBackButton();
-    });
   });
 
   describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
@@ -137,10 +137,6 @@ context(
         field(PHONE_NUMBER).input().should('exist');
         cy.checkAriaLabel(field(PHONE_NUMBER).input(), CONTENT_STRINGS.PHONE_NUMBER);
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
   },
 );

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control.spec.js
@@ -76,10 +76,6 @@ context(
 
         cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/nature-of-business-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/nature-of-business-page.spec.js
@@ -95,10 +95,6 @@ context(
         cy.checkText(field.label(), FIELDS.NATURE_OF_YOUR_BUSINESS[fieldId].LEGEND);
         field.input().should('exist');
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover-currency/turnover-currency-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover-currency/turnover-currency-page.spec.js
@@ -59,10 +59,6 @@ context(
       it('renders a heading caption', () => {
         cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('currency form fields', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
@@ -111,10 +111,6 @@ context(
 
         cy.assertSuffix({ fieldId, value: FIELDS.TURNOVER[fieldId].SUFFIX });
       });
-
-      it('should render save and go back button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/buyer-financial-information/buyer-financial-information-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/buyer-financial-information/buyer-financial-information-page.spec.js
@@ -98,10 +98,6 @@ context(
           cy.checkText(buyerFinancialInformationPage.line2(), CONTENT_STRINGS.SHARING);
         });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('when submitting an empty form', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/company-or-organisation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/company-or-organisation.spec.js
@@ -111,10 +111,6 @@ context('Insurance - Your buyer - Company or organisation page - As an exporter,
 
       field.input().should('exist');
     });
-
-    it('renders a `save and back` button', () => {
-      cy.assertSaveAndBackButton();
-    });
   });
 
   describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-with-the-buyer/connection-with-the-buyer-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-with-the-buyer/connection-with-the-buyer-page.spec.js
@@ -124,10 +124,6 @@ context(
         });
       });
 
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
-
       describe('form submission', () => {
         describe(`when submitting the form with ${CONNECTION_WITH_BUYER} as "no"`, () => {
           it(`should redirect to ${TRADED_WITH_BUYER} page`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/credit-insurance-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/credit-insurance-cover.spec.js
@@ -84,10 +84,6 @@ context(
 
           cy.checkRadioInputYesAriaLabel(FIELD_STRINGS[fieldId].LABEL);
         });
-
-        it('renders a `save and back` button', () => {
-          cy.assertSaveAndBackButton();
-        });
       });
 
       describe(PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/failed-to-pay-on-time/failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/failed-to-pay-on-time/failed-to-pay-on-time.spec.js
@@ -78,10 +78,6 @@ context(
       it('renders `yes` and `no` radio buttons in the correct order', () => {
         cy.assertYesNoRadiosOrder({ noRadioFirst: true });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments.spec.js
@@ -111,10 +111,6 @@ context(
           cy.checkText(field(TOTAL_AMOUNT_OVERDUE).prefix(), SYMBOLS.GBP);
         });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/traded-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/traded-with-buyer.spec.js
@@ -88,10 +88,6 @@ context('Insurance - Your buyer - Traded with buyer page - As an exporter, I wan
     it('renders `yes` and `no` radio buttons in the correct order', () => {
       cy.assertYesNoRadiosOrder({ noRadioFirst: true });
     });
-
-    it('renders a `save and back` button', () => {
-      cy.assertSaveAndBackButton();
-    });
   });
 
   describe('when submitting an empty form', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-page.spec.js
@@ -82,10 +82,6 @@ context(
       it('renders `yes` and `no` radio buttons in the correct order', () => {
         cy.assertYesNoRadiosOrder({ noRadioFirst: true });
       });
-
-      it('renders a `save and back` button', () => {
-        cy.assertSaveAndBackButton();
-      });
     });
 
     describe('form submission', () => {


### PR DESCRIPTION
## Introduction :pencil2:
- A lot of E2E tests were missing assertions for the rendering of a "save and back" button.
- The majority of pages/forms have a "save and back" button.

## Resolution :heavy_check_mark:
- Update `corePageChecks` to assert "save and back" buttons by default.
- Update various E2E test to pass `assertSaveAndBackButtonDoesNotExist` to `corePageChecks`.
- Remove "save and back" button assertions from individual E2E tests.