### PR TITLE
fix(EMS-4088): application submission - small export builder calculation

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -1589,7 +1589,7 @@ var get2 = async (policyType, policyCurrencyCode, maximumBuyerWillOwe) => {
         const source = GBP;
         const target = String(policyCurrencyCode);
         const exchangeRate = await get_APIM_currencies_exchange_rate_default.get(source, target);
-        maximumBuyerWillOweInGbp = round_number_default(maximumBuyerWillOwe * exchangeRate);
+        maximumBuyerWillOweInGbp = round_number_default(maximumBuyerWillOwe / exchangeRate);
       }
       const threshold = Number(SMALL_EXPORT_BUILDER?.MAXIMUM_BUYER_WILL_OWE);
       const eligibileForSmallExportBuilder = maximumBuyerWillOweInGbp <= threshold;
@@ -6349,13 +6349,11 @@ var send4 = async (application2, xlsxPath) => {
     };
     const sendOwnerEmailVars = {
       ...sharedEmailVars,
-      buyerName: replace_character_codes_with_characters_default(String(buyer.companyOrOrganisationName)),
       name: replace_character_codes_with_characters_default(get_full_name_string_default(owner)),
       emailAddress: email,
     };
     const sendContactEmailVars = {
       ...sharedEmailVars,
-      buyerName: replace_character_codes_with_characters_default(String(buyer.companyOrOrganisationName)),
       name: replace_character_codes_with_characters_default(get_full_name_string_default(policyContact)),
       emailAddress: policyContact.email,
     };

