### PR TITLE
feat(EMS-4060): declarations - modern slavery - change answers

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/modern-slavery-radios-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/modern-slavery-radios-no-to-yes.spec.js
@@ -1,0 +1,125 @@
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { DECLARATIONS as DECLARATIONS_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/declarations';
+
+const {
+  ROOT: INSURANCE_ROOT,
+  DECLARATIONS: { MODERN_SLAVERY },
+} = INSURANCE_ROUTES;
+
+const {
+  MODERN_SLAVERY: {
+    WILL_ADHERE_TO_ALL_REQUIREMENTS,
+    HAS_NO_OFFENSES_OR_INVESTIGATIONS,
+    IS_NOT_AWARE_OF_EXISTING_SLAVERY,
+    CONDITIONAL_REASONS: { CANNOT_ADHERE_TO_ALL_REQUIREMENTS, OFFENSES_OR_INVESTIGATIONS, AWARE_OF_EXISTING_SLAVERY },
+  },
+} = DECLARATIONS_FIELD_IDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Declarations - Modern slavery page - radios - No to yes', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MODERN_SLAVERY}`;
+
+      cy.navigateToUrl(url);
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when submitting all radios as `no` and submitting conditional fields', () => {
+    before(() => {
+      cy.navigateToUrl(url);
+
+      cy.completeModernSlaveryForm({
+        willAdhereToAllRequirements: false,
+        hasNoOffensesOrInvestigations: false,
+        isNotAwareOfExistingSlavery: false,
+      });
+
+      cy.completeAndSubmitModernSlaveryFormConditionalFields({});
+    });
+
+    describe('after changing the answers from no to yes and going back to the page', () => {
+      before(() => {
+        cy.navigateToUrl(url);
+
+        cy.completeAndSubmitModernSlaveryForm({
+          willAdhereToAllRequirements: true,
+          hasNoOffensesOrInvestigations: true,
+          isNotAwareOfExistingSlavery: true,
+        });
+      });
+
+      describe(WILL_ADHERE_TO_ALL_REQUIREMENTS, () => {
+        beforeEach(() => {
+          cy.navigateToUrl(url);
+        });
+
+        it('should render the submitted radio value', () => {
+          cy.assertYesRadioOptionIsChecked(0);
+        });
+
+        it('should have an empty textarea', () => {
+          cy.clickNoRadioInput();
+
+          cy.checkTextareaValue({
+            fieldId: CANNOT_ADHERE_TO_ALL_REQUIREMENTS,
+            expectedValue: '',
+          });
+        });
+      });
+
+      describe(HAS_NO_OFFENSES_OR_INVESTIGATIONS, () => {
+        beforeEach(() => {
+          cy.navigateToUrl(url);
+        });
+
+        it('should render the submitted radio value', () => {
+          cy.assertYesRadioOptionIsChecked(1);
+        });
+
+        it('should have an empty textarea', () => {
+          cy.clickNoRadioInput();
+
+          cy.checkTextareaValue({
+            fieldId: OFFENSES_OR_INVESTIGATIONS,
+            expectedValue: '',
+          });
+        });
+      });
+
+      describe(IS_NOT_AWARE_OF_EXISTING_SLAVERY, () => {
+        beforeEach(() => {
+          cy.navigateToUrl(url);
+        });
+
+        it('should render the submitted radio value', () => {
+          cy.assertYesRadioOptionIsChecked(1);
+        });
+
+        it('should have an empty textarea', () => {
+          cy.clickNoRadioInput();
+
+          cy.checkTextareaValue({
+            fieldId: AWARE_OF_EXISTING_SLAVERY,
+            expectedValue: '',
+          });
+        });
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/modern-slavery-radios-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/modern-slavery-radios-yes-to-no.spec.js
@@ -1,0 +1,126 @@
+import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
+import { DECLARATIONS as DECLARATIONS_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/declarations';
+import application from '../../../../../../fixtures/application';
+
+const {
+  ROOT: INSURANCE_ROOT,
+  DECLARATIONS: { MODERN_SLAVERY },
+} = INSURANCE_ROUTES;
+
+const {
+  MODERN_SLAVERY: {
+    WILL_ADHERE_TO_ALL_REQUIREMENTS,
+    HAS_NO_OFFENSES_OR_INVESTIGATIONS,
+    IS_NOT_AWARE_OF_EXISTING_SLAVERY,
+    CONDITIONAL_REASONS: { CANNOT_ADHERE_TO_ALL_REQUIREMENTS, OFFENSES_OR_INVESTIGATIONS, AWARE_OF_EXISTING_SLAVERY },
+  },
+} = DECLARATIONS_FIELD_IDS;
+
+const baseUrl = Cypress.config('baseUrl');
+
+context('Insurance - Declarations - Modern slavery page - radios - Yes to no', () => {
+  let referenceNumber;
+  let url;
+
+  before(() => {
+    cy.completeSignInAndGoToApplication({}).then(({ referenceNumber: refNumber }) => {
+      referenceNumber = refNumber;
+
+      url = `${baseUrl}${INSURANCE_ROOT}/${referenceNumber}${MODERN_SLAVERY}`;
+
+      cy.navigateToUrl(url);
+      cy.assertUrl(url);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  after(() => {
+    cy.deleteApplication(referenceNumber);
+  });
+
+  describe('when submitting all radios as `yes` and submitting conditional fields', () => {
+    before(() => {
+      cy.navigateToUrl(url);
+
+      cy.completeAndSubmitModernSlaveryForm({
+        willAdhereToAllRequirements: true,
+        hasNoOffensesOrInvestigations: true,
+        isNotAwareOfExistingSlavery: true,
+      });
+    });
+
+    describe('after changing the answers from yes to no and going back to the page', () => {
+      before(() => {
+        cy.navigateToUrl(url);
+
+        cy.completeAndSubmitModernSlaveryForm({
+          willAdhereToAllRequirements: false,
+          hasNoOffensesOrInvestigations: false,
+          isNotAwareOfExistingSlavery: false,
+        });
+
+        cy.completeAndSubmitModernSlaveryFormConditionalFields({});
+      });
+
+      describe(WILL_ADHERE_TO_ALL_REQUIREMENTS, () => {
+        beforeEach(() => {
+          cy.navigateToUrl(url);
+        });
+
+        it('should render the submitted radio value', () => {
+          cy.assertNoRadioOptionIsChecked(0);
+        });
+
+        it(`should have the submitted "${CANNOT_ADHERE_TO_ALL_REQUIREMENTS}" textarea value`, () => {
+          const fieldId = CANNOT_ADHERE_TO_ALL_REQUIREMENTS;
+
+          cy.checkTextareaValue({
+            fieldId,
+            expectedValue: application.DECLARATION.MODERN_SLAVERY[fieldId],
+          });
+        });
+      });
+
+      describe(HAS_NO_OFFENSES_OR_INVESTIGATIONS, () => {
+        beforeEach(() => {
+          cy.navigateToUrl(url);
+        });
+
+        it('should render the submitted radio value', () => {
+          cy.assertNoRadioOptionIsChecked(1);
+        });
+
+        it(`should have the submitted "${OFFENSES_OR_INVESTIGATIONS}" textarea value`, () => {
+          const fieldId = OFFENSES_OR_INVESTIGATIONS;
+
+          cy.checkTextareaValue({
+            fieldId,
+            expectedValue: application.DECLARATION.MODERN_SLAVERY[fieldId],
+          });
+        });
+      });
+
+      describe(IS_NOT_AWARE_OF_EXISTING_SLAVERY, () => {
+        beforeEach(() => {
+          cy.navigateToUrl(url);
+        });
+
+        it('should render the submitted radio value', () => {
+          cy.assertNoRadioOptionIsChecked(1);
+        });
+
+        it(`should have the submitted "${AWARE_OF_EXISTING_SLAVERY}" textarea value`, () => {
+          const fieldId = AWARE_OF_EXISTING_SLAVERY;
+
+          cy.checkTextareaValue({
+            fieldId,
+            expectedValue: application.DECLARATION.MODERN_SLAVERY[fieldId],
+          });
+        });
+      });
+    });
+  });
+});

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/modern-slavery.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/modern-slavery.spec.js
@@ -148,7 +148,7 @@ context(
             cy.navigateToUrl(url);
           });
 
-          it('should have the submitted radio values', () => {
+          it('should render the submitted radio values', () => {
             cy.assertNoRadioOptionIsChecked(0);
             cy.assertNoRadioOptionIsChecked(1);
             cy.assertNoRadioOptionIsChecked(2);

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/save-and-back.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/save-and-back.spec.js
@@ -159,7 +159,7 @@ context('Insurance - Declarations - Modern slavery page - Save and go back', () 
         cy.navigateToUrl(url);
       });
 
-      it('should have the submitted radio values', () => {
+      it('should render the submitted radio values', () => {
         cy.completeModernSlaveryForm({
           willAdhereToAllRequirements: false,
           hasNoOffensesOrInvestigations: false,

--- a/src/ui/server/controllers/insurance/declarations/map-submitted-data/modern-slavery/index.test.ts
+++ b/src/ui/server/controllers/insurance/declarations/map-submitted-data/modern-slavery/index.test.ts
@@ -1,9 +1,14 @@
 import mapSubmittedData from '.';
-import FIELD_IDS from '../../../../../constants/field-ids/insurance/declarations';
+import DECLARATIONS_FIELD_IDS from '../../../../../constants/field-ids/insurance/declarations';
 
 const {
-  MODERN_SLAVERY: { WILL_ADHERE_TO_ALL_REQUIREMENTS, HAS_NO_OFFENSES_OR_INVESTIGATIONS, IS_NOT_AWARE_OF_EXISTING_SLAVERY },
-} = FIELD_IDS;
+  MODERN_SLAVERY: {
+    WILL_ADHERE_TO_ALL_REQUIREMENTS,
+    HAS_NO_OFFENSES_OR_INVESTIGATIONS,
+    IS_NOT_AWARE_OF_EXISTING_SLAVERY,
+    CONDITIONAL_REASONS: { CANNOT_ADHERE_TO_ALL_REQUIREMENTS, OFFENSES_OR_INVESTIGATIONS, AWARE_OF_EXISTING_SLAVERY },
+  },
+} = DECLARATIONS_FIELD_IDS;
 
 describe('controllers/insurance/declarations/map-submitted-data/modern-slavery', () => {
   describe(`when ${WILL_ADHERE_TO_ALL_REQUIREMENTS} is provided with an empty string`, () => {
@@ -48,6 +53,57 @@ describe('controllers/insurance/declarations/map-submitted-data/modern-slavery',
 
       const expected = {
         [IS_NOT_AWARE_OF_EXISTING_SLAVERY]: null,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when ${WILL_ADHERE_TO_ALL_REQUIREMENTS} is 'true'`, () => {
+    it(`should return ${CANNOT_ADHERE_TO_ALL_REQUIREMENTS} as an empty string`, () => {
+      const mockFormBody = {
+        [WILL_ADHERE_TO_ALL_REQUIREMENTS]: 'true',
+      };
+
+      const result = mapSubmittedData(mockFormBody);
+
+      const expected = {
+        ...mockFormBody,
+        [CANNOT_ADHERE_TO_ALL_REQUIREMENTS]: '',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when ${HAS_NO_OFFENSES_OR_INVESTIGATIONS} is 'true'`, () => {
+    it(`should return ${OFFENSES_OR_INVESTIGATIONS} as an empty string`, () => {
+      const mockFormBody = {
+        [HAS_NO_OFFENSES_OR_INVESTIGATIONS]: 'true',
+      };
+
+      const result = mapSubmittedData(mockFormBody);
+
+      const expected = {
+        ...mockFormBody,
+        [OFFENSES_OR_INVESTIGATIONS]: '',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when ${IS_NOT_AWARE_OF_EXISTING_SLAVERY} is 'true'`, () => {
+    it(`should return ${AWARE_OF_EXISTING_SLAVERY} as an empty string`, () => {
+      const mockFormBody = {
+        [IS_NOT_AWARE_OF_EXISTING_SLAVERY]: 'true',
+      };
+
+      const result = mapSubmittedData(mockFormBody);
+
+      const expected = {
+        ...mockFormBody,
+        [AWARE_OF_EXISTING_SLAVERY]: '',
       };
 
       expect(result).toEqual(expected);

--- a/src/ui/server/controllers/insurance/declarations/map-submitted-data/modern-slavery/index.ts
+++ b/src/ui/server/controllers/insurance/declarations/map-submitted-data/modern-slavery/index.ts
@@ -1,10 +1,15 @@
-import FIELD_IDS from '../../../../../constants/field-ids/insurance/declarations';
+import DECLARATIONS_FIELD_IDS from '../../../../../constants/field-ids/insurance/declarations';
 import { isEmptyString } from '../../../../../helpers/string';
 import { RequestBody } from '../../../../../../types';
 
 const {
-  MODERN_SLAVERY: { WILL_ADHERE_TO_ALL_REQUIREMENTS, HAS_NO_OFFENSES_OR_INVESTIGATIONS, IS_NOT_AWARE_OF_EXISTING_SLAVERY },
-} = FIELD_IDS;
+  MODERN_SLAVERY: {
+    WILL_ADHERE_TO_ALL_REQUIREMENTS,
+    HAS_NO_OFFENSES_OR_INVESTIGATIONS,
+    IS_NOT_AWARE_OF_EXISTING_SLAVERY,
+    CONDITIONAL_REASONS: { CANNOT_ADHERE_TO_ALL_REQUIREMENTS, OFFENSES_OR_INVESTIGATIONS, AWARE_OF_EXISTING_SLAVERY },
+  },
+} = DECLARATIONS_FIELD_IDS;
 
 /**
  * mapSubmittedData
@@ -15,6 +20,10 @@ const {
 const mapSubmittedData = (formBody: RequestBody): object => {
   const populatedData = formBody;
 
+  /**
+   * If any of the following fields are an empty string,
+   * The value needs to be null, as per the data model.
+   */
   if (isEmptyString(formBody[WILL_ADHERE_TO_ALL_REQUIREMENTS])) {
     populatedData[WILL_ADHERE_TO_ALL_REQUIREMENTS] = null;
   }
@@ -25,6 +34,22 @@ const mapSubmittedData = (formBody: RequestBody): object => {
 
   if (isEmptyString(formBody[IS_NOT_AWARE_OF_EXISTING_SLAVERY])) {
     populatedData[IS_NOT_AWARE_OF_EXISTING_SLAVERY] = null;
+  }
+
+  /**
+   * If any of the following fields are true,
+   * The related conditional fields (for an answer of false) should be wiped.
+   */
+  if (formBody[WILL_ADHERE_TO_ALL_REQUIREMENTS] === 'true') {
+    populatedData[CANNOT_ADHERE_TO_ALL_REQUIREMENTS] = '';
+  }
+
+  if (formBody[HAS_NO_OFFENSES_OR_INVESTIGATIONS] === 'true') {
+    populatedData[OFFENSES_OR_INVESTIGATIONS] = '';
+  }
+
+  if (formBody[IS_NOT_AWARE_OF_EXISTING_SLAVERY] === 'true') {
+    populatedData[AWARE_OF_EXISTING_SLAVERY] = '';
   }
 
   return populatedData;


### PR DESCRIPTION
## Introduction :pencil2:
This PR updates the data saving mapping for the "Modern slavery" declaration form so that if the answers are changed from "no" to "yes" all conditional fields for "no" answers are wiped.

## Resolution :heavy_check_mark:
- Add E2E test coverage for changing the answers from "no" to "yes" and vice versa.
- Update `mapSubmittedData` to appropriately wipe conditional fields.

## Miscellaneous :heavy_plus_sign:
- Align some test descriptions.
