### PR TITLE
chore(EMS-3955): update all e2e tests to use assertPrefix command

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-much-the-agent-is-charging/how-much-the-agent-is-charging.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-much-the-agent-is-charging/how-much-the-agent-is-charging.spec.js
@@ -68,7 +68,7 @@ context(
 
         cy.checkText(field.hint(), FIELD_STRINGS.AGENT_CHARGES[FIELD_ID].HINT);
 
-        cy.checkText(field.prefix(), SYMBOLS.GBP);
+        cy.assertPrefix({ fieldId: FIELD_ID, value: SYMBOLS.GBP });
 
         field.input().should('exist');
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value-alternative-currency.spec.js
@@ -72,11 +72,11 @@ context('Insurance - Policy - Multiple contract policy - Export value page - Alt
     });
 
     it(`should NOT render a ${TOTAL_SALES_TO_BUYER} prefix`, () => {
-      field(TOTAL_SALES_TO_BUYER).prefix().should('not.exist');
+      cy.assertPrefix({ fieldId: TOTAL_SALES_TO_BUYER });
     });
 
     it(`should NOT render a ${MAXIMUM_BUYER_WILL_OWE} prefix`, () => {
-      field(MAXIMUM_BUYER_WILL_OWE).prefix().should('not.exist');
+      cy.assertPrefix({ fieldId: MAXIMUM_BUYER_WILL_OWE });
     });
 
     it('should prepopulate the radio on the single contract value page', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value-non-gbp-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value-non-gbp-currency.spec.js
@@ -67,11 +67,11 @@ context('Insurance - Policy - Multiple contract policy - Export value page - Non
     });
 
     it(`should render a ${TOTAL_SALES_TO_BUYER} ${USD.name} prefix`, () => {
-      cy.checkText(field(TOTAL_SALES_TO_BUYER).prefix(), SYMBOLS.USD);
+      cy.assertPrefix({ fieldId: TOTAL_SALES_TO_BUYER, value: SYMBOLS.USD });
     });
 
     it(`should render a ${MAXIMUM_BUYER_WILL_OWE} ${USD.name} prefix`, () => {
-      cy.checkText(field(MAXIMUM_BUYER_WILL_OWE).prefix(), SYMBOLS.USD);
+      cy.assertPrefix({ fieldId: MAXIMUM_BUYER_WILL_OWE, value: SYMBOLS.USD });
     });
 
     it('should prepopulate the radio on the multiple contract value page', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value.spec.js
@@ -79,7 +79,7 @@ context(
 
         cy.checkText(field.hint(), EXPORT_VALUE.MULTIPLE[fieldId].HINT);
 
-        cy.checkText(field.prefix(), SYMBOLS.GBP);
+        cy.assertPrefix({ fieldId: TOTAL_SALES_TO_BUYER, value: SYMBOLS.GBP });
 
         field.input().should('exist');
       });
@@ -91,7 +91,7 @@ context(
 
         cy.checkText(field.label(), EXPORT_VALUE.MULTIPLE[fieldId].LABEL);
 
-        cy.checkText(field.prefix(), SYMBOLS.GBP);
+        cy.assertPrefix({ fieldId, value: SYMBOLS.GBP });
 
         cy.checkText(field.hint.forExample(), HINT.FOR_EXAMPLE);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value-alternative-currency.spec.js
@@ -65,11 +65,11 @@ context('Insurance - Policy - Single contract policy - Total contract value page
     });
 
     it(`should NOT render a ${TOTAL_CONTRACT_VALUE} prefix`, () => {
-      field(TOTAL_CONTRACT_VALUE).prefix().should('not.exist');
+      cy.assertPrefix({ fieldId: TOTAL_CONTRACT_VALUE });
     });
 
     it(`should NOT render a ${REQUESTED_CREDIT_LIMIT} prefix`, () => {
-      field(REQUESTED_CREDIT_LIMIT).prefix().should('not.exist');
+      cy.assertPrefix({ fieldId: REQUESTED_CREDIT_LIMIT });
     });
 
     it('should prepopulate the radio on the single contract value page', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value-non-gbp-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value-non-gbp-currency.spec.js
@@ -65,11 +65,11 @@ context('Insurance - Policy - Single contract policy - Total contract value page
     });
 
     it(`should render a ${TOTAL_CONTRACT_VALUE} ${USD.name} prefix`, () => {
-      cy.checkText(field(TOTAL_CONTRACT_VALUE).prefix(), SYMBOLS.USD);
+      cy.assertPrefix({ fieldId: TOTAL_CONTRACT_VALUE, value: SYMBOLS.USD });
     });
 
     it(`should render a ${REQUESTED_CREDIT_LIMIT} ${USD.name} prefix`, () => {
-      cy.checkText(field(REQUESTED_CREDIT_LIMIT).prefix(), SYMBOLS.USD);
+      cy.assertPrefix({ fieldId: REQUESTED_CREDIT_LIMIT, value: SYMBOLS.USD });
     });
 
     it('should prepopulate the radio on the single contract value page', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value.spec.js
@@ -71,7 +71,7 @@ context(
 
         cy.checkText(field.hint(), FIELDS.CONTRACT_POLICY.SINGLE[fieldId].HINT);
 
-        cy.checkText(field.prefix(), SYMBOLS.GBP);
+        cy.assertPrefix({ fieldId, value: SYMBOLS.GBP });
 
         field.input().should('exist');
       });
