### PR TITLE
chore(EMS-3983): dry heading caption cypress selectors

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-confirm-address/broker-confirm-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-confirm-address/broker-confirm-address.spec.js
@@ -1,5 +1,4 @@
-import { headingCaption } from '../../../../../../partials';
-import { insetTextHtml, insetTextHtmlLineBreak } from '../../../../../../pages/shared';
+import { insetTextHtml, insetTextHtmlLineBreak, headingCaption } from '../../../../../../pages/shared';
 import { brokerConfirmAddressPage } from '../../../../../../pages/insurance/policy';
 import { BUTTONS, PAGES } from '../../../../../../content-strings';
 import { EXPECTED_SINGLE_LINE_STRING } from '../../../../../../constants';

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-details/broker-details-page.spec.js
@@ -1,5 +1,4 @@
-import { headingCaption } from '../../../../../../partials';
-import { field as fieldSelector } from '../../../../../../pages/shared';
+import { field as fieldSelector, headingCaption } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
@@ -1,6 +1,5 @@
 import { brokerPage } from '../../../../../../pages/insurance/policy';
-import { headingCaption } from '../../../../../../partials';
-import { field as fieldSelector, yesRadio, noRadio, noRadioInput } from '../../../../../../pages/shared';
+import { field as fieldSelector, yesRadio, noRadio, noRadioInput, headingCaption } from '../../../../../../pages/shared';
 import { PAGES, ERROR_MESSAGES, LINKS } from '../../../../../../content-strings';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/loss-payee-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/loss-payee-details.spec.js
@@ -1,5 +1,4 @@
-import { headingCaption } from '../../../../../../partials';
-import { field as fieldSelector } from '../../../../../../pages/shared';
+import { field as fieldSelector, headingCaption } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/loss-payee-financial-details-international.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-international/loss-payee-financial-details-international.spec.js
@@ -1,5 +1,4 @@
-import { headingCaption } from '../../../../../../partials';
-import { field as fieldSelector } from '../../../../../../pages/shared';
+import { field as fieldSelector, headingCaption } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/loss-payee-financial-details-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-financial-details-uk/loss-payee-financial-details-uk.spec.js
@@ -1,5 +1,4 @@
-import { headingCaption } from '../../../../../../partials';
-import { field as fieldSelector } from '../../../../../../pages/shared';
+import { field as fieldSelector, headingCaption } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee/loss-payee.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee/loss-payee.spec.js
@@ -1,5 +1,4 @@
-import { headingCaption } from '../../../../../../partials';
-import { field as fieldSelector, noRadio, noRadioInput, yesRadio } from '../../../../../../pages/shared';
+import { field as fieldSelector, headingCaption, noRadio, noRadioInput, yesRadio } from '../../../../../../pages/shared';
 import { ERROR_MESSAGES, PAGES } from '../../../../../../content-strings';
 import { FIELD_VALUES } from '../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/alternative-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/alternative-trading-address.spec.js
@@ -1,5 +1,5 @@
-import { headingCaption, html } from '../../../../../../partials';
-import { field as fieldSelector } from '../../../../../../pages/shared';
+import { html } from '../../../../../../partials';
+import { field as fieldSelector, headingCaption } from '../../../../../../pages/shared';
 import { PAGES, ERROR_MESSAGES } from '../../../../../../content-strings';
 import { EXPORTER_BUSINESS_FIELDS as FIELD_STRINGS } from '../../../../../../content-strings/fields/insurance/business';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
@@ -1,6 +1,5 @@
 import { companyDetails } from '../../../../../../pages/your-business';
