### PR TITLE
chore(EMS-3980): remove unnecessary 'should exist' e2e assertions

### DIFF
--- a/e2e-tests/commands/core-page-checks.js
+++ b/e2e-tests/commands/core-page-checks.js
@@ -21,7 +21,6 @@ const baseUrl = Cypress.config('baseUrl');
  * @param {String} expectedHref - Expected "back" HREF/route
  */
 const checkBackLink = (currentHref, expectedHref) => {
-  backLinkSelector().should('exist');
   cy.checkText(backLinkSelector(), LINKS.BACK);
 
   cy.clickBackLink();

--- a/e2e-tests/commands/insurance/account/assert-password-reveal-button.js
+++ b/e2e-tests/commands/insurance/account/assert-password-reveal-button.js
@@ -14,8 +14,6 @@ const EXPECTED_ARIA_LABELS = {
 };
 
 const shouldRender = () => {
-  passwordField.revealButton().should('exist');
-
   cy.checkText(passwordField.revealButton(), FIELD_STRINGS.REVEAL.SHOW);
   cy.checkAriaLabel(passwordField.revealButton(), EXPECTED_ARIA_LABELS.SHOW);
 };

--- a/e2e-tests/commands/shared-commands/assertions/check-email-field-rendering.js
+++ b/e2e-tests/commands/shared-commands/assertions/check-email-field-rendering.js
@@ -11,8 +11,6 @@ const checkEmailFieldRendering = ({ fieldId, contentStrings }) => {
 
   cy.checkText(field.label(), contentStrings.LABEL);
 
-  field.input().should('exist');
-
   cy.checkTypeAttribute(field.input(), 'email');
 };
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/enter-code/account-sign-in-enter-code.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/account/sign-in/enter-code/account-sign-in-enter-code.spec.js
@@ -69,8 +69,6 @@ context(
 
           cy.checkText(field.label(), FIELD_STRINGS.LABEL);
 
-          field.input().should('exist');
-
           cy.checkClassName(field.input(), 'govuk-input govuk-input--width-4 govuk-input--extra-letter-spacing');
         });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/all-sections.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/all-sections.spec.js