--- a/src/api/emails/application/get-submitted-confirmation-template-id/multiple-policy-type/index.test.ts
+++ b/src/api/emails/application/get-submitted-confirmation-template-id/multiple-policy-type/index.test.ts
@@ -55,7 +55,7 @@ describe('emails/application/get-submitted-confirmation-template-id/multiple-pol
 
       describe(`when ${MAXIMUM_BUYER_WILL_OWE} is below ${SMALL_EXPORT_BUILDER?.MAXIMUM_BUYER_WILL_OWE}`, () => {
         it('should return the correct email template ID', async () => {
-          const mockMaximumBuyerWillOwe = Number(threshold - 1);
+          const mockMaximumBuyerWillOwe = threshold - 1;
 
           const result = await multiplePolicyTypeTemplateId.get(policyType, mockPolicyCurrencyCode, mockMaximumBuyerWillOwe);
 
@@ -67,7 +67,7 @@ describe('emails/application/get-submitted-confirmation-template-id/multiple-pol
 
       describe(`when ${MAXIMUM_BUYER_WILL_OWE} is equal to ${SMALL_EXPORT_BUILDER?.MAXIMUM_BUYER_WILL_OWE}`, () => {
         it('should return the correct email template ID', async () => {
-          const mockMaximumBuyerWillOwe = SMALL_EXPORT_BUILDER?.MAXIMUM_BUYER_WILL_OWE;
+          const mockMaximumBuyerWillOwe = threshold;
 
           const result = await multiplePolicyTypeTemplateId.get(policyType, mockPolicyCurrencyCode, mockMaximumBuyerWillOwe);
 
@@ -79,7 +79,7 @@ describe('emails/application/get-submitted-confirmation-template-id/multiple-pol
 
       describe(`when ${MAXIMUM_BUYER_WILL_OWE} is over ${SMALL_EXPORT_BUILDER?.MAXIMUM_BUYER_WILL_OWE}`, () => {
         it('should return the correct email template ID', async () => {
-          const mockMaximumBuyerWillOwe = Number(threshold + 1);
+          const mockMaximumBuyerWillOwe = threshold + 1;
 
           const result = await multiplePolicyTypeTemplateId.get(policyType, mockPolicyCurrencyCode, mockMaximumBuyerWillOwe);
 
@@ -105,7 +105,7 @@ describe('emails/application/get-submitted-confirmation-template-id/multiple-pol
         it('should return the correct email template ID', async () => {
           apimCurrencyExchangeRate.get = jest.fn(() => Promise.resolve(1));
 
-          const mockMaximumBuyerWillOwe = Number(threshold - 1);
+          const mockMaximumBuyerWillOwe = threshold - 1;
 
           const result = await multiplePolicyTypeTemplateId.get(policyType, mockPolicyCurrencyCode, mockMaximumBuyerWillOwe);
 
@@ -117,11 +117,13 @@ describe('emails/application/get-submitted-confirmation-template-id/multiple-pol
 
       describe(`when ${MAXIMUM_BUYER_WILL_OWE} in ${GBP} is over ${SMALL_EXPORT_BUILDER?.MAXIMUM_BUYER_WILL_OWE}`, () => {
         it('should return the correct email template ID', async () => {
-          const mockResponse = Number(SMALL_EXPORT_BUILDER?.MAXIMUM_BUYER_WILL_OWE);
+          /**
+           * Mock return an exchange rate of zero.
+           * This allows us to easily create a mock MAXIMUM_BUYER_WILL_OWE that is just above the threshold.
+           */
+          apimCurrencyExchangeRate.get = jest.fn(() => Promise.resolve(0));
 
-          apimCurrencyExchangeRate.get = jest.fn(() => Promise.resolve(mockResponse));
-
-          const mockMaximumBuyerWillOwe = Number(threshold + 1);
+          const mockMaximumBuyerWillOwe = threshold + 1;
 
           const result = await multiplePolicyTypeTemplateId.get(policyType, mockPolicyCurrencyCode, mockMaximumBuyerWillOwe);
 

--- a/src/api/emails/application/get-submitted-confirmation-template-id/multiple-policy-type/index.ts
+++ b/src/api/emails/application/get-submitted-confirmation-template-id/multiple-policy-type/index.ts
@@ -37,7 +37,7 @@ const get = async (policyType: string, policyCurrencyCode: string, maximumBuyerW
 
         const exchangeRate = await apimCurrencyExchangeRate.get(source, target);
 
-        maximumBuyerWillOweInGbp = roundNumber(maximumBuyerWillOwe * exchangeRate);
+        maximumBuyerWillOweInGbp = roundNumber(maximumBuyerWillOwe / exchangeRate);
       }
 
       const threshold = Number(SMALL_EXPORT_BUILDER?.MAXIMUM_BUYER_WILL_OWE);

--- a/src/api/emails/send-application-submitted-emails/index.test.ts
+++ b/src/api/emails/send-application-submitted-emails/index.test.ts
@@ -66,14 +66,12 @@ describe('emails/send-email-application-submitted', () => {
       expectedSendOwnerEmailVars = {
         ...sharedEmailVars,
         emailAddress: email,
-        buyerName: replaceCharacterCodesWithCharacters(String(buyer.companyOrOrganisationName)),
         name: replaceCharacterCodesWithCharacters(getFullNameString(owner)),
       } as ApplicationSubmissionEmailVariables;
 
       expectedContactSendEmailVars = {
         ...sharedEmailVars,
         emailAddress: policyContact.email,
-        buyerName: replaceCharacterCodesWithCharacters(String(buyer.companyOrOrganisationName)),
         name: replaceCharacterCodesWithCharacters(getFullNameString(policyContact)),
       } as ApplicationSubmissionEmailVariables;
     });

--- a/src/api/emails/send-application-submitted-emails/index.ts
+++ b/src/api/emails/send-application-submitted-emails/index.ts
@@ -10,7 +10,7 @@ import { SuccessResponse, ApplicationSubmissionEmailVariables, Application } fro
  * Send "application submitted" emails
  * @param {Application} application
  * @param {String} xlsxPath: Path to XLSX file for underwriting team email
- * @returns {Promise<Object>} Object with success flag and emailRecipient
+ * @returns {Promise<SuccessResponse>} Object with success flag and emailRecipient
  */
 const send = async (application: Application, xlsxPath: string): Promise<SuccessResponse> => {
   try {
@@ -18,10 +18,11 @@ const send = async (application: Application, xlsxPath: string): Promise<Success
 
     const { requestedStartDate } = policy;
 
-    // generate email variables
     const { email } = owner;
 
-    // shared variables for sending email
+    /**
+     * Shared email variables for all emails
+     */
     const sharedEmailVars = {
       referenceNumber,
       buyerName: replaceCharacterCodesWithCharacters(String(buyer.companyOrOrganisationName)),
@@ -32,11 +33,10 @@ const send = async (application: Application, xlsxPath: string): Promise<Success
 
     /**
      * Email variables for sending email to:
-     * the application owner of application
+     * the owner of the application
      */
     const sendOwnerEmailVars = {
       ...sharedEmailVars,
-      buyerName: replaceCharacterCodesWithCharacters(String(buyer.companyOrOrganisationName)),
       name: replaceCharacterCodesWithCharacters(getFullNameString(owner)),
       emailAddress: email,
     } as ApplicationSubmissionEmailVariables;
@@ -47,7 +47,6 @@ const send = async (application: Application, xlsxPath: string): Promise<Success
      */
     const sendContactEmailVars = {
       ...sharedEmailVars,
-      buyerName: replaceCharacterCodesWithCharacters(String(buyer.companyOrOrganisationName)),
       name: replaceCharacterCodesWithCharacters(getFullNameString(policyContact)),
       emailAddress: policyContact.email,
     } as ApplicationSubmissionEmailVariables;


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where, during application submission the "eligible for small export builder" calculation would incorrectly calculate non GBP currencies.

## Resolution :heavy_check_mark:
- Update `multiplePolicyTypeTemplateId.get` to divide instead of multiply.

## Miscellaneous :heavy_plus_sign:
- Simplify some test mocks.
- Remove some unnecessary `buyerName` instances in `applicationSubmittedEmails.send`.
- Minor documentation improvements.
