### PR TITLE
chore(EMS-3788): rename 'complete currency form' cypress command

### DIFF
--- a/e2e-tests/commands/insurance/complete-and-submit-currency-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-currency-form.js
@@ -5,14 +5,14 @@ import { NON_STANDARD_CURRENCY_CODE } from '../../fixtures/currencies';
 const { CURRENCY_CODE } = INSURANCE_FIELD_IDS.CURRENCY;
 
 /**
- * completeAndSubmitAlternativeCurrencyForm
- * conditionally clicks "alternative currency" hyperlink and completes the alternative currency form
+ * completeAndSubmitCurrencyForm
+ * conditionally clicks "alternative currency" radio and selects an alternative currency
  * if isoCode provided - clicks the radio for currency and submits alternative currency form
  * if alternativeCurrency true, then enters alternative currency and submits alternative currency form
  * @param {String} isoCode: isoCode for radio selection.
  * @param {Boolean} alternativeCurrency: If alternative currency should be entered.
  */
-const completeAndSubmitAlternativeCurrencyForm = ({ isoCode, alternativeCurrency = false }) => {
+const completeAndSubmitCurrencyForm = ({ isoCode, alternativeCurrency = false }) => {
   if (isoCode) {
     radios(CURRENCY_CODE, isoCode).option.label().click();
     cy.clickSubmitButton();
@@ -27,4 +27,4 @@ const completeAndSubmitAlternativeCurrencyForm = ({ isoCode, alternativeCurrency
   }
 };
 
-export default completeAndSubmitAlternativeCurrencyForm;
+export default completeAndSubmitCurrencyForm;

--- a/e2e-tests/commands/insurance/complete-business-section.js
+++ b/e2e-tests/commands/insurance/complete-business-section.js
@@ -25,7 +25,7 @@ const completeBusinessSection = ({
   }
 
   cy.completeAndSubmitNatureOfYourBusiness();
-  cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency: alternativeCurrencyTurnover });
+  cy.completeAndSubmitCurrencyForm({ alternativeCurrency: alternativeCurrencyTurnover });
   cy.completeAndSubmitTurnoverForm();
   cy.completeAndSubmitCreditControlForm({ hasCreditControlProcess });
 

--- a/e2e-tests/commands/insurance/complete-buyer-section.js
+++ b/e2e-tests/commands/insurance/complete-buyer-section.js
@@ -34,7 +34,7 @@ const completeBuyerSection = ({
     cy.completeAndSubmitTradingHistoryWithBuyerForm({ outstandingPayments: outstandingPayments || fullyPopulatedBuyerTradingHistory });
 
     if (outstandingPayments || fullyPopulatedBuyerTradingHistory) {
-      cy.completeAndSubmitAlternativeCurrencyForm({});
+      cy.completeAndSubmitCurrencyForm({});
       cy.completeAndSubmitOutstandingOrOverduePaymentsForm({ outstandingPayments });
     }
 

--- a/e2e-tests/commands/insurance/complete-export-contract-section.js
+++ b/e2e-tests/commands/insurance/complete-export-contract-section.js
@@ -71,7 +71,7 @@ const completeExportContractSection = ({
       });
 
       if (agentChargeMethodFixedSum) {
-        cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency });
+        cy.completeAndSubmitCurrencyForm({ alternativeCurrency });
 
         cy.completeAndSubmitHowMuchTheAgentIsChargingForm({
           fixedSumAmount: agentChargeFixedSumAmount,

--- a/e2e-tests/commands/insurance/export-contract/complete-and-submit-export-contract-forms.js
+++ b/e2e-tests/commands/insurance/export-contract/complete-and-submit-export-contract-forms.js
@@ -49,7 +49,7 @@ const completeAndSubmitExportContractForms = ({
   if (fixedSumMethod) {
     steps = [
       ...steps,
-      { name: 'currencyOfAgentCharges', action: () => cy.completeAndSubmitAlternativeCurrencyForm({}) },
+      { name: 'currencyOfAgentCharges', action: () => cy.completeAndSubmitCurrencyForm({}) },
       { name: 'howMuchAgentIsCharging', action: () => cy.completeAndSubmitHowMuchTheAgentIsChargingForm({ fixedSumAmount }) },
     ];
   }

--- a/e2e-tests/commands/insurance/your-business/complete-and-submit-your-business-forms.js
+++ b/e2e-tests/commands/insurance/your-business/complete-and-submit-your-business-forms.js
@@ -19,7 +19,7 @@ const completeAndSubmitYourBusinessForms = ({ formToStopAt, hasCreditControlProc
   const steps = [
     ...initialSteps,
     { name: 'natureOfYourBusiness', action: () => cy.completeAndSubmitNatureOfYourBusiness() },
-    { name: 'turnoverCurrency', action: () => cy.completeAndSubmitAlternativeCurrencyForm({}) },
+    { name: 'turnoverCurrency', action: () => cy.completeAndSubmitCurrencyForm({}) },
     { name: 'turnover', action: () => cy.completeAndSubmitTurnoverForm() },
     { name: 'creditControl', action: () => cy.completeAndSubmitCreditControlForm({ hasCreditControlProcess }) },
   ];

--- a/e2e-tests/commands/insurance/your-buyer/complete-and-submit-your-buyer-forms.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-and-submit-your-buyer-forms.js
@@ -46,7 +46,7 @@ const completeAndSubmitYourBuyerForms = ({
     if (outstandingPayments) {
       steps.push({
         name: 'currencyOfLatePayments',
-        action: () => cy.completeAndSubmitAlternativeCurrencyForm({ isoCode, alternativeCurrency }),
+        action: () => cy.completeAndSubmitCurrencyForm({ isoCode, alternativeCurrency }),
       });
       steps.push({ name: 'outstandingOrOverduePayments', action: () => cy.completeAndSubmitOutstandingOrOverduePaymentsForm({ outstandingPayments }) });
     }

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-service/change-your-answers-agent-service-charging-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-service/change-your-answers-agent-service-charging-no-to-yes.spec.js
@@ -88,7 +88,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
           percentageMethod: false,
         });
 
-        cy.completeAndSubmitAlternativeCurrencyForm({});
+        cy.completeAndSubmitCurrencyForm({});
 
         cy.completeAndSubmitHowMuchTheAgentIsChargingForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-service/change-your-answers-agent-service-charging-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/agent-service/change-your-answers-agent-service-charging-yes-to-no.spec.js
@@ -119,7 +119,7 @@ context('Insurance - Change your answers - Export contract - Summary list - Agen
 
           cy.assertRadioOptionIsChecked(option.input());
 
-          cy.completeAndSubmitAlternativeCurrencyForm({});
+          cy.completeAndSubmitCurrencyForm({});
 
           // assert HOW_MUCH_THE_AGENT_IS_CHARGING field values.
           cy.checkValue(field(FIXED_SUM_AMOUNT), '');

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/currency-of-agents-charge/change-your-answers-currency-of-agents-charge-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/export-contract/change-your-answers/currency-of-agents-charge/change-your-answers-currency-of-agents-charge-alternative-currency.spec.js
@@ -73,7 +73,7 @@ context(
 
         summaryList.field(CURRENCY_CODE).changeLink().click();
 
-        cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency: true });
+        cy.completeAndSubmitCurrencyForm({ alternativeCurrency: true });
       });
 
       it(`should redirect to ${EXPORT_CONTRACT}`, () => {
@@ -99,7 +99,7 @@ context(
 
         summaryList.field(CURRENCY_CODE).changeLink().click();
 
-        cy.completeAndSubmitAlternativeCurrencyForm({ isoCode: currencyCode });
+        cy.completeAndSubmitCurrencyForm({ isoCode: currencyCode });
       });
 
       it(`should render the new answer for ${CURRENCY_CODE} and ${FIXED_SUM_AMOUNT}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-turnover-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-business/change-your-answers/change-your-answers-change-turnover-currency.spec.js
@@ -68,7 +68,7 @@ context('Insurance - Check your answers - Turnover currency - Your business - Su
 
         summaryList.field(fieldId).changeLink().click();
 
-        cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency: true });
+        cy.completeAndSubmitCurrencyForm({ alternativeCurrency: true });
       });
 
       it(`should redirect to ${YOUR_BUSINESS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-alternative-currency.spec.js
@@ -74,7 +74,7 @@ context('Insurance - Check your answers - Your buyer - Alternative currency - As
 
         summaryList.field(currencyFieldId).changeLink().click();
 
-        cy.completeAndSubmitAlternativeCurrencyForm({ isoCode: EUR_CURRENCY_CODE });
+        cy.completeAndSubmitCurrencyForm({ isoCode: EUR_CURRENCY_CODE });
 
         cy.clickSubmitButton();
       });
@@ -124,7 +124,7 @@ context('Insurance - Check your answers - Your buyer - Alternative currency - As
 
         summaryList.field(currencyFieldId).changeLink().click();
 
-        cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency: true });
+        cy.completeAndSubmitCurrencyForm({ alternativeCurrency: true });
 
         cy.clickSubmitButton();
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-traded-with-buyer-no-to-yes-outstanding-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-traded-with-buyer-no-to-yes-outstanding-yes.spec.js
@@ -64,7 +64,7 @@ context(
 
       cy.completeAndSubmitTradedWithBuyerForm({ exporterHasTradedWithBuyer: true });
       cy.completeAndSubmitTradingHistoryWithBuyerForm({ outstandingPayments: true });
-      cy.completeAndSubmitAlternativeCurrencyForm({});
+      cy.completeAndSubmitCurrencyForm({});
       cy.completeAndSubmitOutstandingOrOverduePaymentsForm({});
       cy.completeAndSubmitFailedToPayForm({ failedToPay: true });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-trading-history-outstanding-payments-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/your-buyer/change-your-answers/change-your-answers-change-trading-history-outstanding-payments-no-to-yes.spec.js
@@ -75,7 +75,7 @@ context(
         summaryList.field(fieldId).changeLink().click();
 
         cy.completeAndSubmitTradingHistoryWithBuyerForm({ outstandingPayments: true });
-        cy.completeAndSubmitAlternativeCurrencyForm({});
+        cy.completeAndSubmitCurrencyForm({});
         cy.completeAndSubmitOutstandingOrOverduePaymentsForm({});
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent-service/change-your-answers-agent-service-charging-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent-service/change-your-answers-agent-service-charging-no-to-yes.spec.js
@@ -77,7 +77,7 @@ context(
             percentageMethod: false,
           });
 
-          cy.completeAndSubmitAlternativeCurrencyForm({});
+          cy.completeAndSubmitCurrencyForm({});
 
           cy.completeAndSubmitHowMuchTheAgentIsChargingForm({});
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent-service/change-your-answers-agent-service-charging-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/agent-service/change-your-answers-agent-service-charging-yes-to-no.spec.js
@@ -108,7 +108,7 @@ context(
 
             cy.assertRadioOptionIsChecked(option.input());
 
-            cy.completeAndSubmitAlternativeCurrencyForm({});
+            cy.completeAndSubmitCurrencyForm({});
 
             // assert HOW_MUCH_THE_AGENT_IS_CHARGING field values.
             cy.checkValue(field(FIXED_SUM_AMOUNT), '');

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/currency-of-agents-charge/change-your-answers-currency-of-agents-charge-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/change-your-answers/currency-of-agents-charge/change-your-answers-currency-of-agents-charge-alternative-currency.spec.js
@@ -65,7 +65,7 @@ context(
 
         summaryList.field(CURRENCY_CODE).changeLink().click();
 
-        cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency: true });
+        cy.completeAndSubmitCurrencyForm({ alternativeCurrency: true });
       });
 
       it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {
@@ -91,7 +91,7 @@ context(
 
         summaryList.field(CURRENCY_CODE).changeLink().click();
 
-        cy.completeAndSubmitAlternativeCurrencyForm({ isoCode: currencyCode });
+        cy.completeAndSubmitCurrencyForm({ isoCode: currencyCode });
       });
 
       it(`should render the new answer for ${CURRENCY_CODE} and ${FIXED_SUM_AMOUNT}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/currency-of-agent-charges/currency-of-agent-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/currency-of-agent-charges/currency-of-agent-charges.spec.js
@@ -93,7 +93,7 @@ context(
       it(`should redirect to ${HOW_MUCH_THE_AGENT_IS_CHARGING}`, () => {
         cy.navigateToUrl(url);
 
-        cy.completeAndSubmitAlternativeCurrencyForm({});
+        cy.completeAndSubmitCurrencyForm({});
 
         cy.assertUrl(howMuchAgentIsChargingUrl);
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
@@ -97,7 +97,7 @@ context('Insurance - Your business - Change your answers - Turnover - As an expo
 
         summaryList.field(fieldId).changeLink().click();
 
-        cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency: true });
+        cy.completeAndSubmitCurrencyForm({ alternativeCurrency: true });
       });
 
       it(`should redirect to ${CHECK_YOUR_ANSWERS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-alternative-currency.spec.js
@@ -60,7 +60,7 @@ context('Insurance - Your buyer - Change your answers - Alternative currency - A
 
         summaryList.field(currencyFieldId).changeLink().click();
 
-        cy.completeAndSubmitAlternativeCurrencyForm({ isoCode: EUR_CURRENCY_CODE });
+        cy.completeAndSubmitCurrencyForm({ isoCode: EUR_CURRENCY_CODE });
         cy.clickSubmitButton();
       });
 
@@ -109,7 +109,7 @@ context('Insurance - Your buyer - Change your answers - Alternative currency - A
 
         summaryList.field(currencyFieldId).changeLink().click();
 
-        cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency: true });
+        cy.completeAndSubmitCurrencyForm({ alternativeCurrency: true });
         cy.clickSubmitButton();
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-traded-with-buyer-no-to-yes-outstanding-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-traded-with-buyer-no-to-yes-outstanding-yes.spec.js
@@ -56,7 +56,7 @@ context(
 
       cy.completeAndSubmitTradedWithBuyerForm({ exporterHasTradedWithBuyer: true });
       cy.completeAndSubmitTradingHistoryWithBuyerForm({ outstandingPayments: true });
-      cy.completeAndSubmitAlternativeCurrencyForm({});
+      cy.completeAndSubmitCurrencyForm({});
       cy.completeAndSubmitOutstandingOrOverduePaymentsForm({});
       cy.completeAndSubmitFailedToPayForm({ failedToPay: true });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-trading-history-outstanding-payments-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-trading-history-outstanding-payments-no-to-yes.spec.js
@@ -62,7 +62,7 @@ context(
         summaryList.field(fieldId).changeLink().click();
 
         cy.completeAndSubmitTradingHistoryWithBuyerForm({ outstandingPayments: true });
-        cy.completeAndSubmitAlternativeCurrencyForm({});
+        cy.completeAndSubmitCurrencyForm({});
         cy.completeAndSubmitOutstandingOrOverduePaymentsForm({});
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/currency-of-late-payments/currency-of-late-payments-change-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/currency-of-late-payments/currency-of-late-payments-change-currency.spec.js
@@ -49,7 +49,7 @@ context('Insurance - Your business - Turnover currency page - As an Exporter I w
       cy.saveSession();
       cy.navigateToUrl(url);
       // change to GBP
-      cy.completeAndSubmitAlternativeCurrencyForm({ isoCode: GBP_CURRENCY_CODE });
+      cy.completeAndSubmitCurrencyForm({ isoCode: GBP_CURRENCY_CODE });
     });
 
     const { prefixAssertions } = assertCurrencyFormFields({ fieldId: TOTAL_AMOUNT_OVERDUE });

--- a/e2e-tests/insurance/cypress/support/application/index.js
+++ b/e2e-tests/insurance/cypress/support/application/index.js
@@ -18,4 +18,4 @@ Cypress.Commands.add('startInsuranceYourBuyerSection', require('../../../../comm
 Cypress.Commands.add('startInsurancePolicySection', require('../../../../commands/insurance/start-insurance-policy-section'));
 Cypress.Commands.add('startInsuranceExportContractSection', require('../../../../commands/insurance/start-insurance-export-contract-section'));
 
-Cypress.Commands.add('completeAndSubmitAlternativeCurrencyForm', require('../../../../commands/insurance/complete-and-submit-alternative-currency-form'));
+Cypress.Commands.add('completeAndSubmitCurrencyForm', require('../../../../commands/insurance/complete-and-submit-currency-form'));

--- a/e2e-tests/shared-test-assertions/currency-form-fields/prefix.js
+++ b/e2e-tests/shared-test-assertions/currency-form-fields/prefix.js
@@ -17,28 +17,28 @@ const prefixAssertions = ({ fieldId }) => {
 
   describe(`when selecting ${USD_CURRENCY_CODE} as the currency code`, () => {
     it(`should display ${SYMBOLS.USD} as the prefix`, () => {
-      cy.completeAndSubmitAlternativeCurrencyForm({ isoCode: USD_CURRENCY_CODE });
+      cy.completeAndSubmitCurrencyForm({ isoCode: USD_CURRENCY_CODE });
       cy.assertPrefix({ fieldId, value: SYMBOLS.USD });
     });
   });
 
   describe(`when selecting ${JPY_CURRENCY_CODE} as the currency code`, () => {
     it(`should display ${SYMBOLS.JPY} as the prefix`, () => {
-      cy.completeAndSubmitAlternativeCurrencyForm({ isoCode: JPY_CURRENCY_CODE });
+      cy.completeAndSubmitCurrencyForm({ isoCode: JPY_CURRENCY_CODE });
       cy.assertPrefix({ fieldId, value: SYMBOLS.JPY });
     });
   });
 
   describe(`when selecting ${EUR_CURRENCY_CODE} as the currency code`, () => {
     it(`should display ${SYMBOLS.EUR} as the prefix`, () => {
-      cy.completeAndSubmitAlternativeCurrencyForm({ isoCode: EUR_CURRENCY_CODE });
+      cy.completeAndSubmitCurrencyForm({ isoCode: EUR_CURRENCY_CODE });
       cy.assertPrefix({ fieldId, value: SYMBOLS.EUR });
     });
   });
 
   describe('when selecting an alternate currency as the currency code', () => {
     it('should not display a prefix', () => {
-      cy.completeAndSubmitAlternativeCurrencyForm({ alternativeCurrency: true });
+      cy.completeAndSubmitCurrencyForm({ alternativeCurrency: true });
       cy.assertPrefix({ fieldId });
     });
   });


### PR DESCRIPTION
## Introduction :pencil2:
Previously, the "alternative currency" functionality had a different flow. This has been removed and is now part of the "currency form" flows.

## Resolution :heavy_check_mark:
- Rename `completeAndSubmitAlternativeCurrencyForm` cypress command to `completeAndSubmitCurrencyForm`.
