### PR TITLE
fix(EMS-3901): data migration - requestedCreditLimit column

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-search/companies-house-search.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-search/companies-house-search.spec.js
@@ -12,7 +12,7 @@ import {
 } from '../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance';
-import { FIELDS_ELIGIBILITY } from '../../../../../../../content-strings/fields/insurance/eligibility';
+import { ELIGIBILITY_FIELDS } from '../../../../../../../content-strings/fields/insurance/eligibility';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER;
 
@@ -26,7 +26,7 @@ const {
   ELIGIBILITY: { COMPANIES_HOUSE_NUMBER: FIELD_ID },
 } = INSURANCE_FIELD_IDS;
 
-const FIELD_STRINGS = FIELDS_ELIGIBILITY[FIELD_ID];
+const FIELD_STRINGS = ELIGIBILITY_FIELDS[FIELD_ID];
 
 const field = fieldSelector(FIELD_ID);
 

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -6536,7 +6536,10 @@ var POLICY_FIELDS = {
       },
       [CONTRACT_POLICY.SINGLE.REQUESTED_CREDIT_LIMIT]: {
         LABEL: 'What credit limit do you require?',
-        HINT: 'For example, your total contract maybe \xA3250,000 but the amount you want to insure is \xA3100,000.',
+        HINT: {
+          INTRO: 'For example, your total contract maybe \xA3250,000 but the amount you want to insure is \xA3100,000.',
+          OUTRO: 'Enter a whole number. Do not enter decimals.',
+        },
         SUMMARY: {
           TITLE: 'Credit limit',
           FORM_TITLE: POLICY_FORM_TITLES.CONTRACT_POLICY,

--- a/src/api/data-migration/version-2-to-version-3/update-applications/add-policy-requested-credit-limit-field.ts
+++ b/src/api/data-migration/version-2-to-version-3/update-applications/add-policy-requested-credit-limit-field.ts
@@ -10,7 +10,7 @@ import executeSqlQuery from '../../execute-sql-query';
 const addPolicyRequestedCreditLimitField = (connection: Connection) =>
   executeSqlQuery({
     connection,
-    query: `ALTER TABLE Policy ADD requestedCreditLimit tinyint(1) DEFAULT NULL`,
+    query: `ALTER TABLE Policy ADD requestedCreditLimit int DEFAULT NULL`,
     loggingMessage: 'Adding FIELD requestedCreditLimit to policy table',
   });
 

--- a/src/api/tsconfig.json
+++ b/src/api/tsconfig.json
@@ -21,7 +21,6 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
 
     "noPropertyAccessFromIndexSignature": false,
-    "suppressImplicitAnyIndexErrors": true,
     "ignoreDeprecations": "5.0",
     "resolveJsonModule": true,
 

--- a/src/ui/tsconfig.json
+++ b/src/ui/tsconfig.json
@@ -21,7 +21,6 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
 
     "noPropertyAccessFromIndexSignature": false,
-    "suppressImplicitAnyIndexErrors": true,
     "ignoreDeprecations": "5.0",
     "resolveJsonModule": true,
 

--- a/src/ui/tsconfig.json
+++ b/src/ui/tsconfig.json
@@ -21,6 +21,7 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
 
     "noPropertyAccessFromIndexSignature": false,
+    "suppressImplicitAnyIndexErrors": true,
     "ignoreDeprecations": "5.0",
     "resolveJsonModule": true,
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue with data migration (v2 to v3), where the `requestedCreditLimit` column in the `policy` table was a `tinyint`, instead of an `int`.

## Resolution :heavy_check_mark:
- Update `addPolicyRequestedCreditLimitField`.

## Miscellaneous :heavy_plus_sign:
- Remove now outdated TS config (`suppressImplicitAnyIndexErrors`)
- Fix a typo in an E2E test.