-import { headingCaption } from '../../../../../../partials';
-import { body, field, yesRadioInput, noRadioInput } from '../../../../../../pages/shared';
+import { body, field, headingCaption, noRadioInput, yesRadioInput } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control.spec.js
@@ -1,5 +1,4 @@
-import { headingCaption } from '../../../../../../partials';
-import { yesNoRadioHint, yesRadio, noRadio } from '../../../../../../pages/shared';
+import { headingCaption, noRadio, yesNoRadioHint, yesRadio } from '../../../../../../pages/shared';
 import { ERROR_MESSAGES, PAGES } from '../../../../../../content-strings';
 import { EXPORTER_BUSINESS_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/business';
 import { FIELD_VALUES } from '../../../../../../constants';

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/nature-of-business-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/nature-of-business-page.spec.js
@@ -1,5 +1,4 @@
-import { headingCaption } from '../../../../../../partials';
-import { field as fieldSelector } from '../../../../../../pages/shared';
+import { field as fieldSelector, headingCaption } from '../../../../../../pages/shared';
 import { PAGES } from '../../../../../../content-strings';
 import { EXPORTER_BUSINESS_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/business';
 import { INSURANCE_FIELD_IDS } from '../../../../../../constants/field-ids/insurance';

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
@@ -1,5 +1,4 @@
-import { headingCaption } from '../../../../../../partials';
-import { field as fieldSelector } from '../../../../../../pages/shared';
+import { field as fieldSelector, headingCaption } from '../../../../../../pages/shared';
 import { turnoverPage } from '../../../../../../pages/your-business';
 import { PAGES } from '../../../../../../content-strings';
 import { EXPORTER_BUSINESS_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/business';

--- a/e2e-tests/pages/shared/index.js
+++ b/e2e-tests/pages/shared/index.js
@@ -16,7 +16,7 @@ const emailPrefix = () => cy.get('[data-cy="email-prefix"]');
 const emailLink = () => cy.get('[data-cy="email-link"]');
 const form = () => cy.get('[data-cy="form"]');
 const heading = () => cy.get('[data-cy="heading"]');
-const headingCaption = () => cy.get('[data-cy="heading-caption"]');
+const headingCaption = () => cy.get('[data-cy="{{ DATA_CY.HEADING_CAPTION }}"]');
 const insetText = () => cy.get('[data-cy="inset-text"]');
 const insetTextHtml = () => cy.get('[data-cy="inset-text-html"]');
 const insetTextHtmlLineBreak = () => cy.get('[data-cy="inset-text-html"] br');

--- a/e2e-tests/pages/shared/index.js
+++ b/e2e-tests/pages/shared/index.js
@@ -16,7 +16,7 @@ const emailPrefix = () => cy.get('[data-cy="email-prefix"]');
 const emailLink = () => cy.get('[data-cy="email-link"]');
 const form = () => cy.get('[data-cy="form"]');
 const heading = () => cy.get('[data-cy="heading"]');
-const headingCaption = () => cy.get('[data-cy="{{ DATA_CY.HEADING_CAPTION }}"]');
+const headingCaption = () => cy.get('[data-cy="heading-caption"]');
 const insetText = () => cy.get('[data-cy="inset-text"]');
 const insetTextHtml = () => cy.get('[data-cy="inset-text-html"]');
 const insetTextHtmlLineBreak = () => cy.get('[data-cy="inset-text-html"] br');

--- a/e2e-tests/partials/headingCaption.js
+++ b/e2e-tests/partials/headingCaption.js
@@ -1,1 +1,0 @@
-export const headingCaption = () => cy.get('[data-cy="heading-caption');

--- a/e2e-tests/partials/index.js
+++ b/e2e-tests/partials/index.js
@@ -4,7 +4,6 @@ export * from './creditPeriodWithBuyer';
 export * from './errorSummaryList';
 export * from './footer';
 export * from './header';
-export * from './headingCaption';
 export * from './html';
 export * from './insurance';
 export * from './pagination';

--- a/src/ui/server/helpers/page-variables/core/index.test.ts
+++ b/src/ui/server/helpers/page-variables/core/index.test.ts
@@ -64,6 +64,7 @@ describe('server/helpers/page-variables/core', () => {
         ATTRIBUTES,
         DATA_CY: {
           HEADING: 'heading',
+          HEADING_CAPTION: 'heading-caption',
           BACK_LINK: 'back-link',
           INTRO: 'intro',
         },
@@ -101,6 +102,7 @@ describe('server/helpers/page-variables/core', () => {
         ATTRIBUTES,
         DATA_CY: {
           HEADING: 'heading',
+          HEADING_CAPTION: 'heading-caption',
           BACK_LINK: 'back-link',
           INTRO: 'intro',
         },
@@ -138,6 +140,7 @@ describe('server/helpers/page-variables/core', () => {
         ATTRIBUTES,
         DATA_CY: {
           HEADING: 'heading',
+          HEADING_CAPTION: 'heading-caption',
           BACK_LINK: 'back-link',
           INTRO: 'intro',
         },
@@ -176,6 +179,7 @@ describe('server/helpers/page-variables/core', () => {
         ATTRIBUTES,
         DATA_CY: {
           HEADING: 'heading',
+          HEADING_CAPTION: 'heading-caption',
           BACK_LINK: 'back-link',
           INTRO: 'intro',
         },
@@ -214,6 +218,7 @@ describe('server/helpers/page-variables/core', () => {
         ATTRIBUTES,
         DATA_CY: {
           HEADING: 'heading',
+          HEADING_CAPTION: 'heading-caption',
           BACK_LINK: 'back-link',
           INTRO: 'intro',
         },

--- a/src/ui/server/helpers/page-variables/core/index.ts
+++ b/src/ui/server/helpers/page-variables/core/index.ts
@@ -74,6 +74,7 @@ const corePageVariables = ({ PAGE_CONTENT_STRINGS, BACK_LINK, ORIGINAL_URL, USE_
     ATTRIBUTES,
     DATA_CY: {
       HEADING: 'heading',
+      HEADING_CAPTION: 'heading-caption',
       BACK_LINK: 'back-link',
       INTRO: 'intro',
     },

--- a/src/ui/templates/insurance/check-your-answers/check-your-answers.njk
+++ b/src/ui/templates/insurance/check-your-answers/check-your-answers.njk
@@ -34,7 +34,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>
   </div>

--- a/src/ui/templates/insurance/declarations/anti-bribery.njk
+++ b/src/ui/templates/insurance/declarations/anti-bribery.njk
@@ -27,7 +27,7 @@
     }) }}
   {% endif %}
 
-  <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+  <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
   <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 
   <div class="govuk-grid-row">

--- a/src/ui/templates/insurance/declarations/confidentiality.njk
+++ b/src/ui/templates/insurance/declarations/confidentiality.njk
@@ -27,7 +27,7 @@
     }) }}
   {% endif %}
 
-  <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+  <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
   <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 
   <div class="govuk-grid-row">

--- a/src/ui/templates/insurance/eligibility/check-your-answers.njk
+++ b/src/ui/templates/insurance/eligibility/check-your-answers.njk
@@ -21,7 +21,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
 
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-l" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 
       {{ govukSummaryList({

--- a/src/ui/templates/insurance/export-contract/about-goods-or-services.njk
+++ b/src/ui/templates/insurance/export-contract/about-goods-or-services.njk
@@ -28,7 +28,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
       <div class="govuk-grid-column-three-quarters-from-desktop govuk-!-padding-right-0 govuk-!-padding-left-0">
-        <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+        <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
         <h1 class="govuk-heading-l" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
       </div>
     </div>

--- a/src/ui/templates/insurance/export-contract/agent-charges.njk
+++ b/src/ui/templates/insurance/export-contract/agent-charges.njk
@@ -29,7 +29,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>
   </div>

--- a/src/ui/templates/insurance/export-contract/agent-details.njk
+++ b/src/ui/templates/insurance/export-contract/agent-details.njk
@@ -30,7 +30,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>
   </div>

--- a/src/ui/templates/insurance/export-contract/agent-service.njk
+++ b/src/ui/templates/insurance/export-contract/agent-service.njk
@@ -28,7 +28,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>
   </div>

--- a/src/ui/templates/insurance/export-contract/check-your-answers.njk
+++ b/src/ui/templates/insurance/export-contract/check-your-answers.njk
@@ -19,7 +19,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-l" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>
   </div>

--- a/src/ui/templates/insurance/export-contract/declined-by-private-market.njk
+++ b/src/ui/templates/insurance/export-contract/declined-by-private-market.njk
@@ -27,7 +27,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>
   </div>

--- a/src/ui/templates/insurance/export-contract/how-much-the-agent-is-charging.njk
+++ b/src/ui/templates/insurance/export-contract/how-much-the-agent-is-charging.njk
@@ -28,7 +28,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
       <div class="govuk-grid-column-three-quarters-from-desktop govuk-!-padding-right-0 govuk-!-padding-left-0">
-        <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+        <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
         <h1 class="govuk-heading-l" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
       </div>
     </div>

--- a/src/ui/templates/insurance/export-contract/how-was-the-contract-awarded.njk
+++ b/src/ui/templates/insurance/export-contract/how-was-the-contract-awarded.njk
@@ -26,7 +26,7 @@
     }) }}
   {% endif %}
 
-  <span class="govuk-caption-xl" data-cy="heading-caption">
+  <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">
     {{ CONTENT_STRINGS.HEADING_CAPTION }}
   </span>
 

--- a/src/ui/templates/insurance/export-contract/how-will-you-get-paid.njk
+++ b/src/ui/templates/insurance/export-contract/how-will-you-get-paid.njk
@@ -27,7 +27,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>
   </div>

--- a/src/ui/templates/insurance/policy/broker-confirm-address.njk
+++ b/src/ui/templates/insurance/policy/broker-confirm-address.njk
@@ -24,7 +24,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters-from-desktop">
 
-        <span class="govuk-caption-xl" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+        <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
 
         <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 

--- a/src/ui/templates/insurance/policy/broker-details.njk
+++ b/src/ui/templates/insurance/policy/broker-details.njk
@@ -34,7 +34,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters-from-desktop">
 
-        <span class="govuk-caption-xl" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+        <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
 
         <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 

--- a/src/ui/templates/insurance/policy/check-your-answers.njk
+++ b/src/ui/templates/insurance/policy/check-your-answers.njk
@@ -19,7 +19,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-l" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>
   </div>

--- a/src/ui/templates/insurance/policy/different-name-on-policy.njk
+++ b/src/ui/templates/insurance/policy/different-name-on-policy.njk
@@ -36,7 +36,7 @@
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">
-        <span class="govuk-caption-xl" data-cy="heading-caption">
+        <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">
           {{ CONTENT_STRINGS.HEADING_CAPTION }}
         </span>
         <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>

--- a/src/ui/templates/insurance/policy/loss-payee-details.njk
+++ b/src/ui/templates/insurance/policy/loss-payee-details.njk
@@ -36,7 +36,7 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters-from-desktop">
-        <span class="govuk-caption-xl" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+        <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
 
         <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
       </div>

--- a/src/ui/templates/insurance/policy/loss-payee-financial-details-international.njk
+++ b/src/ui/templates/insurance/policy/loss-payee-financial-details-international.njk
@@ -32,7 +32,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      <span class="govuk-caption-xl" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
 
       <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 

--- a/src/ui/templates/insurance/policy/loss-payee-financial-details-uk.njk
+++ b/src/ui/templates/insurance/policy/loss-payee-financial-details-uk.njk
@@ -32,7 +32,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      <span class="govuk-caption-xl" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
 
       <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 

--- a/src/ui/templates/insurance/policy/multiple-contract-policy-export-value.njk
+++ b/src/ui/templates/insurance/policy/multiple-contract-policy-export-value.njk
@@ -27,7 +27,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-l" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }} {{ CURRENCY_NAME }}</h1>
     </div>
   </div>

--- a/src/ui/templates/insurance/policy/multiple-contract-policy.njk
+++ b/src/ui/templates/insurance/policy/multiple-contract-policy.njk
@@ -29,7 +29,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-l" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>
   </div>

--- a/src/ui/templates/insurance/policy/name-on-policy.njk
+++ b/src/ui/templates/insurance/policy/name-on-policy.njk
@@ -29,7 +29,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-l" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>
   </div>

--- a/src/ui/templates/insurance/policy/other-company-details.njk
+++ b/src/ui/templates/insurance/policy/other-company-details.njk
@@ -32,7 +32,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      <span class="govuk-caption-xl" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
 
       <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>

--- a/src/ui/templates/insurance/policy/single-contract-policy-total-contract-value.njk
+++ b/src/ui/templates/insurance/policy/single-contract-policy-total-contract-value.njk
@@ -29,7 +29,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
 
       <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>

--- a/src/ui/templates/insurance/policy/single-contract-policy.njk
+++ b/src/ui/templates/insurance/policy/single-contract-policy.njk
@@ -29,7 +29,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
       <div class="govuk-grid-column-three-quarters-from-desktop govuk-!-padding-right-0 govuk-!-padding-left-0">
-        <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+        <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
         <h1 class="govuk-heading-l" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
       </div>
     </div>

--- a/src/ui/templates/insurance/policy/type-of-policy.njk
+++ b/src/ui/templates/insurance/policy/type-of-policy.njk
@@ -33,7 +33,7 @@
       <div class="govuk-grid-column-three-quarters-from-desktop">
 
         {% set legendHtml %}
-          <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+          <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
           <span class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading" id="heading" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
           </span>

--- a/src/ui/templates/insurance/your-business/alternative-trading-address.njk
+++ b/src/ui/templates/insurance/your-business/alternative-trading-address.njk
@@ -31,7 +31,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      <span class="govuk-caption-xl" data-cy="heading-caption">
+      <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">
         {{ CONTENT_STRINGS.HEADING_CAPTION }}
       </span>
     </div>

--- a/src/ui/templates/insurance/your-business/check-your-answers.njk
+++ b/src/ui/templates/insurance/your-business/check-your-answers.njk
@@ -19,7 +19,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>
   </div>

--- a/src/ui/templates/insurance/your-business/company-details.njk
+++ b/src/ui/templates/insurance/your-business/company-details.njk
@@ -35,7 +35,7 @@
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">
-        <span class="govuk-caption-xl" data-cy="heading-caption">
+        <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">
           {{ CONTENT_STRINGS.HEADING_CAPTION }}
         </span>
 

--- a/src/ui/templates/insurance/your-business/nature-of-your-business.njk
+++ b/src/ui/templates/insurance/your-business/nature-of-your-business.njk
@@ -34,7 +34,7 @@
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">
-        <span class="govuk-caption-xl" data-cy="heading-caption">
+        <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">
           {{ CONTENT_STRINGS.HEADING_CAPTION }}
         </span>
         <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>

--- a/src/ui/templates/insurance/your-business/turnover.njk
+++ b/src/ui/templates/insurance/your-business/turnover.njk
@@ -37,7 +37,7 @@
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">
-        <span class="govuk-caption-xl" data-cy="heading-caption">
+        <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">
           {{ CONTENT_STRINGS.HEADING_CAPTION }}
         </span>
         <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>

--- a/src/ui/templates/insurance/your-buyer/check-your-answers.njk
+++ b/src/ui/templates/insurance/your-buyer/check-your-answers.njk
@@ -20,7 +20,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>
   </div>

--- a/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
+++ b/src/ui/templates/insurance/your-buyer/company-or-organisation.njk
@@ -29,7 +29,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-from-desktop">
-      <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+      <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
       <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
     </div>
   </div>

--- a/src/ui/templates/insurance/your-buyer/outstanding-or-overdue-payments.njk
+++ b/src/ui/templates/insurance/your-buyer/outstanding-or-overdue-payments.njk
@@ -35,7 +35,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters-from-desktop">
 
-        <span class="govuk-caption-xl" data-cy="heading-caption">
+        <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">
           {{ CONTENT_STRINGS.HEADING_CAPTION }}
         </span>
 

--- a/src/ui/templates/insurance/your-buyer/trading-history.njk
+++ b/src/ui/templates/insurance/your-buyer/trading-history.njk
@@ -37,7 +37,7 @@
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
       <div class="govuk-grid-column-three-quarters-from-desktop">
-        <span class="govuk-caption-xl" data-cy="heading-caption">
+        <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">
           {{ CONTENT_STRINGS.HEADING_CAPTION }}
         </span>
 

--- a/src/ui/templates/shared-pages/currency.njk
+++ b/src/ui/templates/shared-pages/currency.njk
@@ -35,7 +35,7 @@
   <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-    <span class="govuk-caption-xl" data-cy="heading-caption">
+    <span class="govuk-caption-xl" data-cy="{{ DATA_CY.HEADING_CAPTION }}">
       {{ CONTENT_STRINGS.HEADING_CAPTION }}
     </span>
 

--- a/src/ui/templates/shared-pages/declaration.njk
+++ b/src/ui/templates/shared-pages/declaration.njk
@@ -26,7 +26,7 @@
     }) }}
   {% endif %}
 
-  <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+  <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
   <h1 class="govuk-heading-xl" data-cy="{{ DATA_CY.HEADING }}">{{ CONTENT_STRINGS.PAGE_TITLE }}</h1>
 
   <div class="govuk-grid-row">

--- a/src/ui/templates/shared-pages/single-radio.njk
+++ b/src/ui/templates/shared-pages/single-radio.njk
@@ -33,7 +33,7 @@
     {% set submittedAnswer = submittedValues[FIELD_ID] or applicationAnswer %}
   {% endif %}
 
-  <span class="govuk-caption-l" data-cy="heading-caption">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
+  <span class="govuk-caption-l" data-cy="{{ DATA_CY.HEADING_CAPTION }}">{{ CONTENT_STRINGS.HEADING_CAPTION }}</span>
 
   <form method="POST" data-cy="form" enctype="application/x-www-form-urlencoded" novalidate>
 

--- a/src/ui/types/page-variables.d.ts
+++ b/src/ui/types/page-variables.d.ts
@@ -16,6 +16,7 @@ interface PageVariablesContentStrings {
 
 interface PageVariablesDataCy {
   HEADING: string;
+  HEADING_CAPTION: string;
   BACK_LINK: string;
   INTRO: string;
 }


### PR DESCRIPTION
## Introduction :pencil2:
- We had a `DATA_CY.HEADING` value, but not for `DATA_CY.HEADING_CAPTION`
- The `headingCaption` cypress selector was dupicated in `pages/shared` and `partials`.

## Resolution :heavy_check_mark:
- Create a new `DATA_CY.HEADING_CAPTION` core page variable.
- Update nunjucks template.
- Remove `heading` selector from cypress partials.
- Update E2E tests.