### PR TITLE
feat(EMS-4046): declarations - modern slavery - save and back

### DIFF
--- a/e2e-tests/commands/insurance/declarations/complete-and-submit-modern-slavery-form-conditional-fields.js
+++ b/e2e-tests/commands/insurance/declarations/complete-and-submit-modern-slavery-form-conditional-fields.js
@@ -1,0 +1,18 @@
+/**
+ * completeAndSubmitModernSlaveryFormConditionalFields
+ * complete and submit the conditional "modern slavery" form fields.
+ * @param {String} cannotAdhereToAllRequirements: Textarea answer
+ * @param {String} offensesOrInvestigations: Textarea answer
+ * @param {String} awareOfExistingSlavery: Textarea answer
+ */
+const completeModernSlaveryFormConditionalFields = ({ cannotAdhereToAllRequirements, offensesOrInvestigations, awareOfExistingSlavery }) => {
+  cy.completeModernSlaveryFormConditionalFields({
+    cannotAdhereToAllRequirements,
+    offensesOrInvestigations,
+    awareOfExistingSlavery,
+  });
+
+  cy.clickSubmitButton();
+};
+
+export default completeModernSlaveryFormConditionalFields;

--- a/e2e-tests/commands/insurance/declarations/complete-and-submit-modern-slavery-form.js
+++ b/e2e-tests/commands/insurance/declarations/complete-and-submit-modern-slavery-form.js
@@ -4,25 +4,12 @@
  * @param {Boolean} willAdhereToAllRequirements: radio answer
  * @param {Boolean} hasNoOffensesOrInvestigations: radio answer
  * @param {Boolean} isNotAwareOfExistingSlavery: radio answer
- * @param {String} conditionalFields.cannotAdhereToAllRequirements: Textarea answer
- * @param {String} conditionalFields.offensesOrInvestigations: Textarea answer
- * @param {String} conditionalFields.awareOfExistingSlavery: Textarea answer
  */
