### PR TITLE
chore(EMS-3855): agent charges - change answers - improve e2e test coverage

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/currency-of-agents-charge/change-your-answers-currency-of-agents-charge.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/currency-of-agents-charge/change-your-answers-currency-of-agents-charge.spec.js
@@ -1,7 +1,9 @@
 import { summaryList } from '../../../../../../../../pages/shared';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
+import application from '../../../../../../../../fixtures/application';
 import { USD } from '../../../../../../../../fixtures/currencies';
+import formatCurrency from '../../../../../../../../helpers/format-currency';
 
 const {
   ROOT,
@@ -11,6 +13,9 @@ const {
 
 const {
   CURRENCY: { CURRENCY_CODE },
+  EXPORT_CONTRACT: {
+    AGENT_CHARGES: { FIXED_SUM_AMOUNT },
+  },
 } = INSURANCE_FIELD_IDS;
 
 const getFieldVariables = (fieldId, referenceNumber) => ({
@@ -95,8 +100,12 @@ context('Insurance - Change your answers - Export contract - Summary list - Curr
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: EXPORT_CONTRACT, fieldId });
       });
 
-      it('should render the new answer', () => {
-        cy.checkChangeAnswerRendered({ fieldVariables });
+      it(`should render the new answer for ${CURRENCY_CODE} and ${FIXED_SUM_AMOUNT}`, () => {
+        cy.checkText(summaryList.field(CURRENCY_CODE).value(), USD.name);
+
+        const expectedAmount = formatCurrency(application.EXPORT_CONTRACT.AGENT_CHARGES[FIXED_SUM_AMOUNT], USD.isoCode);
+
+        cy.checkText(summaryList.field(FIXED_SUM_AMOUNT).value(), expectedAmount);
       });
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/currency-of-agents-charge/change-your-answers-currency-of-agents-charge.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/currency-of-agents-charge/change-your-answers-currency-of-agents-charge.spec.js
@@ -1,7 +1,9 @@
 import { summaryList } from '../../../../../../../pages/shared';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
+import application from '../../../../../../../fixtures/application';
 import { USD } from '../../../../../../../fixtures/currencies';
+import formatCurrency from '../../../../../../../helpers/format-currency';
 
 const {
   ROOT,
@@ -10,6 +12,9 @@ const {
 
 const {
   CURRENCY: { CURRENCY_CODE },
+  EXPORT_CONTRACT: {
+    AGENT_CHARGES: { FIXED_SUM_AMOUNT },
+  },
 } = INSURANCE_FIELD_IDS;
 
 const getFieldVariables = (fieldId, referenceNumber) => ({
@@ -86,8 +91,12 @@ context(
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: CHECK_YOUR_ANSWERS, fieldId });
         });
 
-        it('should render the new answer', () => {
-          cy.checkChangeAnswerRendered({ fieldVariables });
+        it(`should render the new answer for ${CURRENCY_CODE} and ${FIXED_SUM_AMOUNT}`, () => {
+          cy.checkText(summaryList.field(CURRENCY_CODE).value(), USD.name);
+
+          const expectedAmount = formatCurrency(application.EXPORT_CONTRACT.AGENT_CHARGES[FIXED_SUM_AMOUNT], USD.isoCode);
+
+          cy.checkText(summaryList.field(FIXED_SUM_AMOUNT).value(), expectedAmount);
         });
       });
     });


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates 2x "change your answers" tests to test 2x fields affecting by the change, instead of one.

## Resolution :heavy_check_mark:
- Update 2x E2E tests to check for `CURRENCY_CODE` and `FIXED_SUM_AMOUNT`.