### PR TITLE
chore(EMS-4005): remove unnecessary expectedErrorsCount params

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/cookies.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/cookies.spec.js
@@ -174,13 +174,9 @@ context('Cookies page - Insurance', () => {
         });
 
         it('should render validation errors', () => {
-          const expectedErrorsCount = 1;
-          const expectedErrorMessage = ERROR_MESSAGES[FIELD_ID];
-
           cy.submitAndAssertRadioErrors({
             field: cookiesPage[FIELD_ID].accept,
-            expectedErrorsCount,
-            expectedErrorMessage,
+            expectedErrorMessage: ERROR_MESSAGES[FIELD_ID],
           });
         });
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/anti-bribery.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/anti-bribery.spec.js
@@ -147,11 +147,8 @@ context(
         });
 
         it('should render a validation error', () => {
-          const expectedErrorsCount = 1;
-
           cy.submitAndAssertFieldErrors({
             field,
-            expectedErrorsCount,
             expectedErrorMessage: ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY,
             clearInput: false,
           });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
@@ -106,11 +106,8 @@ context(
         });
 
         it('should render a validation error', () => {
-          const expectedErrorsCount = 1;
-
           cy.submitAndAssertRadioErrors({
             field: yesRadio(FIELD_ID),
-            expectedErrorsCount,
             expectedErrorMessage: ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY,
           });
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/anti-bribery-exporting-with-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/exporting-with-code-of-conduct/anti-bribery-exporting-with-code-of-conduct.spec.js
@@ -88,11 +88,8 @@ context(
         });
 
         it('should render a validation error', () => {
-          const expectedErrorsCount = 1;
-
           cy.submitAndAssertRadioErrors({
             field: yesRadio(FIELD_ID),
-            expectedErrorsCount,
             expectedErrorMessage: ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY,
           });
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/confidentiality/confidentiality.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/confidentiality/confidentiality.spec.js
@@ -122,11 +122,8 @@ context(
         });
 
         it('should render a validation error', () => {
-          const expectedErrorsCount = 1;
-
           cy.submitAndAssertRadioErrors({
             field,
-            expectedErrorsCount,
             expectedErrorMessage: ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY,
           });
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/confirmation-and-acknowledgements/confirmation-and-acknowledgements.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/confirmation-and-acknowledgements/confirmation-and-acknowledgements.spec.js
@@ -107,11 +107,8 @@ context(
         });
 
         it('should render a validation error', () => {
-          const expectedErrorsCount = 1;
-
           cy.submitAndAssertRadioErrors({
             field,
-            expectedErrorsCount,
             expectedErrorMessage: ERROR_MESSAGES.INSURANCE.DECLARATIONS[FIELD_ID].IS_EMPTY,
           });
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-number/companies-house-number.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-number/companies-house-number.spec.js
@@ -65,11 +65,8 @@ context(
         });
 
         it('should render validation errors', () => {
-          const expectedErrorsCount = 1;
-
           cy.submitAndAssertRadioErrors({
             field: yesRadio(FIELD_ID),
-            expectedErrorsCount,
             expectedErrorMessage: ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY,
           });
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cover-period/cover-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/cover-period/cover-period.spec.js
@@ -81,11 +81,8 @@ context(
         it('should render validation errors', () => {
           const fieldId = `${FIELD_ID}-${BELOW.ID}`;
 
-          const expectedErrorsCount = 1;
-
           cy.submitAndAssertRadioErrors({
             field: fieldSelector(fieldId),
-            expectedErrorsCount,
             expectedErrorMessage: ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY,
           });
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/end-buyer/end-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/end-buyer/end-buyer.spec.js
@@ -97,11 +97,8 @@ context(
       });
 
       it('should render validation errors', () => {
-        const expectedErrorsCount = 1;
-
         cy.submitAndAssertRadioErrors({
           field: yesRadio(FIELD_ID),
-          expectedErrorsCount,
           expectedErrorMessage: ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY,
         });
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/exporter-location/exporter-location.spec.js
@@ -57,11 +57,8 @@ context('Insurance - Exporter location page - as an exporter, I want to check if
   describe('form submission', () => {
     describe('when submitting an empty form', () => {
       it('should render validation errors', () => {
-        const expectedErrorsCount = 1;
-
         cy.submitAndAssertRadioErrors({
           field: yesRadio(FIELD_ID),
-          expectedErrorsCount,
           expectedErrorMessage: ERROR_MESSAGES.ELIGIBILITY[FIELD_ID],
         });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/have-an-account/have-an-account.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/have-an-account/have-an-account.spec.js
@@ -75,11 +75,8 @@ context(
         });
 
         it('should render validation errors', () => {
-          const expectedErrorsCount = 1;
-
           cy.submitAndAssertRadioErrors({
             field: yesRadio(FIELD_ID),
-            expectedErrorsCount,
             expectedErrorMessage: ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY,
           });
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/member-of-a-group/member-of-a-group.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/member-of-a-group/member-of-a-group.spec.js
@@ -83,11 +83,8 @@ context(
       });
 
       it('should render validation errors', () => {
-        const expectedErrorsCount = 1;
-
         cy.submitAndAssertRadioErrors({
           field: yesRadio(FIELD_ID),
-          expectedErrorsCount,
           expectedErrorMessage: ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY,
         });
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/party-to-consortium/party-to-consortium.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/party-to-consortium/party-to-consortium.spec.js
@@ -67,11 +67,8 @@ context(
       });
 
       it('should render validation errors', () => {
-        const expectedErrorsCount = 1;
-
         cy.submitAndAssertRadioErrors({
           field: yesRadio(FIELD_ID),
-          expectedErrorsCount,
           expectedErrorMessage: ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY,
         });
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/total-value-insured/total-value-insured.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/total-value-insured/total-value-insured.spec.js
@@ -83,11 +83,8 @@ context(
         it('should render validation errors', () => {
           const fieldId = `${FIELD_ID}-${BELOW.ID}`;
 
-          const expectedErrorsCount = 1;
-
           cy.submitAndAssertRadioErrors({
             field: fieldSelector(fieldId),
-            expectedErrorsCount,
             expectedErrorMessage: ERROR_MESSAGES.INSURANCE.ELIGIBILITY[FIELD_ID].IS_EMPTY,
           });
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/uk-goods-or-services/uk-goods-or-services.spec.js
@@ -104,11 +104,8 @@ context('Insurance - UK goods or services page - as an exporter, I want to check
     });
 
     it('should render validation errors', () => {
-      const expectedErrorsCount = 1;
-
       cy.submitAndAssertRadioErrors({
         field: yesRadio(FIELD_ID),
-        expectedErrorsCount,
         expectedErrorMessage: ERROR_MESSAGES.ELIGIBILITY[FIELD_ID].IS_EMPTY,
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/how-will-you-get-paid.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/how-will-you-get-paid.spec.js
@@ -24,7 +24,6 @@ const {
 } = ERROR_MESSAGES;
 
 const field = howWillYouGetPaidPage[FIELD_ID];
-const expectedErrorsCount = 1;
 
 const baseUrl = Cypress.config('baseUrl');
 
@@ -98,7 +97,6 @@ context(
       it(`should display validation errors if ${FIELD_ID} is left empty`, () => {
         cy.submitAndAssertFieldErrors({
           field,
-          expectedErrorsCount,
           expectedErrorMessage: ERRORS[FIELD_ID].IS_EMPTY,
         });
       });
@@ -110,7 +108,6 @@ context(
           cy.submitAndAssertFieldErrors({
             field,
             value: submittedValue,
-            expectedErrorsCount,
             expectedErrorMessage: ERRORS[FIELD_ID].ABOVE_MAXIMUM,
           });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
@@ -57,13 +57,9 @@ context('Insurance - Policy - Name on policy - Validation', () => {
     });
 
     it('should display validation error', () => {
-      const expectedErrorsCount = 1;
-      const expectedErrorMessage = NAME_ON_POLICY_ERRORS[NAME].IS_EMPTY;
-
       cy.submitAndAssertRadioErrors({
         field: fieldSelector(SAME_NAME),
-        expectedErrorsCount,
-        expectedErrorMessage,
+        expectedErrorMessage: NAME_ON_POLICY_ERRORS[NAME].IS_EMPTY,
       });
     });
   });

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/validation/pre-credit-period-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/pre-credit-period/validation/pre-credit-period-validation.spec.js
@@ -48,13 +48,9 @@ context('Insurance - Policy - Pre-credit period page - validation', () => {
   it(`should render a validation error when ${NEED_PRE_CREDIT_PERIOD} is not provided`, () => {
     const fieldId = NEED_PRE_CREDIT_PERIOD;
 
-    const expectedErrorsCount = 1;
-    const expectedErrorMessage = POLICY_ERROR_MESSAGES[fieldId].IS_EMPTY;
-
     cy.submitAndAssertRadioErrors({
       field: noRadio(fieldId),
-      expectedErrorsCount,
-      expectedErrorMessage,
+      expectedErrorMessage: POLICY_ERROR_MESSAGES[fieldId].IS_EMPTY,
     });
   });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/type-of-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/type-of-policy/type-of-policy.spec.js
@@ -97,8 +97,6 @@ context('Insurance - Policy - Type of policy page - As an exporter, I want to en
       });
 
       it('should render a validation error', () => {
-        const expectedErrorsCount = 1;
-
         const { errorMessage } = field(FIELD_ID);
 
         const radioField = {
@@ -108,7 +106,6 @@ context('Insurance - Policy - Type of policy page - As an exporter, I want to en
 
         cy.submitAndAssertRadioErrors({
           field: radioField,
-          expectedErrorsCount,
           expectedErrorMessage: ERROR_MESSAGES.INSURANCE.POLICY.TYPE_OF_POLICY[FIELD_ID].IS_EMPTY,
         });
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/credit-control/credit-control.spec.js
@@ -87,11 +87,8 @@ context(
         });
 
         it('should render validation errors', () => {
-          const expectedErrorsCount = 1;
-
           cy.submitAndAssertRadioErrors({
             field: yesRadio(FIELD_ID),
-            expectedErrorsCount,
             expectedErrorMessage: ERROR_MESSAGES.INSURANCE.EXPORTER_BUSINESS[FIELD_ID].IS_EMPTY,
           });
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/buyer-financial-information/buyer-financial-information-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/buyer-financial-information/buyer-financial-information-page.spec.js
@@ -106,11 +106,8 @@ context(
       });
 
       it('should render validation errors', () => {
-        const expectedErrorsCount = 1;
-
         cy.submitAndAssertRadioErrors({
           field: noRadio(FIELD_ID),
-          expectedErrorsCount,
           expectedErrorMessage: ERROR_MESSAGE.IS_EMPTY,
         });
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/traded-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/traded-with-buyer/traded-with-buyer.spec.js
@@ -96,11 +96,8 @@ context('Insurance - Your buyer - Traded with buyer page - As an exporter, I wan
     });
 
     it('should render validation errors', () => {
-      const expectedErrorsCount = 1;
-
       cy.submitAndAssertRadioErrors({
         field: noRadio(FIELD_ID),
-        expectedErrorsCount,
         expectedErrorMessage: ERROR_MESSAGE.IS_EMPTY,
       });
     });


### PR DESCRIPTION
## Introduction :pencil2:
The `submitAndAssertFieldErrors` and `submitAndAssertRadioErrors` cypress commands have a default `expectedErrorsCount` value. Therefore, there is no need to pass the same default into these commands.

## Resolution :heavy_check_mark:
- Remove `unnecessary` instances of `expectedErrorsCount`.
