### PR TITLE
chore(EMS-3968): rename formToStopAt cypress command params

### DIFF
--- a/e2e-tests/commands/insurance/declarations/complete-and-submit-declarations-forms.js
+++ b/e2e-tests/commands/insurance/declarations/complete-and-submit-declarations-forms.js
@@ -2,10 +2,10 @@
  * completeAndDeclarationsForms
  * completes declarations forms up to the specified form to stop at
  * eg, when 'antiBribery' is passed, it will complete all forms up to and including 'antiBribery'
- * @param {String} formToStopAt: the form to stop at
- * @param {String} referenceNumber: application reference number
+ * @param {String} stopSubmittingAfter: The final form to submit
+ * @param {String} referenceNumber: Application reference number
  */
-const completeAndSubmitDeclarationsForms = ({ formToStopAt, referenceNumber }) => {
+const completeAndSubmitDeclarationsForms = ({ stopSubmittingAfter, referenceNumber }) => {
   cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
 
   cy.completeAndSubmitCheckYourAnswers();
@@ -27,7 +27,7 @@ const completeAndSubmitDeclarationsForms = ({ formToStopAt, referenceNumber }) =
   for (const step of steps) {
     step.action();
 
-    if (step.name === formToStopAt) {
+    if (step.name === stopSubmittingAfter) {
       break;
     }
   }

--- a/e2e-tests/commands/insurance/eligibility/complete-and-submit-eligibility-forms.js
+++ b/e2e-tests/commands/insurance/eligibility/complete-and-submit-eligibility-forms.js
@@ -2,13 +2,13 @@
  * completeAndSubmitEligibilityForms
  * completes eligibility forms up to the specified form to stop at
  * eg, when 'companyDetails' is passed, it will complete all forms up to and including 'companyDetails'
- * @param {String} formToStopAt: the form to stop at
+ * @param {String} stopSubmittingAfter: The final form to submit
  * @param {String} companyNumber: the company number to use in the companies house search form
  * @param {Boolean} coverPeriodIsUnderThreshold: whether the cover period is under the threshold
  * @param {Boolean} memberOfAGroup: whether the company is a member of a group
  * @param {Boolean} partyToConsortium: whether the company is a party to a consortium
  */
-const completeAndSubmitEligibilityForms = ({ formToStopAt, companyNumber, coverPeriodIsUnderThreshold, memberOfAGroup, partyToConsortium }) => {
+const completeAndSubmitEligibilityForms = ({ stopSubmittingAfter, companyNumber, coverPeriodIsUnderThreshold, memberOfAGroup, partyToConsortium }) => {
   cy.navigateToCheckIfEligibleUrl();
 
   const steps = [
@@ -33,7 +33,7 @@ const completeAndSubmitEligibilityForms = ({ formToStopAt, companyNumber, coverP
   for (const step of steps) {
     step.action();
 
-    if (step.name === formToStopAt) {
+    if (step.name === stopSubmittingAfter) {
       break;
     }
   }

--- a/e2e-tests/commands/insurance/export-contract/complete-and-submit-export-contract-forms.js
+++ b/e2e-tests/commands/insurance/export-contract/complete-and-submit-export-contract-forms.js
@@ -2,7 +2,7 @@
  * completeAndSubmitExportContractForms
  * completes export contract forms up to the specified form to stop at
  * eg, when 'aboutGoodsOrServices' is passed, it will complete all forms up to and including 'aboutGoodsOrServices'
- * @param {String} formToStopAt: the form to stop at
+ * @param {String} stopSubmittingAfter: The final form to submit
  * @param {Boolean} viaTaskList: Start the "export contract" section from the task list.
  * @param {Boolean} finalDestinationKnown: whether the final destination is known
  * @param {Boolean} totalContractValueOverThreshold: whether total contract value is over threshold
@@ -13,7 +13,7 @@
  * @param {String} fixedSumAmount: Fixed sum amount
  */
 const completeAndSubmitExportContractForms = ({
-  formToStopAt,
+  stopSubmittingAfter,
   viaTaskList,
   finalDestinationKnown,
   totalContractValueOverThreshold,
@@ -61,7 +61,7 @@ const completeAndSubmitExportContractForms = ({
   for (const step of steps) {
     step.action();
 
-    if (step.name === formToStopAt) {
+    if (step.name === stopSubmittingAfter) {
       break;
     }
   }

--- a/e2e-tests/commands/insurance/policy/complete-and-submit-policy-forms.js
+++ b/e2e-tests/commands/insurance/policy/complete-and-submit-policy-forms.js
@@ -6,7 +6,7 @@ const { SINGLE } = APPLICATION.POLICY_TYPE;
  * completeAndPolicyForms
  * completes policy forms up to the specified form to stop at
  * eg, when 'exportValue' is passed, it will complete all forms up to and including 'exportValue'
- * @param {String} formToStopAt: the form to stop at
+ * @param {String} stopSubmittingAfter: The final form to submit
  * @param {String} policyType: Single or multiple. Defaults to single.
  * @param {Boolean} sameName: if name on policy is the same as the signed in user - defaults to true
  * @param {Boolean} usingBroker: Should submit "yes" or "no" to "using a broker"
@@ -17,7 +17,7 @@ const { SINGLE } = APPLICATION.POLICY_TYPE;
  * @param {Boolean} otherCompanyInvolved: If "another company to be insured" is on.
  */
 const completeAndPolicyForms = ({
-  formToStopAt,
+  stopSubmittingAfter,
   policyType = SINGLE,
   sameName = true,
   usingBroker,
@@ -67,7 +67,7 @@ const completeAndPolicyForms = ({
   for (const step of steps) {
     step.action();
 
-    if (step.name === formToStopAt) {
+    if (step.name === stopSubmittingAfter) {
       break;
     }
   }

--- a/e2e-tests/commands/insurance/your-business/complete-and-submit-your-business-forms.js
+++ b/e2e-tests/commands/insurance/your-business/complete-and-submit-your-business-forms.js
@@ -2,12 +2,12 @@
  * completeAndSubmitYourBusinessForms
  * completes your business forms up to the specified form to stop at
  * eg, when 'turnover' is passed, it will complete all forms up to and including 'turnover'
- * @param {String} formToStopAt: the form to stop at
+ * @param {String} stopSubmittingAfter: The final form to submit
  * @param {Boolean} hasCreditControlProcess: whether the exporter has a credit control process
  * @param {Boolean} differentTradingAddress: whether the exporter has a different trading address
  * @param {Boolean} differentTradingName: whether the exporter has a different trading name
  */
-const completeAndSubmitYourBusinessForms = ({ formToStopAt, hasCreditControlProcess, differentTradingAddress, differentTradingName }) => {
+const completeAndSubmitYourBusinessForms = ({ stopSubmittingAfter, hasCreditControlProcess, differentTradingAddress, differentTradingName }) => {
   cy.startYourBusinessSection({});
 
   const initialSteps = [{ name: 'companyDetails', action: () => cy.completeAndSubmitCompanyDetails({ differentTradingAddress, differentTradingName }) }];
@@ -31,7 +31,7 @@ const completeAndSubmitYourBusinessForms = ({ formToStopAt, hasCreditControlProc
   for (const step of steps) {
     step.action();
 
-    if (step.name === formToStopAt) {
+    if (step.name === stopSubmittingAfter) {
       break;
     }
   }

--- a/e2e-tests/commands/insurance/your-buyer/complete-and-submit-your-buyer-forms.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-and-submit-your-buyer-forms.js
@@ -5,7 +5,7 @@
  * @param {Boolean} alternativeCurrency: If alternative currency should be entered.
  * @param {Boolean} exporterHasTradedWithBuyer: whether the exporter has traded with the buyer
  * @param {Boolean} failedToPay: whether the buyer has failed to pay the exporter
- * @param {String} formToStopAt: the form to stop at
+ * @param {String} stopSubmittingAfter: The final form to submit
  * @param {Boolean} fullyPopulatedBuyerTradingHistory: whether to fully populate the buyer trading history form
  * @param {Boolean} hasConnectionToBuyer: whether the exporter has a connection with the buyer
  * @param {Boolean} exporterHasBuyerFinancialAccounts: whether the exporter has buyer financial accounts
@@ -17,7 +17,7 @@ const completeAndSubmitYourBuyerForms = ({
   alternativeCurrency,
   exporterHasTradedWithBuyer,
   failedToPay,
-  formToStopAt,
+  stopSubmittingAfter,
   fullyPopulatedBuyerTradingHistory,
   exporterHasBuyerFinancialAccounts,
   hasConnectionToBuyer,
@@ -63,7 +63,7 @@ const completeAndSubmitYourBuyerForms = ({
   for (const step of steps) {
     step.action();
 
-    if (step.name === formToStopAt) {
+    if (step.name === stopSubmittingAfter) {
       break;
     }
   }

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/anti-bribery-expandable-definition-content.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/anti-bribery-expandable-definition-content.spec.js
@@ -31,7 +31,7 @@ context('Insurance - Declarations - Anti-bribery page - expandable `definition` 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitDeclarationsForms({ formToStopAt: 'confidentiality', referenceNumber });
+      cy.completeAndSubmitDeclarationsForms({ stopSubmittingAfter: 'confidentiality', referenceNumber });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ANTI_BRIBERY_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/anti-bribery.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/anti-bribery.spec.js
@@ -28,7 +28,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitDeclarationsForms({ formToStopAt: 'confidentiality', referenceNumber });
+        cy.completeAndSubmitDeclarationsForms({ stopSubmittingAfter: 'confidentiality', referenceNumber });
 
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ANTI_BRIBERY_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-no.spec.js
@@ -20,7 +20,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitDeclarationsForms({ formToStopAt: 'antiBribery', referenceNumber });
+        cy.completeAndSubmitDeclarationsForms({ stopSubmittingAfter: 'antiBribery', referenceNumber });
 
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CODE_OF_CONDUCT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct-answer-yes.spec.js
@@ -19,7 +19,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitDeclarationsForms({ formToStopAt: 'antiBribery', referenceNumber });
+        cy.completeAndSubmitDeclarationsForms({ stopSubmittingAfter: 'antiBribery', referenceNumber });
 
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CODE_OF_CONDUCT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
@@ -27,7 +27,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitDeclarationsForms({ formToStopAt: 'antiBribery', referenceNumber });
+        cy.completeAndSubmitDeclarationsForms({ stopSubmittingAfter: 'antiBribery', referenceNumber });
 
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CODE_OF_CONDUCT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/save-and-back.spec.js
@@ -25,7 +25,7 @@ context('Insurance - Declarations - Anti-bribery - Code of conduct page - Save a
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitDeclarationsForms({ formToStopAt: 'antiBribery', referenceNumber });
+      cy.completeAndSubmitDeclarationsForms({ stopSubmittingAfter: 'antiBribery', referenceNumber });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CODE_OF_CONDUCT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/anti-bribery-exporting-with-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/anti-bribery-exporting-with-code-of-conduct.spec.js
@@ -27,7 +27,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitDeclarationsForms({ formToStopAt: 'codeOfConduct', referenceNumber });
+        cy.completeAndSubmitDeclarationsForms({ stopSubmittingAfter: 'codeOfConduct', referenceNumber });
 
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/save-and-back.spec.js
@@ -25,7 +25,7 @@ context('Insurance - Declarations - Exporting with code of conduct page - Save a
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitDeclarationsForms({ formToStopAt: 'codeOfConduct', referenceNumber });
+      cy.completeAndSubmitDeclarationsForms({ stopSubmittingAfter: 'codeOfConduct', referenceNumber });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${EXPORTING_WITH_CODE_OF_CONDUCT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/save-and-back.spec.js
@@ -23,7 +23,7 @@ context('Insurance - Declarations - Anti-bribery page - Save and go back', () =>
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitDeclarationsForms({ formToStopAt: 'confidentiality', referenceNumber });
+      cy.completeAndSubmitDeclarationsForms({ stopSubmittingAfter: 'confidentiality', referenceNumber });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ANTI_BRIBERY_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/confirmation-and-acknowledgements/confirmation-and-acknowledgements.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/confirmation-and-acknowledgements/confirmation-and-acknowledgements.spec.js
@@ -30,7 +30,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitDeclarationsForms({ formToStopAt: 'exportingWithCodeOfConduct', referenceNumber });
+        cy.completeAndSubmitDeclarationsForms({ stopSubmittingAfter: 'exportingWithCodeOfConduct', referenceNumber });
 
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CONFIRMATION_AND_ACKNOWLEDGEMENTS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/confirmation-and-acknowledgements/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/confirmation-and-acknowledgements/save-and-back.spec.js
@@ -19,7 +19,7 @@ context('Insurance - Declarations - Confirmation and acknowledgements page - Sav
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitDeclarationsForms({ formToStopAt: 'exportingWithCodeOfConduct', referenceNumber });
+      cy.completeAndSubmitDeclarationsForms({ stopSubmittingAfter: 'exportingWithCodeOfConduct', referenceNumber });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CONFIRMATION_AND_ACKNOWLEDGEMENTS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/buyer-country/buyer-country-no-short-term-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/buyer-country/buyer-country-no-short-term-cover.spec.js
@@ -14,7 +14,7 @@ context(
     beforeEach(() => {
       cy.saveSession();
 
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'companyDetails' });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'companyDetails' });
     });
 
     describe(COUNTRY_NAME_1, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/buyer-country/buyer-country-unsupported-countries.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/buyer-country/buyer-country-unsupported-countries.spec.js
@@ -17,7 +17,7 @@ context(`Insurance - Buyer country page - ${contextString} - Unsupported countri
   beforeEach(() => {
     cy.saveSession();
 
-    cy.completeAndSubmitEligibilityForms({ formToStopAt: 'companyDetails' });
+    cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'companyDetails' });
   });
 
   describe(COUNTRY_NAME_1, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/buyer-country/buyer-country.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/buyer-country/buyer-country.spec.js
@@ -19,7 +19,7 @@ const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Buyer country page - as an exporter, I want to check if UKEF offer credit insurance policy for where my buyer is based', () => {
   beforeEach(() => {
-    cy.completeAndSubmitEligibilityForms({ formToStopAt: 'companyDetails' });
+    cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'companyDetails' });
 
     const expectedUrl = `${baseUrl}${BUYER_COUNTRY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-multiple-risks/cannot-apply-multiple-risks.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-multiple-risks/cannot-apply-multiple-risks.spec.js
@@ -20,7 +20,7 @@ context(
     const url = `${baseUrl}${CANNOT_APPLY_MULTIPLE_RISKS_EXIT}`;
 
     before(() => {
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'ukGoodsAndServices' });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'ukGoodsAndServices' });
 
       cy.clickYesRadioInput();
       cy.clickSubmitButton();

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply-page.spec.js
@@ -18,7 +18,7 @@ const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance Eligibility - Cannot apply exit page', () => {
   beforeEach(() => {
-    cy.completeAndSubmitEligibilityForms({ formToStopAt: 'companyDetails' });
+    cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'companyDetails' });
 
     cy.keyboardInput(autoCompleteField(FIELD_ID).input(), COUNTRY_NAME_UNSUPPORTED);
     const results = autoCompleteField(FIELD_ID).results();

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply/cannot-apply-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply/cannot-apply-page.spec.js
@@ -25,7 +25,7 @@ context(
 
       cy.navigateToCheckIfEligibleUrl();
 
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'companyDetails' });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'companyDetails' });
 
       cy.keyboardInput(autoCompleteField(FIELD_ID).input(), COUNTRY_NAME);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-number/companies-house-number-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-number/companies-house-number-answer-no.spec.js
@@ -14,7 +14,7 @@ context(
     const url = `${baseUrl}${COMPANIES_HOUSE_NUMBER}`;
 
     before(() => {
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'exporterLocation' });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'exporterLocation' });
     });
 
     beforeEach(() => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-number/companies-house-number.spec.js
@@ -17,7 +17,7 @@ context(
     const url = `${baseUrl}${ROUTES.INSURANCE.ELIGIBILITY.COMPANIES_HOUSE_NUMBER}`;
 
     before(() => {
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'exporterLocation' });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'exporterLocation' });
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-search/companies-house-search-no-financial-year-end-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-search/companies-house-search-no-financial-year-end-date.spec.js
@@ -14,7 +14,7 @@ context(
 
     before(() => {
       cy.completeAndSubmitEligibilityForms({
-        formToStopAt: 'companiesHouseNumberSearch',
+        stopSubmittingAfter: 'companiesHouseNumberSearch',
         companyNumber: COMPANIES_HOUSE_NUMBER_NO_FINANCIAL_YEAR_END_DATE,
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-search/companies-house-search.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-search/companies-house-search.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Eligibility - Companies house search page - I want to check
   let companyNumber;
 
   before(() => {
-    cy.completeAndSubmitEligibilityForms({ formToStopAt: 'companiesHouseNumber' });
+    cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'companiesHouseNumber' });
 
     cy.assertUrl(url);
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-details/company-details-company-name-special-characters.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-details/company-details-company-name-special-characters.spec.js
@@ -15,7 +15,7 @@ context(
 
     before(() => {
       cy.completeAndSubmitEligibilityForms({
-        formToStopAt: 'companiesHouseNumberSearch',
+        stopSubmittingAfter: 'companiesHouseNumberSearch',
         companyNumber: COMPANIES_HOUSE_NUMBER_SPECIAL_CHARACTERS_NAME,
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-details/company-details-multiple-SIC-codes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-details/company-details-multiple-SIC-codes.spec.js
@@ -21,7 +21,7 @@ context(
 
     before(() => {
       cy.completeAndSubmitEligibilityForms({
-        formToStopAt: 'companiesHouseNumberSearch',
+        stopSubmittingAfter: 'companiesHouseNumberSearch',
         companyNumber: COMPANIES_HOUSE_NUMBER_MULTIPLE_SIC_CODES,
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-details/company-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-details/company-details.spec.js
@@ -16,7 +16,7 @@ context('Insurance - Eligibility - Companies details page - I want to check if I
   const url = `${baseUrl}${COMPANY_DETAILS}`;
 
   before(() => {
-    cy.completeAndSubmitEligibilityForms({ formToStopAt: 'companiesHouseNumberSearch' });
+    cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'companiesHouseNumberSearch' });
 
     cy.assertUrl(url);
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-not-active/company-not-active.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/company-not-active/company-not-active.spec.js
@@ -20,7 +20,7 @@ context('Insurance - Eligibility - Company not active - I want to check if I can
 
   before(() => {
     cy.completeAndSubmitEligibilityForms({
-      formToStopAt: 'companiesHouseNumberSearch',
+      stopSubmittingAfter: 'companiesHouseNumberSearch',
       companyNumber: COMPANIES_HOUSE_NUMBER_NOT_ACTIVE,
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cover-period/cover-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cover-period/cover-period.spec.js
@@ -25,7 +25,7 @@ context(
     let url;
 
     before(() => {
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'totalValueInsured' });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'totalValueInsured' });
 
       url = `${baseUrl}${COVER_PERIOD_ROUTE}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/end-buyer/end-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/end-buyer/end-buyer.spec.js
@@ -24,7 +24,7 @@ context(
     const url = `${baseUrl}${END_BUYER}`;
 
     before(() => {
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'ukGoodsAndServices' });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'ukGoodsAndServices' });
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location-answer-no.spec.js
@@ -16,7 +16,7 @@ context(
     const url = `${baseUrl}${EXPORTER_LOCATION}`;
 
     before(() => {
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'checkIfEligible' });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'checkIfEligible' });
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
@@ -19,7 +19,7 @@ const baseUrl = Cypress.config('baseUrl');
 
 context('Insurance - Exporter location page - as an exporter, I want to check if my company can get UKEF issue credit insurance cover', () => {
   beforeEach(() => {
-    cy.completeAndSubmitEligibilityForms({ formToStopAt: 'checkIfEligible' });
+    cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'checkIfEligible' });
 
     const expectedUrl = `${baseUrl}${EXPORTER_LOCATION}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/long-term-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/long-term-cover.spec.js
@@ -15,7 +15,7 @@ context(
     let url;
 
     before(() => {
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'coverPeriod', coverPeriodIsUnderThreshold: false });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'coverPeriod', coverPeriodIsUnderThreshold: false });
 
       url = `${baseUrl}${LONG_TERM_COVER_EXIT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/member-of-a-group-exit-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/member-of-a-group-exit-page.spec.js
@@ -15,7 +15,7 @@ context(
     let url;
 
     before(() => {
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'memberOfAGroup', memberOfAGroup: true });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'memberOfAGroup', memberOfAGroup: true });
 
       url = `${baseUrl}${MEMBER_OF_A_GROUP_EXIT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/member-of-a-group/member-of-a-group.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/member-of-a-group/member-of-a-group.spec.js
@@ -23,7 +23,7 @@ context(
     const url = `${baseUrl}${MEMBER_OF_A_GROUP}`;
 
     before(() => {
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'partyToConsortium' });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'partyToConsortium' });
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/party-to-consortium-exit-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/party-to-consortium-exit-page.spec.js
@@ -15,7 +15,7 @@ context(
     let url;
 
     before(() => {
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'partyToConsortium', partyToConsortium: true });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'partyToConsortium', partyToConsortium: true });
 
       url = `${baseUrl}${PARTY_TO_CONSORTIUM_EXIT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/party-to-consortium/party-to-consortium.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/party-to-consortium/party-to-consortium.spec.js
@@ -22,7 +22,7 @@ context(
     const url = `${baseUrl}${PARTY_TO_CONSORTIUM}`;
 
     before(() => {
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'endBuyer' });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'endBuyer' });
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/total-value-insured/total-value-insured.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/total-value-insured/total-value-insured.spec.js
@@ -25,7 +25,7 @@ context(
     let url;
 
     before(() => {
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'buyerCountry' });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'buyerCountry' });
 
       url = `${baseUrl}${TOTAL_VALUE_INSURED}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services-answer-no.spec.js
@@ -10,7 +10,7 @@ context(
   'Insurance - UK goods or services page - as an exporter, I want to check if my export value is eligible for UKEF credit insurance cover - submit `no - UK goods/services is below the minimum`',
   () => {
     beforeEach(() => {
-      cy.completeAndSubmitEligibilityForms({ formToStopAt: 'coverPeriod' });
+      cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'coverPeriod' });
 
       cy.clickNoRadioInput();
       cy.clickSubmitButton();

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -29,7 +29,7 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
   const url = `${baseUrl}${UK_GOODS_OR_SERVICES}`;
 
   before(() => {
-    cy.completeAndSubmitEligibilityForms({ formToStopAt: 'coverPeriod' });
+    cy.completeAndSubmitEligibilityForms({ stopSubmittingAfter: 'coverPeriod' });
 
     cy.assertUrl(url);
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services-final-destination-not-known-and-total-contract-value-over-threshold.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services-final-destination-not-known-and-total-contract-value-over-threshold.spec.js
@@ -16,7 +16,7 @@ context('Insurance - Export contract - About goods or services page - Final dest
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'howWasTheContractAwarded' });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'howWasTheContractAwarded' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services-final-destination-not-known.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services-final-destination-not-known.spec.js
@@ -28,7 +28,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitExportContractForms({ formToStopAt: 'howWasTheContractAwarded' });
+        cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'howWasTheContractAwarded' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services-total-contract-value-over-threshold.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services-total-contract-value-over-threshold.spec.js
@@ -16,7 +16,7 @@ context('Insurance - Export contract - About goods or services page - Submission
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'howWasTheContractAwarded' });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'howWasTheContractAwarded' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/about-goods-or-services.spec.js
@@ -35,7 +35,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitExportContractForms({ formToStopAt: 'howWasTheContractAwarded' });
+        cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'howWasTheContractAwarded' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/save-and-back.spec.js
@@ -25,7 +25,7 @@ context('Insurance - Export contract - About goods or services page - Save and g
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'howWasTheContractAwarded' });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'howWasTheContractAwarded' });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/validation/about-goods-or-services-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/validation/about-goods-or-services-validation.spec.js
@@ -50,7 +50,7 @@ context('Insurance - Export contract - About goods or services page - form valid
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'howWasTheContractAwarded' });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'howWasTheContractAwarded' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${ABOUT_GOODS_OR_SERVICES}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges-change-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges-change-currency.spec.js
@@ -22,7 +22,7 @@ context("Insurance - Export contract - Agent charges page - As an Exporter I wan
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'agentService', isUsingAgent: true, agentIsCharging: true });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agentService', isUsingAgent: true, agentIsCharging: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_CHARGES}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges-fixed-sum-amount-as-decimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges-fixed-sum-amount-as-decimal.spec.js
@@ -22,7 +22,7 @@ context('Insurance - Export contract - Agent charges page - Fixed sum amount as 
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'agentService', isUsingAgent: true, agentIsCharging: true });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agentService', isUsingAgent: true, agentIsCharging: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_CHARGES}`;
       agentChargesCurrencyUrl = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_CHARGES_CURRENCY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges-fixed-sum-amount-with-comma.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges-fixed-sum-amount-with-comma.spec.js
@@ -22,7 +22,7 @@ context('Insurance - Export contract - Agent charges page - Fixed sum amount wit
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'agentService', isUsingAgent: true, agentIsCharging: true });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agentService', isUsingAgent: true, agentIsCharging: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_CHARGES}`;
       agentChargesCurrencyUrl = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_CHARGES_CURRENCY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges.spec.js
@@ -32,7 +32,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitExportContractForms({ formToStopAt: 'agentService', isUsingAgent: true, agentIsCharging: true });
+        cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agentService', isUsingAgent: true, agentIsCharging: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_CHARGES}`;
         agentChargesCurrencyUrl = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_CHARGES_CURRENCY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/save-and-back-method-fixed-sum.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/save-and-back-method-fixed-sum.spec.js
@@ -21,7 +21,7 @@ context(`Insurance - Export contract - Agent charges - Save and go back - ${METH
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'agentService', isUsingAgent: true, agentIsCharging: true });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agentService', isUsingAgent: true, agentIsCharging: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_CHARGES}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/save-and-back-method-percentage.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/save-and-back-method-percentage.spec.js
@@ -21,7 +21,7 @@ context(`Insurance - Export contract - Agent charges - Save and go back - ${METH
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'agentService', isUsingAgent: true, agentIsCharging: true });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agentService', isUsingAgent: true, agentIsCharging: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_CHARGES}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/save-and-back.spec.js
@@ -21,7 +21,7 @@ context(`Insurance - Export contract - Agent charges - Save and go back - empty 
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'agentService', isUsingAgent: true, agentIsCharging: true });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agentService', isUsingAgent: true, agentIsCharging: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_CHARGES}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/validation/agent-charges-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/validation/agent-charges-validation.spec.js
@@ -32,7 +32,7 @@ context('Insurance - Export contract - Agent charges page - form validation', ()
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'agentService', isUsingAgent: true, agentIsCharging: true });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agentService', isUsingAgent: true, agentIsCharging: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_CHARGES}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-details/agent-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-details/agent-details.spec.js
@@ -32,7 +32,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitExportContractForms({ formToStopAt: 'agent', isUsingAgent: true });
+        cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agent', isUsingAgent: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_DETAILS}`;
         agentServiceUrl = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_SERVICE}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-details/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-details/save-and-back.spec.js
@@ -16,7 +16,7 @@ context('Insurance - Export contract - Agent details - Save and go back', () => 
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'agent', isUsingAgent: true });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agent', isUsingAgent: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_DETAILS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-details/validation/agent-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-details/validation/agent-details-validation.spec.js
@@ -33,7 +33,7 @@ context('Insurance - Export contract - Agent details page - form validation', ()
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'agent', isUsingAgent: true });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agent', isUsingAgent: true });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${AGENT_DETAILS}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-service/agent-service.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-service/agent-service.spec.js
@@ -31,7 +31,15 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitExportContractForms({ formToStopAt: 'agentDetails', isUsingAgent: true });
+        cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agentDetails', isUsingAgent: true });
+
+        // stopSubmittingAfter is ACTUALLY
+        // "the last form to submit"
+        // lastFormSubmission
+        // finalFormSubmission
+        //
+        // formSubmissionToStopAt
+        // stopSubmittingAfter
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_SERVICE}`;
         checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-service/agent-service.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-service/agent-service.spec.js
@@ -33,14 +33,6 @@ context(
         // go to the page we want to test.
         cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agentDetails', isUsingAgent: true });
 
-        // stopSubmittingAfter is ACTUALLY
-        // "the last form to submit"
-        // lastFormSubmission
-        // finalFormSubmission
-        //
-        // formSubmissionToStopAt
-        // stopSubmittingAfter
-
         url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_SERVICE}`;
         checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
         agentChargesUrl = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_CHARGES}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-service/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-service/save-and-back.spec.js
@@ -16,7 +16,7 @@ context('Insurance - Export contract - Agent service - Save and go back', () => 
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'agentDetails', isUsingAgent: true });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agentDetails', isUsingAgent: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_SERVICE}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-service/validation/agent-service-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-service/validation/agent-service-validation.spec.js
@@ -32,7 +32,7 @@ context('Insurance - Export contract - Agent service page - form validation', ()
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'agentDetails', isUsingAgent: true });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agentDetails', isUsingAgent: true });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${AGENT_SERVICE}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent/agent.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent/agent.spec.js
@@ -30,7 +30,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitExportContractForms({ formToStopAt: 'howYouWillGetPaid' });
+        cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'howYouWillGetPaid' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT}`;
         agentDetailsUrl = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_DETAILS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent/save-and-back.spec.js
@@ -21,7 +21,7 @@ context('Insurance - Export contract - Agent - Save and go back', () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'howYouWillGetPaid' });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'howYouWillGetPaid' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/currency-of-agent-charges/currency-of-agent-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/currency-of-agent-charges/currency-of-agent-charges.spec.js
@@ -36,7 +36,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitExportContractForms({ formToStopAt: 'agentCharges', isUsingAgent: true, agentIsCharging: true, fixedSumMethod: true });
+        cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'agentCharges', isUsingAgent: true, agentIsCharging: true, fixedSumMethod: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${AGENT_CHARGES_CURRENCY}`;
         howMuchAgentIsChargingUrl = `${baseUrl}${ROOT}/${referenceNumber}${HOW_MUCH_THE_AGENT_IS_CHARGING}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/declined-by-private-market/declined-by-private-market.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/declined-by-private-market/declined-by-private-market.spec.js
@@ -41,7 +41,11 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitExportContractForms({ formToStopAt: 'privateMarket', totalContractValueOverThreshold: true, attemptedPrivateMarketCover: true });
+        cy.completeAndSubmitExportContractForms({
+          stopSubmittingAfter: 'privateMarket',
+          totalContractValueOverThreshold: true,
+          attemptedPrivateMarketCover: true,
+        });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${DECLINED_BY_PRIVATE_MARKET}`;
         agentUrl = `${baseUrl}${ROOT}/${referenceNumber}${AGENT}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/declined-by-private-market/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/declined-by-private-market/save-and-back.spec.js
@@ -22,7 +22,11 @@ context('Insurance - Export contract - Declined by private market - Save and go 
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'privateMarket', totalContractValueOverThreshold: true, attemptedPrivateMarketCover: true });
+      cy.completeAndSubmitExportContractForms({
+        stopSubmittingAfter: 'privateMarket',
+        totalContractValueOverThreshold: true,
+        attemptedPrivateMarketCover: true,
+      });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${DECLINED_BY_PRIVATE_MARKET}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-much-the-agent-is-charging/how-much-the-agent-is-charging.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-much-the-agent-is-charging/how-much-the-agent-is-charging.spec.js
@@ -31,7 +31,12 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitExportContractForms({ formToStopAt: 'currencyOfAgentCharges', isUsingAgent: true, agentIsCharging: true, fixedSumMethod: true });
+        cy.completeAndSubmitExportContractForms({
+          stopSubmittingAfter: 'currencyOfAgentCharges',
+          isUsingAgent: true,
+          agentIsCharging: true,
+          fixedSumMethod: true,
+        });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${HOW_MUCH_THE_AGENT_IS_CHARGING}`;
         checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-much-the-agent-is-charging/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-much-the-agent-is-charging/save-and-back.spec.js
@@ -23,7 +23,7 @@ context('Insurance - Export contract - How much the agent is charging - Save and
 
       // go to the page we want to test.
       cy.completeAndSubmitExportContractForms({
-        formToStopAt: 'currencyOfAgentCharges',
+        stopSubmittingAfter: 'currencyOfAgentCharges',
         isUsingAgent: true,
         agentIsCharging: true,
         fixedSumMethod: true,

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/how-will-you-get-paid-total-contract-value-over-threshold.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/how-will-you-get-paid-total-contract-value-over-threshold.spec.js
@@ -16,7 +16,7 @@ context('Insurance - Export contract - How will you get paid page - Submission w
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'aboutGoodsOrServices' });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'aboutGoodsOrServices' });
 
       privateMarketUrl = `${baseUrl}${ROOT}/${referenceNumber}${PRIVATE_MARKET}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/how-will-you-get-paid.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/how-will-you-get-paid.spec.js
@@ -39,7 +39,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitExportContractForms({ formToStopAt: 'aboutGoodsOrServices' });
+        cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'aboutGoodsOrServices' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${HOW_WILL_YOU_GET_PAID}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/save-and-back.spec.js
@@ -26,7 +26,7 @@ context('Insurance - Export contract - How will you get paid page - Save and go 
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'aboutGoodsOrServices' });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'aboutGoodsOrServices' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${HOW_WILL_YOU_GET_PAID}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/private-market.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/private-market.spec.js
@@ -37,7 +37,7 @@ context(
         declinedByPrivateMarketUrl = `${baseUrl}${ROOT}/${referenceNumber}${DECLINED_BY_PRIVATE_MARKET}`;
 
         // go to the page we want to test.
-        cy.completeAndSubmitExportContractForms({ formToStopAt: 'howYouWillGetPaid' });
+        cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'howYouWillGetPaid' });
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/save-and-back.spec.js
@@ -21,7 +21,7 @@ context('Insurance - Export contract - Private market - Save and go back', () =>
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitExportContractForms({ formToStopAt: 'howYouWillGetPaid' });
+      cy.completeAndSubmitExportContractForms({ stopSubmittingAfter: 'howYouWillGetPaid' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${PRIVATE_MARKET}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/another-company.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/another-company.spec.js
@@ -42,7 +42,7 @@ context(`Insurance - Policy - Another company page - ${story}`, () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'preCreditPeriod' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'preCreditPeriod' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${ANOTHER_COMPANY}`;
       brokerUrl = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/another-company/save-and-back.spec.js
@@ -21,7 +21,7 @@ context('Insurance - Policy - Another company page - Save and back', () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'preCreditPeriod' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'preCreditPeriod' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${ANOTHER_COMPANY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-confirm-address/broker-confirm-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-confirm-address/broker-confirm-address.spec.js
@@ -32,7 +32,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'brokerDetails', usingBroker: true });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'brokerDetails', usingBroker: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_CONFIRM_ADDRESS_ROOT}`;
         lossPayeeUrl = `${baseUrl}${ROOT}/${referenceNumber}${LOSS_PAYEE_ROOT}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
@@ -32,7 +32,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'broker', usingBroker: true });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'broker', usingBroker: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_DETAILS_ROOT}`;
         brokerConfirmAddressUrl = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_CONFIRM_ADDRESS_ROOT}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/save-and-back.spec.js
@@ -23,7 +23,7 @@ context('Insurance - Policy - Broker details page - Save and back', () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'broker', usingBroker: true });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'broker', usingBroker: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_DETAILS_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/validation/broker-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/validation/broker-details-validation.spec.js
@@ -31,7 +31,7 @@ context('Insurance - Policy - Broker details page - validation', () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'broker', usingBroker: true });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'broker', usingBroker: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_DETAILS_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
@@ -40,7 +40,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'anotherCompany' });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'anotherCompany' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
         lossPayeeUrl = `${baseUrl}${ROOT}/${referenceNumber}${LOSS_PAYEE_ROOT}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/save-and-back.spec.js
@@ -19,7 +19,7 @@ context('Insurance - Policy - Broker page - Save and back', () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'anotherCompany' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'anotherCompany' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-multiple-contract-policy.spec.js
@@ -9,7 +9,7 @@ context('Insurance - Policy - Complete the entire section as a multiple contract
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayee', policyType });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayee', policyType });
 
       /**
        * Submit the "Policy - check your answers" form,

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/complete-policy-as-single-contract-policy.spec.js
@@ -5,7 +5,7 @@ context('Insurance - Policy - Complete the entire section as a single contract p
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayee' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayee' });
 
       /**
        * Submit the "Policy - check your answers" form,

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/changing-from-different-name-to-same-name-then-back-to-different-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/changing-from-different-name-to-same-name-then-back-to-different-name.spec.js
@@ -24,7 +24,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayee' });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayee' });
 
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/changing-from-same-name-to-different-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/changing-from-same-name-to-different-name.spec.js
@@ -24,7 +24,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayee' });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayee' });
 
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
@@ -35,7 +35,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'nameOnPolicy', sameName: false });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'nameOnPolicy', sameName: false });
 
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${DIFFERENT_NAME_ON_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/entering-details-of-policy-owner.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/entering-details-of-policy-owner.spec.js
@@ -30,7 +30,7 @@ context(`Insurance - Policy - Different name on Policy page - Entering name of p
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'nameOnPolicy', sameName: false });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'nameOnPolicy', sameName: false });
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${DIFFERENT_NAME_ON_POLICY}`;
 
       cy.assertUrl(url);

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/save-and-back.spec.js
@@ -27,7 +27,7 @@ context('Insurance - Policy - Different name on policy - Save and go back', () =
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'nameOnPolicy', sameName: false });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'nameOnPolicy', sameName: false });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${DIFFERENT_NAME_ON_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/validation/different-name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/validation/different-name-on-policy-validation.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Policy - Different name on Policy page - Validation', () =>
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'nameOnPolicy', sameName: false });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'nameOnPolicy', sameName: false });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${DIFFERENT_NAME_ON_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/loss-payee-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/loss-payee-details.spec.js
@@ -36,7 +36,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayee', isAppointingLossPayee: true });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayee', isAppointingLossPayee: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${LOSS_PAYEE_DETAILS_ROOT}`;
         lossPayeeFinancialUkUrl = `${baseUrl}${ROOT}/${referenceNumber}${LOSS_PAYEE_FINANCIAL_DETAILS_UK_ROOT}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/save-and-back.spec.js
@@ -25,7 +25,7 @@ context('Insurance - Policy - Loss payee details page - Save and back', () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayee', isAppointingLossPayee: true });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayee', isAppointingLossPayee: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${LOSS_PAYEE_DETAILS_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/validation/loss-payee-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/validation/loss-payee-details-validation.spec.js
@@ -27,7 +27,7 @@ context('Insurance - Policy - Loss Payee Details - Validation', () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayee', isAppointingLossPayee: true });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayee', isAppointingLossPayee: true });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${LOSS_PAYEE_DETAILS_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/loss-payee-financial-details-international-lower-case.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/loss-payee-financial-details-international-lower-case.spec.js
@@ -21,7 +21,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayeeDetails', isAppointingLossPayee: true, locatedInUK: false });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayeeDetails', isAppointingLossPayee: true, locatedInUK: false });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT}`;
         checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/loss-payee-financial-details-international.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/loss-payee-financial-details-international.spec.js
@@ -31,7 +31,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayeeDetails', isAppointingLossPayee: true, locatedInUK: false });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayeeDetails', isAppointingLossPayee: true, locatedInUK: false });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT}`;
         checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/save-and-back.spec.js
@@ -24,7 +24,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayeeDetails', isAppointingLossPayee: true, locatedInUK: false });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayeeDetails', isAppointingLossPayee: true, locatedInUK: false });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/validation/bic-swift-code-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/validation/bic-swift-code-validation.spec.js
@@ -17,7 +17,7 @@ context('Insurance - Policy - Loss Payee Financial Details International - BIC/S
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayeeDetails', isAppointingLossPayee: true, locatedInUK: false });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayeeDetails', isAppointingLossPayee: true, locatedInUK: false });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/validation/financial-address-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/validation/financial-address-validation.spec.js
@@ -17,7 +17,7 @@ context('Insurance - Policy - Loss Payee Financial Details International - Finan
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayeeDetails', isAppointingLossPayee: true, locatedInUK: false });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayeeDetails', isAppointingLossPayee: true, locatedInUK: false });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/validation/iban-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/validation/iban-validation.spec.js
@@ -17,7 +17,7 @@ context('Insurance - Policy - Loss Payee Financial Details International - IBAN 
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayeeDetails', isAppointingLossPayee: true, locatedInUK: false });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayeeDetails', isAppointingLossPayee: true, locatedInUK: false });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${LOSS_PAYEE_FINANCIAL_DETAILS_INTERNATIONAL_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/loss-payee-financial-details-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/loss-payee-financial-details-uk.spec.js
@@ -31,7 +31,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayeeDetails', isAppointingLossPayee: true });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayeeDetails', isAppointingLossPayee: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${LOSS_PAYEE_FINANCIAL_DETAILS_UK_ROOT}`;
         checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/save-and-back.spec.js
@@ -24,7 +24,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayeeDetails', isAppointingLossPayee: true });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayeeDetails', isAppointingLossPayee: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${LOSS_PAYEE_FINANCIAL_DETAILS_UK_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/account-number-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/account-number-validation.spec.js
@@ -31,7 +31,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Account number -
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayeeDetails', isAppointingLossPayee: true });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayeeDetails', isAppointingLossPayee: true });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${LOSS_PAYEE_FINANCIAL_DETAILS_UK_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/financial-address-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/financial-address-validation.spec.js
@@ -17,7 +17,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Financial addres
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayeeDetails', isAppointingLossPayee: true });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayeeDetails', isAppointingLossPayee: true });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${LOSS_PAYEE_FINANCIAL_DETAILS_UK_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/sort-code-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/validation/sort-code-validation.spec.js
@@ -31,7 +31,7 @@ context('Insurance - Policy - Loss Payee Financial Details UK - Sort code - Vali
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'lossPayeeDetails', isAppointingLossPayee: true });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'lossPayeeDetails', isAppointingLossPayee: true });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${LOSS_PAYEE_FINANCIAL_DETAILS_UK_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee/loss-payee.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee/loss-payee.spec.js
@@ -36,7 +36,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'broker' });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'broker' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${LOSS_PAYEE_ROOT}`;
         checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee/save-and-back.spec.js
@@ -21,7 +21,7 @@ context('Insurance - Policy - Loss payee page - Save and back', () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'broker' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'broker' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${LOSS_PAYEE_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value-alternative-currency.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Policy - Multiple contract policy - Export value page - Alt
       referenceNumber = refNumber;
 
       cy.completeAndSubmitPolicyForms({
-        formToStopAt: 'multipleContractPolicy',
+        stopSubmittingAfter: 'multipleContractPolicy',
         policyType,
         isoCode: NON_STANDARD_CURRENCY_CODE,
         alternativeCurrency: true,

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value-non-gbp-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value-non-gbp-currency.spec.js
@@ -36,7 +36,7 @@ context('Insurance - Policy - Multiple contract policy - Export value page - Non
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'multipleContractPolicy', policyType, isoCode: USD.isoCode });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'multipleContractPolicy', policyType, isoCode: USD.isoCode });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE}`;
       multipleContractPolicyUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value.spec.js
@@ -38,7 +38,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'multipleContractPolicy', policyType });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'multipleContractPolicy', policyType });
 
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/save-and-back.spec.js
@@ -27,7 +27,7 @@ context('Insurance - Policy - Multiple contract policy Export value page - Save 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'multipleContractPolicy', policyType });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'multipleContractPolicy', policyType });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/validation/multiple-contract-policy-export-value-validation-maximum-buyer-will-owe.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/validation/multiple-contract-policy-export-value-validation-maximum-buyer-will-owe.spec.js
@@ -36,7 +36,7 @@ context('Insurance - Policy - Multiple contract policy - Export value page - for
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'multipleContractPolicy', policyType });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'multipleContractPolicy', policyType });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/validation/multiple-contract-policy-export-value-validation-total-sales-to-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/validation/multiple-contract-policy-export-value-validation-total-sales-to-buyer.spec.js
@@ -36,7 +36,7 @@ context('Insurance - Policy - Multiple contract policy - Export value page - for
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'multipleContractPolicy', policyType });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'multipleContractPolicy', policyType });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/multiple-contract-policy.spec.js
@@ -46,7 +46,7 @@ context('Insurance - Policy - Multiple contract policy page - As an exporter, I 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'policyType', policyType: MULTIPLE });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'policyType', policyType: MULTIPLE });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/save-and-back.spec.js
@@ -18,7 +18,7 @@ context('Insurance - Policy - Multiple contract policy page - Save and go back',
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'policyType', policyType: MULTIPLE });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'policyType', policyType: MULTIPLE });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-requested-start-date.spec.js
@@ -42,7 +42,7 @@ context('Insurance - Policy - Multiple contract policy page - form validation - 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'policyType', policyType: MULTIPLE });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'policyType', policyType: MULTIPLE });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-total-months-of-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation-total-months-of-cover.spec.js
@@ -48,7 +48,7 @@ context('Insurance - Policy - Multiple contract policy page - form validation - 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'policyType', policyType: MULTIPLE });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'policyType', policyType: MULTIPLE });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/validation/multiple-contract-policy-validation.spec.js
@@ -37,7 +37,7 @@ context('Insurance - Policy - Multiple contract policy page - form validation', 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'policyType', policyType: MULTIPLE });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'policyType', policyType: MULTIPLE });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/name-on-policy-page.spec.js
@@ -33,7 +33,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'totalContractValue' });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'totalContractValue' });
 
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${NAME_ON_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/save-and-back.spec.js
@@ -24,7 +24,7 @@ context('Insurance - Policy - Name on policy - Save and go back', () => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'totalContractValue' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'totalContractValue' });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${NAME_ON_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
@@ -35,7 +35,7 @@ context('Insurance - Policy - Name on policy - Validation', () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'totalContractValue' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'totalContractValue' });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${NAME_ON_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/changing-another-company-from-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/changing-another-company-from-yes-to-no.spec.js
@@ -23,7 +23,7 @@ context(`Insurance - Policy - Other company details page - Changing ${REQUESTED}
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'anotherCompany', otherCompanyInvolved: true });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'anotherCompany', otherCompanyInvolved: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${OTHER_COMPANY_DETAILS}`;
       anotherCompanyUrl = `${baseUrl}${ROOT}/${referenceNumber}${ANOTHER_COMPANY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/other-company-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/other-company-details.spec.js
@@ -33,7 +33,7 @@ context(`Insurance - Policy - Other company details page - ${story}`, () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'anotherCompany', otherCompanyInvolved: true });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'anotherCompany', otherCompanyInvolved: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${OTHER_COMPANY_DETAILS}`;
       brokerUrl = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ROOT}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/save-and-back.spec.js
@@ -25,7 +25,7 @@ context('Insurance - Policy - Other company details page - Save and back', () =>
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'anotherCompany', otherCompanyInvolved: true });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'anotherCompany', otherCompanyInvolved: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${OTHER_COMPANY_DETAILS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/validation/other-company-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/other-company-details/validation/other-company-details-validation.spec.js
@@ -33,7 +33,7 @@ context('Insurance - Policy - Other company details page - Validation', () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'anotherCompany', otherCompanyInvolved: true });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'anotherCompany', otherCompanyInvolved: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${OTHER_COMPANY_DETAILS}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/pre-credit-period.spec.js
@@ -32,7 +32,7 @@ context(`Insurance - Policy - Pre-credit period page - ${story}`, () => {
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'nameOnPolicy' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'nameOnPolicy' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${PRE_CREDIT_PERIOD}`;
       anotherCompanyUrl = `${baseUrl}${ROOT}/${referenceNumber}${ANOTHER_COMPANY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/save-and-back.spec.js
@@ -24,7 +24,7 @@ context('Insurance - Policy - Pre-credit period page - Save and go back', () => 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'nameOnPolicy' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'nameOnPolicy' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${PRE_CREDIT_PERIOD}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/save-and-back.spec.js
@@ -25,7 +25,7 @@ context('Insurance - Policy - Single contract policy page - Save and go back', (
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'policyType' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'policyType' });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/single-contract-policy.spec.js
@@ -43,7 +43,7 @@ context('Insurance - Policy - Single contract policy page - As an exporter, I wa
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'policyType' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'policyType' });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/save-and-back.spec.js
@@ -24,7 +24,7 @@ context('Insurance - Policy - Single contract policy - Total contract value page
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'singleContractPolicy' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'singleContractPolicy' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value-alternative-currency.spec.js
@@ -33,7 +33,7 @@ context('Insurance - Policy - Single contract policy - Total contract value page
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'singleContractPolicy', isoCode: NON_STANDARD_CURRENCY_CODE, alternativeCurrency: true });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'singleContractPolicy', isoCode: NON_STANDARD_CURRENCY_CODE, alternativeCurrency: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`;
       singleContractPolicyUrl = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value-non-gbp-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value-non-gbp-currency.spec.js
@@ -33,7 +33,7 @@ context('Insurance - Policy - Single contract policy - Total contract value page
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'singleContractPolicy', isoCode: USD.isoCode });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'singleContractPolicy', isoCode: USD.isoCode });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`;
       singleContractPolicyUrl = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/single-contract-policy-total-contract-value.spec.js
@@ -32,7 +32,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitPolicyForms({ formToStopAt: 'singleContractPolicy' });
+        cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'singleContractPolicy' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/validation/single-contract-policy-credit-limit-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/validation/single-contract-policy-credit-limit-validation.spec.js
@@ -35,7 +35,7 @@ context(`Insurance - Policy - Single contract policy - Total contract value page
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'singleContractPolicy' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'singleContractPolicy' });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/validation/single-contract-policy-total-contract-value-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/total-contract-value/validation/single-contract-policy-total-contract-value-validation.spec.js
@@ -35,7 +35,7 @@ context(`Insurance - Policy - Single contract policy - Total contract value page
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'singleContractPolicy' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'singleContractPolicy' });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY_TOTAL_CONTRACT_VALUE}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-contract-completion-date.spec.js
@@ -45,7 +45,7 @@ context('Insurance - Policy - Single contract policy page - form validation - co
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'policyType' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'policyType' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation-requested-start-date.spec.js
@@ -39,7 +39,7 @@ context('Insurance - Policy - Single contract policy page - form validation - re
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'policyType' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'policyType' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/single-contract-policy/validation/single-contract-policy-validation.spec.js
@@ -36,7 +36,7 @@ context('Insurance - Policy - Single contract policy page - form validation', ()
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitPolicyForms({ formToStopAt: 'policyType' });
+      cy.completeAndSubmitPolicyForms({ stopSubmittingAfter: 'policyType' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${SINGLE_CONTRACT_POLICY}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-export-contract.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/submit-name-fields-with-special-characters/submit-name-fields-with-special-characters-export-contract.spec.js
@@ -26,7 +26,7 @@ context('Insurance - Name fields - Export contract - Name field should render an
       // go to the page we want to test.
       cy.completeAndSubmitExportContractForms({
         isUsingAgent: true,
-        formToStopAt: 'agent',
+        stopSubmittingAfter: 'agent',
       });
 
       agentDetailsUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${AGENT_DETAILS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/alternative-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/alternative-trading-address.spec.js
@@ -45,7 +45,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'companyDetails', differentTradingAddress: true });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'companyDetails', differentTradingAddress: true });
 
         alternativeAddressUrl = `${baseUrl}${ROOT}/${referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/save-and-back.spec.js
@@ -27,7 +27,7 @@ context('Insurance - Your business - Alternative trading address - Save and go b
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'companyDetails', differentTradingAddress: true });
+      cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'companyDetails', differentTradingAddress: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${ALTERNATIVE_TRADING_ADDRESS_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-company-details-trading-address-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-company-details-trading-address-yes-to-no.spec.js
@@ -29,7 +29,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'creditControl', differentTradingAddress: true });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'creditControl', differentTradingAddress: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-company-details.spec.js
@@ -30,7 +30,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'creditControl' });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'creditControl' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-credit-control-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-credit-control-no-to-yes.spec.js
@@ -24,7 +24,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'creditControl', hasCreditControlProcess: false });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'creditControl', hasCreditControlProcess: false });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-credit-control-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-credit-control-yes-to-no.spec.js
@@ -24,7 +24,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'creditControl', hasCreditControlProcess: true });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'creditControl', hasCreditControlProcess: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-nature-of-your-business.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-nature-of-your-business.spec.js
@@ -25,7 +25,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'creditControl' });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'creditControl' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-trading-address.spec.js
@@ -30,7 +30,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'creditControl' });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'creditControl' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/change-your-answers/change-your-answers-change-turnover.spec.js
@@ -28,7 +28,7 @@ context('Insurance - Your business - Change your answers - Turnover - As an expo
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'creditControl' });
+      cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'creditControl' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-page.spec.js
@@ -19,7 +19,7 @@ context('Insurance - Your Business - Check your answers - As an exporter, I want
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'creditControl' });
+      cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'creditControl' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list.spec.js
@@ -28,7 +28,7 @@ context('Insurance - Your business - Check your answers - Summary list - your bu
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'creditControl', hasCreditControlProcess: true });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'creditControl', hasCreditControlProcess: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });
@@ -94,7 +94,7 @@ context('Insurance - Your business - Check your answers - Summary list - your bu
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'creditControl', differentTradingAddress: true });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'creditControl', differentTradingAddress: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });
@@ -120,7 +120,7 @@ context('Insurance - Your business - Check your answers - Summary list - your bu
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'creditControl', differentTradingName: true });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'creditControl', differentTradingName: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control-answer-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control-answer-no.spec.js
@@ -18,7 +18,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'turnover' });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'turnover' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CREDIT_CONTROL}`;
         brokerUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control.spec.js
@@ -28,7 +28,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'turnover' });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'turnover' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CREDIT_CONTROL}`;
         checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/save-and-back.spec.js
@@ -15,7 +15,7 @@ context('Insurance - Your business - Credit control - Save and go back', () => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'turnover' });
+      cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'turnover' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CREDIT_CONTROL}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/nature-of-business-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/nature-of-business-page.spec.js
@@ -32,7 +32,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'companyDetails' });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'companyDetails' });
 
         natureOfBusinessUrl = `${baseUrl}${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/save-and-back.spec.js
@@ -21,7 +21,7 @@ context('Insurance - Your business - Nature of your business page - Save and bac
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'companyDetails' });
+      cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'companyDetails' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
@@ -34,7 +34,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'companyDetails' });
+      cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'companyDetails' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
@@ -34,7 +34,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'companyDetails' });
+      cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'companyDetails' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${NATURE_OF_BUSINESS_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
@@ -27,7 +27,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'companyDetails' });
+      cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'companyDetails' });
 
       url = `${baseUrl}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.NATURE_OF_BUSINESS_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover-currency/turnover-change-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover-currency/turnover-change-currency.spec.js
@@ -24,7 +24,7 @@ context('Insurance - Your business - Turnover currency page - As an Exporter I w
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'natureOfYourBusiness' });
+      cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'natureOfYourBusiness' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${TURNOVER_CURRENCY_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover-currency/turnover-currency-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover-currency/turnover-currency-page.spec.js
@@ -26,7 +26,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'natureOfYourBusiness' });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'natureOfYourBusiness' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${TURNOVER_CURRENCY_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/save-and-back.spec.js
@@ -21,7 +21,7 @@ context('Insurance - Your business - Turnover page - Save and back', () => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'turnoverCurrency' });
+      cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'turnoverCurrency' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${TURNOVER_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-financial-year-end.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-financial-year-end.spec.js
@@ -43,7 +43,7 @@ context(`Insurance - Your business - Turnover page - when ${fieldId} exists`, ()
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'turnoverCurrency' });
+      cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'turnoverCurrency' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${TURNOVER_ROOT}`;
 
@@ -76,7 +76,7 @@ context(`Insurance - Your business - Turnover page - when ${fieldId} does not ex
     }).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'turnoverCurrency' });
+      cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'turnoverCurrency' });
 
       const url = `${baseUrl}${ROOT}/${referenceNumber}${TURNOVER_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
@@ -40,7 +40,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'turnoverCurrency' });
+        cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'turnoverCurrency' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${TURNOVER_ROOT}`;
         creditControlUrl = `${baseUrl}${ROOT}/${referenceNumber}${CREDIT_CONTROL}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
@@ -25,7 +25,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'turnoverCurrency' });
+      cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'turnoverCurrency' });
 
       url = `${baseUrl}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.TURNOVER_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-percentage-turnover-validation.spec.js
@@ -19,7 +19,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBusinessForms({ formToStopAt: 'turnoverCurrency' });
+      cy.completeAndSubmitYourBusinessForms({ stopSubmittingAfter: 'turnoverCurrency' });
 
       url = `${baseUrl}${ROUTES.INSURANCE.ROOT}/${referenceNumber}${ROUTES.INSURANCE.EXPORTER_BUSINESS.TURNOVER_ROOT}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/buyer-financial-information/buyer-financial-information-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/buyer-financial-information/buyer-financial-information-page.spec.js
@@ -35,7 +35,7 @@ context(
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;
         checkYourAnswersUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'tradedWithBuyer' });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'tradedWithBuyer' });
 
         cy.assertUrl(url);
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/buyer-financial-information/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/buyer-financial-information/save-and-back.spec.js
@@ -15,7 +15,7 @@ context('Insurance - Your buyer - Buyer financial information - Save and back', 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'tradedWithBuyer' });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'tradedWithBuyer' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-alternative-currency.spec.js
@@ -27,7 +27,7 @@ context('Insurance - Your buyer - Change your answers - Alternative currency - A
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation', exporterHasTradedWithBuyer: true, outstandingPayments: true });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation', exporterHasTradedWithBuyer: true, outstandingPayments: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-buyer-financial-accounts.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-buyer-financial-accounts.spec.js
@@ -22,7 +22,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation' });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-company-or-organisation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-company-or-organisation.spec.js
@@ -25,7 +25,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation' });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-connection-with-buyer-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-connection-with-buyer-no-to-yes.spec.js
@@ -22,7 +22,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation', hasConnectionToBuyer: false });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation', hasConnectionToBuyer: false });
 
         checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-connection-with-buyer-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-connection-with-buyer-yes-to-no.spec.js
@@ -22,7 +22,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation', hasConnectionToBuyer: true });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation', hasConnectionToBuyer: true });
 
         checkYourAnswersUrl = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-credit-insurance-history.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-credit-insurance-history.spec.js
@@ -25,7 +25,7 @@ context(
       cy.completeSignInAndGoToApplication({ totalContractValueOverThreshold: true }).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation' });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation' });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-traded-with-buyer-no-to-yes-outstanding-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-traded-with-buyer-no-to-yes-outstanding-no.spec.js
@@ -25,7 +25,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation', exporterHasTradedWithBuyer: false });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation', exporterHasTradedWithBuyer: false });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-traded-with-buyer-no-to-yes-outstanding-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-traded-with-buyer-no-to-yes-outstanding-yes.spec.js
@@ -35,7 +35,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation', exporterHasTradedWithBuyer: false });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation', exporterHasTradedWithBuyer: false });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-traded-with-buyer-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-traded-with-buyer-yes-to-no.spec.js
@@ -27,7 +27,7 @@ context(
         referenceNumber = refNumber;
 
         cy.completeAndSubmitYourBuyerForms({
-          formToStopAt: 'buyerFinancialInformation',
+          stopSubmittingAfter: 'buyerFinancialInformation',
           exporterHasTradedWithBuyer: true,
           outstandingPayments: true,
           failedToPay: true,

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-trading-history-failed-payments.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-trading-history-failed-payments.spec.js
@@ -24,7 +24,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation', exporterHasTradedWithBuyer: true, failedToPay: true });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation', exporterHasTradedWithBuyer: true, failedToPay: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-trading-history-outstanding-payments-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-trading-history-outstanding-payments-no-to-yes.spec.js
@@ -31,7 +31,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation', exporterHasTradedWithBuyer: true });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation', exporterHasTradedWithBuyer: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-trading-history-outstanding-payments-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-trading-history-outstanding-payments-yes-to-no.spec.js
@@ -25,7 +25,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation', exporterHasTradedWithBuyer: true });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation', exporterHasTradedWithBuyer: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
         tradingHistoryUrl = `${baseUrl}${ROOT}/${referenceNumber}${TRADING_HISTORY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer-no-to-yes.spec.js
@@ -36,7 +36,7 @@ context(
       cy.completeSignInAndGoToApplication({ totalContractValueOverThreshold: true }).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation', hasConnectionToBuyer: false });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation', hasConnectionToBuyer: false });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/change-your-answers/change-your-answers-change-working-with-buyer-yes-to-no.spec.js
@@ -34,7 +34,7 @@ context(
       cy.completeSignInAndGoToApplication({ totalContractValueOverThreshold: true }).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation', hasConnectionToBuyer: true });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation', hasConnectionToBuyer: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
         connectionWithBuyerUrl = `${baseUrl}${ROOT}/${referenceNumber}${CONNECTION_WITH_BUYER}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/check-your-answers/check-your-answers-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/check-your-answers/check-your-answers-page.spec.js
@@ -19,7 +19,7 @@ context('Insurance - Your buyer - Check your answers - As an exporter, I want to
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation' });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/check-your-answers/check-your-answers-summary-list/check-your-answers-summary-list-minimal.spec.js
@@ -39,7 +39,7 @@ context(
         cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
           referenceNumber = refNumber;
 
-          cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'buyerFinancialInformation' });
+          cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'buyerFinancialInformation' });
 
           url = `${baseUrl}${ROOT}/${referenceNumber}${CHECK_YOUR_ANSWERS}`;
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-with-the-buyer/connection-with-the-buyer-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-with-the-buyer/connection-with-the-buyer-page.spec.js
@@ -27,7 +27,7 @@ context(
       cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
         referenceNumber = refNumber;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'companyOrOrganisation' });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'companyOrOrganisation' });
 
         url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CONNECTION_WITH_BUYER_ROUTE}`;
         tradedWithBuyerUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${TRADED_WITH_BUYER}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-with-the-buyer/save-and-back/no-connection-with-the-buyer-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-with-the-buyer/save-and-back/no-connection-with-the-buyer-save-and-back.spec.js
@@ -15,7 +15,7 @@ context('Insurance - Your buyer - Connection with the buyer - No connection to b
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'companyOrOrganisation' });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'companyOrOrganisation' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CONNECTION_WITH_BUYER_ROUTE}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-with-the-buyer/save-and-back/yes-connection-with-the-buyer-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-with-the-buyer/save-and-back/yes-connection-with-the-buyer-save-and-back.spec.js
@@ -22,7 +22,7 @@ context('Insurance - Your buyer - Connection with the buyer - Has connection to 
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'companyOrOrganisation' });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'companyOrOrganisation' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CONNECTION_WITH_BUYER_ROUTE}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-with-the-buyer/validation/connection-with-the-buyer-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-with-the-buyer/validation/connection-with-the-buyer-validation.spec.js
@@ -25,7 +25,7 @@ context('Insurance - Your buyer - Connection to the buyer page - form validation
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'companyOrOrganisation' });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'companyOrOrganisation' });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${CONNECTION_WITH_BUYER_ROUTE}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/credit-insurance-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/credit-insurance-cover.spec.js
@@ -33,7 +33,7 @@ context(
         url = `${baseUrl}${ROOT}/${referenceNumber}${CREDIT_INSURANCE_COVER}`;
         buyerFinancialInformationUrl = `${baseUrl}${ROOT}/${referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'tradedWithBuyer' });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'tradedWithBuyer' });
 
         cy.assertUrl(url);
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/save-and-back/credit-insurance-cover-answer-no-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/save-and-back/credit-insurance-cover-answer-no-save-and-back.spec.js
@@ -15,7 +15,7 @@ context('Insurance - Your buyer - Credit insurance cover - Save and back - No', 
     cy.completeSignInAndGoToApplication({ totalContractValueOverThreshold: true }).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'tradedWithBuyer' });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'tradedWithBuyer' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CREDIT_INSURANCE_COVER}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/save-and-back/credit-insurance-cover-answer-yes-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/save-and-back/credit-insurance-cover-answer-yes-save-and-back.spec.js
@@ -22,7 +22,7 @@ context('Insurance - Your buyer - Credit insurance cover - Save and back - Yes',
     cy.completeSignInAndGoToApplication({ totalContractValueOverThreshold: true }).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'tradedWithBuyer' });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'tradedWithBuyer' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CREDIT_INSURANCE_COVER}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/validation/credit-insurance-cover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/validation/credit-insurance-cover-validation.spec.js
@@ -27,7 +27,7 @@ context('Insurance - Your buyer - Credit insurance cover - form validation', () 
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CREDIT_INSURANCE_COVER}`;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'tradedWithBuyer' });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'tradedWithBuyer' });
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/currency-of-late-payments/currency-of-late-payments-change-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/currency-of-late-payments/currency-of-late-payments-change-currency.spec.js
@@ -21,7 +21,7 @@ context('Insurance - Your business - Turnover currency page - As an Exporter I w
       referenceNumber = refNumber;
 
       // go to the page we want to test.
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'tradingHistoryWithBuyer', outstandingPayments: true, exporterHasTradedWithBuyer: true });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'tradingHistoryWithBuyer', outstandingPayments: true, exporterHasTradedWithBuyer: true });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${CURRENCY_OF_LATE_PAYMENTS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/currency-of-late-payments/currency-of-late-payments.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/currency-of-late-payments/currency-of-late-payments.spec.js
@@ -33,7 +33,7 @@ context(
         referenceNumber = refNumber;
 
         // go to the page we want to test.
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'tradingHistoryWithBuyer', outstandingPayments: true, exporterHasTradedWithBuyer: true });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'tradingHistoryWithBuyer', outstandingPayments: true, exporterHasTradedWithBuyer: true });
 
         url = `${baseUrl}${ROOT}/${referenceNumber}${CURRENCY_OF_LATE_PAYMENTS}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/failed-to-pay-on-time/failed-to-pay-on-time-total-contract-value-over-threshold.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/failed-to-pay-on-time/failed-to-pay-on-time-total-contract-value-over-threshold.spec.js
@@ -19,7 +19,7 @@ context('Insurance - Your buyer - Failed to pay on time page - total contract va
       url = `${baseUrl}${ROOT}/${referenceNumber}${FAILED_TO_PAY}`;
       creditInsuranceCoverUrl = `${baseUrl}${ROOT}/${referenceNumber}${CREDIT_INSURANCE_COVER}`;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'outstandingOrOverduePayments', exporterHasTradedWithBuyer: true, outstandingPayments: true });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'outstandingOrOverduePayments', exporterHasTradedWithBuyer: true, outstandingPayments: true });
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/failed-to-pay-on-time/failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/failed-to-pay-on-time/failed-to-pay-on-time.spec.js
@@ -30,7 +30,11 @@ context(
         url = `${baseUrl}${ROOT}/${referenceNumber}${FAILED_TO_PAY}`;
         buyerFinancialInformationUrl = `${baseUrl}${ROOT}/${referenceNumber}${BUYER_FINANCIAL_INFORMATION}`;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'outstandingOrOverduePayments', exporterHasTradedWithBuyer: true, outstandingPayments: true });
+        cy.completeAndSubmitYourBuyerForms({
+          stopSubmittingAfter: 'outstandingOrOverduePayments',
+          exporterHasTradedWithBuyer: true,
+          outstandingPayments: true,
+        });
 
         cy.assertUrl(url);
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/failed-to-pay-on-time/save-and-back/failed-to-pay-on-time-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/failed-to-pay-on-time/save-and-back/failed-to-pay-on-time-save-and-back.spec.js
@@ -18,7 +18,7 @@ context('Insurance - Your buyer - Failed to pay on time - Save and back', () => 
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${FAILED_TO_PAY}`;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'outstandingOrOverduePayments', exporterHasTradedWithBuyer: true, outstandingPayments: true });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'outstandingOrOverduePayments', exporterHasTradedWithBuyer: true, outstandingPayments: true });
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/failed-to-pay-on-time/validation/failed-to-pay-on-time-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/failed-to-pay-on-time/validation/failed-to-pay-on-time-validation.spec.js
@@ -26,7 +26,7 @@ context('Insurance - Your buyer - Failed to pay on time page - Validation', () =
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${FAILED_TO_PAY}`;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'outstandingOrOverduePayments', exporterHasTradedWithBuyer: true, outstandingPayments: true });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'outstandingOrOverduePayments', exporterHasTradedWithBuyer: true, outstandingPayments: true });
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-alternative-currency.spec.js
@@ -26,7 +26,7 @@ context('Insurance - Your buyer - Outstanding or overdue payments - Alternative 
       url = `${baseUrl}${ROOT}/${referenceNumber}${OUTSTANDING_OR_OVERDUE_PAYMENTS}`;
 
       cy.completeAndSubmitYourBuyerForms({
-        formToStopAt: 'currencyOfLatePayments',
+        stopSubmittingAfter: 'currencyOfLatePayments',
         outstandingPayments: true,
         exporterHasTradedWithBuyer: true,
         alternativeCurrency: true,

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-non-gbp-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments-non-gbp-currency.spec.js
@@ -26,7 +26,7 @@ context('Insurance - Your buyer - Outstanding or overdue payments - Non-GBP (sup
       url = `${baseUrl}${ROOT}/${referenceNumber}${OUTSTANDING_OR_OVERDUE_PAYMENTS}`;
 
       cy.completeAndSubmitYourBuyerForms({
-        formToStopAt: 'currencyOfLatePayments',
+        stopSubmittingAfter: 'currencyOfLatePayments',
         outstandingPayments: true,
         exporterHasTradedWithBuyer: true,
         isoCode: USD.isoCode,

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/outstanding-or-overdue-payments.spec.js
@@ -37,7 +37,7 @@ context(
         failedToPayUrl = `${baseUrl}${ROOT}/${referenceNumber}${FAILED_TO_PAY}`;
         tradingHistoryUrl = `${baseUrl}${ROOT}/${referenceNumber}${TRADING_HISTORY}`;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'currencyOfLatePayments', outstandingPayments: true, exporterHasTradedWithBuyer: true });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'currencyOfLatePayments', outstandingPayments: true, exporterHasTradedWithBuyer: true });
 
         cy.assertUrl(url);
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/save-and-back/outstanding-or-overdue-payments-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/save-and-back/outstanding-or-overdue-payments-save-and-back.spec.js
@@ -24,7 +24,7 @@ context('Insurance - Your buyer - Outstanding or overdue payments - Save and bac
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${OUTSTANDING_OR_OVERDUE_PAYMENTS}`;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'currencyOfLatePayments', outstandingPayments: true, exporterHasTradedWithBuyer: true });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'currencyOfLatePayments', outstandingPayments: true, exporterHasTradedWithBuyer: true });
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/validation/outstanding-or-overdue-payments-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/outstanding-or-overdue-payments/validation/outstanding-or-overdue-payments-validation.spec.js
@@ -52,7 +52,7 @@ context('Insurance - Your buyer - Outstanding or overdue payments - validation',
       url = `${baseUrl}${ROOT}/${referenceNumber}${OUTSTANDING_OR_OVERDUE_PAYMENTS}`;
       failedToPayUrl = `${baseUrl}${ROOT}/${referenceNumber}${FAILED_TO_PAY}`;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'currencyOfLatePayments', outstandingPayments: true, exporterHasTradedWithBuyer: true });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'currencyOfLatePayments', outstandingPayments: true, exporterHasTradedWithBuyer: true });
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/save-and-back.spec.js
@@ -15,7 +15,7 @@ context('Insurance - Your buyer - Working with buyer - Save and back', () => {
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'connectionWithTheBuyer' });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'connectionWithTheBuyer' });
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${TRADED_WITH_BUYER}`;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/traded-with-buyer-total-contract-value-over-threshold.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/traded-with-buyer-total-contract-value-over-threshold.spec.js
@@ -17,7 +17,7 @@ context('Insurance - Your buyer - Traded with buyer page - Submission with total
     cy.completeSignInAndGoToApplication({ totalContractValueOverThreshold: true }).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'connectionWithTheBuyer' });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'connectionWithTheBuyer' });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${TRADED_WITH_BUYER}`;
       tradingHistoryUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${TRADING_HISTORY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/traded-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/traded-with-buyer.spec.js
@@ -30,7 +30,7 @@ context('Insurance - Your buyer - Traded with buyer page - As an exporter, I wan
     cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
       referenceNumber = refNumber;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'connectionWithTheBuyer' });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'connectionWithTheBuyer' });
 
       url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${TRADED_WITH_BUYER}`;
       tradingHistoryUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${TRADING_HISTORY}`;

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/save-and-back/trading-history-save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/save-and-back/trading-history-save-and-back.spec.js
@@ -18,7 +18,7 @@ context('Insurance - Your buyer - Trading history - No outstanding payments - Sa
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${TRADING_HISTORY}`;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'tradedWithBuyer', exporterHasTradedWithBuyer: true });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'tradedWithBuyer', exporterHasTradedWithBuyer: true });
 
       cy.assertUrl(url);
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/trading-history-page.spec.js
@@ -32,7 +32,7 @@ context(
         failedToPayUrl = `${baseUrl}${ROOT}/${referenceNumber}${FAILED_TO_PAY}`;
         currencyOfLatePaymentsUrl = `${baseUrl}${ROOT}/${referenceNumber}${CURRENCY_OF_LATE_PAYMENTS}`;
 
-        cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'tradedWithBuyer', exporterHasTradedWithBuyer: true });
+        cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'tradedWithBuyer', exporterHasTradedWithBuyer: true });
 
         cy.assertUrl(url);
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/validation/trading-history-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/trading-history/validation/trading-history-validation.spec.js
@@ -26,7 +26,7 @@ context('Insurance - Your buyer - Trading history page - Validation', () => {
 
       url = `${baseUrl}${ROOT}/${referenceNumber}${TRADING_HISTORY}`;
 
-      cy.completeAndSubmitYourBuyerForms({ formToStopAt: 'tradedWithBuyer', exporterHasTradedWithBuyer: true });
+      cy.completeAndSubmitYourBuyerForms({ stopSubmittingAfter: 'tradedWithBuyer', exporterHasTradedWithBuyer: true });
 
       cy.assertUrl(url);
     });


### PR DESCRIPTION
## Introduction :pencil2:
- Some cypress commands that complete X forms in a section, have a param called `formToStopAt`.
- `formToStopAt` is a confusing param because it does not actually stop at the provided form name. Instead, the provided form name is the _last_ form to be submitted.

For example, if the flow is:

1) "Agent details" form
2) "Agent service" form

In the "Agent service" E2E test, we have the following:

```js
cy.completeAndSubmitExportContractForms({ formToStopAt: 'agentDetails' });
```

What actually happens is, the "Agent details" form is submitted and the flow is stopped at the "Agent service" form. It is not "stopping" on the `agentDetails` form.

This is misleading and so it should be renamed.

## Resolution :heavy_check_mark:
- Rename `formToStopAt` to `stopSubmittingAfter`
