### PR TITLE
feat(EMS-3993): multiple contract policy - small export builder content

### DIFF
--- a/e2e-tests/content-strings/fields/insurance/policy/index.js
+++ b/e2e-tests/content-strings/fields/insurance/policy/index.js
@@ -1,6 +1,7 @@
 import { APPLICATION, ELIGIBILITY, FIELD_VALUES, MAXIMUM_CHARACTERS } from '../../../../constants';
 import { INSURANCE_FIELD_IDS } from '../../../../constants/field-ids/insurance';
 import { FORM_TITLES } from '../../../form-titles';
+import { LINKS } from '../../../links';
 
 const {
   ACCOUNT: { EMAIL },
@@ -140,6 +141,13 @@ export const POLICY_FIELDS = {
         LABEL: 'Estimate the maximum amount your buyer will owe you at any single point during this time',
         HINT: {
           FOR_EXAMPLE: 'For example, your total sales might be £250,000 but the maximum the buyer will owe you at any single point is £100,000.',
+          INITIAL_CREDIT_LIMIT: {
+            INTRO: 'If your initial credit limit request is £25,000 or less you could be eligible for the',
+            LINK: {
+              TEXT: 'Small Export Builder.',
+              HREF: LINKS.EXTERNAL.SMALL_EXPORT_BUILDER,
+            },
+          },
           NO_DECIMALS: 'Enter a whole number. Do not enter decimals.',
         },
         SUMMARY: {

--- a/e2e-tests/content-strings/links.js
+++ b/e2e-tests/content-strings/links.js
@@ -31,5 +31,6 @@ export const LINKS = {
     BRIBERY_ACT_2010_GUIDANCE: 'https://assets.publishing.service.gov.uk/media/5d80cfc3ed915d51e9aff85a/bribery-act-2010-guidance.pdf',
     ICO_MAKE_A_COMPLAINT: 'https://ico.org.uk/make-a-complaint',
     COMPANIES_HOUSE: 'https://find-and-update.company-information.service.gov.uk',
+    SMALL_EXPORT_BUILDER: 'Small Export Builder',
   },
 };

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/multiple-contract-policy/export-value/multiple-contract-policy-export-value.spec.js
@@ -1,6 +1,6 @@
 import { field as fieldSelector, headingCaption } from '../../../../../../../pages/shared';
 import { multipleContractPolicyExportValuePage } from '../../../../../../../pages/insurance/policy';
-import { PAGES } from '../../../../../../../content-strings';
+import { LINKS, PAGES } from '../../../../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../content-strings/fields/insurance/policy';
 import { FIELD_VALUES } from '../../../../../../../constants';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../constants/field-ids/insurance/policy';
@@ -54,7 +54,7 @@ context(
       cy.deleteApplication(referenceNumber);
     });
 
-    it('renders core page elements', () => {
+    it('should render core page elements', () => {
       cy.corePageChecks({
         pageTitle: `${CONTENT_STRINGS.PAGE_TITLE} ${GBP.name}`,
         currentHref: `${INSURANCE_ROOT}/${referenceNumber}${MULTIPLE_CONTRACT_POLICY_EXPORT_VALUE}`,
@@ -67,11 +67,11 @@ context(
         cy.navigateToUrl(url);
       });
 
-      it('renders a heading caption', () => {
+      it('should render a heading caption', () => {
         cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
       });
 
-      it('renders `total sales to buyer` label, hint, prefix and input', () => {
+      it('should render `total sales to buyer` label, hint, prefix and input', () => {
         const fieldId = TOTAL_SALES_TO_BUYER;
         const field = fieldSelector(fieldId);
 
@@ -84,20 +84,43 @@ context(
         field.input().should('exist');
       });
 
-      it('renders `maximum buyer will owe` label, hint, prefix, input', () => {
+      describe('`maximum buyer will owe` field', () => {
         const fieldId = MAXIMUM_BUYER_WILL_OWE;
         const field = multipleContractPolicyExportValuePage[fieldId];
         const { HINT } = EXPORT_VALUE.MULTIPLE[fieldId];
 
-        cy.checkText(field.label(), EXPORT_VALUE.MULTIPLE[fieldId].LABEL);
+        it('should render a label', () => {
+          cy.checkText(field.label(), EXPORT_VALUE.MULTIPLE[fieldId].LABEL);
 
-        cy.assertPrefix({ fieldId, value: SYMBOLS.GBP });
+          cy.assertPrefix({ fieldId, value: SYMBOLS.GBP });
+        });
 
-        cy.checkText(field.hint.forExample(), HINT.FOR_EXAMPLE);
+        it('should render a prefix', () => {
+          cy.assertPrefix({ fieldId, value: SYMBOLS.GBP });
+        });
 
-        cy.checkText(field.hint.noDecimals(), HINT.NO_DECIMALS);
+        it('should render a `for example` hint', () => {
+          cy.checkText(field.hint.forExample(), HINT.FOR_EXAMPLE);
+        });
 
-        field.input().should('exist');
+        it('should render an `initial credit limit` hint intro', () => {
+          cy.checkText(field.hint.initialCreditLimit.intro(), HINT.INITIAL_CREDIT_LIMIT.INTRO);
+        });
+
+        it('should render an `initial credit limit` hint link', () => {
+          const expectedHref = LINKS.EXTERNAL.SMALL_EXPORT_BUILDER;
+          const expectedText = HINT.INITIAL_CREDIT_LIMIT.LINK.TEXT;
+
+          cy.checkLink(field.hint.initialCreditLimit.link(), expectedHref, expectedText);
+        });
+
+        it('should render a `no decimals` hint', () => {
+          cy.checkText(field.hint.noDecimals(), HINT.NO_DECIMALS);
+        });
+
+        it('should render an input', () => {
+          field.input().should('exist');
+        });
       });
     });
 

--- a/e2e-tests/pages/insurance/policy/multipleContractPolicyExportValue.js
+++ b/e2e-tests/pages/insurance/policy/multipleContractPolicyExportValue.js
@@ -12,8 +12,10 @@ const multipleContractPolicyExportValue = {
     ...field(MAXIMUM_BUYER_WILL_OWE),
     hint: {
       forExample: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-hint-for-example"]`),
-      needMoreCover: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-hint-need-more-cover"]`),
-      fillInFormLink: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-hint-fill-in-form-link"]`),
+      initialCreditLimit: {
+        intro: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-hint-initial-credit-limit-intro"]`),
+        link: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-hint-initial-credit-limit-link"]`),
+      },
       noDecimals: () => cy.get(`[data-cy="${MAXIMUM_BUYER_WILL_OWE}-hint-no-decimals"]`),
     },
     text: () => cy.get('[data-cy="details-1"]'),

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -6267,6 +6267,7 @@ var LINKS = {
     BRIBERY_ACT_2010_GUIDANCE: 'https://www.justice.gov.uk/downloads/legislation/bribery-act-2010-guidance.pdf',
     ICO_MAKE_A_COMPLAINT: 'https://ico.org.uk/make-a-complaint',
     COMPANIES_HOUSE: 'https://find-and-update.company-information.service.gov.uk',
+    SMALL_EXPORT_BUILDER: 'Small Export Builder',
   },
 };
 
@@ -6628,6 +6629,13 @@ var POLICY_FIELDS = {
         LABEL: 'Estimate the maximum amount your buyer will owe you at any single point during this time',
         HINT: {
           FOR_EXAMPLE: 'For example, your total sales might be \xA3250,000 but the maximum the buyer will owe you at any single point is \xA3100,000.',
+          INITIAL_CREDIT_LIMIT: {
+            INTRO: 'If your initial credit limit request is \xA325,000 or less you could be eligible for the',
+            LINK: {
+              TEXT: 'Small Export Builder.',
+              HREF: LINKS.EXTERNAL.SMALL_EXPORT_BUILDER,
+            },
+          },
           NO_DECIMALS: 'Enter a whole number. Do not enter decimals.',
         },
         SUMMARY: {

--- a/src/api/constants/application/versions/index.ts
+++ b/src/api/constants/application/versions/index.ts
@@ -29,15 +29,16 @@ const VERSION_3: ApplicationVersion = {
 /**
  * VERSIONS
  * All possible application versions.
- * These versions highlight changes to certain features involving data changes,
- * That differ as the service is iterated.
+ * These versions highlight changes to certain features, involving:
+ * - Data changes
+ * - Changes to thresholds
+ * - Required questions/answers
+ * These differ as the service is iterated.
  * This should be manually updated each time a phase of EXIP is started. For example:
  * - Version number 1: MVP, no support for applications over 500k.
  * - Version number 2: Support for applications over 500k.
  * - Version number 3: Design and content iterations. 1x new database field.
- * - Version number 4: Address lookup
- * - Version number 5: File uploads
- * - Version number 6: Payments integration
+ * - Version number 4: Payments integration
  * @returns {Array<ApplicationVersion>} All application versions
  */
 const VERSIONS: Array<ApplicationVersion> = [VERSION_1, VERSION_2, VERSION_3];

--- a/src/api/constants/application/versions/index.ts
+++ b/src/api/constants/application/versions/index.ts
@@ -1,7 +1,7 @@
-import { ApplicationVersion } from '../../../types';
 import { GBP } from '../../supported-currencies';
+import { ApplicationVersion } from '../../../types';
 
-const VERSION_1 = {
+const VERSION_1: ApplicationVersion = {
   VERSION_NUMBER: '1',
   OVER_500K_SUPPORT: false,
   MAXIMUM_BUYER_CAN_OWE: 500000,
@@ -9,22 +9,22 @@ const VERSION_1 = {
   DEFAULT_FINAL_DESTINATION_KNOWN: true,
   DEFAULT_NEED_PRE_CREDIT_PERIOD_COVER: false,
   BROKER_ADDRESS_AS_MULTIPLE_FIELDS: true,
-} as ApplicationVersion;
+};
 
-const VERSION_2 = {
+const VERSION_2: ApplicationVersion = {
   VERSION_NUMBER: '2',
   OVER_500K_SUPPORT: true,
   DEFAULT_FINAL_DESTINATION_KNOWN: null,
   DEFAULT_NEED_PRE_CREDIT_PERIOD_COVER: null,
   DEFAULT_CURRENCY: GBP,
   BROKER_ADDRESS_AS_MULTIPLE_FIELDS: false,
-} as ApplicationVersion;
+};
 
-const VERSION_3 = {
+const VERSION_3: ApplicationVersion = {
   ...VERSION_2,
   VERSION_NUMBER: '3',
   REQUESTED_CREDIT_LIMIT_REQUIRED: true,
-} as ApplicationVersion;
+};
 
 /**
  * VERSIONS
@@ -35,9 +35,11 @@ const VERSION_3 = {
  * - Version number 1: MVP, no support for applications over 500k.
  * - Version number 2: Support for applications over 500k.
  * - Version number 3: Design and content iterations. 1x new database field.
- * - Version number 4: Payments integration
+ * - Version number 4: Address lookup
+ * - Version number 5: File uploads
+ * - Version number 6: Payments integration
  * @returns {Array<ApplicationVersion>} All application versions
  */
-const VERSIONS = [VERSION_1, VERSION_2, VERSION_3] as Array<ApplicationVersion>;
+const VERSIONS: Array<ApplicationVersion> = [VERSION_1, VERSION_2, VERSION_3];
 
 export default VERSIONS;

--- a/src/api/content-strings/fields/insurance/policy/index.ts
+++ b/src/api/content-strings/fields/insurance/policy/index.ts
@@ -1,6 +1,7 @@
 import { APPLICATION, ELIGIBILITY, FIELD_VALUES, MAXIMUM_CHARACTERS } from '../../../../constants';
 import INSURANCE_FIELD_IDS from '../../../../constants/field-ids/insurance';
 import { FORM_TITLES } from '../../../form-titles';
+import { LINKS } from '../../../links';
 
 const {
   ACCOUNT: { EMAIL },
@@ -140,6 +141,13 @@ export const POLICY_FIELDS = {
         LABEL: 'Estimate the maximum amount your buyer will owe you at any single point during this time',
         HINT: {
           FOR_EXAMPLE: 'For example, your total sales might be £250,000 but the maximum the buyer will owe you at any single point is £100,000.',
+          INITIAL_CREDIT_LIMIT: {
+            INTRO: 'If your initial credit limit request is £25,000 or less you could be eligible for the',
+            LINK: {
+              TEXT: 'Small Export Builder.',
+              HREF: LINKS.EXTERNAL.SMALL_EXPORT_BUILDER,
+            },
+          },
           NO_DECIMALS: 'Enter a whole number. Do not enter decimals.',
         },
         SUMMARY: {

--- a/src/api/content-strings/links.ts
+++ b/src/api/content-strings/links.ts
@@ -18,5 +18,6 @@ export const LINKS = {
     BRIBERY_ACT_2010_GUIDANCE: 'https://www.justice.gov.uk/downloads/legislation/bribery-act-2010-guidance.pdf',
     ICO_MAKE_A_COMPLAINT: 'https://ico.org.uk/make-a-complaint',
     COMPANIES_HOUSE: 'https://find-and-update.company-information.service.gov.uk',
+    SMALL_EXPORT_BUILDER: 'Small Export Builder',
   },
 };

--- a/src/ui/server/constants/application/versions/index.ts
+++ b/src/ui/server/constants/application/versions/index.ts
@@ -29,15 +29,16 @@ const VERSION_3: ApplicationVersion = {
 /**
  * VERSIONS
  * All possible application versions.
- * During each phase of EXIP that contains major feature/data changes or additions,
- * the application version number should be changed.
- * For example:
+ * These versions highlight changes to certain features, involving:
+ * - Data changes
+ * - Changes to thresholds
+ * - Required questions/answers
+ * These differ as the service is iterated.
+ * This should be manually updated each time a phase of EXIP is started. For example:
  * - Version number 1: MVP, no support for applications over 500k.
  * - Version number 2: Support for applications over 500k.
  * - Version number 3: Design and content iterations. 1x new database field.
- * - Version number 4: Address lookup
- * - Version number 5: File uploads
- * - Version number 6: Payments integration
+ * - Version number 4: Payments integration
  * @returns {Array<ApplicationVersion>} All application versions
  */
 const VERSIONS: Array<ApplicationVersion> = [VERSION_1, VERSION_2, VERSION_3];

--- a/src/ui/server/constants/application/versions/index.ts
+++ b/src/ui/server/constants/application/versions/index.ts
@@ -1,4 +1,30 @@
+import { GBP } from '../../supported-currencies';
 import { ApplicationVersion } from '../../../../types';
+
+const VERSION_1: ApplicationVersion = {
+  VERSION_NUMBER: '1',
+  OVER_500K_SUPPORT: false,
+  MAXIMUM_BUYER_CAN_OWE: 500000,
+  TOTAL_VALUE_OF_CONTRACT: 500000,
+  DEFAULT_FINAL_DESTINATION_KNOWN: true,
+  DEFAULT_NEED_PRE_CREDIT_PERIOD_COVER: false,
+  BROKER_ADDRESS_AS_MULTIPLE_FIELDS: true,
+};
+
+const VERSION_2: ApplicationVersion = {
+  VERSION_NUMBER: '2',
+  OVER_500K_SUPPORT: true,
+  DEFAULT_FINAL_DESTINATION_KNOWN: null,
+  DEFAULT_NEED_PRE_CREDIT_PERIOD_COVER: null,
+  DEFAULT_CURRENCY: GBP,
+  BROKER_ADDRESS_AS_MULTIPLE_FIELDS: false,
+};
+
+const VERSION_3: ApplicationVersion = {
+  ...VERSION_2,
+  VERSION_NUMBER: '3',
+  REQUESTED_CREDIT_LIMIT_REQUIRED: true,
+};
 
 /**
  * VERSIONS
@@ -8,26 +34,12 @@ import { ApplicationVersion } from '../../../../types';
  * For example:
  * - Version number 1: MVP, no support for applications over 500k.
  * - Version number 2: Support for applications over 500k.
- * - Version number 3: File uploads
+ * - Version number 3: Design and content iterations. 1x new database field.
  * - Version number 4: Address lookup
- * - Version number 5: Payments integration
+ * - Version number 5: File uploads
+ * - Version number 6: Payments integration
  * @returns {Array<ApplicationVersion>} All application versions
  */
-const VERSIONS = [
-  {
-    VERSION_NUMBER: '1',
-    OVER_500K_SUPPORT: false,
-    MAXIMUM_BUYER_CAN_OWE: 500000,
-    TOTAL_VALUE_OF_CONTRACT: 500000,
-    DEFAULT_FINAL_DESTINATION_KNOWN: true,
-    DEFAULT_NEED_PRE_CREDIT_PERIOD_COVER: false,
-  },
-  {
-    VERSION_NUMBER: '2',
-    OVER_500K_SUPPORT: true,
-    DEFAULT_FINAL_DESTINATION_KNOWN: null,
-    DEFAULT_NEED_PRE_CREDIT_PERIOD_COVER: null,
-  },
-] as Array<ApplicationVersion>;
+const VERSIONS: Array<ApplicationVersion> = [VERSION_1, VERSION_2, VERSION_3];
 
 export default VERSIONS;

--- a/src/ui/server/content-strings/fields/insurance/policy/index.ts
+++ b/src/ui/server/content-strings/fields/insurance/policy/index.ts
@@ -1,6 +1,7 @@
 import { APPLICATION, ELIGIBILITY, FIELD_VALUES, MAXIMUM_CHARACTERS } from '../../../../constants';
 import INSURANCE_FIELD_IDS from '../../../../constants/field-ids/insurance';
 import { FORM_TITLES } from '../../../form-titles';
+import { LINKS } from '../../../links';
 
 const {
   ACCOUNT: { EMAIL },
@@ -140,6 +141,13 @@ export const POLICY_FIELDS = {
         LABEL: 'Estimate the maximum amount your buyer will owe you at any single point during this time',
         HINT: {
           FOR_EXAMPLE: 'For example, your total sales might be £250,000 but the maximum the buyer will owe you at any single point is £100,000.',
+          INITIAL_CREDIT_LIMIT: {
+            INTRO: 'If your initial credit limit request is £25,000 or less you could be eligible for the',
+            LINK: {
+              TEXT: 'Small Export Builder.',
+              HREF: LINKS.EXTERNAL.SMALL_EXPORT_BUILDER,
+            },
+          },
           NO_DECIMALS: 'Enter a whole number. Do not enter decimals.',
         },
         SUMMARY: {

--- a/src/ui/server/content-strings/links.ts
+++ b/src/ui/server/content-strings/links.ts
@@ -31,5 +31,6 @@ export const LINKS = {
     BRIBERY_ACT_2010_GUIDANCE: 'https://assets.publishing.service.gov.uk/media/5d80cfc3ed915d51e9aff85a/bribery-act-2010-guidance.pdf',
     ICO_MAKE_A_COMPLAINT: 'https://ico.org.uk/make-a-complaint',
     COMPANIES_HOUSE: 'https://find-and-update.company-information.service.gov.uk',
+    SMALL_EXPORT_BUILDER: 'Small Export Builder',
   },
 };

--- a/src/ui/templates/insurance/policy/multiple-contract-policy-export-value.njk
+++ b/src/ui/templates/insurance/policy/multiple-contract-policy-export-value.njk
@@ -57,8 +57,21 @@
         {% set MAXIMUM_HINT = FIELDS.MAXIMUM_BUYER_WILL_OWE.HINT %}
 
         {% set maximumBuyerWillOweHintHtml %}
-          <p data-cy="{{ maximumBuyerWillOweId }}-hint-for-example">{{ MAXIMUM_HINT.FOR_EXAMPLE }}</p>
-          <p data-cy="{{ maximumBuyerWillOweId }}-hint-no-decimals">{{ MAXIMUM_HINT.NO_DECIMALS }}</p>
+
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-three-quarters-from-desktop">
+
+              <p data-cy="{{ maximumBuyerWillOweId }}-hint-for-example">{{ MAXIMUM_HINT.FOR_EXAMPLE }}</p>
+
+              <p>
+                <span data-cy="{{ maximumBuyerWillOweId }}-hint-initial-credit-limit-intro">{{ MAXIMUM_HINT.INITIAL_CREDIT_LIMIT.INTRO }}</span>&nbsp;
+                <a class="govuk-link" href="{{ MAXIMUM_HINT.INITIAL_CREDIT_LIMIT.LINK.HREF }}" data-cy="{{ maximumBuyerWillOweId }}-hint-initial-credit-limit-link">{{ MAXIMUM_HINT.INITIAL_CREDIT_LIMIT.LINK.TEXT }}</a>
+              </p>
+
+              <p data-cy="{{ maximumBuyerWillOweId }}-hint-no-decimals">{{ MAXIMUM_HINT.NO_DECIMALS }}</p>
+
+            </div>
+          </div>
         {% endset %}
 
         {{ monetaryValueInput.render({

--- a/src/ui/types/application.ts
+++ b/src/ui/types/application.ts
@@ -293,10 +293,13 @@ type ApplicationFlat = ApplicationFlatCore & ApplicationPolicy & ApplicationBrok
 interface ApplicationVersion {
   VERSION_NUMBER: string;
   OVER_500K_SUPPORT: boolean;
-  MAXIMUM_BUYER_CAN_OWE: number;
-  TOTAL_VALUE_OF_CONTRACT: number;
-  DEFAULT_FINAL_DESTINATION_KNOWN: boolean;
-  DEFAULT_NEED_PRE_CREDIT_PERIOD_COVER: boolean;
+  MAXIMUM_BUYER_CAN_OWE?: number;
+  TOTAL_VALUE_OF_CONTRACT?: number;
+  DEFAULT_FINAL_DESTINATION_KNOWN: boolean | null;
+  DEFAULT_NEED_PRE_CREDIT_PERIOD_COVER: boolean | null;
+  DEFAULT_CURRENCY?: string;
+  BROKER_ADDRESS_AS_MULTIPLE_FIELDS: boolean;
+  REQUESTED_CREDIT_LIMIT_REQUIRED?: boolean;
 }
 
 export {


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the "Multiple contract policy - export value" page to include an "intial credit limit" hint.

This new hint tells users that they could be eligible for the "Small Export Builder".

## Resolution :heavy_check_mark:
- Update content strings.
- Add E2E tests.
- Update nunjucks template.

## Miscellaneous :heavy_plus_sign:
- Minor E2E improvements.
- Update/align application version constants (The UI constants were out of date).
