### PR TITLE
chore(EMS-3966): update dependabot to run during non working hours

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
       time: '03:00'
     labels:
       - 'chore'
@@ -21,7 +21,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/src/api'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
       time: '03:00'
     labels:
       - 'chore'
@@ -30,7 +30,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/src/ui'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
       time: '03:00'
     labels:
       - 'chore'
@@ -39,7 +39,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/generate-exip-pricing-grid'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
       time: '03:00'
     labels:
       - 'chore'
@@ -48,7 +48,7 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/src/api'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
       time: '03:00'
     labels:
       - 'chore'
@@ -57,7 +57,7 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/src/ui'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
       time: '03:00'
     labels:
       - 'chore'
@@ -68,7 +68,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
       time: '03:00'
     labels:
       - 'chore'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
       time: '03:00'
     labels:
       - 'chore'
@@ -21,7 +21,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/src/api'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
       time: '03:00'
     labels:
       - 'chore'
@@ -30,7 +30,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/src/ui'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
       time: '03:00'
     labels:
       - 'chore'
@@ -39,7 +39,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/generate-exip-pricing-grid'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
       time: '03:00'
     labels:
       - 'chore'
@@ -48,7 +48,7 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/src/api'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
       time: '03:00'
     labels:
       - 'chore'
@@ -57,7 +57,7 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/src/ui'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
       time: '03:00'
     labels:
       - 'chore'
@@ -68,7 +68,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
       time: '03:00'
     labels:
       - 'chore'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 # EXIP Git Hub Actions
 #####################################
-# Automatic daily dependencies updates
+# Automatic dependencies updates
 # for the following services:
 # 1. NPM
 # 2. Docker

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+      time: '03:00'
     labels:
       - 'chore'
 
@@ -21,6 +22,7 @@ updates:
     directory: '/src/api'
     schedule:
       interval: 'daily'
+      time: '03:00'
     labels:
       - 'chore'
 
@@ -29,6 +31,7 @@ updates:
     directory: '/src/ui'
     schedule:
       interval: 'daily'
+      time: '03:00'
     labels:
       - 'chore'
 
@@ -37,6 +40,7 @@ updates:
     directory: '/generate-exip-pricing-grid'
     schedule:
       interval: 'daily'
+      time: '03:00'
     labels:
       - 'chore'
 
@@ -45,6 +49,7 @@ updates:
     directory: '/src/api'
     schedule:
       interval: 'daily'
+      time: '03:00'
     labels:
       - 'chore'
 
@@ -53,6 +58,7 @@ updates:
     directory: '/src/ui'
     schedule:
       interval: 'daily'
+      time: '03:00'
     labels:
       - 'chore'
 
@@ -63,5 +69,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+      time: '03:00'
     labels:
       - 'chore'


### PR DESCRIPTION
## Introduction :pencil2:
- Dependabot runs at a random time. When this is during working hours, it uses a lot of runners.

## Resolution :heavy_check_mark:
- Change time to be 3am.

## Miscellaneous :heavy_plus_sign:
- Update dependabot to run weekly instead of monthly.