@@ -82,7 +82,7 @@ context(
 
         cy.checkText(field.hint(), FIELDS.CONTRACT_POLICY.SINGLE[fieldId].HINT);
 
-        cy.checkText(field.prefix(), SYMBOLS.GBP);
+        cy.assertPrefix({ fieldId, value: SYMBOLS.GBP });
 
         field.input().should('exist');
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
@@ -98,7 +98,7 @@ context(
           withQuestionMark: true,
         });
 
-        cy.checkText(field.prefix(), FIELDS.TURNOVER[fieldId].PREFIX);
+        cy.assertPrefix({ fieldId, value: FIELDS.TURNOVER[fieldId].PREFIX });
       });
 
       it(`should render ${PERCENTAGE_TURNOVER} section`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-alternative-currency.spec.js
@@ -59,7 +59,7 @@ context('Insurance - Your buyer - Outstanding or overdue payments - Alternative 
       });
 
       it('should NOT render a prefix', () => {
-        field(TOTAL_OUTSTANDING_PAYMENTS).prefix().should('not.exist');
+        cy.assertPrefix({ fieldId: TOTAL_OUTSTANDING_PAYMENTS });
       });
     });
 
@@ -73,7 +73,7 @@ context('Insurance - Your buyer - Outstanding or overdue payments - Alternative 
       });
 
       it('should NOT render a prefix', () => {
-        field(TOTAL_AMOUNT_OVERDUE).prefix().should('not.exist');
+        cy.assertPrefix({ fieldId: TOTAL_AMOUNT_OVERDUE });
       });
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-non-gbp-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-non-gbp-currency.spec.js
@@ -59,7 +59,7 @@ context('Insurance - Your buyer - Outstanding or overdue payments - Non-GBP (sup
       });
 
       it('should render a prefix', () => {
-        cy.checkText(field(TOTAL_OUTSTANDING_PAYMENTS).prefix(), SYMBOLS.USD);
+        cy.assertPrefix({ fieldId: TOTAL_OUTSTANDING_PAYMENTS, value: SYMBOLS.USD });
       });
     });
 
@@ -73,7 +73,7 @@ context('Insurance - Your buyer - Outstanding or overdue payments - Non-GBP (sup
       });
 
       it('should render a prefix', () => {
-        cy.checkText(field(TOTAL_AMOUNT_OVERDUE).prefix(), SYMBOLS.USD);
+        cy.assertPrefix({ fieldId: TOTAL_AMOUNT_OVERDUE, value: SYMBOLS.USD });
       });
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments.spec.js
@@ -86,7 +86,7 @@ context(
         });
 
         it('should render a prefix', () => {
-          cy.checkText(field(TOTAL_OUTSTANDING_PAYMENTS).prefix(), SYMBOLS.GBP);
+          cy.assertPrefix({ fieldId: TOTAL_OUTSTANDING_PAYMENTS, value: SYMBOLS.GBP });
         });
       });
 
@@ -108,7 +108,7 @@ context(
         });
 
         it('should render a prefix', () => {
-          cy.checkText(field(TOTAL_AMOUNT_OVERDUE).prefix(), SYMBOLS.GBP);
+          cy.assertPrefix({ fieldId: TOTAL_AMOUNT_OVERDUE, value: SYMBOLS.GBP });
         });
       });
     });


### PR DESCRIPTION
## Introduction :pencil2:
- Some E2E tests were using `.prefix()` field selectors instead of the `assertPrefix` command.

## Resolution :heavy_check_mark:
- Update all `.prefix()` E2E tests to use `cy.assertPrefix`.