@@ -165,13 +165,10 @@ context('Insurance - All sections - new application', () => {
     });
 
     it('should render a heading', () => {
-      insurance.allSectionsPage.submissionDeadlineHeading().should('exist');
       cy.checkText(insurance.allSectionsPage.submissionDeadlineHeading(), CONTENT_STRINGS.DEADLINE_TO_SUBMIT);
     });
 
     it('should render correct submission deadline', () => {
-      insurance.allSectionsPage.submissionDeadline().should('exist');
-
       const now = new Date();
 
       const timestamp = addMonths(new Date(now), APPLICATION.SUBMISSION_DEADLINE_IN_MONTHS);
@@ -187,13 +184,10 @@ context('Insurance - All sections - new application', () => {
     });
 
     it('should render a heading', () => {
-      insurance.allSectionsPage.yourReferenceNumberHeading().should('exist');
       cy.checkText(insurance.allSectionsPage.yourReferenceNumberHeading(), CONTENT_STRINGS.REFERENCE_NUMBER);
     });
 
     it('should render correct reference number', () => {
-      insurance.allSectionsPage.yourReferenceNumber().should('exist');
-
       const expectedReferenceNumber = String(referenceNumber);
 
       cy.checkText(insurance.allSectionsPage.yourReferenceNumber(), expectedReferenceNumber);

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/anti-bribery-expandable-definition-content.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/anti-bribery-expandable-definition-content.spec.js
@@ -50,8 +50,6 @@ context('Insurance - Declarations - Anti-bribery page - expandable `definition` 
   });
 
   it('renders summary text', () => {
-    expandable.summary().should('exist');
-
     cy.checkText(expandable.summary(), INTRO);
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply/cannot-apply-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cannot-apply/cannot-apply-page.spec.js
@@ -42,9 +42,8 @@ context(
     });
 
     it('renders a reason', () => {
-      cannotApplyPage.reason().should('exist');
-
       const expected = `${REASON.INTRO} ${REASON.UNSUPPORTED_BUYER_COUNTRY_1} ${COUNTRY_NAME}, ${REASON.UNSUPPORTED_BUYER_COUNTRY_2}`;
+
       cy.checkText(cannotApplyPage.reason(), expected);
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/eligible-to-apply-online/eligible-to-apply-online.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/eligible-to-apply-online/eligible-to-apply-online.spec.js
@@ -51,8 +51,6 @@ context(
       });
 
       it('renders inset text', () => {
-        eligibleToApplyOnlinePage.insetText().should('exist');
-
         cy.checkText(eligibleToApplyOnlinePage.insetText(), CONTENT_STRINGS.INSET);
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
@@ -125,7 +125,6 @@ context(
       it('should display the company website text input', () => {
         cy.checkText(field(WEBSITE).label(), CONTENT_STRINGS.WEBSITE);
 
-        field(WEBSITE).input().should('exist');
         cy.checkAriaLabel(field(WEBSITE).input(), CONTENT_STRINGS.WEBSITE);
       });
 
@@ -134,7 +133,6 @@ context(
 
         cy.checkText(field(PHONE_NUMBER).hint(), CONTENT_STRINGS.PHONE_NUMBER_HINT);
 
-        field(PHONE_NUMBER).input().should('exist');
         cy.checkAriaLabel(field(PHONE_NUMBER).input(), CONTENT_STRINGS.PHONE_NUMBER);
       });
     });

--- a/e2e-tests/quote/cypress/e2e/journeys/cookies-consent/banner/cookies-consent-reject.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/cookies-consent/banner/cookies-consent-reject.spec.js
@@ -45,7 +45,6 @@ context('Cookies consent - reject', () => {
 
       cy.checkLink(cookieBanner.cookiesLink(), ROUTES.COOKIES, COOKIES_CONSENT.COOKIES_LINK);
 
-      cookieBanner.hideButton().should('exist');
       cy.checkText(cookieBanner.hideButton(), COOKIES_CONSENT.HIDE_BUTTON);
     });
 

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-policy-type-and-length.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/change-your-answers/change-your-answers-policy-type-and-length.spec.js
@@ -178,8 +178,6 @@ context('Change your answers - as an exporter, I want to change the details befo
       });
 
       it('renders a back link with correct url', () => {
-        backLink().should('exist');
-
         const expectedHref = `${baseUrl}${CHECK_YOUR_ANSWERS}`;
 
         cy.checkLink(backLink(), expectedHref, LINKS.BACK);

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-multi-policy.spec.js
@@ -61,7 +61,6 @@ context('Tell us about your multiple policy page - as an exporter, I want to pro
 
       const field = fieldSelector(fieldId);
 
-      field.legend().should('exist');
       cy.checkText(field.legend(), FIELDS[fieldId].MULTIPLE_POLICY.LEGEND);
     });
 

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/tell-us-about-your-policy/tell-us-about-your-single-policy.spec.js
@@ -67,7 +67,6 @@ context('Tell us about your single policy page - as an exporter, I want to provi
 
       const field = fieldSelector(fieldId);
 
-      field.legend().should('exist');
       cy.checkText(field.legend(), FIELDS[fieldId].SINGLE_POLICY.LEGEND);
     });
 

--- a/e2e-tests/quote/cypress/e2e/journeys/skip-link.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/skip-link.spec.js
@@ -10,8 +10,6 @@ context('Skip link should take user to the main content of a page', () => {
   it("When a user keyboard tabs from the html body, skip link should be focused and take the user to the page's #main-content", () => {
     cy.navigateToRootUrl();
 
-    skipLink().should('exist');
-
     cy.checkText(skipLink(), LINKS.SKIP_TO_MAIN_CONTENT);
   });
 });


### PR DESCRIPTION
## Introduction :pencil2:
Some E2E tests were checking that an element exists, before asserting something in the element.

This is unnecessary because if the element doesn't exist, the proceeding assertion would fail.

## Resolution :heavy_check_mark:
- Remove unnecessary `should('exist')` assertions.