### PR TITLE
feat(EMS-3979): broker details - task list logic

### DIFF
--- a/e2e-tests/commands/insurance/complete-and-submit-broker-addresses-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-broker-addresses-form.js
@@ -1,0 +1,12 @@
+/**
+ * completeAndSubmitBrokerAddressesForm
+ * Complete and submit "broker addresses" form
+ * @param {String} optionValue: Address option value
+ */
+const completeAndSubmitBrokerAddressesForm = ({ optionValue }) => {
+  cy.completeBrokerAddressesForm({ optionValue });
+
+  cy.clickSubmitButton();
+};
+
+export default completeAndSubmitBrokerAddressesForm;

--- a/e2e-tests/commands/insurance/complete-and-submit-broker-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-broker-form.js
@@ -1,7 +1,7 @@
 /**
  * completeAndSubmitBrokerForm
  * Complete and submit "using broker" form
- * @param {Boolean} usingBroker: Should submit "yes" or "no" to "using a broker". Defaults to "no".
+ * @param {Boolean} usingBroker: Should submit "yes" or "no" to "using a broker". Defaults to false.
  */
 const completeAndSubmitBrokerForm = ({ usingBroker = false }) => {
   if (usingBroker) {

--- a/e2e-tests/commands/insurance/complete-and-submit-loss-payee-form.js
+++ b/e2e-tests/commands/insurance/complete-and-submit-loss-payee-form.js
@@ -1,7 +1,7 @@
 /**
  * completeAndSubmitLossPayeeForm
  * Complete and submit "loss payee" form
- * @param {Boolean} isAppointingLossPayee: Should submit "yes" or "no" to "appointing a loss payee". Defaults to "no".
+ * @param {Boolean} isAppointingLossPayee: Should submit "yes" or "no" to "appointing a loss payee". Defaults to false.
  */
 const completeAndSubmitLossPayeeForm = ({ isAppointingLossPayee = false }) => {
   if (isAppointingLossPayee) {

--- a/e2e-tests/commands/insurance/complete-broker-addresses-form.js
+++ b/e2e-tests/commands/insurance/complete-broker-addresses-form.js
@@ -1,0 +1,19 @@
+import { radios } from '../../pages/shared';
+import { POLICY as POLICY_FIELD_IDS } from '../../constants/field-ids/insurance/policy';
+
+const {
+  BROKER_ADDRESSES: { SELECT_THE_ADDRESS: FIELD_ID },
+} = POLICY_FIELD_IDS;
+
+/**
+ * completeBrokerAddressesForm
+ * Complete "broker addresses" form
+ * @param {String} optionValue: Address option value
+ */
+const completeBrokerAddressesForm = ({ optionValue = 'BRITISH BROADCASTING CORPORATION WOGAN HOUSE PORTLAND PLACE' }) => {
+  const optionId = `${FIELD_ID}-${optionValue}`;
+
+  radios(optionId).option.label().click();
+};
+
+export default completeBrokerAddressesForm;

--- a/e2e-tests/commands/insurance/complete-buyer-section.js
+++ b/e2e-tests/commands/insurance/complete-buyer-section.js
@@ -2,7 +2,7 @@
  * completeBuyerSection
  * Complete the "Buyer" section
  * @param {Boolean} viaTaskList: Start the "buyer" section from the task list.
- * @param {Boolean} hasConnectionToBuyer: Should submit "yes" to "have connection to buyer" radio. Defaults to "no".
+ * @param {Boolean} hasConnectionToBuyer: Should submit "yes" to "have connection to buyer" radio. Defaults to false.
  * @param {Boolean} exporterHasTradedWithBuyer: Submit "yes" to "have traded with buyer before" in the "working with buyer" form.
  * @param {Boolean} outstandingPayments: Exporter has outstanding payments with the buyer
  * @param {Boolean} failedToPay: Buyer has failed to pay the exporter on the time

--- a/e2e-tests/commands/insurance/complete-declarations.js
+++ b/e2e-tests/commands/insurance/complete-declarations.js
@@ -4,7 +4,7 @@ import { FIELD_VALUES } from '../../constants';
  * completeDeclarations
  * Runs through the full declarations journey
  * @param {Object} Object with flags on how to complete specific declaration forms.
- * - exportingWithCodeOfConduct: Should submit "yes" in the "exporting with code of conduct" form. Defaults to "yes".
+ * - exportingWithCodeOfConduct: Should submit "yes" in the "exporting with code of conduct" form. Defaults to true.
  */
 const completeDeclarations = ({ hasAntiBriberyCodeOfConduct = true, exportingWithCodeOfConduct = true }) => {
   cy.clickTaskDeclarationsAndSubmit();

--- a/e2e-tests/commands/insurance/complete-policy-section.js
+++ b/e2e-tests/commands/insurance/complete-policy-section.js
@@ -12,9 +12,10 @@ const { POLICY_TYPE } = APPLICATION;
  * @param {Boolean} alternativeCurrency: Select the "alternative currency" option
  * @param {Boolean} sameName: If name on policy is the same as the signed in user - defaults to true
  * @param {Boolean} needPreCreditPeriod: If the user needs a pre-credit period - defaults to false
- * @param {Boolean} usingBroker: If "using broker" on  - defaults to false
- * @param {Boolean} otherCompanyInvolved: If "another company to be insured" is on  - defaults to false
- * @param {Boolean} isAppointingLossPayee: Should submit "yes" or "no" to "appointing a loss payee". Defaults to "no".
+ * @param {Boolean} usingBroker: If "using broker" - defaults to false
+ * @param {Boolean} brokerIsBasedInUk: Broker is based in the UK - defaults to false
+ * @param {Boolean} otherCompanyInvolved: Should submit "yes" to "another company to be insured". Defaults to false.
+ * @param {Boolean} isAppointingLossPayee: Should submit "yes" or "no" to "appointing a loss payee". Defaults to false.
  * @param {Boolean} lossPayeeIsLocatedInUK: Should submit "UK" to "loss payee details". Defaults to false.
  * @param {Boolean} submitCheckYourAnswers: Click policy "check your answers" submit button
  */
@@ -27,6 +28,7 @@ const completePolicySection = ({
   sameName = true,
   needPreCreditPeriod = false,
   usingBroker = false,
+  brokerIsBasedInUk = false,
   otherCompanyInvolved = false,
   isAppointingLossPayee = false,
   lossPayeeIsLocatedInUK = false,
@@ -69,10 +71,16 @@ const completePolicySection = ({
   cy.completeAndSubmitBrokerForm({ usingBroker });
 
   if (usingBroker) {
-    cy.completeAndSubmitBrokerDetailsForm({});
+    cy.completeAndSubmitBrokerDetailsForm({ isBasedInUk: brokerIsBasedInUk });
 
-    // submit the "confirm broker address" form
-    cy.clickSubmitButton();
+    if (brokerIsBasedInUk) {
+      cy.completeAndSubmitBrokerAddressesForm({});
+
+      // submit the "confirm broker address" form
+      cy.clickSubmitButton();
+    }
+
+    // TODO: else - manual address entry
   }
 
   cy.completeAndSubmitLossPayeeForm({ isAppointingLossPayee });

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-multiple-policy-type.js
@@ -41,6 +41,7 @@ const { POLICY_TYPE } = APPLICATION;
  * @param {Boolean} submitCheckYourAnswers: Should click each section's "check your answers" submit button.
  * @param {Boolean} totalContractValueOverThreshold: If total contract value in eligibility should be over threshold.
  * @param {Boolean} usingBroker: Should submit "yes" or "no" to "using a broker".
+ * @param {Boolean} brokerIsBasedInUk: Should submit "yes or "no" to "broker is based in the UK".
  */
 const completePrepareApplicationMultiplePolicyType = ({
   agentChargeMethodFixedSum = false,
@@ -78,6 +79,7 @@ const completePrepareApplicationMultiplePolicyType = ({
   totalContractValueOverThreshold = false,
   submitCheckYourAnswers = true,
   usingBroker = false,
+  brokerIsBasedInUk = false,
 }) => {
   cy.completeBusinessSection({
     differentTradingName,
@@ -106,6 +108,7 @@ const completePrepareApplicationMultiplePolicyType = ({
     policyValueOverMvpMaximum,
     submitCheckYourAnswers,
     usingBroker,
+    brokerIsBasedInUk,
     otherCompanyInvolved,
     needPreCreditPeriod,
     isAppointingLossPayee,

--- a/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
+++ b/e2e-tests/commands/insurance/complete-prepare-application-section-single-policy-type.js
@@ -41,6 +41,7 @@ const { POLICY_TYPE } = FIELD_VALUES;
  * @param {Boolean} submitCheckYourAnswers: Should click each section's "check your answers" submit button.
  * @param {Boolean} totalContractValueOverThreshold: If total contract value in eligibility should be over threshold.
  * @param {Boolean} usingBroker: Should submit "yes" or "no" to "using a broker".
+ * @param {Boolean} brokerIsBasedInUk: Should submit "yes or "no" to "broker is based in the UK".
  */
 const completePrepareApplicationSinglePolicyType = ({
   agentChargeMethodFixedSum = false,
@@ -78,6 +79,7 @@ const completePrepareApplicationSinglePolicyType = ({
   totalContractValueOverThreshold = false,
   submitCheckYourAnswers = true,
   usingBroker = false,
+  brokerIsBasedInUk = false,
 }) => {
   cy.completeBusinessSection({
     differentTradingName,
@@ -106,6 +108,7 @@ const completePrepareApplicationSinglePolicyType = ({
     policyValueOverMvpMaximum,
     submitCheckYourAnswers,
     usingBroker,
+    brokerIsBasedInUk,
     otherCompanyInvolved,
     needPreCreditPeriod,
     isAppointingLossPayee,

--- a/e2e-tests/commands/insurance/complete-sign-in-and-submit-an-application.js
+++ b/e2e-tests/commands/insurance/complete-sign-in-and-submit-an-application.js
@@ -35,11 +35,12 @@ import completeSignInAndGoToApplication from './account/complete-sign-in-and-go-
  * @param {Boolean} isUsingAgent: Should submit "yes" to "using an agent" form.
  * @param {Boolean} lossPayeeIsLocatedInUK: Should submit "UK" to "loss payee details".
  * @param {Boolean} needPreCreditPeriod: If the user needs a pre-credit period.
- * @param {Boolean} otherCompanyInvolved: If "another company to be insured" is on.
+ * @param {Boolean} otherCompanyInvolved: Should submit "yes" to "another company to be insured".
  * @param {Boolean} policyValueOverMvpMaximum: Should submit an application with the value over the MVP maximum amount.
  * @param {Boolean} submitCheckYourAnswers: Should click each section's "check your answers" submit button.
  * @param {Boolean} totalContractValueOverThreshold: If total contract value in eligibility should be over threshold.
  * @param {Boolean} usingBroker: Should submit "yes" or "no" to "using a broker".
+ * @param {Boolean} brokerIsBasedInUk: Should submit "yes or "no" to "broker is based in the UK".
  * @return {String} Application reference number
  */
 const completeSignInAndSubmitAnApplication = ({
@@ -76,6 +77,7 @@ const completeSignInAndSubmitAnApplication = ({
   policyValueOverMvpMaximum = false,
   totalContractValueOverThreshold = false,
   usingBroker = false,
+  brokerIsBasedInUk = false,
 }) => {
   completeSignInAndGoToApplication({
     companyNumber,
@@ -113,6 +115,7 @@ const completeSignInAndSubmitAnApplication = ({
         referenceNumber,
         totalContractValueOverThreshold,
         usingBroker,
+        brokerIsBasedInUk,
       });
     } else {
       cy.completePrepareApplicationSinglePolicyType({
@@ -145,6 +148,7 @@ const completeSignInAndSubmitAnApplication = ({
         referenceNumber,
         totalContractValueOverThreshold,
         usingBroker,
+        brokerIsBasedInUk,
       });
     }
     cy.completeAndSubmitCheckYourAnswers();

--- a/e2e-tests/commands/insurance/your-buyer/complete-and-submit-buyer-financial-information-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-and-submit-buyer-financial-information-form.js
@@ -2,7 +2,7 @@
  * completeAndSubmitBuyerFinancialInformationForm
  * Completes and submits the "buyer financial information" form.
  * @param {Object} Object with flags on how to complete the form.
- * - exporterHasBuyerFinancialAccounts: Should submit "yes" to "buyer financial information" radio. Defaults to "no".
+ * - exporterHasBuyerFinancialAccounts: Should submit "yes" to "buyer financial information" radio. Defaults to false.
  */
 const completeAndSubmitBuyerFinancialInformationForm = ({ exporterHasBuyerFinancialAccounts = false }) => {
   cy.completeBuyerFinancialInformationForm({ exporterHasBuyerFinancialAccounts });

--- a/e2e-tests/commands/insurance/your-buyer/complete-and-submit-connection-with-the-buyer-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-and-submit-connection-with-the-buyer-form.js
@@ -1,7 +1,7 @@
 /**
  * completeAndSubmitConnectionWithTheBuyerForm
  * Complete and submit the "connection with the buyer" form.
- * @param {Boolean} hasConnectionToBuyer: Should submit "yes" to "have connection to buyer" radio. Defaults to "no".
+ * @param {Boolean} hasConnectionToBuyer: Should submit "yes" to "have connection to buyer" radio. Defaults to false.
  * @param {String} description: "Connection with buyer" description.
  */
 const completeAndSubmitConnectionWithTheBuyerForm = ({ hasConnectionToBuyer = false, description }) => {

--- a/e2e-tests/commands/insurance/your-buyer/complete-and-submit-traded-with-buyer-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-and-submit-traded-with-buyer-form.js
@@ -2,7 +2,7 @@
  * completeAndSubmitConnectionToTheBuyerForm
  * Completes and submits the "traded with buyer" form.
  * @param {Object} Object with flags on how to complete the form.
- * - exporterHasTradedWithBuyer: Should submit "yes" to "traded with buyer" radio. Defaults to "no".
+ * - exporterHasTradedWithBuyer: Should submit "yes" to "traded with buyer" radio. Defaults to false.
  */
 const completeAndSubmitTradedWithBuyerForm = ({ exporterHasTradedWithBuyer = false }) => {
   cy.completeTradedWithBuyerForm({ exporterHasTradedWithBuyer });

--- a/e2e-tests/commands/insurance/your-buyer/complete-buyer-financial-information-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-buyer-financial-information-form.js
@@ -2,7 +2,7 @@
  * completeBuyerFinancialInformationForm
  * Completes the "buyer financial information" form.
  * @param {Object} Object with flags on how to complete the form.
- * - exporterHasBuyerFinancialAccounts: Should submit "yes" to "buyer financial information" radio. Defaults to "no".
+ * - exporterHasBuyerFinancialAccounts: Should submit "yes" to "buyer financial information" radio. Defaults to false.
  */
 const completeBuyerFinancialInformationForm = ({ exporterHasBuyerFinancialAccounts = false }) => {
   if (exporterHasBuyerFinancialAccounts) {

--- a/e2e-tests/commands/insurance/your-buyer/complete-connection-with-the-buyer-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-connection-with-the-buyer-form.js
@@ -7,7 +7,7 @@ const { CONNECTION_WITH_BUYER_DESCRIPTION } = INSURANCE_FIELD_IDS.YOUR_BUYER;
 /**
  * completeConnectionWithTheBuyerForm
  * Complete the "connection with the buyer" form.
- * @param {Boolean} hasConnectionToBuyer: Should submit "yes" to "have connection to buyer" radio. Defaults to "no".
+ * @param {Boolean} hasConnectionToBuyer: Should submit "yes" to "have connection to buyer" radio. Defaults to false.
  * @param {String} description: "Connection with buyer" description.
  */
 const completeConnectionWithTheBuyerForm = ({ hasConnectionToBuyer = false, description = application.BUYER[CONNECTION_WITH_BUYER_DESCRIPTION] }) => {

--- a/e2e-tests/commands/insurance/your-buyer/complete-traded-with-buyer-form.js
+++ b/e2e-tests/commands/insurance/your-buyer/complete-traded-with-buyer-form.js
@@ -2,7 +2,7 @@
  * completeTradedWithBuyerForm
  * Completes the "traded with buyer" form.
  * @param {Object} Object with flags on how to complete the form.
- * - exporterHasTradedWithBuyer: Should submit "yes" to "traded with buyer" radio. Defaults to "no".
+ * - exporterHasTradedWithBuyer: Should submit "yes" to "traded with buyer" radio. Defaults to false.
  */
 const completeTradedWithBuyerForm = ({ exporterHasTradedWithBuyer = false }) => {
   if (exporterHasTradedWithBuyer) {

--- a/e2e-tests/constants/field-ids/insurance/policy/index.js
+++ b/e2e-tests/constants/field-ids/insurance/policy/index.js
@@ -64,8 +64,12 @@ export const POLICY = {
     // TODO: EMS-3975
     FULL_ADDRESS: 'fullAddress',
     IS_BASED_IN_UK: 'isBasedInUk',
-    POSTCODE: 'postcode',
     BUILDING_NUMBER_OR_NAME: 'buildingNumberOrName',
+    ADDRESS_LINE_1: 'addressLine1',
+    ADDRESS_LINE_2: 'addressLine2',
+    TOWN: 'town',
+    COUNTY: 'county',
+    POSTCODE: 'postcode',
   },
   BROKER_ADDRESSES: {
     SELECT_THE_ADDRESS: 'selectTheAddress',

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-policy-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-policy-fully-populated.spec.js
@@ -13,6 +13,7 @@ context('Insurance - submit an application - Multiple policy type - fully popula
       totalContractValueOverThreshold: true,
       hasHadCreditInsuranceCoverWithBuyer: true,
       usingBroker: true,
+      brokerIsBasedInUk: true,
     }).then((refNumber) => {
       referenceNumber = refNumber;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-with-broker-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-with-broker-based-in-uk.spec.js
@@ -1,10 +1,16 @@
+import { APPLICATION } from '../../../../../../../constants';
+
 context(
-  'Insurance - submit an application - Single policy type with a broker - As an Exporter, I want to submit my completed credit insurance application, So that UKEF can process and make a decision on my application',
+  'Insurance - submit an application - Multiple policy type with a broker - based in UK - As an Exporter, I want to submit my completed credit insurance application, So that UKEF can process and make a decision on my application',
   () => {
     let referenceNumber;
 
     before(() => {
-      cy.completeSignInAndSubmitAnApplication({ usingBroker: true }).then((refNumber) => {
+      cy.completeSignInAndSubmitAnApplication({
+        policyType: APPLICATION.POLICY_TYPE.MULTIPLE,
+        usingBroker: true,
+        brokerIsBasedInUk: true,
+      }).then((refNumber) => {
         referenceNumber = refNumber;
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-with-broker-not-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-with-broker-not-based-in-uk.spec.js
@@ -1,7 +1,7 @@
 import { APPLICATION } from '../../../../../../../constants';
 
 context(
-  'Insurance - submit an application - Multiple policy type with a broker - As an Exporter, I want to submit my completed credit insurance application, So that UKEF can process and make a decision on my application',
+  'Insurance - submit an application - Multiple policy type with a broker - not based in UK - As an Exporter, I want to submit my completed credit insurance application, So that UKEF can process and make a decision on my application',
   () => {
     let referenceNumber;
 
@@ -9,6 +9,7 @@ context(
       cy.completeSignInAndSubmitAnApplication({
         policyType: APPLICATION.POLICY_TYPE.MULTIPLE,
         usingBroker: true,
+        brokerIsBasedInUk: false,
       }).then((refNumber) => {
         referenceNumber = refNumber;
       });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-fully-populated.spec.js
@@ -16,6 +16,7 @@ context(
         exportingWithCodeOfConduct: true,
         policyValueOverMvpMaximum: true,
         usingBroker: true,
+        brokerIsBasedInUk: true,
         otherCompanyInvolved: true,
         differentPolicyContact: true,
         needPreCreditPeriod: true,

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-policy-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-policy-fully-populated.spec.js
@@ -10,6 +10,7 @@ context('Insurance - submit an application - Single policy type - fully populate
       totalContractValueOverThreshold: true,
       hasHadCreditInsuranceCoverWithBuyer: true,
       usingBroker: true,
+      brokerIsBasedInUk: true,
     }).then((refNumber) => {
       referenceNumber = refNumber;
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-with-broker-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-with-broker-based-in-uk.spec.js
@@ -1,0 +1,31 @@
+context(
+  'Insurance - submit an application - Single policy type with a broker - based in UK - As an Exporter, I want to submit my completed credit insurance application, So that UKEF can process and make a decision on my application',
+  () => {
+    let referenceNumber;
+
+    before(() => {
+      cy.completeSignInAndSubmitAnApplication({
+        usingBroker: true,
+        brokerIsBasedInUk: true,
+      }).then((refNumber) => {
+        referenceNumber = refNumber;
+      });
+    });
+
+    beforeEach(() => {
+      cy.saveSession();
+    });
+
+    after(() => {
+      cy.deleteApplication(referenceNumber);
+    });
+
+    it('should successfully submit the application and redirect to `application submitted`', () => {
+      cy.assertApplicationSubmittedUrl(referenceNumber);
+    });
+
+    it('should render in a `submitted` state in the dashboard', () => {
+      cy.assertDashboardApplicationSubmitted(referenceNumber);
+    });
+  },
+);

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-with-broker-not-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-with-broker-not-based-in-uk.spec.js
@@ -1,0 +1,31 @@
+context(
+  'Insurance - submit an application - Single policy type with a broker - not based in UK - As an Exporter, I want to submit my completed credit insurance application, So that UKEF can process and make a decision on my application',
+  () => {
+    let referenceNumber;
+
+    before(() => {
+      cy.completeSignInAndSubmitAnApplication({
+        usingBroker: true,
+        brokerIsBasedInUk: false,
+      }).then((refNumber) => {
+        referenceNumber = refNumber;
+      });
+    });
+
+    beforeEach(() => {
+      cy.saveSession();
+    });
+
+    after(() => {
+      cy.deleteApplication(referenceNumber);
+    });
+
+    it('should successfully submit the application and redirect to `application submitted`', () => {
+      cy.assertApplicationSubmittedUrl(referenceNumber);
+    });
+
+    it('should render in a `submitted` state in the dashboard', () => {
+      cy.assertDashboardApplicationSubmitted(referenceNumber);
+    });
+  },
+);

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-fully-populated.spec.js
@@ -13,6 +13,7 @@ context(
         exportingWithCodeOfConduct: true,
         policyValueOverMvpMaximum: true,
         usingBroker: true,
+        brokerIsBasedInUk: true,
         otherCompanyInvolved: true,
         differentPolicyContact: true,
         needPreCreditPeriod: true,

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-addresses/broker-addresses-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-addresses/broker-addresses-page.spec.js
@@ -112,9 +112,7 @@ context('Insurance - Policy - Broker addresses page', () => {
     });
 
     it(`should redirect to ${BROKER_CONFIRM_ADDRESS_ROOT}`, () => {
-      radios(optionId).option.label().click();
-
-      cy.clickSubmitButton();
+      cy.completeAndSubmitBrokerAddressesForm({});
 
       cy.assertUrl(brokerConfirmAddressUrl);
     });

--- a/e2e-tests/insurance/cypress/support/application/policy/index.js
+++ b/e2e-tests/insurance/cypress/support/application/policy/index.js
@@ -28,6 +28,8 @@ Cypress.Commands.add('completeAndSubmitOtherCompanyDetailsForm', require('../../
 Cypress.Commands.add('completeAndSubmitBrokerForm', require('../../../../../commands/insurance/complete-and-submit-broker-form'));
 Cypress.Commands.add('completeBrokerDetailsForm', require('../../../../../commands/insurance/complete-broker-details-form'));
 Cypress.Commands.add('completeAndSubmitBrokerDetailsForm', require('../../../../../commands/insurance/complete-and-submit-broker-details-form'));
+Cypress.Commands.add('completeBrokerAddressesForm', require('../../../../../commands/insurance/complete-broker-addresses-form'));
+Cypress.Commands.add('completeAndSubmitBrokerAddressesForm', require('../../../../../commands/insurance/complete-and-submit-broker-addresses-form'));
 Cypress.Commands.add('completeAndSubmitLossPayeeForm', require('../../../../../commands/insurance/complete-and-submit-loss-payee-form'));
 Cypress.Commands.add('completeLossPayeeDetailsForm', require('../../../../../commands/insurance/complete-loss-payee-details-form'));
 Cypress.Commands.add('completeAndSubmitLossPayeeDetailsForm', require('../../../../../commands/insurance/complete-and-submit-loss-payee-details-form'));

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -350,8 +350,12 @@ var POLICY = {
     // TODO: EMS-3975
     FULL_ADDRESS: 'fullAddress',
     IS_BASED_IN_UK: 'isBasedInUk',
-    POSTCODE: 'postcode',
     BUILDING_NUMBER_OR_NAME: 'buildingNumberOrName',
+    ADDRESS_LINE_1: 'addressLine1',
+    ADDRESS_LINE_2: 'addressLine2',
+    TOWN: 'town',
+    COUNTY: 'county',
+    POSTCODE: 'postcode',
   },
   BROKER_ADDRESSES: {
     SELECT_THE_ADDRESS: 'selectTheAddress',

--- a/src/api/constants/field-ids/insurance/policy/index.ts
+++ b/src/api/constants/field-ids/insurance/policy/index.ts
@@ -64,8 +64,12 @@ export const POLICY = {
     // TODO: EMS-3975
     FULL_ADDRESS: 'fullAddress',
     IS_BASED_IN_UK: 'isBasedInUk',
-    POSTCODE: 'postcode',
     BUILDING_NUMBER_OR_NAME: 'buildingNumberOrName',
+    ADDRESS_LINE_1: 'addressLine1',
+    ADDRESS_LINE_2: 'addressLine2',
+    TOWN: 'town',
+    COUNTY: 'county',
+    POSTCODE: 'postcode',
   },
   BROKER_ADDRESSES: {
     SELECT_THE_ADDRESS: 'selectTheAddress',

--- a/src/ui/server/constants/field-ids/insurance/policy/index.ts
+++ b/src/ui/server/constants/field-ids/insurance/policy/index.ts
@@ -64,8 +64,12 @@ export const POLICY = {
     // TODO: EMS-3975
     FULL_ADDRESS: 'fullAddress',
     IS_BASED_IN_UK: 'isBasedInUk',
-    POSTCODE: 'postcode',
     BUILDING_NUMBER_OR_NAME: 'buildingNumberOrName',
+    ADDRESS_LINE_1: 'addressLine1',
+    ADDRESS_LINE_2: 'addressLine2',
+    TOWN: 'town',
+    COUNTY: 'county',
+    POSTCODE: 'postcode',
   },
   BROKER_ADDRESSES: {
     SELECT_THE_ADDRESS: 'selectTheAddress',

--- a/src/ui/server/controllers/insurance/all-sections/index.test.ts
+++ b/src/ui/server/controllers/insurance/all-sections/index.test.ts
@@ -54,7 +54,7 @@ describe('controllers/insurance/all-sections', () => {
         },
       } = exportContract;
 
-      const { isUsingBroker } = broker;
+      const { isUsingBroker, isBasedInUk: brokerIsBasedInUk } = broker;
       const { hasDifferentTradingName } = company;
       const { hasAntiBriberyCodeOfConduct } = declaration;
       const { buyerTradingHistory, relationship } = buyer;
@@ -70,6 +70,7 @@ describe('controllers/insurance/all-sections', () => {
         finalDestinationKnown,
         jointlyInsuredParty.requested,
         isUsingBroker,
+        brokerIsBasedInUk,
         isAppointingLossPayee,
         lossPayeeIsLocatedInUk,
         lossPayeeIsLocatedInternationally,

--- a/src/ui/server/controllers/insurance/all-sections/index.ts
+++ b/src/ui/server/controllers/insurance/all-sections/index.ts
@@ -46,7 +46,7 @@ export const get = (req: Request, res: Response) => {
     },
   } = exportContract;
 
-  const { isUsingBroker } = broker;
+  const { isUsingBroker, isBasedInUk: brokerIsBasedInUk } = broker;
   const { hasDifferentTradingName } = company;
   const { hasAntiBriberyCodeOfConduct } = declaration;
   const { buyerTradingHistory, relationship } = buyer;
@@ -62,6 +62,7 @@ export const get = (req: Request, res: Response) => {
     finalDestinationKnown,
     jointlyInsuredParty.requested,
     isUsingBroker,
+    brokerIsBasedInUk,
     isAppointingLossPayee,
     lossPayeeIsLocatedInUk,
     lossPayeeIsLocatedInternationally,

--- a/src/ui/server/helpers/required-fields/policy/index.test.ts
+++ b/src/ui/server/helpers/required-fields/policy/index.test.ts
@@ -9,7 +9,7 @@ const { POLICY_TYPE } = FIELD_VALUES;
 const { REQUESTED_START_DATE, POLICY_CURRENCY_CODE } = SHARED_CONTRACT_POLICY;
 
 const {
-  BROKER_DETAILS: { NAME, BROKER_EMAIL },
+  BROKER_DETAILS: { NAME, BROKER_EMAIL, ADDRESS_LINE_1, ADDRESS_LINE_2, TOWN, POSTCODE, FULL_ADDRESS },
   CONTRACT_POLICY: {
     SINGLE: { CONTRACT_COMPLETION_DATE, REQUESTED_CREDIT_LIMIT, TOTAL_CONTRACT_VALUE },
     MULTIPLE: { TOTAL_MONTHS_OF_COVER },
@@ -116,13 +116,27 @@ describe('server/helpers/required-fields/policy', () => {
   });
 
   describe('getBrokerTasks', () => {
-    describe('when isUsingBroker is true', () => {
+    describe('when isUsingBroker is true, brokerIsBasedInUk is false', () => {
       it('should return multiple field ids in an array', () => {
         const isUsingBrokerFlag = true;
+        const brokerIsBasedInUkFlag = false;
 
-        const result = getBrokerTasks(isUsingBrokerFlag);
+        const result = getBrokerTasks(isUsingBrokerFlag, brokerIsBasedInUkFlag);
 
-        const expected = [NAME, BROKER_EMAIL];
+        const expected = [NAME, BROKER_EMAIL, FULL_ADDRESS];
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('when isUsingBroker is true, brokerIsBasedInUk is true', () => {
+      it('should return multiple field ids in an array', () => {
+        const isUsingBrokerFlag = true;
+        const brokerIsBasedInUkFlag = true;
+
+        const result = getBrokerTasks(isUsingBrokerFlag, brokerIsBasedInUkFlag);
+
+        const expected = [NAME, BROKER_EMAIL, ADDRESS_LINE_1, ADDRESS_LINE_2, TOWN, POSTCODE];
 
         expect(result).toEqual(expected);
       });

--- a/src/ui/server/helpers/required-fields/policy/index.ts
+++ b/src/ui/server/helpers/required-fields/policy/index.ts
@@ -5,7 +5,7 @@ import { isSinglePolicyType, isMultiplePolicyType } from '../../policy-type';
 const { REQUESTED_START_DATE, POLICY_CURRENCY_CODE } = SHARED_CONTRACT_POLICY;
 
 const {
-  BROKER_DETAILS: { NAME, BROKER_EMAIL },
+  BROKER_DETAILS: { NAME, BROKER_EMAIL, ADDRESS_LINE_1, ADDRESS_LINE_2, TOWN, POSTCODE, FULL_ADDRESS },
   CONTRACT_POLICY: {
     SINGLE: { CONTRACT_COMPLETION_DATE, REQUESTED_CREDIT_LIMIT, TOTAL_CONTRACT_VALUE },
     MULTIPLE: { TOTAL_MONTHS_OF_COVER },
@@ -72,17 +72,23 @@ export const getJointlyInsuredPartyTasks = (jointlyInsuredParty?: boolean) => {
  * getBrokerTasks
  * Get "Broker" tasks depending on the isUsingBroker field
  * @param {Boolean} isUsingBroker: "Is using broker" flag
+ * @param {Boolean} brokerIsBasedInUk: "Broker is based in the UK" flag
  * @returns {Array} Array of tasks
  */
-export const getBrokerTasks = (isUsingBroker?: boolean) => {
-  if (isUsingBroker) {
-    // TODO: EMS-3979
-    // return [NAME, BROKER_EMAIL, FULL_ADDRESS];
+export const getBrokerTasks = (isUsingBroker?: boolean, brokerIsBasedInUk?: boolean) => {
+  let tasks: Array<string> = [];
 
-    return [NAME, BROKER_EMAIL];
+  if (isUsingBroker) {
+    tasks = [NAME, BROKER_EMAIL];
+
+    if (brokerIsBasedInUk) {
+      tasks = [...tasks, ADDRESS_LINE_1, ADDRESS_LINE_2, TOWN, POSTCODE];
+    } else {
+      tasks = [...tasks, FULL_ADDRESS];
+    }
   }
 
-  return [];
+  return tasks;
 };
 
 /**
@@ -113,6 +119,7 @@ interface RequiredFields {
   policyType?: string;
   jointlyInsuredParty?: boolean;
   isUsingBroker?: boolean;
+  brokerIsBasedInUk?: boolean;
   isAppointingLossPayee?: boolean;
   lossPayeeIsLocatedInUk?: boolean;
   lossPayeeIsLocatedInternationally?: boolean;
@@ -124,12 +131,17 @@ interface RequiredFields {
  * @param {Boolean} finalDestinationKnown: "Final destination known"
  * @param {Boolean} jointlyInsuredParty: "Jointly insured party" flag
  * @param {Boolean} isUsingBroker: "Is using broker"
+ * @param {Boolean} brokerIsBasedInUk: "Broker is based in the UK" flag
+ * @param {Boolean} isAppointingLossPayee: "Is using loss payee" flag
+ * @param {Boolean} lossPayeeIsLocatedInUk: "Loss payee is located in the UK" flag
+ * @param {Boolean} lossPayeeIsLocatedInternationally: "Loss payee is located internationally" flag
  * @returns {Array} Required field IDs
  */
 const requiredFields = ({
   policyType,
   jointlyInsuredParty,
   isUsingBroker,
+  brokerIsBasedInUk,
   isAppointingLossPayee,
   lossPayeeIsLocatedInUk,
   lossPayeeIsLocatedInternationally,
@@ -145,7 +157,7 @@ const requiredFields = ({
   POLICY_CONTACT_EMAIL,
   POSITION,
   USING_BROKER,
-  ...getBrokerTasks(isUsingBroker),
+  ...getBrokerTasks(isUsingBroker, brokerIsBasedInUk),
   ...lossPayeeTasks(isAppointingLossPayee, lossPayeeIsLocatedInUk, lossPayeeIsLocatedInternationally),
 ];
 

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/index.test.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/index.test.ts
@@ -10,7 +10,7 @@ const { INITIAL_CHECKS, PREPARE_APPLICATION, SUBMIT_APPLICATION } = TASKS.LIST;
 
 describe('server/helpers/task-list/generate-groups-and-tasks', () => {
   const {
-    broker: { isUsingBroker },
+    broker: { isUsingBroker, isBasedInUk: brokerIsBasedInUk },
     buyer: {
       relationship: { exporterIsConnectedWithBuyer, exporterHasPreviousCreditInsuranceWithBuyer },
       buyerTradingHistory: { exporterHasTradedWithBuyer, outstandingPayments },
@@ -46,6 +46,7 @@ describe('server/helpers/task-list/generate-groups-and-tasks', () => {
       finalDestinationKnown,
       jointlyInsuredParty.requested,
       isUsingBroker,
+      brokerIsBasedInUk,
       isAppointingLossPayee,
       lossPayeeIsLocatedInUk,
       lossPayeeIsLocatedInInternationally,
@@ -80,6 +81,7 @@ describe('server/helpers/task-list/generate-groups-and-tasks', () => {
         finalDestinationKnown,
         jointlyInsuredParty: jointlyInsuredParty.requested,
         isUsingBroker,
+        brokerIsBasedInUk,
         isAppointingLossPayee,
         lossPayeeIsLocatedInUk,
         hasDifferentTradingName,

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/index.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/index.ts
@@ -14,6 +14,7 @@ const { INITIAL_CHECKS, PREPARE_APPLICATION, SUBMIT_APPLICATION } = TASKS.LIST;
  * @param {Boolean} finalDestinationKnown: "Final destination known" flag
  * @param {Boolean} jointlyInsuredParty: "Jointly insured party" flag
  * @param {Boolean} isUsingBroker: "Is using broker" flag
+ * @param {Boolean} brokerIsBasedInUk: "Broker is based in the UK" flag
  * @param {Boolean} isAppointingLossPayee: "Is using loss payee" flag
  * @param {Boolean} lossPayeeIsLocatedInUk: "Loss payee is located in the UK" flag
  * @param {Boolean} lossPayeeIsLocatedInternationally: "Loss payee is located internationally" flag
@@ -37,6 +38,7 @@ const generateGroupsAndTasks = (
   finalDestinationKnown?: boolean,
   jointlyInsuredParty?: boolean,
   isUsingBroker?: boolean,
+  brokerIsBasedInUk?: boolean,
   isAppointingLossPayee?: boolean,
   lossPayeeIsLocatedInUk?: boolean,
   lossPayeeIsLocatedInternationally?: boolean,
@@ -74,6 +76,7 @@ const generateGroupsAndTasks = (
         finalDestinationKnown,
         jointlyInsuredParty,
         isUsingBroker,
+        brokerIsBasedInUk,
         isAppointingLossPayee,
         lossPayeeIsLocatedInUk,
         lossPayeeIsLocatedInternationally,

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/prepare-application.test.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/prepare-application.test.ts
@@ -23,7 +23,7 @@ const { PREPARE_APPLICATION } = TASKS.LIST;
 
 describe('server/helpers/task-list/prepare-application', () => {
   const {
-    broker: { isUsingBroker },
+    broker: { isUsingBroker, isBasedInUk: brokerIsBasedInUk },
     buyer: {
       relationship: { exporterIsConnectedWithBuyer, exporterHasPreviousCreditInsuranceWithBuyer },
       buyerTradingHistory: { exporterHasTradedWithBuyer, outstandingPayments },
@@ -70,6 +70,7 @@ describe('server/helpers/task-list/prepare-application', () => {
         finalDestinationKnown,
         jointlyInsuredParty: jointlyInsuredParty.requested,
         isUsingBroker,
+        brokerIsBasedInUk,
         isAppointingLossPayee,
         lossPayeeIsLocatedInUk,
         lossPayeeIsLocatedInternationally,
@@ -118,6 +119,7 @@ describe('server/helpers/task-list/prepare-application', () => {
           policyType,
           jointlyInsuredParty: jointlyInsuredParty.requested,
           isUsingBroker,
+          brokerIsBasedInUk,
           isAppointingLossPayee,
           lossPayeeIsLocatedInUk,
           lossPayeeIsLocatedInternationally,

--- a/src/ui/server/helpers/task-list/generate-groups-and-tasks/prepare-application.ts
+++ b/src/ui/server/helpers/task-list/generate-groups-and-tasks/prepare-application.ts
@@ -24,6 +24,7 @@ const { PREPARE_APPLICATION } = TASKS.LIST;
  * @param {Array} otherGroups: Task list groups
  * @param {String} policyType: Application "Policy type"
  * @param {Boolean} isUsingBroker: "Is using broker" flag
+ * @param {Boolean} brokerIsBasedInUk: "Broker is based in the UK" flag
  * @param {Boolean} isAppointingLossPayee: "Is using loss payee" flag
  * @param {Boolean} lossPayeeIsLocatedInUk: "Loss payee is located in the UK" flag
  * @param {Boolean} lossPayeeIsLocatedInternationally: "Loss payee is located internationally" flag
@@ -41,6 +42,7 @@ const createPrepareApplicationTasks = ({
   finalDestinationKnown,
   jointlyInsuredParty,
   isUsingBroker,
+  brokerIsBasedInUk,
   isAppointingLossPayee,
   lossPayeeIsLocatedInUk,
   lossPayeeIsLocatedInternationally,
@@ -92,6 +94,7 @@ const createPrepareApplicationTasks = ({
       policyType,
       jointlyInsuredParty,
       isUsingBroker,
+      brokerIsBasedInUk,
       isAppointingLossPayee,
       lossPayeeIsLocatedInUk,
       lossPayeeIsLocatedInternationally,

--- a/src/ui/types/application.ts
+++ b/src/ui/types/application.ts
@@ -125,9 +125,10 @@ interface ApplicationBusiness {
 interface ApplicationBroker {
   id: string;
   isUsingBroker?: boolean;
+  isBasedInUk?: boolean;
   name?: string;
-  fullAddress?: string;
   email?: string;
+  fullAddress?: string;
 }
 
 interface ApplicationBuyerCountry {

--- a/src/ui/types/task-list.ts
+++ b/src/ui/types/task-list.ts
@@ -37,6 +37,7 @@ interface CreatePrepareApplicationTasksParams {
   finalDestinationKnown?: boolean;
   jointlyInsuredParty?: boolean;
   isUsingBroker?: boolean;
+  brokerIsBasedInUk?: boolean;
   isAppointingLossPayee?: boolean;
   lossPayeeIsLocatedInUk?: boolean;
   lossPayeeIsLocatedInternationally?: boolean;


### PR DESCRIPTION
## ⚠️ Need these PRs merged first:

- https://github.com/UK-Export-Finance/exip/pull/3324
- https://github.com/UK-Export-Finance/exip/pull/3321
- https://github.com/UK-Export-Finance/exip/pull/3318

## Introduction :pencil2:
This PR updates the task list logic to accomodate for recently introduced broker fields, depending on if the broker is based in the UK.

## Resolution :heavy_check_mark:
- Create new `completeAndSubmitBrokerAddressesForm` and `completeBrokerAddressesForm` cypress commands.
- Update various cypress commands to consume and pass `brokerIsBasedInUk`.
- Update `completePolicySection` cypress command.
- Update field ID constants.
- Add E2E coverage for submitting applications with a broker based in or outside of the UK.
- Update task list functions.

## Miscellaneous :heavy_plus_sign:
- Minor documentation improvments.
