### PR TITLE
fix(EMS-3988): quote tool - type of policy - hint text

### DIFF
--- a/e2e-tests/content-strings/fields/index.js
+++ b/e2e-tests/content-strings/fields/index.js
@@ -6,6 +6,7 @@ import { FIELD_VALUES } from '../../constants/field-values';
 import { LINKS } from '../links';
 
 const { MAX_COVER_PERIOD_MONTHS } = ELIGIBILITY;
+
 const {
   POLICY: { TOTAL_MONTHS_OF_COVER },
 } = APPLICATION;
@@ -127,23 +128,9 @@ export const FIELDS = {
         VALUE: FIELD_VALUES.POLICY_TYPE.MULTIPLE,
         TEXT: 'Multiple contract policy (Revolving credit)',
         HINT: [
-          `Covers multiple contracts with the same buyer, usually for ${TOTAL_MONTHS_OF_COVER} months`,
+          `Covers multiple contracts with the same buyer, usually for ${TOTAL_MONTHS_OF_COVER.MAXIMUM} months`,
           "Best if you'll have an ongoing relationship with the buyer but you're not sure yet how many contracts or sales you'll have",
           'You only pay for your insurance each time you declare a new contract or sale - no need to pay before the policy starts',
-        ],
-        INSET: [
-          [
-            {
-              text: `If you need a policy of over ${TOTAL_MONTHS_OF_COVER} months`,
-            },
-            {
-              text: 'fill in this form',
-              href: LINKS.EXTERNAL.NBI_FORM,
-            },
-            {
-              text: ' and email it to UKEF.',
-            },
-          ],
         ],
       },
     },

--- a/e2e-tests/quote/cypress/e2e/journeys/quote/policy-type/policy-type.spec.js
+++ b/e2e-tests/quote/cypress/e2e/journeys/quote/policy-type/policy-type.spec.js
@@ -1,6 +1,6 @@
 import { policyTypePage } from '../../../../../../pages/quote';
 import { FIELDS, PAGES } from '../../../../../../content-strings';
-import { ROUTES, FIELD_IDS } from '../../../../../../constants';
+import { APPLICATION, ELIGIBILITY, FIELD_IDS, ROUTES } from '../../../../../../constants';
 
 const CONTENT_STRINGS = PAGES.QUOTE.POLICY_TYPE;
 
@@ -9,6 +9,12 @@ const { POLICY_TYPE: FIELD_ID } = FIELD_IDS;
 const {
   QUOTE: { POLICY_TYPE: POLICY_TYPE_ROUTE, UK_GOODS_OR_SERVICES, TELL_US_ABOUT_YOUR_POLICY },
 } = ROUTES;
+
+const {
+  POLICY: { TOTAL_MONTHS_OF_COVER },
+} = APPLICATION;
+
+const { MAX_COVER_PERIOD_MONTHS } = ELIGIBILITY;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -52,32 +58,64 @@ context('Policy type page - as an exporter, I want to get UKEF credit insurance 
       cy.navigateToUrl(url);
     });
 
-    it('should render `single policy type` radio input with a label and hint', () => {
-      const field = policyTypePage[FIELD_ID].single;
+    const { multiple: multiplePolicyField, single: singlePolicyField } = policyTypePage[FIELD_ID];
 
-      field.input().should('exist');
+    describe('`single policy type` radio', () => {
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+      });
 
-      cy.checkText(field.label(), FIELDS[FIELD_ID].OPTIONS.SINGLE.TEXT);
+      it('should render an input and label', () => {
+        singlePolicyField.input().should('exist');
 
-      const HINT_STRINGS = FIELDS[FIELD_ID].OPTIONS.SINGLE.HINT;
+        cy.checkText(singlePolicyField.label(), FIELDS[FIELD_ID].OPTIONS.SINGLE.TEXT);
+      });
 
-      cy.checkText(field.hintListItem(1), HINT_STRINGS[0]);
-      cy.checkText(field.hintListItem(2), HINT_STRINGS[1]);
-      cy.checkText(field.hintListItem(3), HINT_STRINGS[2]);
-      cy.checkText(field.hintListItem(4), HINT_STRINGS[3]);
+      it('should render a hint', () => {
+        const HINT_STRINGS = FIELDS[FIELD_ID].OPTIONS.SINGLE.HINT;
+
+        cy.checkText(singlePolicyField.hintListItem(1), HINT_STRINGS[0]);
+
+        cy.checkText(singlePolicyField.hintListItem(2), HINT_STRINGS[1]);
+
+        singlePolicyField
+          .hintListItem(2)
+          .invoke('text')
+          .then((text) => {
+            expect(text).includes(`${MAX_COVER_PERIOD_MONTHS} months`);
+          });
+
+        cy.checkText(singlePolicyField.hintListItem(3), HINT_STRINGS[2]);
+        cy.checkText(singlePolicyField.hintListItem(4), HINT_STRINGS[3]);
+      });
     });
 