-const completeAndSubmitModernSlaveryForm = ({
-  willAdhereToAllRequirements,
-  hasNoOffensesOrInvestigations,
-  isNotAwareOfExistingSlavery,
-  conditionalFields = {
-    cannotAdhereToAllRequirements: '',
-    offensesOrInvestigations: '',
-    awareOfExistingSlavery: '',
-  },
-}) => {
+const completeAndSubmitModernSlaveryForm = ({ willAdhereToAllRequirements, hasNoOffensesOrInvestigations, isNotAwareOfExistingSlavery }) => {
   cy.completeModernSlaveryForm({
     willAdhereToAllRequirements,
     hasNoOffensesOrInvestigations,
     isNotAwareOfExistingSlavery,
-    conditionalFields,
   });
 
   cy.clickSubmitButton();

--- a/e2e-tests/commands/insurance/declarations/complete-modern-slavery-form-conditional-fields.js
+++ b/e2e-tests/commands/insurance/declarations/complete-modern-slavery-form-conditional-fields.js
@@ -1,5 +1,6 @@
 import { autoCompleteField } from '../../../pages/shared';
 import { DECLARATIONS as DECLARATIONS_FIELD_IDS } from '../../../constants/field-ids/insurance/declarations';
+import application from '../../../fixtures/application';
 
 const {
   MODERN_SLAVERY: {
@@ -14,7 +15,11 @@ const {
  * @param {String} offensesOrInvestigations: Textarea answer
  * @param {String} awareOfExistingSlavery: Textarea answer
  */
-const completeModernSlaveryFormConditionalFields = ({ cannotAdhereToAllRequirements, offensesOrInvestigations, awareOfExistingSlavery }) => {
+const completeModernSlaveryFormConditionalFields = ({
+  cannotAdhereToAllRequirements = application.DECLARATION.MODERN_SLAVERY[CANNOT_ADHERE_TO_ALL_REQUIREMENTS],
+  offensesOrInvestigations = application.DECLARATION.MODERN_SLAVERY[OFFENSES_OR_INVESTIGATIONS],
+  awareOfExistingSlavery = application.DECLARATION.MODERN_SLAVERY[AWARE_OF_EXISTING_SLAVERY],
+}) => {
   if (cannotAdhereToAllRequirements) {
     cy.keyboardInput(autoCompleteField(CANNOT_ADHERE_TO_ALL_REQUIREMENTS).input(), cannotAdhereToAllRequirements);
   }

--- a/e2e-tests/commands/insurance/declarations/complete-modern-slavery-form.js
+++ b/e2e-tests/commands/insurance/declarations/complete-modern-slavery-form.js
@@ -12,11 +12,8 @@ const completeModernSlaveryForm = ({
   willAdhereToAllRequirements = true,
   hasNoOffensesOrInvestigations = true,
   isNotAwareOfExistingSlavery = true,
-  conditionalFields = {
-    cannotAdhereToAllRequirements: '',
-    offensesOrInvestigations: '',
-    awareOfExistingSlavery: '',
-  },
+  conditionalFields = {},
+  submitConditionalFields = false,
 }) => {
   if (willAdhereToAllRequirements) {
     cy.clickYesRadioInput(0);
@@ -42,7 +39,9 @@ const completeModernSlaveryForm = ({
     cy.clickNoRadioInput(2);
   }
 
-  cy.completeModernSlaveryFormConditionalFields(conditionalFields);
+  if (submitConditionalFields) {
+    cy.completeModernSlaveryFormConditionalFields(conditionalFields);
+  }
 };
 
 export default completeModernSlaveryForm;

--- a/e2e-tests/commands/insurance/declarations/complete-modern-slavery-form.js
+++ b/e2e-tests/commands/insurance/declarations/complete-modern-slavery-form.js
@@ -4,17 +4,8 @@
  * @param {Boolean} willAdhereToAllRequirements: radio answer
  * @param {Boolean} hasNoOffensesOrInvestigations: radio answer
  * @param {Boolean} isNotAwareOfExistingSlavery: radio answer
- * @param {String} conditionalFields.cannotAdhereToAllRequirements: Textarea answer
- * @param {String} conditionalFields.offensesOrInvestigations: Textarea answer
- * @param {String} conditionalFields.awareOfExistingSlavery: Textarea answer
  */
-const completeModernSlaveryForm = ({
-  willAdhereToAllRequirements = true,
-  hasNoOffensesOrInvestigations = true,
-  isNotAwareOfExistingSlavery = true,
-  conditionalFields = {},
-  submitConditionalFields = false,
-}) => {
+const completeModernSlaveryForm = ({ willAdhereToAllRequirements = true, hasNoOffensesOrInvestigations = true, isNotAwareOfExistingSlavery = true }) => {
   if (willAdhereToAllRequirements) {
     cy.clickYesRadioInput(0);
   }
@@ -37,10 +28,6 @@ const completeModernSlaveryForm = ({
 
   if (isNotAwareOfExistingSlavery === false) {
     cy.clickNoRadioInput(2);
-  }
-
-  if (submitConditionalFields) {
-    cy.completeModernSlaveryFormConditionalFields(conditionalFields);
   }
 };
 

--- a/e2e-tests/constants/routes/insurance/declarations.js
+++ b/e2e-tests/constants/routes/insurance/declarations.js
@@ -15,6 +15,7 @@ export const DECLARATIONS = {
     EXPORTING_WITH_CODE_OF_CONDUCT_SAVE_AND_BACK: `${ANTI_BRIBERY_ROOT}/exporting-with-code-of-conduct/save-and-back`,
   },
   MODERN_SLAVERY: `${ROOT}/modern-slavery`,
+  MODERN_SLAVERY_SAVE_AND_BACK: `${ROOT}/modern-slavery/save-and-back`,
   CONFIRMATION_AND_ACKNOWLEDGEMENTS: `${ROOT}/confirmation-and-acknowledgements`,
   CONFIRMATION_AND_ACKNOWLEDGEMENTS_SAVE_AND_BACK: `${ROOT}/confirmation-and-acknowledgements/save-and-back`,
 };

--- a/e2e-tests/fixtures/application.js
+++ b/e2e-tests/fixtures/application.js
@@ -82,6 +82,11 @@ const {
       HAS_BUYER_FINANCIAL_ACCOUNTS,
     },
     CURRENCY: { CURRENCY_CODE },
+    DECLARATIONS: {
+      MODERN_SLAVERY: {
+        CONDITIONAL_REASONS: { CANNOT_ADHERE_TO_ALL_REQUIREMENTS, OFFENSES_OR_INVESTIGATIONS, AWARE_OF_EXISTING_SLAVERY },
+      },
+    },
   },
 } = FIELD_IDS;
 
@@ -220,6 +225,13 @@ const application = {
   },
   DIFFERENT_TRADING_ADDRESS: {
     [EXPORTER_BUSINESS_FULL_ALT_TRADING_ADDRESS]: 'Mock full address',
+  },
+  DECLARATION: {
+    MODERN_SLAVERY: {
+      [CANNOT_ADHERE_TO_ALL_REQUIREMENTS]: 'Mock cannot adhere to all requirements reason',
+      [OFFENSES_OR_INVESTIGATIONS]: 'Mock offenses or investigations reason',
+      [AWARE_OF_EXISTING_SLAVERY]: 'Mock aware of existing slavery reason',
+    },
   },
 };
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/modern-slavery-radios.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/modern-slavery-radios.spec.js
@@ -22,187 +22,190 @@ const { YES, NO } = FIELD_VALUES;
 
 const baseUrl = Cypress.config('baseUrl');
 
-context('Insurance - Declarations - Modern slavery page - radios - TODO EMS-4023', () => {
-  let referenceNumber;
-  let url;
+context(
+  'Insurance - Declarations - Modern slavery page - radios - As a UKEF legal adviser, I want to know whether an exporter adheres to the Modern Slavery Act 2015, So that UKEF is not at risk of supporting ethically unsustainable businesses',
+  () => {
+    let referenceNumber;
+    let url;
 
-  before(() => {
-    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
-      referenceNumber = refNumber;
+    before(() => {
+      cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+        referenceNumber = refNumber;
 
-      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MODERN_SLAVERY}`;
+        url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MODERN_SLAVERY}`;
+
+        cy.navigateToUrl(url);
+        cy.assertUrl(url);
+      });
+    });
+
+    beforeEach(() => {
+      cy.saveSession();
 
       cy.navigateToUrl(url);
-      cy.assertUrl(url);
-    });
-  });
-
-  beforeEach(() => {
-    cy.saveSession();
-
-    cy.navigateToUrl(url);
-  });
-
-  after(() => {
-    cy.deleteApplication(referenceNumber);
-  });
-
-  describe(WILL_ADHERE_TO_ALL_REQUIREMENTS, () => {
-    const fieldId = WILL_ADHERE_TO_ALL_REQUIREMENTS;
-    const conditionalFieldId = CANNOT_ADHERE_TO_ALL_REQUIREMENTS;
-
-    const fieldStrings = FIELDS.MODERN_SLAVERY[fieldId].VERSIONS[0];
-
-    it('should render a legend', () => {
-      cy.checkText(fieldSelector(fieldId).legend(), fieldStrings.LABEL);
     });
 
-    describe('`yes` radio', () => {
-      const selector = yesRadio();
+    after(() => {
+      cy.deleteApplication(referenceNumber);
+    });
 
-      it('should render a label', () => {
-        cy.checkText(selector.label().first(), YES);
+    describe(WILL_ADHERE_TO_ALL_REQUIREMENTS, () => {
+      const fieldId = WILL_ADHERE_TO_ALL_REQUIREMENTS;
+      const conditionalFieldId = CANNOT_ADHERE_TO_ALL_REQUIREMENTS;
 
-        cy.checkRadioInputYesAriaLabel(fieldStrings.LABEL);
+      const fieldStrings = FIELDS.MODERN_SLAVERY[fieldId].VERSIONS[0];
+
+      it('should render a legend', () => {
+        cy.checkText(fieldSelector(fieldId).legend(), fieldStrings.LABEL);
       });
 
-      it('should render an input', () => {
-        selector.input().first().should('exist');
-      });
-    });
+      describe('`yes` radio', () => {
+        const selector = yesRadio();
 
-    describe('`no` radio', () => {
-      const selector = noRadio();
+        it('should render a label', () => {
+          cy.checkText(selector.label().first(), YES);
 
-      it('should render a label', () => {
-        cy.checkText(selector.label().first(), NO);
+          cy.checkRadioInputYesAriaLabel(fieldStrings.LABEL);
+        });
 
-        cy.checkRadioInputNoAriaLabel(fieldStrings.LABEL);
-      });
-
-      it('should render an input', () => {
-        selector.input().first().should('exist');
-      });
-    });
-
-    it(`should NOT display conditional "${conditionalFieldId}" field`, () => {
-      fieldSelector(conditionalFieldId).textarea().should('not.be.visible');
-    });
-
-    it(`should display conditional "${conditionalFieldId}" field when selecting the ${fieldId} radio`, () => {
-      cy.clickNoRadioInput(0);
-
-      cy.assertTextareaRendering({
-        fieldId: conditionalFieldId,
-        expectedLabel: fieldStrings.CONDITIONAL_REASON.LABEL,
-        maximumCharacters: MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON,
-      });
-    });
-  });
-
-  describe(HAS_NO_OFFENSES_OR_INVESTIGATIONS, () => {
-    const fieldId = HAS_NO_OFFENSES_OR_INVESTIGATIONS;
-    const conditionalFieldId = OFFENSES_OR_INVESTIGATIONS;
-
-    const fieldStrings = FIELDS.MODERN_SLAVERY[fieldId].VERSIONS[0];
-
-    it('should render a legend', () => {
-      cy.checkText(fieldSelector(fieldId).legend(), fieldStrings.LABEL);
-    });
-
-    describe('`yes` radio', () => {
-      const selector = yesRadio();
-
-      it('should render a label', () => {
-        cy.checkText(selector.label().eq(1), YES);
-
-        cy.checkRadioInputYesAriaLabel(fieldStrings.LABEL, 1);
+        it('should render an input', () => {
+          selector.input().first().should('exist');
+        });
       });
 
-      it('should render an input', () => {
-        selector.input().eq(1).should('exist');
+      describe('`no` radio', () => {
+        const selector = noRadio();
+
+        it('should render a label', () => {
+          cy.checkText(selector.label().first(), NO);
+
+          cy.checkRadioInputNoAriaLabel(fieldStrings.LABEL);
+        });
+
+        it('should render an input', () => {
+          selector.input().first().should('exist');
+        });
+      });
+
+      it(`should NOT display conditional "${conditionalFieldId}" field`, () => {
+        fieldSelector(conditionalFieldId).textarea().should('not.be.visible');
+      });
+
+      it(`should display conditional "${conditionalFieldId}" field when selecting the ${fieldId} radio`, () => {
+        cy.clickNoRadioInput(0);
+
+        cy.assertTextareaRendering({
+          fieldId: conditionalFieldId,
+          expectedLabel: fieldStrings.CONDITIONAL_REASON.LABEL,
+          maximumCharacters: MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON,
+        });
       });
     });
 
-    describe('`no` radio', () => {
-      const selector = noRadio();
+    describe(HAS_NO_OFFENSES_OR_INVESTIGATIONS, () => {
+      const fieldId = HAS_NO_OFFENSES_OR_INVESTIGATIONS;
+      const conditionalFieldId = OFFENSES_OR_INVESTIGATIONS;
 
-      it('should render a label', () => {
-        cy.checkText(selector.label().first(), NO);
+      const fieldStrings = FIELDS.MODERN_SLAVERY[fieldId].VERSIONS[0];
 
-        cy.checkRadioInputNoAriaLabel(fieldStrings.LABEL, 1);
+      it('should render a legend', () => {
+        cy.checkText(fieldSelector(fieldId).legend(), fieldStrings.LABEL);
       });
 
-      it('should render an input', () => {
-        selector.input().first().should('exist');
-      });
-    });
+      describe('`yes` radio', () => {
+        const selector = yesRadio();
 
-    it(`should NOT display conditional "${conditionalFieldId}" field`, () => {
-      fieldSelector(conditionalFieldId).textarea().should('not.be.visible');
-    });
+        it('should render a label', () => {
+          cy.checkText(selector.label().eq(1), YES);
 
-    it(`should display conditional "${conditionalFieldId}" field when selecting the ${fieldId} radio`, () => {
-      cy.clickNoRadioInput(1);
+          cy.checkRadioInputYesAriaLabel(fieldStrings.LABEL, 1);
+        });
 
-      cy.assertTextareaRendering({
-        fieldId: conditionalFieldId,
-        expectedLabel: fieldStrings.CONDITIONAL_REASON.LABEL,
-        maximumCharacters: MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON,
-      });
-    });
-  });
-
-  describe(IS_NOT_AWARE_OF_EXISTING_SLAVERY, () => {
-    const fieldId = IS_NOT_AWARE_OF_EXISTING_SLAVERY;
-    const conditionalFieldId = AWARE_OF_EXISTING_SLAVERY;
-
-    const fieldStrings = FIELDS.MODERN_SLAVERY[fieldId].VERSIONS[0];
-
-    it('should render a legend', () => {
-      cy.checkText(fieldSelector(fieldId).legend(), fieldStrings.LABEL);
-    });
-
-    describe('`yes` radio', () => {
-      const selector = yesRadio();
-
-      it('should render a label', () => {
-        cy.checkText(selector.label().eq(1), YES);
-
-        cy.checkRadioInputYesAriaLabel(fieldStrings.LABEL, 2);
+        it('should render an input', () => {
+          selector.input().eq(1).should('exist');
+        });
       });
 
-      it('should render an input', () => {
-        selector.input().eq(1).should('exist');
+      describe('`no` radio', () => {
+        const selector = noRadio();
+
+        it('should render a label', () => {
+          cy.checkText(selector.label().first(), NO);
+
+          cy.checkRadioInputNoAriaLabel(fieldStrings.LABEL, 1);
+        });
+
+        it('should render an input', () => {
+          selector.input().first().should('exist');
+        });
       });
-    });
 
-    describe('`no` radio', () => {
-      const selector = noRadio();
-
-      it('should render a label', () => {
-        cy.checkText(selector.label().first(), NO);
-
-        cy.checkRadioInputNoAriaLabel(fieldStrings.LABEL, 2);
+      it(`should NOT display conditional "${conditionalFieldId}" field`, () => {
+        fieldSelector(conditionalFieldId).textarea().should('not.be.visible');
       });
 
-      it('should render an input', () => {
-        selector.input().first().should('exist');
+      it(`should display conditional "${conditionalFieldId}" field when selecting the ${fieldId} radio`, () => {
+        cy.clickNoRadioInput(1);
+
+        cy.assertTextareaRendering({
+          fieldId: conditionalFieldId,
+          expectedLabel: fieldStrings.CONDITIONAL_REASON.LABEL,
+          maximumCharacters: MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON,
+        });
       });
     });
 
-    it(`should NOT display conditional "${conditionalFieldId}" field`, () => {
-      fieldSelector(conditionalFieldId).textarea().should('not.be.visible');
-    });
+    describe(IS_NOT_AWARE_OF_EXISTING_SLAVERY, () => {
+      const fieldId = IS_NOT_AWARE_OF_EXISTING_SLAVERY;
+      const conditionalFieldId = AWARE_OF_EXISTING_SLAVERY;
 
-    it(`should display conditional "${conditionalFieldId}" field when selecting the ${fieldId} radio`, () => {
-      cy.clickNoRadioInput(2);
+      const fieldStrings = FIELDS.MODERN_SLAVERY[fieldId].VERSIONS[0];
 
-      cy.assertTextareaRendering({
-        fieldId: conditionalFieldId,
-        expectedLabel: fieldStrings.CONDITIONAL_REASON.LABEL,
-        maximumCharacters: MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON,
+      it('should render a legend', () => {
+        cy.checkText(fieldSelector(fieldId).legend(), fieldStrings.LABEL);
+      });
+
+      describe('`yes` radio', () => {
+        const selector = yesRadio();
+
+        it('should render a label', () => {
+          cy.checkText(selector.label().eq(1), YES);
+
+          cy.checkRadioInputYesAriaLabel(fieldStrings.LABEL, 2);
+        });
+
+        it('should render an input', () => {
+          selector.input().eq(1).should('exist');
+        });
+      });
+
+      describe('`no` radio', () => {
+        const selector = noRadio();
+
+        it('should render a label', () => {
+          cy.checkText(selector.label().first(), NO);
+
+          cy.checkRadioInputNoAriaLabel(fieldStrings.LABEL, 2);
+        });
+
+        it('should render an input', () => {
+          selector.input().first().should('exist');
+        });
+      });
+
+      it(`should NOT display conditional "${conditionalFieldId}" field`, () => {
+        fieldSelector(conditionalFieldId).textarea().should('not.be.visible');
+      });
+
+      it(`should display conditional "${conditionalFieldId}" field when selecting the ${fieldId} radio`, () => {
+        cy.clickNoRadioInput(2);
+
+        cy.assertTextareaRendering({
+          fieldId: conditionalFieldId,
+          expectedLabel: fieldStrings.CONDITIONAL_REASON.LABEL,
+          maximumCharacters: MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON,
+        });
       });
     });
-  });
-});
+  },
+);

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/modern-slavery.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/modern-slavery.spec.js
@@ -4,6 +4,7 @@ import { expandable } from '../../../../../../partials';
 import { PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { DECLARATIONS as DECLARATIONS_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/declarations';
+import application from '../../../../../../fixtures/application';
 
 const CONTENT_STRINGS = PAGES.INSURANCE.DECLARATIONS.MODERN_SLAVERY;
 
@@ -25,181 +26,172 @@ const {
 
 const baseUrl = Cypress.config('baseUrl');
 
-context('Insurance - Declarations - Modern slavery page - TODO EMS-4023', () => {
-  let referenceNumber;
-  let url;
+context(
+  'Insurance - Declarations - Modern slavery page - As a UKEF legal adviser, I want to know whether an exporter adheres to the Modern Slavery Act 2015, So that UKEF is not at risk of supporting ethically unsustainable businesses',
+  () => {
+    let referenceNumber;
+    let url;
 
-  before(() => {
-    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
-      referenceNumber = refNumber;
+    before(() => {
+      cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+        referenceNumber = refNumber;
 
-      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MODERN_SLAVERY}`;
+        url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MODERN_SLAVERY}`;
 
-      cy.navigateToUrl(url);
-      cy.assertUrl(url);
+        cy.navigateToUrl(url);
+        cy.assertUrl(url);
+      });
     });
-  });
 
-  beforeEach(() => {
-    cy.saveSession();
-  });
-
-  after(() => {
-    cy.deleteApplication(referenceNumber);
-  });
-
-  it('renders core page elements', () => {
-    cy.corePageChecks({
-      pageTitle: CONTENT_STRINGS.PAGE_TITLE,
-      currentHref: `${INSURANCE_ROOT}/${referenceNumber}${MODERN_SLAVERY}`,
-      backLink: `${INSURANCE_ROOT}/${referenceNumber}${MODERN_SLAVERY}#`,
-    });
-  });
-
-  describe('page tests', () => {
     beforeEach(() => {
-      cy.navigateToUrl(url);
+      cy.saveSession();
     });
 
-    it('renders a heading caption', () => {
-      cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
+    after(() => {
+      cy.deleteApplication(referenceNumber);
     });
 
-    describe('intro', () => {
-      it('should render `answer the questions` copy', () => {
-        cy.checkText(answerTheQuestions(), CONTENT_STRINGS.INTRO.ANSWER_THE_QUESTIONS);
-      });
-
-      it('should render a `guiding principles` link', () => {
-        cy.checkLink(guidingPrinciplesLink(), '#', CONTENT_STRINGS.INTRO.GUIDING_PRINCIPLES_LINK.TEXT);
-      });
-
-      it('should render `if you say no` copy', () => {
-        cy.checkText(ifYouSayNo(), CONTENT_STRINGS.INTRO.IF_YOU_SAY_NO);
+    it('renders core page elements', () => {
+      cy.corePageChecks({
+        pageTitle: CONTENT_STRINGS.PAGE_TITLE,
+        currentHref: `${INSURANCE_ROOT}/${referenceNumber}${MODERN_SLAVERY}`,
+        backLink: `${INSURANCE_ROOT}/${referenceNumber}${MODERN_SLAVERY}#`,
       });
     });
 
-    describe('expandable details - definition of terms', () => {
+    describe('page tests', () => {
       beforeEach(() => {
         cy.navigateToUrl(url);
       });
 
-      it('should render summary text with collapsed conditional `details` content', () => {
-        const expectedText = CONTENT_STRINGS.EXPANDABLE.VERSIONS[0].INTRO;
-
-        cy.checkText(expandable.summary(), expectedText);
-
-        expandable.details().should('not.have.attr', 'open');
+      it('renders a heading caption', () => {
+        cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
       });
 
-      describe('when clicking the summary text', () => {
-        it('should expand the collapsed `details` content', () => {
-          expandable.summary().click();
-
-          expandable.details().should('have.attr', 'open');
-        });
-      });
-    });
-  });
-
-  describe('form submission', () => {
-    describe('when submitting all radios as `yes`', () => {
-      it(`should redirect to ${ALL_SECTIONS}`, () => {
-        cy.navigateToUrl(url);
-
-        cy.completeAndSubmitModernSlaveryForm({
-          willAdhereToAllRequirements: true,
-          hasNoOffensesOrInvestigations: true,
-          isNotAwareOfExistingSlavery: true,
+      describe('intro', () => {
+        it('should render `answer the questions` copy', () => {
+          cy.checkText(answerTheQuestions(), CONTENT_STRINGS.INTRO.ANSWER_THE_QUESTIONS);
         });
 
-        const expectedUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
-
-        cy.assertUrl(expectedUrl);
-      });
-
-      it('should have the submitted values when going back to the page', () => {
-        cy.navigateToUrl(url);
-
-        cy.assertYesRadioOptionIsChecked(0);
-        cy.assertYesRadioOptionIsChecked(1);
-        cy.assertYesRadioOptionIsChecked(2);
-      });
-    });
-
-    describe('when submitting all radios as `no` and submitting conditional fields', () => {
-      const mockReasons = {
-        [CANNOT_ADHERE_TO_ALL_REQUIREMENTS]: 'Mock cannot adhere to all requirements reason',
-        [OFFENSES_OR_INVESTIGATIONS]: 'Mock offenses or investigations reason',
-        [AWARE_OF_EXISTING_SLAVERY]: 'Mock aware of existing slavery reason',
-      };
-
-      it(`should redirect to ${ALL_SECTIONS}`, () => {
-        cy.navigateToUrl(url);
-
-        // TODO: EMS-4046 - use application fixtures.
-        cy.completeAndSubmitModernSlaveryForm({
-          willAdhereToAllRequirements: false,
-          hasNoOffensesOrInvestigations: false,
-          isNotAwareOfExistingSlavery: false,
-          conditionalFields: mockReasons,
+        it('should render a `guiding principles` link', () => {
+          cy.checkLink(guidingPrinciplesLink(), '#', CONTENT_STRINGS.INTRO.GUIDING_PRINCIPLES_LINK.TEXT);
         });
 
-        const expectedUrl = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
-
-        cy.assertUrl(expectedUrl);
+        it('should render `if you say no` copy', () => {
+          cy.checkText(ifYouSayNo(), CONTENT_STRINGS.INTRO.IF_YOU_SAY_NO);
+        });
       });
 
-      describe('when going back to the page', () => {
+      describe('expandable details - definition of terms', () => {
         beforeEach(() => {
           cy.navigateToUrl(url);
         });
 
-        it('should have the submitted radio values', () => {
-          cy.assertNoRadioOptionIsChecked(0);
-          cy.assertNoRadioOptionIsChecked(1);
-          cy.assertNoRadioOptionIsChecked(2);
+        it('should render summary text with collapsed conditional `details` content', () => {
+          const expectedText = CONTENT_STRINGS.EXPANDABLE.VERSIONS[0].INTRO;
+
+          cy.checkText(expandable.summary(), expectedText);
+
+          expandable.details().should('not.have.attr', 'open');
         });
 
-        it(`should render conditional "${CANNOT_ADHERE_TO_ALL_REQUIREMENTS}" field`, () => {
-          field(CANNOT_ADHERE_TO_ALL_REQUIREMENTS).textarea().should('be.visible');
-        });
+        describe('when clicking the summary text', () => {
+          it('should expand the collapsed `details` content', () => {
+            expandable.summary().click();
 
-        it(`should render conditional "${OFFENSES_OR_INVESTIGATIONS}" field`, () => {
-          field(OFFENSES_OR_INVESTIGATIONS).textarea().should('be.visible');
-        });
-
-        it(`should render conditional "${AWARE_OF_EXISTING_SLAVERY}" field`, () => {
-          field(AWARE_OF_EXISTING_SLAVERY).textarea().should('be.visible');
-        });
-
-        it(`should have the submitted "${CANNOT_ADHERE_TO_ALL_REQUIREMENTS}" textarea value`, () => {
-          const fieldId = CANNOT_ADHERE_TO_ALL_REQUIREMENTS;
-
-          cy.checkTextareaValue({
-            fieldId,
-            expectedValue: mockReasons[fieldId],
-          });
-        });
-
-        it(`should have the submitted "${OFFENSES_OR_INVESTIGATIONS}" textarea value`, () => {
-          const fieldId = OFFENSES_OR_INVESTIGATIONS;
-
-          cy.checkTextareaValue({
-            fieldId,
-            expectedValue: mockReasons[fieldId],
-          });
-        });
-
-        it(`should have the submitted "${AWARE_OF_EXISTING_SLAVERY}" textarea value`, () => {
-          const fieldId = AWARE_OF_EXISTING_SLAVERY;
-
-          cy.checkTextareaValue({
-            fieldId,
-            expectedValue: mockReasons[fieldId],
+            expandable.details().should('have.attr', 'open');
           });
         });
       });
     });
-  });
-});
+
+    describe('form submission', () => {
+      describe('when submitting all radios as `yes`', () => {
+        it(`should redirect to ${ALL_SECTIONS}`, () => {
+          cy.navigateToUrl(url);
+
+          cy.completeAndSubmitModernSlaveryForm({
+            willAdhereToAllRequirements: true,
+            hasNoOffensesOrInvestigations: true,
+            isNotAwareOfExistingSlavery: true,
+          });
+
+          cy.assertAllSectionsUrl(referenceNumber);
+        });
+
+        it('should have the submitted values when going back to the page', () => {
+          cy.navigateToUrl(url);
+
+          cy.assertYesRadioOptionIsChecked(0);
+          cy.assertYesRadioOptionIsChecked(1);
+          cy.assertYesRadioOptionIsChecked(2);
+        });
+      });
+
+      describe('when submitting all radios as `no` and submitting conditional fields', () => {
+        it(`should redirect to ${ALL_SECTIONS}`, () => {
+          cy.navigateToUrl(url);
+
+          cy.completeAndSubmitModernSlaveryForm({
+            willAdhereToAllRequirements: false,
+            hasNoOffensesOrInvestigations: false,
+            isNotAwareOfExistingSlavery: false,
+          });
+
+          cy.assertAllSectionsUrl(referenceNumber);
+        });
+
+        describe('when going back to the page', () => {
+          beforeEach(() => {
+            cy.navigateToUrl(url);
+          });
+
+          it('should have the submitted radio values', () => {
+            cy.assertNoRadioOptionIsChecked(0);
+            cy.assertNoRadioOptionIsChecked(1);
+            cy.assertNoRadioOptionIsChecked(2);
+          });
+
+          it(`should render conditional "${CANNOT_ADHERE_TO_ALL_REQUIREMENTS}" field`, () => {
+            field(CANNOT_ADHERE_TO_ALL_REQUIREMENTS).textarea().should('be.visible');
+          });
+
+          it(`should render conditional "${OFFENSES_OR_INVESTIGATIONS}" field`, () => {
+            field(OFFENSES_OR_INVESTIGATIONS).textarea().should('be.visible');
+          });
+
+          it(`should render conditional "${AWARE_OF_EXISTING_SLAVERY}" field`, () => {
+            field(AWARE_OF_EXISTING_SLAVERY).textarea().should('be.visible');
+          });
+
+          it(`should have the submitted "${CANNOT_ADHERE_TO_ALL_REQUIREMENTS}" textarea value`, () => {
+            const fieldId = CANNOT_ADHERE_TO_ALL_REQUIREMENTS;
+
+            cy.checkTextareaValue({
+              fieldId,
+              expectedValue: application.DECLARATION.MODERN_SLAVERY[fieldId],
+            });
+          });
+
+          it(`should have the submitted "${OFFENSES_OR_INVESTIGATIONS}" textarea value`, () => {
+            const fieldId = OFFENSES_OR_INVESTIGATIONS;
+
+            cy.checkTextareaValue({
+              fieldId,
+              expectedValue: application.DECLARATION.MODERN_SLAVERY[fieldId],
+            });
+          });
+
+          it(`should have the submitted "${AWARE_OF_EXISTING_SLAVERY}" textarea value`, () => {
+            const fieldId = AWARE_OF_EXISTING_SLAVERY;
+
+            cy.checkTextareaValue({
+              fieldId,
+              expectedValue: application.DECLARATION.MODERN_SLAVERY[fieldId],
+            });
+          });
+        });
+      });
+    });
+  },
+);

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/modern-slavery.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/modern-slavery.spec.js
@@ -138,6 +138,8 @@ context(
             isNotAwareOfExistingSlavery: false,
           });
 
+          cy.completeAndSubmitModernSlaveryFormConditionalFields({});
+
           cy.assertAllSectionsUrl(referenceNumber);
         });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/save-and-back.spec.js
@@ -1,0 +1,208 @@
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { DECLARATIONS as DECLARATIONS_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/declarations';
+import application from '../../../../../../fixtures/application';
+
+const {
+  ROOT: INSURANCE_ROOT,
+  DECLARATIONS: { MODERN_SLAVERY },
+} = INSURANCE_ROUTES;
+
+const {
+  MODERN_SLAVERY: {
+    CONDITIONAL_REASONS: { CANNOT_ADHERE_TO_ALL_REQUIREMENTS, OFFENSES_OR_INVESTIGATIONS, AWARE_OF_EXISTING_SLAVERY },
+  },
+} = DECLARATIONS_FIELD_IDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Declarations - Modern slavery page - Save and go back', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      cy.completePrepareApplicationSinglePolicyType({ referenceNumber });
+      cy.completeAndSubmitCheckYourAnswers();
+
+      // go to the page we want to test.
+      cy.clickTaskDeclarationsAndSubmit();
+
+      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MODERN_SLAVERY}`;
+
+      cy.navigateToUrl(url);
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when submitting an empty form via `save and go back` button', () => {
+    beforeEach(() => {
+      cy.navigateToUrl(url);
+
+      cy.clickSaveAndBackButton();
+    });
+
+    it('should redirect to `all sections`', () => {
+      cy.assertAllSectionsUrl(referenceNumber);
+    });
+
+    // TODO: EMS-4059
+    it.skip('should retain the status of task `declarations and submit` as `in progress`', () => {
+      cy.checkTaskDeclarationsAndSubmitStatusIsInProgress();
+    });
+  });
+
+  describe('when fields are partially completed', () => {
+    // TODO: EMS-4059
+    it.skip('should retain the status of task `declarations and submit` as `in progress`', () => {
+      cy.navigateToUrl(url);
+
+      cy.completeModernSlaveryForm({
+        willAdhereToAllRequirements: true,
+        hasNoOffensesOrInvestigations: null,
+        isNotAwareOfExistingSlavery: null,
+      });
+
+      cy.clickSaveAndBackButton();
+
+      cy.assertAllSectionsUrl(referenceNumber);
+
+      cy.checkTaskDeclarationsAndSubmitStatusIsInProgress();
+    });
+
+    describe('when going back to the page', () => {
+      it('should have the submitted value', () => {
+        cy.navigateToUrl(url);
+
+        cy.completeModernSlaveryForm({
+          willAdhereToAllRequirements: null,
+          hasNoOffensesOrInvestigations: true,
+          isNotAwareOfExistingSlavery: null,
+        });
+
+        cy.assertYesRadioOptionIsChecked(1);
+      });
+    });
+  });
+
+  describe('when all fields are submitted with `yes` radios', () => {
+    // TODO: EMS-4059
+    it.skip('should retain the status of task `declarations and submit` as `in progress`', () => {
+      cy.navigateToUrl(url);
+
+      cy.completeModernSlaveryForm({
+        willAdhereToAllRequirements: true,
+        hasNoOffensesOrInvestigations: true,
+        isNotAwareOfExistingSlavery: true,
+      });
+
+      cy.clickSaveAndBackButton();
+
+      cy.navigateToAllSectionsUrl(referenceNumber);
+
+      cy.checkTaskDeclarationsAndSubmitStatusIsInProgress();
+    });
+
+    describe('when going back to the page', () => {
+      it('should have the submitted values', () => {
+        cy.navigateToAllSectionsUrl(referenceNumber);
+
+        // TODO: EMS-4041
+        // go through the first 4 declaration forms.
+        // cy.clickSubmitButtonMultipleTimes({ count: 4 });
+        cy.navigateToUrl(url);
+
+        cy.completeModernSlaveryForm({
+          willAdhereToAllRequirements: true,
+          hasNoOffensesOrInvestigations: true,
+          isNotAwareOfExistingSlavery: true,
+        });
+
+        cy.assertYesRadioOptionIsChecked(0);
+        cy.assertYesRadioOptionIsChecked(1);
+        cy.assertYesRadioOptionIsChecked(2);
+      });
+    });
+  });
+
+  describe('when all fields are submitted with `no` radios', () => {
+    // TODO: EMS-4059
+    it.skip('should retain the status of task `declarations and submit` as `in progress`', () => {
+      cy.navigateToUrl(url);
+
+      cy.completeModernSlaveryForm({
+        willAdhereToAllRequirements: false,
+        hasNoOffensesOrInvestigations: false,
+        isNotAwareOfExistingSlavery: false,
+        submitConditionalFields: true,
+      });
+
+      cy.clickSaveAndBackButton();
+
+      cy.navigateToAllSectionsUrl(referenceNumber);
+
+      cy.checkTaskDeclarationsAndSubmitStatusIsInProgress();
+    });
+
+    describe('when going back to the page', () => {
+      beforeEach(() => {
+        cy.navigateToUrl(url);
+      });
+
+      it('should have the submitted radio values', () => {
+        cy.completeModernSlaveryForm({
+          willAdhereToAllRequirements: false,
+          hasNoOffensesOrInvestigations: false,
+          isNotAwareOfExistingSlavery: false,
+          submitConditionalFields: true,
+        });
+
+        cy.clickSaveAndBackButton();
+
+        cy.navigateToAllSectionsUrl(referenceNumber);
+
+        cy.navigateToUrl(url);
+
+        cy.assertNoRadioOptionIsChecked(0);
+        cy.assertNoRadioOptionIsChecked(1);
+        cy.assertNoRadioOptionIsChecked(2);
+      });
+
+      it(`should have the submitted "${CANNOT_ADHERE_TO_ALL_REQUIREMENTS}" textarea value`, () => {
+        const fieldId = CANNOT_ADHERE_TO_ALL_REQUIREMENTS;
+
+        cy.checkTextareaValue({
+          fieldId,
+          expectedValue: application.DECLARATION.MODERN_SLAVERY[fieldId],
+        });
+      });
+
+      it(`should have the submitted "${OFFENSES_OR_INVESTIGATIONS}" textarea value`, () => {
+        const fieldId = OFFENSES_OR_INVESTIGATIONS;
+
+        cy.checkTextareaValue({
+          fieldId,
+          expectedValue: application.DECLARATION.MODERN_SLAVERY[fieldId],
+        });
+      });
+
+      it(`should have the submitted "${AWARE_OF_EXISTING_SLAVERY}" textarea value`, () => {
+        const fieldId = AWARE_OF_EXISTING_SLAVERY;
+
+        cy.checkTextareaValue({
+          fieldId,
+          expectedValue: application.DECLARATION.MODERN_SLAVERY[fieldId],
+        });
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/save-and-back.spec.js
@@ -143,8 +143,9 @@ context('Insurance - Declarations - Modern slavery page - Save and go back', () 
         willAdhereToAllRequirements: false,
         hasNoOffensesOrInvestigations: false,
         isNotAwareOfExistingSlavery: false,
-        submitConditionalFields: true,
       });
+
+      cy.completeModernSlaveryFormConditionalFields({});
 
       cy.clickSaveAndBackButton();
 
@@ -163,8 +164,9 @@ context('Insurance - Declarations - Modern slavery page - Save and go back', () 
           willAdhereToAllRequirements: false,
           hasNoOffensesOrInvestigations: false,
           isNotAwareOfExistingSlavery: false,
-          submitConditionalFields: true,
         });
+
+        cy.completeModernSlaveryFormConditionalFields({});
 
         cy.clickSaveAndBackButton();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/validation/modern-slavery-validation-has-no-offenses-or-investigations.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/validation/modern-slavery-validation-has-no-offenses-or-investigations.spec.js
@@ -54,8 +54,14 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
     it(`should render a ${conditionalFieldId} validation error`, () => {
       cy.navigateToUrl(url);
 
-      cy.completeAndSubmitModernSlaveryForm({
+      cy.completeModernSlaveryForm({
         hasNoOffensesOrInvestigations: false,
+      });
+
+      cy.completeAndSubmitModernSlaveryFormConditionalFields({
+        offensesOrInvestigations: null,
+        cannotAdhereToAllRequirements: null,
+        awareOfExistingSlavery: null,
       });
 
       cy.assertFieldErrors({
@@ -71,19 +77,20 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
     beforeEach(() => {
       cy.navigateToUrl(url);
 
-      cy.completeAndSubmitModernSlaveryForm({
-        hasNoOffensesOrInvestigations: false,
-        conditionalFields: {
-          offensesOrInvestigations: reasonOverMaximum,
-        },
+      cy.completeAndSubmitModernSlaveryForm({ hasNoOffensesOrInvestigations: false });
+
+      cy.completeAndSubmitModernSlaveryFormConditionalFields({
+        offensesOrInvestigations: reasonOverMaximum,
+        cannotAdhereToAllRequirements: null,
+        awareOfExistingSlavery: null,
       });
     });
 
     it(`should render a ${conditionalFieldId} validation error`, () => {
       cy.assertFieldErrors({
         field: autoCompleteField(conditionalFieldId),
-        errorIndex: 0,
-        errorSummaryLength: 1,
+        errorIndex: 1,
+        errorSummaryLength: 3,
         errorMessage: ERROR_STRINGS.CONDITIONAL_REASONS[conditionalFieldId].ABOVE_MAXIMUM,
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/validation/modern-slavery-validation-is-not-aware-of-existing-slavery.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/validation/modern-slavery-validation-is-not-aware-of-existing-slavery.spec.js
@@ -73,17 +73,20 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
 
       cy.completeAndSubmitModernSlaveryForm({
         isNotAwareOfExistingSlavery: false,
-        conditionalFields: {
-          awareOfExistingSlavery: reasonOverMaximum,
-        },
+      });
+
+      cy.completeAndSubmitModernSlaveryFormConditionalFields({
+        awareOfExistingSlavery: reasonOverMaximum,
+        offensesOrInvestigations: null,
+        cannotAdhereToAllRequirements: null,
       });
     });
 
     it(`should render a ${conditionalFieldId} validation error`, () => {
       cy.assertFieldErrors({
         field: autoCompleteField(conditionalFieldId),
-        errorIndex: 0,
-        errorSummaryLength: 1,
+        errorIndex: 2,
+        errorSummaryLength: 3,
         errorMessage: ERROR_STRINGS.CONDITIONAL_REASONS[conditionalFieldId].ABOVE_MAXIMUM,
       });
     });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/validation/modern-slavery-validation-will-adhere-to-all-requirements.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/validation/modern-slavery-validation-will-adhere-to-all-requirements.spec.js
@@ -58,10 +58,16 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
         willAdhereToAllRequirements: false,
       });
 
+      cy.completeAndSubmitModernSlaveryFormConditionalFields({
+        cannotAdhereToAllRequirements: null,
+        awareOfExistingSlavery: null,
+        offensesOrInvestigations: null,
+      });
+
       cy.assertFieldErrors({
         field: autoCompleteField(conditionalFieldId),
         errorIndex: 0,
-        errorSummaryLength: 1,
+        errorSummaryLength: 3,
         errorMessage: ERROR_STRINGS.CONDITIONAL_REASONS[conditionalFieldId].IS_EMPTY,
       });
     });
@@ -73,9 +79,12 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
 
       cy.completeAndSubmitModernSlaveryForm({
         willAdhereToAllRequirements: false,
-        conditionalFields: {
-          cannotAdhereToAllRequirements: reasonOverMaximum,
-        },
+      });
+
+      cy.completeAndSubmitModernSlaveryFormConditionalFields({
+        cannotAdhereToAllRequirements: reasonOverMaximum,
+        offensesOrInvestigations: null,
+        awareOfExistingSlavery: null,
       });
     });
 
@@ -83,7 +92,7 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
       cy.assertFieldErrors({
         field: autoCompleteField(conditionalFieldId),
         errorIndex: 0,
-        errorSummaryLength: 1,
+        errorSummaryLength: 3,
         errorMessage: ERROR_STRINGS.CONDITIONAL_REASONS[conditionalFieldId].ABOVE_MAXIMUM,
       });
     });

--- a/e2e-tests/insurance/cypress/support/declarations/index.js
+++ b/e2e-tests/insurance/cypress/support/declarations/index.js
@@ -20,6 +20,11 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
+  'completeAndSubmitModernSlaveryFormConditionalFields',
+  require('../../../../commands/insurance/declarations/complete-and-submit-modern-slavery-form-conditional-fields'),
+);
+
+Cypress.Commands.add(
   'completeAndSubmitDeclarationConfirmationAndAcknowledgements',
   require('../../../../commands/insurance/declarations/complete-and-submit-confirmation-and-acknowledgements-form'),
 );

--- a/src/ui/server/constants/routes/insurance/declarations.ts
+++ b/src/ui/server/constants/routes/insurance/declarations.ts
@@ -15,6 +15,7 @@ export const DECLARATIONS = {
     EXPORTING_WITH_CODE_OF_CONDUCT_SAVE_AND_BACK: `${ANTI_BRIBERY_ROOT}/exporting-with-code-of-conduct/save-and-back`,
   },
   MODERN_SLAVERY: `${ROOT}/modern-slavery`,
+  MODERN_SLAVERY_SAVE_AND_BACK: `${ROOT}/modern-slavery/save-and-back`,
   CONFIRMATION_AND_ACKNOWLEDGEMENTS: `${ROOT}/confirmation-and-acknowledgements`,
   CONFIRMATION_AND_ACKNOWLEDGEMENTS_SAVE_AND_BACK: `${ROOT}/confirmation-and-acknowledgements/save-and-back`,
 };

--- a/src/ui/server/controllers/insurance/business/save-data/business/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/save-data/business/index.test.ts
@@ -36,7 +36,9 @@ describe('controllers/insurance/business/save-data/business', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = stripEmptyFormFields(getDataToSave(mockFormBody, mockValidationErrors.errorList));
+
       const expectedSanitisedData = sanitiseData(dataToSave);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.business.id, expectedSanitisedData);
     });
 
@@ -54,7 +56,9 @@ describe('controllers/insurance/business/save-data/business', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = getDataToSave(mockFormBody);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.business.id, expectedSanitisedData);
     });
 

--- a/src/ui/server/controllers/insurance/business/save-data/company-details/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/save-data/company-details/index.test.ts
@@ -35,7 +35,9 @@ describe('controllers/insurance/business/save-data/company-details', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = getDataToSave(mockFormBody, mockValidationErrors.errorList);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.company.id, expectedSanitisedData);
     });
 
@@ -53,7 +55,9 @@ describe('controllers/insurance/business/save-data/company-details', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = getDataToSave(mockFormBody);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.company.id, expectedSanitisedData);
     });
 

--- a/src/ui/server/controllers/insurance/business/save-data/company-different-trading-address/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/save-data/company-different-trading-address/index.test.ts
@@ -23,7 +23,9 @@ describe('controllers/insurance/business/save-data/company-different-trading-add
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = getDataToSave(mockFormBody, mockValidationErrors.errorList);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.company.differentTradingAddress.id, expectedSanitisedData);
     });
 
@@ -41,7 +43,9 @@ describe('controllers/insurance/business/save-data/company-different-trading-add
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = getDataToSave(mockFormBody);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.company.differentTradingAddress.id, expectedSanitisedData);
     });
 

--- a/src/ui/server/controllers/insurance/business/save-data/company-different-trading-address/index.test.ts
+++ b/src/ui/server/controllers/insurance/business/save-data/company-different-trading-address/index.test.ts
@@ -1,16 +1,37 @@
 import save from '.';
 import api from '../../../../../api';
+import generateValidationErrors from '../../../../../helpers/validation';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
 import getDataToSave from '../../../../../helpers/get-data-to-save';
-import { mockApplication, mockCompanyDifferentTradingAddress } from '../../../../../test-mocks';
+import { mockApplication } from '../../../../../test-mocks';
 
 describe('controllers/insurance/business/save-data/company-different-trading-address', () => {
   const mockUpdateApplicationResponse = mockApplication;
   const updateApplicationSpy = jest.fn(() => Promise.resolve(mockUpdateApplicationResponse));
-  const mockFormBody = mockCompanyDifferentTradingAddress;
+  const mockFormBody = {};
 
   beforeEach(() => {
     api.keystone.application.update.companyDifferentTradingAddress = updateApplicationSpy;
+  });
+
+  describe('when errorList is provided', () => {
+    const mockValidationErrors = generateValidationErrors('mock id', 'error', {});
+
+    it('should call api.keystone.application.update.companyDifferentTradingAddress with all fields', async () => {
+      await save.companyDifferentTradingAddress(mockApplication, mockFormBody, mockValidationErrors.errorList);
+
+      expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
+
+      const dataToSave = getDataToSave(mockFormBody, mockValidationErrors.errorList);
+      const expectedSanitisedData = sanitiseData(dataToSave);
+      expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.company.differentTradingAddress.id, expectedSanitisedData);
+    });
+
+    it('should return the API response', async () => {
+      const result = await save.companyDifferentTradingAddress(mockApplication, mockFormBody);
+
+      expect(result).toEqual(mockUpdateApplicationResponse);
+    });
   });
 
   describe('when errorList is NOT provided', () => {

--- a/src/ui/server/controllers/insurance/check-your-answers/save-data/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/save-data/index.test.ts
@@ -32,6 +32,7 @@ describe('controllers/insurance/check-your-answers/save-data', () => {
     expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
     const expectedSanitisedData = sanitiseData(mockFormBody);
+
     expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.sectionReview.id, expectedSanitisedData);
   });
 

--- a/src/ui/server/controllers/insurance/declarations/map-and-save/modern-slavery/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/map-and-save/modern-slavery/index.api-error.test.ts
@@ -1,0 +1,36 @@
+import mapAndSave from '.';
+import save from '../../save-data/modern-slavery';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
+
+describe('controllers/insurance/declarations/map-and-save/modern-slavery - api errors', () => {
+  jest.mock('../../save-data/modern-slavery');
+
+  const mockFormBody = {
+    _csrf: '1234',
+    mock: true,
+  };
+
+  describe('when save application declarationModernSlavery call does not return anything', () => {
+    beforeEach(() => {
+      save.declarationModernSlavery = jest.fn(() => Promise.resolve());
+    });
+
+    it('should return false', async () => {
+      const result = await mapAndSave.declarationModernSlavery(mockFormBody, mockApplication);
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('when save application declarationModernSlavery call fails', () => {
+    beforeEach(() => {
+      save.declarationModernSlavery = mockSpyPromiseRejection;
+    });
+
+    it('should return false', async () => {
+      const result = await mapAndSave.declarationModernSlavery(mockFormBody, mockApplication);
+
+      expect(result).toEqual(false);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/declarations/map-and-save/modern-slavery/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/map-and-save/modern-slavery/index.test.ts
@@ -1,0 +1,65 @@
+import mapAndSave from '.';
+import save from '../../save-data/modern-slavery';
+import DECLARATIONS_FIELD_IDS from '../../../../../constants/field-ids/insurance/declarations';
+import { mockApplication, mockSpyPromise } from '../../../../../test-mocks';
+import generateValidationErrors from '../../../../../helpers/validation';
+
+const {
+  MODERN_SLAVERY: { WILL_ADHERE_TO_ALL_REQUIREMENTS },
+} = DECLARATIONS_FIELD_IDS;
+
+describe('controllers/insurance/declarations/map-and-save/modern-slavery', () => {
+  jest.mock('../../save-data/modern-slavery');
+
+  let mockFormBody = {
+    _csrf: '1234',
+    [WILL_ADHERE_TO_ALL_REQUIREMENTS]: 'true',
+  };
+
+  const mockSaveDeclarationModernSlavery = mockSpyPromise();
+  save.declarationModernSlavery = mockSaveDeclarationModernSlavery;
+
+  const mockValidationErrors = generateValidationErrors('mock id', 'error', {});
+
+  describe('when the form has data', () => {
+    describe('when the form has validation errors', () => {
+      it('should call save.declarationModernSlavery with application, submitted data and validationErrors.errorList', async () => {
+        await mapAndSave.declarationModernSlavery(mockFormBody, mockApplication, mockValidationErrors);
+
+        expect(save.declarationModernSlavery).toHaveBeenCalledTimes(1);
+        expect(save.declarationModernSlavery).toHaveBeenCalledWith(mockApplication, mockFormBody, mockValidationErrors?.errorList);
+      });
+
+      it('should return true', async () => {
+        const result = await mapAndSave.declarationModernSlavery(mockFormBody, mockApplication, mockValidationErrors);
+
+        expect(result).toEqual(true);
+      });
+    });
+
+    describe('when the form does NOT have validation errors', () => {
+      it('should call save.declarationModernSlavery with application and submitted data', async () => {
+        await mapAndSave.declarationModernSlavery(mockFormBody, mockApplication);
+
+        expect(save.declarationModernSlavery).toHaveBeenCalledTimes(1);
+        expect(save.declarationModernSlavery).toHaveBeenCalledWith(mockApplication, mockFormBody);
+      });
+
+      it('should return true', async () => {
+        const result = await mapAndSave.declarationModernSlavery(mockFormBody, mockApplication, mockValidationErrors);
+
+        expect(result).toEqual(true);
+      });
+    });
+  });
+
+  describe('when the form does not have any data', () => {
+    it('should return true', async () => {
+      mockFormBody = { _csrf: '1234' };
+
+      const result = await mapAndSave.declarationModernSlavery(mockFormBody, mockApplication, mockValidationErrors);
+
+      expect(result).toEqual(true);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/declarations/map-and-save/modern-slavery/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/map-and-save/modern-slavery/index.test.ts
@@ -1,4 +1,5 @@
 import mapAndSave from '.';
+import mapSubmittedData from '../../map-submitted-data/modern-slavery';
 import save from '../../save-data/modern-slavery';
 import DECLARATIONS_FIELD_IDS from '../../../../../constants/field-ids/insurance/declarations';
 import { mockApplication, mockSpyPromise } from '../../../../../test-mocks';
@@ -19,34 +20,36 @@ describe('controllers/insurance/declarations/map-and-save/modern-slavery', () =>
   const mockSaveDeclarationModernSlavery = mockSpyPromise();
   save.declarationModernSlavery = mockSaveDeclarationModernSlavery;
 
+  const populatedData = mapSubmittedData(mockFormBody);
+
   const mockValidationErrors = generateValidationErrors('mock id', 'error', {});
 
   describe('when the form has data', () => {
     describe('when the form has validation errors', () => {
-      it('should call save.declarationModernSlavery with application, submitted data and validationErrors.errorList', async () => {
+      it('should call save.declarationModernSlavery with application, populated submitted data and validationErrors.errorList', async () => {
         await mapAndSave.declarationModernSlavery(mockFormBody, mockApplication, mockValidationErrors);
 
         expect(save.declarationModernSlavery).toHaveBeenCalledTimes(1);
-        expect(save.declarationModernSlavery).toHaveBeenCalledWith(mockApplication, mockFormBody, mockValidationErrors?.errorList);
+        expect(save.declarationModernSlavery).toHaveBeenCalledWith(mockApplication, populatedData, mockValidationErrors?.errorList);
       });
 
       it('should return true', async () => {
-        const result = await mapAndSave.declarationModernSlavery(mockFormBody, mockApplication, mockValidationErrors);
+        const result = await mapAndSave.declarationModernSlavery(populatedData, mockApplication, mockValidationErrors);
 
         expect(result).toEqual(true);
       });
     });
 
     describe('when the form does NOT have validation errors', () => {
-      it('should call save.declarationModernSlavery with application and submitted data', async () => {
-        await mapAndSave.declarationModernSlavery(mockFormBody, mockApplication);
+      it('should call save.declarationModernSlavery with application and populated submitted data', async () => {
+        await mapAndSave.declarationModernSlavery(populatedData, mockApplication);
 
         expect(save.declarationModernSlavery).toHaveBeenCalledTimes(1);
-        expect(save.declarationModernSlavery).toHaveBeenCalledWith(mockApplication, mockFormBody);
+        expect(save.declarationModernSlavery).toHaveBeenCalledWith(mockApplication, populatedData);
       });
 
       it('should return true', async () => {
-        const result = await mapAndSave.declarationModernSlavery(mockFormBody, mockApplication, mockValidationErrors);
+        const result = await mapAndSave.declarationModernSlavery(populatedData, mockApplication, mockValidationErrors);
 
         expect(result).toEqual(true);
       });
@@ -57,7 +60,7 @@ describe('controllers/insurance/declarations/map-and-save/modern-slavery', () =>
     it('should return true', async () => {
       mockFormBody = { _csrf: '1234' };
 
-      const result = await mapAndSave.declarationModernSlavery(mockFormBody, mockApplication, mockValidationErrors);
+      const result = await mapAndSave.declarationModernSlavery(populatedData, mockApplication, mockValidationErrors);
 
       expect(result).toEqual(true);
     });

--- a/src/ui/server/controllers/insurance/declarations/map-and-save/modern-slavery/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/map-and-save/modern-slavery/index.ts
@@ -1,4 +1,5 @@
 import hasFormData from '../../../../../helpers/has-form-data';
+import mapSubmittedData from '../../map-submitted-data/modern-slavery';
 import save from '../../save-data/modern-slavery';
 import { Application, RequestBody, ValidationErrors } from '../../../../../../types';
 
@@ -13,12 +14,14 @@ import { Application, RequestBody, ValidationErrors } from '../../../../../../ty
 const declarationModernSlavery = async (formBody: RequestBody, application: Application, validationErrors?: ValidationErrors) => {
   try {
     if (hasFormData(formBody)) {
+      const populatedData = mapSubmittedData(formBody);
+
       let saveResponse;
 
       if (validationErrors) {
-        saveResponse = await save.declarationModernSlavery(application, formBody, validationErrors.errorList);
+        saveResponse = await save.declarationModernSlavery(application, populatedData, validationErrors.errorList);
       } else {
-        saveResponse = await save.declarationModernSlavery(application, formBody);
+        saveResponse = await save.declarationModernSlavery(application, populatedData);
       }
 
       if (!saveResponse) {
@@ -30,7 +33,7 @@ const declarationModernSlavery = async (formBody: RequestBody, application: Appl
 
     return true;
   } catch (error) {
-    console.error('Error mapping and saving application %o', error);
+    console.error('Error mapping and saving declaration - modern slavery %o', error);
 
     return false;
   }

--- a/src/ui/server/controllers/insurance/declarations/map-and-save/modern-slavery/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/map-and-save/modern-slavery/index.ts
@@ -1,0 +1,41 @@
+import hasFormData from '../../../../../helpers/has-form-data';
+import save from '../../save-data/modern-slavery';
+import { Application, RequestBody, ValidationErrors } from '../../../../../../types';
+
+/**
+ * mapAndSave
+ * Map and save any valid modern slavery fields
+ * @param {RequestBody} formBody: Form body
+ * @param {Application} application
+ * @param {Object} validationErrors: Validation errors
+ * @returns {Promise<Boolean>}
+ */
+const declarationModernSlavery = async (formBody: RequestBody, application: Application, validationErrors?: ValidationErrors) => {
+  try {
+    if (hasFormData(formBody)) {
+      let saveResponse;
+
+      if (validationErrors) {
+        saveResponse = await save.declarationModernSlavery(application, formBody, validationErrors.errorList);
+      } else {
+        saveResponse = await save.declarationModernSlavery(application, formBody);
+      }
+
+      if (!saveResponse) {
+        return false;
+      }
+
+      return true;
+    }
+
+    return true;
+  } catch (error) {
+    console.error('Error mapping and saving application %o', error);
+
+    return false;
+  }
+};
+
+export default {
+  declarationModernSlavery,
+};

--- a/src/ui/server/controllers/insurance/declarations/map-submitted-data/modern-slavery/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/map-submitted-data/modern-slavery/index.test.ts
@@ -1,0 +1,56 @@
+import mapSubmittedData from '.';
+import FIELD_IDS from '../../../../../constants/field-ids/insurance/declarations';
+
+const {
+  MODERN_SLAVERY: { WILL_ADHERE_TO_ALL_REQUIREMENTS, HAS_NO_OFFENSES_OR_INVESTIGATIONS, IS_NOT_AWARE_OF_EXISTING_SLAVERY },
+} = FIELD_IDS;
+
+describe('controllers/insurance/declarations/map-submitted-data/modern-slavery', () => {
+  describe(`when ${WILL_ADHERE_TO_ALL_REQUIREMENTS} is provided with an empty string`, () => {
+    it(`should nullify ${WILL_ADHERE_TO_ALL_REQUIREMENTS}`, () => {
+      const mockFormBody = {
+        [WILL_ADHERE_TO_ALL_REQUIREMENTS]: '',
+      };
+
+      const result = mapSubmittedData(mockFormBody);
+
+      const expected = {
+        [WILL_ADHERE_TO_ALL_REQUIREMENTS]: null,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when ${HAS_NO_OFFENSES_OR_INVESTIGATIONS} is provided with an empty string`, () => {
+    it(`should nullify ${HAS_NO_OFFENSES_OR_INVESTIGATIONS}`, () => {
+      const mockFormBody = {
+        [HAS_NO_OFFENSES_OR_INVESTIGATIONS]: '',
+      };
+
+      const result = mapSubmittedData(mockFormBody);
+
+      const expected = {
+        [HAS_NO_OFFENSES_OR_INVESTIGATIONS]: null,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when ${IS_NOT_AWARE_OF_EXISTING_SLAVERY} is provided with an empty string`, () => {
+    it(`should nullify ${IS_NOT_AWARE_OF_EXISTING_SLAVERY}`, () => {
+      const mockFormBody = {
+        [IS_NOT_AWARE_OF_EXISTING_SLAVERY]: '',
+      };
+
+      const result = mapSubmittedData(mockFormBody);
+
+      const expected = {
+        [IS_NOT_AWARE_OF_EXISTING_SLAVERY]: null,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/declarations/map-submitted-data/modern-slavery/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/map-submitted-data/modern-slavery/index.ts
@@ -1,0 +1,33 @@
+import FIELD_IDS from '../../../../../constants/field-ids/insurance/declarations';
+import { isEmptyString } from '../../../../../helpers/string';
+import { RequestBody } from '../../../../../../types';
+
+const {
+  MODERN_SLAVERY: { WILL_ADHERE_TO_ALL_REQUIREMENTS, HAS_NO_OFFENSES_OR_INVESTIGATIONS, IS_NOT_AWARE_OF_EXISTING_SLAVERY },
+} = FIELD_IDS;
+
+/**
+ * mapSubmittedData
+ * Map "Declarations - Modern slavery" fields
+ * @param {RequestBody} formBody: Form body
+ * @returns {Object} populatedData
+ */
+const mapSubmittedData = (formBody: RequestBody): object => {
+  const populatedData = formBody;
+
+  if (isEmptyString(formBody[WILL_ADHERE_TO_ALL_REQUIREMENTS])) {
+    populatedData[WILL_ADHERE_TO_ALL_REQUIREMENTS] = null;
+  }
+
+  if (isEmptyString(formBody[HAS_NO_OFFENSES_OR_INVESTIGATIONS])) {
+    populatedData[HAS_NO_OFFENSES_OR_INVESTIGATIONS] = null;
+  }
+
+  if (isEmptyString(formBody[IS_NOT_AWARE_OF_EXISTING_SLAVERY])) {
+    populatedData[IS_NOT_AWARE_OF_EXISTING_SLAVERY] = null;
+  }
+
+  return populatedData;
+};
+
+export default mapSubmittedData;

--- a/src/ui/server/controllers/insurance/declarations/modern-slavery/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/modern-slavery/index.test.ts
@@ -7,7 +7,7 @@ import getUserNameFromSession from '../../../../helpers/get-user-name-from-sessi
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
-import save from '../save-data/modern-slavery';
+import save from '../map-and-save/modern-slavery';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import { Request, Response } from '../../../../../types';
 import { mockReq, mockRes, mockApplication, mockSpyPromise, mockSpyPromiseRejection, referenceNumber } from '../../../../test-mocks';
@@ -17,7 +17,12 @@ const { WILL_ADHERE_TO_ALL_REQUIREMENTS, HAS_NO_OFFENSES_OR_INVESTIGATIONS, IS_N
 
 const { MODERN_SLAVERY } = DECLARATIONS.LATEST_DECLARATIONS;
 
-const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
+const {
+  INSURANCE_ROOT,
+  ALL_SECTIONS,
+  DECLARATIONS: { MODERN_SLAVERY_SAVE_AND_BACK },
+  PROBLEM_WITH_SERVICE,
+} = ROUTES.INSURANCE;
 
 describe('controllers/insurance/declarations/modern-slavery', () => {
   jest.mock('../save-data/modern-slavery');
@@ -107,7 +112,7 @@ describe('controllers/insurance/declarations/modern-slavery', () => {
             },
           },
         },
-        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}#`,
+        SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${MODERN_SLAVERY_SAVE_AND_BACK}`,
       };
 
       expect(result).toEqual(expected);
@@ -163,7 +168,7 @@ describe('controllers/insurance/declarations/modern-slavery', () => {
         const payload = constructPayload(req.body, FIELD_IDS);
 
         expect(save.declarationModernSlavery).toHaveBeenCalledTimes(1);
-        expect(save.declarationModernSlavery).toHaveBeenCalledWith(mockApplication, payload);
+        expect(save.declarationModernSlavery).toHaveBeenCalledWith(payload, mockApplication);
       });
 
       it(`should redirect to ${ALL_SECTIONS}`, async () => {

--- a/src/ui/server/controllers/insurance/declarations/modern-slavery/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/modern-slavery/index.ts
@@ -6,7 +6,7 @@ import getUserNameFromSession from '../../../../helpers/get-user-name-from-sessi
 import mapApplicationToFormFields from '../../../../helpers/mappings/map-application-to-form-fields';
 import constructPayload from '../../../../helpers/construct-payload';
 import generateValidationErrors from './validation';
-import save from '../save-data/modern-slavery';
+import save from '../map-and-save/modern-slavery';
 import { sanitiseData } from '../../../../helpers/sanitise-data';
 import { Request, Response } from '../../../../../types';
 
@@ -15,7 +15,12 @@ const { WILL_ADHERE_TO_ALL_REQUIREMENTS, HAS_NO_OFFENSES_OR_INVESTIGATIONS, IS_N
 
 const { MODERN_SLAVERY } = DECLARATIONS.LATEST_DECLARATIONS;
 
-const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = ROUTES.INSURANCE;
+const {
+  INSURANCE_ROOT,
+  ALL_SECTIONS,
+  DECLARATIONS: { MODERN_SLAVERY_SAVE_AND_BACK },
+  PROBLEM_WITH_SERVICE,
+} = ROUTES.INSURANCE;
 
 /**
  * pageVariables
@@ -50,7 +55,7 @@ export const pageVariables = (referenceNumber: number) => ({
       },
     },
   },
-  SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}#`,
+  SAVE_AND_BACK_URL: `${INSURANCE_ROOT}/${referenceNumber}${MODERN_SLAVERY_SAVE_AND_BACK}`,
 });
 
 export const PAGE_CONTENT_STRINGS = {
@@ -139,7 +144,7 @@ export const post = async (req: Request, res: Response) => {
 
   try {
     // save the application
-    const saveResponse = await save.declarationModernSlavery(application, payload);
+    const saveResponse = await save.declarationModernSlavery(payload, application);
 
     if (!saveResponse) {
       return res.redirect(PROBLEM_WITH_SERVICE);

--- a/src/ui/server/controllers/insurance/declarations/modern-slavery/save-and-back/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/modern-slavery/save-and-back/index.test.ts
@@ -1,0 +1,123 @@
+import { post } from '.';
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+import DECLARATIONS_FIELD_IDS from '../../../../../constants/field-ids/insurance/declarations';
+import { FIELD_IDS } from '..';
+import constructPayload from '../../../../../helpers/construct-payload';
+import mapAndSave from '../../map-and-save/modern-slavery';
+import generateValidationErrors from '../validation';
+import { Request, Response } from '../../../../../../types';
+import { mockReq, mockRes, mockSpyPromiseRejection, referenceNumber } from '../../../../../test-mocks';
+
+const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
+
+const {
+  MODERN_SLAVERY: { WILL_ADHERE_TO_ALL_REQUIREMENTS },
+} = DECLARATIONS_FIELD_IDS;
+
+describe('controllers/insurance/declarations/modern-slavery/save-and-back', () => {
+  let req: Request;
+  let res: Response;
+
+  jest.mock('../../map-and-save/modern-slavery');
+
+  let mapAndSaveSpy = jest.fn(() => Promise.resolve(true));
+
+  const mockFormBody = {
+    _csrf: '1234',
+    [WILL_ADHERE_TO_ALL_REQUIREMENTS]: 'true',
+  };
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+
+    mapAndSave.declarationModernSlavery = mapAndSaveSpy;
+  });
+
+  describe('when the form has data', () => {
+    beforeEach(() => {
+      mapAndSaveSpy = jest.fn(() => Promise.resolve(true));
+      mapAndSave.declarationModernSlavery = mapAndSaveSpy;
+
+      req.body = mockFormBody;
+    });
+
+    it('should call mapAndSave.declarationModernSlavery with data from constructPayload function, application and validationErrors', async () => {
+      await post(req, res);
+
+      const payload = constructPayload(req.body, FIELD_IDS);
+
+      const validationErrors = generateValidationErrors(payload);
+
+      expect(mapAndSave.declarationModernSlavery).toHaveBeenCalledTimes(1);
+      expect(mapAndSave.declarationModernSlavery).toHaveBeenCalledWith(payload, res.locals.application, validationErrors);
+    });
+
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
+      mapAndSave.declarationModernSlavery = mapAndSaveSpy;
+
+      await post(req, res);
+
+      const expected = `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      expect(res.redirect).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('when the form does not have any data', () => {
+    it(`should redirect to ${ALL_SECTIONS}`, async () => {
+      req.body = { _csrf: '1234' };
+
+      await post(req, res);
+
+      const expected = `${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`;
+
+      expect(res.redirect).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('when there is no application', () => {
+    beforeEach(() => {
+      delete res.locals.application;
+    });
+
+    it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+      await post(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+    });
+  });
+
+  describe('api error handling', () => {
+    describe('when the mapAndSave call does not return anything', () => {
+      beforeEach(() => {
+        mapAndSaveSpy = jest.fn(() => Promise.resolve(false));
+        mapAndSave.declarationModernSlavery = mapAndSaveSpy;
+
+        req.body = mockFormBody;
+      });
+
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+      });
+    });
+
+    describe('when the mapAndSave call fails', () => {
+      beforeEach(() => {
+        mapAndSaveSpy = mockSpyPromiseRejection;
+
+        mapAndSave.declarationModernSlavery = mapAndSaveSpy;
+
+        req.body = mockFormBody;
+      });
+
+      it(`should redirect to ${PROBLEM_WITH_SERVICE}`, async () => {
+        await post(req, res);
+
+        expect(res.redirect).toHaveBeenCalledWith(PROBLEM_WITH_SERVICE);
+      });
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/declarations/modern-slavery/save-and-back/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/modern-slavery/save-and-back/index.ts
@@ -1,0 +1,53 @@
+import { INSURANCE_ROUTES } from '../../../../../constants/routes/insurance';
+import hasFormData from '../../../../../helpers/has-form-data';
+import { FIELD_IDS } from '..';
+import constructPayload from '../../../../../helpers/construct-payload';
+import generateValidationErrors from '../validation';
+import mapAndSave from '../../map-and-save/modern-slavery';
+import { Request, Response } from '../../../../../../types';
+
+const { INSURANCE_ROOT, ALL_SECTIONS, PROBLEM_WITH_SERVICE } = INSURANCE_ROUTES;
+
+/**
+ * post
+ * Save any valid "Declarations - Modern slavery" form fields and if successful, redirect to the all sections page
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.redirect} All sections page or error page
+ */
+export const post = async (req: Request, res: Response) => {
+  try {
+    const { application } = res.locals;
+
+    if (!application) {
+      return res.redirect(PROBLEM_WITH_SERVICE);
+    }
+
+    const { referenceNumber } = req.params;
+
+    /**
+     * If form data is populated:
+     * 1) generate a payload.
+     * 2) generate validation errors.
+     * 3) call mapAndSave
+     * 4) redirect
+     */
+    if (hasFormData(req.body)) {
+      const payload = constructPayload(req.body, FIELD_IDS);
+
+      const validationErrors = generateValidationErrors(payload);
+
+      const saveResponse = await mapAndSave.declarationModernSlavery(payload, application, validationErrors);
+
+      if (!saveResponse) {
+        return res.redirect(PROBLEM_WITH_SERVICE);
+      }
+    }
+
+    return res.redirect(`${INSURANCE_ROOT}/${referenceNumber}${ALL_SECTIONS}`);
+  } catch (error) {
+    console.error('Error updating application - declarations - modern slavery (save and back) %o', error);
+
+    return res.redirect(PROBLEM_WITH_SERVICE);
+  }
+};

--- a/src/ui/server/controllers/insurance/declarations/save-data/modern-slavery/index.api-error.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/save-data/modern-slavery/index.api-error.test.ts
@@ -1,0 +1,29 @@
+import save from '.';
+import api from '../../../../../api';
+import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
+
+describe('controllers/insurance/declarations/save-data/modern-slavery - API error', () => {
+  const mockUpdateApplicationResponse = mockApplication;
+  let updateApplicationSpy = jest.fn(() => Promise.resolve(mockUpdateApplicationResponse));
+  const mockFormBody = {};
+
+  beforeEach(() => {
+    api.keystone.application.update.declarationModernSlavery = updateApplicationSpy;
+  });
+
+  describe('when there is an error', () => {
+    beforeEach(() => {
+      updateApplicationSpy = mockSpyPromiseRejection;
+      api.keystone.application.update.declarationModernSlavery = updateApplicationSpy;
+    });
+
+    it('should throw an error', async () => {
+      try {
+        await save.declarationModernSlavery(mockApplication, mockFormBody);
+      } catch (error) {
+        const expected = new Error("Updating application's declaration modern slavery");
+        expect(error).toEqual(expected);
+      }
+    });
+  });
+});

--- a/src/ui/server/controllers/insurance/declarations/save-data/modern-slavery/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/save-data/modern-slavery/index.test.ts
@@ -23,7 +23,9 @@ describe('controllers/insurance/declarations/save-data/modern-slavery', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = getDataToSave(mockFormBody, mockValidationErrors.errorList);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.declaration.modernSlavery.id, expectedSanitisedData);
     });
 
@@ -41,7 +43,9 @@ describe('controllers/insurance/declarations/save-data/modern-slavery', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = getDataToSave(mockFormBody);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.declaration.modernSlavery.id, expectedSanitisedData);
     });
 

--- a/src/ui/server/controllers/insurance/declarations/save-data/modern-slavery/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/save-data/modern-slavery/index.test.ts
@@ -1,65 +1,54 @@
 import save from '.';
 import api from '../../../../../api';
+import generateValidationErrors from '../../../../../helpers/validation';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
-import stripEmptyFormFields from '../../../../../helpers/strip-empty-form-fields';
-import { FIELD_IDS } from '../../../../../constants';
-import { mockApplication, mockSpyPromiseRejection } from '../../../../../test-mocks';
-
-const {
-  DECLARATIONS: {
-    MODERN_SLAVERY: { WILL_ADHERE_TO_ALL_REQUIREMENTS },
-  },
-} = FIELD_IDS.INSURANCE;
+import getDataToSave from '../../../../../helpers/get-data-to-save';
+import { mockApplication } from '../../../../../test-mocks';
 
 describe('controllers/insurance/declarations/save-data/modern-slavery', () => {
   const mockUpdateApplicationResponse = mockApplication;
-  let updateApplicationSpy = jest.fn(() => Promise.resolve(mockUpdateApplicationResponse));
-
-  const mockFormBody = {
-    [WILL_ADHERE_TO_ALL_REQUIREMENTS]: 'true',
-  };
+  const updateApplicationSpy = jest.fn(() => Promise.resolve(mockUpdateApplicationResponse));
+  const mockFormBody = {};
 
   beforeEach(() => {
     api.keystone.application.update.declarationModernSlavery = updateApplicationSpy;
   });
 
-  it('should return the API response', async () => {
-    const result = await save.declarationModernSlavery(mockApplication, mockFormBody);
+  describe('when errorList is provided', () => {
+    const mockValidationErrors = generateValidationErrors('mock id', 'error', {});
 
-    expect(result).toEqual(mockUpdateApplicationResponse);
-  });
+    it('should call api.keystone.application.update.declarationModernSlavery with all fields', async () => {
+      await save.declarationModernSlavery(mockApplication, mockFormBody, mockValidationErrors.errorList);
 
-  it('should call api.keystone.application.update.declarationModernSlavery with declarationModernSlavery ID and sanitised data without empty fields', async () => {
-    await save.declarationModernSlavery(mockApplication, mockFormBody);
+      expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
-    expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
-
-    const fieldsWithValues = stripEmptyFormFields(mockFormBody);
-
-    const expectedData = sanitiseData(fieldsWithValues);
-
-    expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.declaration.modernSlavery.id, expectedData);
-  });
-
-  it('should return the API response', async () => {
-    const result = await save.declarationModernSlavery(mockApplication, mockFormBody);
-
-    expect(result).toEqual(mockUpdateApplicationResponse);
-  });
-
-  describe('when there is an error calling the API', () => {
-    beforeEach(() => {
-      updateApplicationSpy = mockSpyPromiseRejection;
-      api.keystone.application.update.declarationModernSlavery = updateApplicationSpy;
+      const dataToSave = getDataToSave(mockFormBody, mockValidationErrors.errorList);
+      const expectedSanitisedData = sanitiseData(dataToSave);
+      expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.declaration.modernSlavery.id, expectedSanitisedData);
     });
 
-    it('should throw an error', async () => {
-      try {
-        await save.declarationModernSlavery(mockApplication, mockFormBody);
-      } catch (error) {
-        const expected = new Error("Updating application's declaration modern slavery");
-        expect(error).toEqual(expected);
-      }
+    it('should return the API response', async () => {
+      const result = await save.declarationModernSlavery(mockApplication, mockFormBody);
+
+      expect(result).toEqual(mockUpdateApplicationResponse);
+    });
+  });
+
+  describe('when errorList is NOT provided', () => {
+    it('should call api.keystone.application.update.declarationModernSlavery with all fields', async () => {
+      await save.declarationModernSlavery(mockApplication, mockFormBody);
+
+      expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
+
+      const dataToSave = getDataToSave(mockFormBody);
+      const expectedSanitisedData = sanitiseData(dataToSave);
+      expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.declaration.modernSlavery.id, expectedSanitisedData);
+    });
+
+    it('should return the API response', async () => {
+      const result = await save.declarationModernSlavery(mockApplication, mockFormBody);
+
+      expect(result).toEqual(mockUpdateApplicationResponse);
     });
   });
 });

--- a/src/ui/server/controllers/insurance/declarations/save-data/modern-slavery/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/save-data/modern-slavery/index.ts
@@ -1,6 +1,6 @@
 import api from '../../../../../api';
+import getDataToSave from '../../../../../helpers/get-data-to-save';
 import { sanitiseData } from '../../../../../helpers/sanitise-data';
-import stripEmptyFormFields from '../../../../../helpers/strip-empty-form-fields';
 import { Application, RequestBody } from '../../../../../../types';
 
 /**
@@ -11,11 +11,11 @@ import { Application, RequestBody } from '../../../../../../types';
  * @param {Express.Request.body} formBody
  * @returns {Promise<Object>} Saved data
  */
-const declarationModernSlavery = async (application: Application, formBody: RequestBody) => {
-  // strip empty form fields.
-  const fieldsWithValues = stripEmptyFormFields(formBody);
+const declarationModernSlavery = async (application: Application, formBody: RequestBody, errorList?: object) => {
+  // determines which fields to save
+  const dataToSave = getDataToSave(formBody, errorList);
 
-  const sanitisedData = sanitiseData(fieldsWithValues);
+  const sanitisedData = sanitiseData(dataToSave);
 
   // send the form data to the API for database update.
   const declarationModernSlaveryId = application.declaration.modernSlavery.id;

--- a/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent-service-charge/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent-service-charge/index.test.ts
@@ -43,6 +43,7 @@ describe('controllers/insurance/export-contract/save-data/export-contract-agent-
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const expectedSanitisedData = sanitiseData(mockFormBody.invalid);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.exportContract.agent.service.charge.id, expectedSanitisedData);
     });
 
@@ -60,6 +61,7 @@ describe('controllers/insurance/export-contract/save-data/export-contract-agent-
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const expectedSanitisedData = sanitiseData(mockFormBody.valid);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.exportContract.agent.service.charge.id, expectedSanitisedData);
     });
 

--- a/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent-service/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent-service/index.test.ts
@@ -39,6 +39,7 @@ describe('controllers/insurance/export-contract/save-data/export-contract-agent-
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const expectedSanitisedData = sanitiseData(mockFormBody.invalid);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.exportContract.agent.service.id, expectedSanitisedData);
     });
 
@@ -56,6 +57,7 @@ describe('controllers/insurance/export-contract/save-data/export-contract-agent-
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const expectedSanitisedData = sanitiseData(mockFormBody.valid);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.exportContract.agent.service.id, expectedSanitisedData);
     });
 

--- a/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/export-contract-agent/index.test.ts
@@ -39,6 +39,7 @@ describe('controllers/insurance/export-contract/save-data/export-contract-agent'
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const expectedSanitisedData = sanitiseData(mockFormBody.invalid);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.exportContract.agent.id, expectedSanitisedData);
     });
 
@@ -56,6 +57,7 @@ describe('controllers/insurance/export-contract/save-data/export-contract-agent'
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const expectedSanitisedData = sanitiseData(mockFormBody.valid);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.exportContract.agent.id, expectedSanitisedData);
     });
 

--- a/src/ui/server/controllers/insurance/export-contract/save-data/export-contract/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/export-contract/index.test.ts
@@ -39,6 +39,7 @@ describe('controllers/insurance/export-contract/save-data/export-contract', () =
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const expectedSanitisedData = sanitiseData(mockFormBody.invalid);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.exportContract.id, expectedSanitisedData);
     });
 
@@ -56,6 +57,7 @@ describe('controllers/insurance/export-contract/save-data/export-contract', () =
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const expectedSanitisedData = sanitiseData(mockFormBody.valid);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.exportContract.id, expectedSanitisedData);
     });
 

--- a/src/ui/server/controllers/insurance/export-contract/save-data/private-market/index.test.ts
+++ b/src/ui/server/controllers/insurance/export-contract/save-data/private-market/index.test.ts
@@ -39,6 +39,7 @@ describe('controllers/insurance/export-contract/save-data/private-market', () =>
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const expectedSanitisedData = sanitiseData(mockFormBody.invalid);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.exportContract.privateMarket.id, expectedSanitisedData);
     });
 
@@ -56,6 +57,7 @@ describe('controllers/insurance/export-contract/save-data/private-market', () =>
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const expectedSanitisedData = sanitiseData(mockFormBody.valid);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.exportContract.privateMarket.id, expectedSanitisedData);
     });
 

--- a/src/ui/server/controllers/insurance/policy/save-data/broker/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/broker/index.test.ts
@@ -28,7 +28,9 @@ describe('controllers/insurance/policy/save-data/broker', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = getDataToSave(mockFormBody, mockValidationErrors.errorList);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.broker.id, expectedSanitisedData);
     });
 
@@ -46,7 +48,9 @@ describe('controllers/insurance/policy/save-data/broker', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = getDataToSave(mockFormBody);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.broker.id, expectedSanitisedData);
     });
 

--- a/src/ui/server/controllers/insurance/policy/save-data/jointly-insured-party/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/jointly-insured-party/index.test.ts
@@ -29,6 +29,7 @@ describe('controllers/insurance/policy/save-data/jointly-insured-party', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = stripEmptyFormFields(getDataToSave(mockFormBody, mockValidationErrors.errorList));
+
       const expectedSanitisedData = sanitiseData(dataToSave);
 
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.policy.jointlyInsuredParty.id, expectedSanitisedData);
@@ -48,6 +49,7 @@ describe('controllers/insurance/policy/save-data/jointly-insured-party', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = getDataToSave(mockFormBody);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
 
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.policy.jointlyInsuredParty.id, expectedSanitisedData);

--- a/src/ui/server/controllers/insurance/policy/save-data/loss-payee-financial-details-international/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/loss-payee-financial-details-international/index.test.ts
@@ -36,6 +36,7 @@ describe('controllers/insurance/policy/save-data/loss-payee-financial-details-in
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = stripEmptyFormFields(getDataToSave(mockFormBody, mockValidationErrors.errorList), NULL_OR_EMPTY_STRING_FIELDS);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
 
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.nominatedLossPayee.financialInternational.id, expectedSanitisedData);
@@ -55,6 +56,7 @@ describe('controllers/insurance/policy/save-data/loss-payee-financial-details-in
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = stripEmptyFormFields(getDataToSave(mockFormBody), NULL_OR_EMPTY_STRING_FIELDS);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
 
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.nominatedLossPayee.financialInternational.id, expectedSanitisedData);

--- a/src/ui/server/controllers/insurance/policy/save-data/loss-payee-financial-details-uk/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/loss-payee-financial-details-uk/index.test.ts
@@ -33,6 +33,7 @@ describe('controllers/insurance/policy/save-data/loss-payee-financial-details-uk
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = stripEmptyFormFields(getDataToSave(mockFormBody, mockValidationErrors.errorList), NULL_OR_EMPTY_STRING_FIELDS);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
 
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.nominatedLossPayee.financialUk.id, expectedSanitisedData);
@@ -52,6 +53,7 @@ describe('controllers/insurance/policy/save-data/loss-payee-financial-details-uk
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = stripEmptyFormFields(getDataToSave(mockFormBody), NULL_OR_EMPTY_STRING_FIELDS);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
 
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.nominatedLossPayee.financialUk.id, expectedSanitisedData);

--- a/src/ui/server/controllers/insurance/policy/save-data/nominated-loss-payee/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/nominated-loss-payee/index.test.ts
@@ -33,6 +33,7 @@ describe('controllers/insurance/policy/save-data/nominated-loss-payee', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = stripEmptyFormFields(getDataToSave(mockFormBody, mockValidationErrors.errorList), NULL_OR_EMPTY_STRING_FIELDS);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
 
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.nominatedLossPayee.id, expectedSanitisedData);
@@ -52,6 +53,7 @@ describe('controllers/insurance/policy/save-data/nominated-loss-payee', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = stripEmptyFormFields(getDataToSave(mockFormBody), NULL_OR_EMPTY_STRING_FIELDS);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
 
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.nominatedLossPayee.id, expectedSanitisedData);

--- a/src/ui/server/controllers/insurance/policy/save-data/policy-contact/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/policy-contact/index.test.ts
@@ -37,6 +37,7 @@ describe('controllers/insurance/policy/save-data/policy-contact', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const expectedSanitisedData = sanitiseData(mockFormBody.invalid);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.policyContact.id, expectedSanitisedData);
     });
 
@@ -54,6 +55,7 @@ describe('controllers/insurance/policy/save-data/policy-contact', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const expectedSanitisedData = sanitiseData(mockFormBody.valid);
+
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.policyContact.id, expectedSanitisedData);
     });
 

--- a/src/ui/server/controllers/insurance/policy/save-data/policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/save-data/policy/index.test.ts
@@ -36,6 +36,7 @@ describe('controllers/insurance/policy/save-data/policy', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = getDataToSave(mockFormBody.invalid, mockErrorList);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
 
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.policy.id, expectedSanitisedData);
@@ -55,6 +56,7 @@ describe('controllers/insurance/policy/save-data/policy', () => {
       expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
       const dataToSave = getDataToSave(mockFormBody.valid);
+
       const expectedSanitisedData = sanitiseData(dataToSave);
 
       expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.policy.id, expectedSanitisedData);

--- a/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-relationship/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-relationship/index.test.ts
@@ -35,7 +35,9 @@ describe('controllers/insurance/your-buyer/save-data/buyer-relationship', () => 
         expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
         const dataToSave = getDataToSave(mockFormBody, mockValidationErrors.errorList);
+
         const expectedSanitisedData = stripEmptyFormFields(sanitiseData(dataToSave), NULL_OR_EMPTY_STRING_FIELDS);
+
         expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.buyer.relationship.id, expectedSanitisedData);
       });
 
@@ -53,7 +55,9 @@ describe('controllers/insurance/your-buyer/save-data/buyer-relationship', () => 
         expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
         const dataToSave = getDataToSave(mockFormBody);
+
         const expectedSanitisedData = stripEmptyFormFields(sanitiseData(dataToSave), NULL_OR_EMPTY_STRING_FIELDS);
+
         expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.buyer.relationship.id, expectedSanitisedData);
       });
 

--- a/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-trading-history/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/save-data/buyer-trading-history/index.test.ts
@@ -40,7 +40,9 @@ describe('controllers/insurance/your-buyer/save-data/buyer-trading-history', () 
         expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
         const dataToSave = getDataToSave(mockFormBody, mockValidationErrors.errorList);
+
         const expectedSanitisedData = stripEmptyFormFields(sanitiseData(dataToSave), NULL_OR_EMPTY_STRING_FIELDS);
+
         expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.buyer.buyerTradingHistory.id, expectedSanitisedData);
       });
 
@@ -58,7 +60,9 @@ describe('controllers/insurance/your-buyer/save-data/buyer-trading-history', () 
         expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
         const dataToSave = getDataToSave(mockFormBody);
+
         const expectedSanitisedData = stripEmptyFormFields(sanitiseData(dataToSave), NULL_OR_EMPTY_STRING_FIELDS);
+
         expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.buyer.buyerTradingHistory.id, expectedSanitisedData);
       });
 

--- a/src/ui/server/controllers/insurance/your-buyer/save-data/buyer/index.test.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/save-data/buyer/index.test.ts
@@ -30,7 +30,9 @@ describe('controllers/insurance/your-buyer/save-data/buyer', () => {
         expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
         const dataToSave = getDataToSave(mockFormBody, mockValidationErrors.errorList);
+
         const expectedSanitisedData = sanitiseData(dataToSave);
+
         expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.buyer.id, expectedSanitisedData);
       });
 
@@ -48,7 +50,9 @@ describe('controllers/insurance/your-buyer/save-data/buyer', () => {
         expect(updateApplicationSpy).toHaveBeenCalledTimes(1);
 
         const dataToSave = getDataToSave(mockFormBody);
+
         const expectedSanitisedData = sanitiseData(dataToSave);
+
         expect(updateApplicationSpy).toHaveBeenCalledWith(mockApplication.buyer.id, expectedSanitisedData);
       });
 

--- a/src/ui/server/routes/insurance/declarations/index.test.ts
+++ b/src/ui/server/routes/insurance/declarations/index.test.ts
@@ -8,6 +8,7 @@ import {
   post as exportingWithCodeOfConductPost,
 } from '../../../controllers/insurance/declarations/anti-bribery/exporting-with-code-of-conduct';
 import { get as modernSlaveryGet, post as modernSlaveryPost } from '../../../controllers/insurance/declarations/modern-slavery';
+import { post as modernSlaverySaveAndBackPost } from '../../../controllers/insurance/declarations/modern-slavery/save-and-back';
 import {
   get as confirmationAndAcknowledgementsGet,
   post as confirmationAndAcknowledgementsPost,
@@ -56,6 +57,7 @@ describe('routes/insurance/declarations', () => {
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.MODERN_SLAVERY}`, modernSlaveryGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.MODERN_SLAVERY}`, modernSlaveryPost);
+    expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.MODERN_SLAVERY_SAVE_AND_BACK}`, modernSlaverySaveAndBackPost);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIRMATION_AND_ACKNOWLEDGEMENTS}`, confirmationAndAcknowledgementsGet);
 

--- a/src/ui/server/routes/insurance/declarations/index.test.ts
+++ b/src/ui/server/routes/insurance/declarations/index.test.ts
@@ -25,7 +25,7 @@ describe('routes/insurance/declarations', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(6);
-    expect(post).toHaveBeenCalledTimes(11);
+    expect(post).toHaveBeenCalledTimes(12);
 
     expect(get).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY}`, confidentialityGet);
     expect(post).toHaveBeenCalledWith(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIDENTIALITY}`, confidentialityPost);

--- a/src/ui/server/routes/insurance/declarations/index.ts
+++ b/src/ui/server/routes/insurance/declarations/index.ts
@@ -8,6 +8,7 @@ import {
   post as exportingWithCodeOfConductPost,
 } from '../../../controllers/insurance/declarations/anti-bribery/exporting-with-code-of-conduct';
 import { get as modernSlaveryGet, post as modernSlaveryPost } from '../../../controllers/insurance/declarations/modern-slavery';
+import { post as modernSlaverySaveAndBackPost } from '../../../controllers/insurance/declarations/modern-slavery/save-and-back';
 import {
   get as confirmationAndAcknowledgementsGet,
   post as confirmationAndAcknowledgementsPost,
@@ -44,7 +45,7 @@ insuranceDeclarationsRouter.post(
 insuranceDeclarationsRouter.get(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.MODERN_SLAVERY}`, modernSlaveryGet);
 insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.MODERN_SLAVERY}`, modernSlaveryPost);
 
-insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.MODERN_SLAVERY_SAVE_AND_BACK}`, saveAndBackPost);
+insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.MODERN_SLAVERY_SAVE_AND_BACK}`, modernSlaverySaveAndBackPost);
 
 insuranceDeclarationsRouter.get(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIRMATION_AND_ACKNOWLEDGEMENTS}`, confirmationAndAcknowledgementsGet);
 insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIRMATION_AND_ACKNOWLEDGEMENTS}`, confirmationAndAcknowledgementsPost);

--- a/src/ui/server/routes/insurance/declarations/index.ts
+++ b/src/ui/server/routes/insurance/declarations/index.ts
@@ -44,6 +44,8 @@ insuranceDeclarationsRouter.post(
 insuranceDeclarationsRouter.get(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.MODERN_SLAVERY}`, modernSlaveryGet);
 insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.MODERN_SLAVERY}`, modernSlaveryPost);
 
+insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.MODERN_SLAVERY_SAVE_AND_BACK}`, saveAndBackPost);
+
 insuranceDeclarationsRouter.get(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIRMATION_AND_ACKNOWLEDGEMENTS}`, confirmationAndAcknowledgementsGet);
 insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIRMATION_AND_ACKNOWLEDGEMENTS}`, confirmationAndAcknowledgementsPost);
 insuranceDeclarationsRouter.post(`/:referenceNumber${INSURANCE_ROUTES.DECLARATIONS.CONFIRMATION_AND_ACKNOWLEDGEMENTS_SAVE_AND_BACK}`, saveAndBackPost);

--- a/src/ui/server/routes/insurance/index.test.ts
+++ b/src/ui/server/routes/insurance/index.test.ts
@@ -22,7 +22,7 @@ describe('routes/insurance', () => {
 
   it('should setup all routes', () => {
     expect(get).toHaveBeenCalledTimes(220);
-    expect(post).toHaveBeenCalledTimes(229);
+    expect(post).toHaveBeenCalledTimes(230);
 
     expect(get).toHaveBeenCalledWith(INSURANCE_ROUTES.START, startGet);
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR adds "save and back" functionality to the new "Modern slavery" declaration.

## Resolution :heavy_check_mark:
- Update cypress commands.
- Update E2E application fixtures.
- Create new E2E test.
- Create new UI helper functions:
  - `mapAndSave.declarationModernSlavery`.
  - `mapSubmittedData`
- Update the GET controller to render a real `SAVE_AND_BACK_URL`
- Create new POST controller.

## Miscellaneous :heavy_plus_sign:
- Address some TODO comments.
- Minor unit tests readability improvements.