-    it('should render `multiple policy type` radio input with a label and hint', () => {
-      const field = policyTypePage[FIELD_ID].multiple;
+    describe('`multiple policy type` radio', () => {
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+      });
 
-      field.input().should('exist');
-      cy.checkText(field.label(), FIELDS[FIELD_ID].OPTIONS.MULTIPLE.TEXT);
+      it('should render an input and label', () => {
+        multiplePolicyField.input().should('exist');
 
-      const HINT_STRINGS = FIELDS[FIELD_ID].OPTIONS.MULTIPLE.HINT;
+        cy.checkText(multiplePolicyField.label(), FIELDS[FIELD_ID].OPTIONS.MULTIPLE.TEXT);
+      });
 
-      cy.checkText(field.hintListItem(1), HINT_STRINGS[0]);
-      cy.checkText(field.hintListItem(2), HINT_STRINGS[1]);
-      cy.checkText(field.hintListItem(3), HINT_STRINGS[2]);
+      it('should render a hint', () => {
+        const HINT_STRINGS = FIELDS[FIELD_ID].OPTIONS.MULTIPLE.HINT;
+
+        cy.checkText(multiplePolicyField.hintListItem(1), HINT_STRINGS[0]);
+
+        multiplePolicyField
+          .hintListItem(1)
+          .invoke('text')
+          .then((text) => {
+            expect(text).includes(`${TOTAL_MONTHS_OF_COVER.MAXIMUM} months`);
+          });
+
+        cy.checkText(multiplePolicyField.hintListItem(2), HINT_STRINGS[1]);
+        cy.checkText(multiplePolicyField.hintListItem(3), HINT_STRINGS[2]);
+      });
     });
 
     describe('when form is valid', () => {

--- a/src/ui/server/content-strings/fields/index.ts
+++ b/src/ui/server/content-strings/fields/index.ts
@@ -2,6 +2,7 @@ import { APPLICATION, ELIGIBILITY, FIELD_IDS, FIELD_VALUES, MAXIMUM_CHARACTERS }
 import { LINKS } from '../links';
 
 const { MAX_COVER_PERIOD_MONTHS } = ELIGIBILITY;
+
 const {
   POLICY: { TOTAL_MONTHS_OF_COVER },
 } = APPLICATION;
@@ -123,23 +124,9 @@ export const FIELDS = {
         VALUE: FIELD_VALUES.POLICY_TYPE.MULTIPLE,
         TEXT: 'Multiple contract policy (Revolving credit)',
         HINT: [
-          `Covers multiple contracts with the same buyer, usually for ${TOTAL_MONTHS_OF_COVER} months`,
+          `Covers multiple contracts with the same buyer, usually for ${TOTAL_MONTHS_OF_COVER.MAXIMUM} months`,
           "Best if you'll have an ongoing relationship with the buyer but you're not sure yet how many contracts or sales you'll have",
           'You only pay for your insurance each time you declare a new contract or sale - no need to pay before the policy starts',
-        ],
-        INSET: [
-          [
-            {
-              text: `If you need a policy of over ${TOTAL_MONTHS_OF_COVER} months`,
-            },
-            {
-              text: 'fill in this form',
-              href: LINKS.EXTERNAL.NBI_FORM,
-            },
-            {
-              text: ' and email it to UKEF.',
-            },
-          ],
         ],
       },
     },


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where in the Quote tool's "type of policy - multiple contract policy", a part of the hint text would display as "[Object Object]".

## Resolution :heavy_check_mark:
- Update content strings.
- Improve E2E test coverage.

## Miscellaneous :heavy_plus_sign:
- Remove an unused `INSET` content string.
