### PR TITLE
feat(EMS-3842-3990): country risk logic - short term cover 

### DIFF
--- a/e2e-tests/fixtures/countries.js
+++ b/e2e-tests/fixtures/countries.js
@@ -8,6 +8,11 @@ export const ARG = {
   ISO_CODE: 'AGO',
 };
 
+export const BLZ = {
+  NAME: 'Belize',
+  ISO_CODE: 'BLZ',
+};
+
 export const BRA = {
   NAME: 'Brazil',
   ISO_CODE: 'BRA',
@@ -38,6 +43,11 @@ export const IOT = {
   ISO_CODE: 'IOT',
 };
 
+export const IRL = {
+  NAME: 'Ireland',
+  ISO_CODE: 'IRL',
+};
+
 export const NCL = {
   NAME: 'New Caledonia',
   ISO_CODE: 'NCL',
@@ -57,15 +67,17 @@ const mockCountries = [DZA, FRA, AGO, GBR, XAD, BRA];
 
 const ONLINE_SUPPORT_1 = DZA;
 
-const NO_ONLINE_SUPPORT_1 = FRA;
-const NO_ONLINE_SUPPORT_2 = AGO;
-const NO_ONLINE_SUPPORT_3 = ARG;
+const NO_ONLINE_SUPPORT_1 = AGO;
+const NO_ONLINE_SUPPORT_2 = ARG;
+const NO_ONLINE_SUPPORT_3 = BLZ;
 const NO_ONLINE_SUPPORT_4 = TN;
 
 const NOT_SUPPORTED_1 = GBR;
 const NOT_SUPPORTED_2 = ERI;
 const NOT_SUPPORTED_3 = IOT;
 const NOT_SUPPORTED_4 = NCL;
+const NOT_SUPPORTED_5 = IRL;
+const NOT_SUPPORTED_6 = FRA;
 
 /**
  * COUNTRY_QUOTE_SUPPORT
@@ -91,6 +103,8 @@ export const COUNTRY_APPLICATION_SUPPORT = {
   NOT_SUPPORTED_2,
   NOT_SUPPORTED_3,
   NOT_SUPPORTED_4,
+  NOT_SUPPORTED_5,
+  NOT_SUPPORTED_6,
 };
 
 export default mockCountries;

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/buyer-country/buyer-country-unsupported-countries.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/buyer-country/buyer-country-unsupported-countries.spec.js
@@ -9,6 +9,8 @@ const COUNTRY_NAME_1 = COUNTRY_APPLICATION_SUPPORT.NOT_SUPPORTED_1.NAME;
 const COUNTRY_NAME_2 = COUNTRY_APPLICATION_SUPPORT.NOT_SUPPORTED_2.NAME;
 const COUNTRY_NAME_3 = COUNTRY_APPLICATION_SUPPORT.NOT_SUPPORTED_3.NAME;
 const COUNTRY_NAME_4 = COUNTRY_APPLICATION_SUPPORT.NOT_SUPPORTED_4.NAME;
+const COUNTRY_NAME_5 = COUNTRY_APPLICATION_SUPPORT.NOT_SUPPORTED_5.NAME;
+const COUNTRY_NAME_6 = COUNTRY_APPLICATION_SUPPORT.NOT_SUPPORTED_6.NAME;
 
 const contextString =
   'As an exporter I want to enter the country where my buyer is based So that I can ascertain if I can obtain UKEF Credit Insurance for the country where my buyer is based - submit countries that cannot apply';
@@ -41,6 +43,18 @@ context(`Insurance - Buyer country page - ${contextString} - Unsupported countri
   describe(COUNTRY_NAME_4, () => {
     it(`should redirect to ${CANNOT_APPLY_EXIT} exit page`, () => {
       cy.enterCountryAndAssertExitPageUrlBuyerCountry(COUNTRY_NAME_4, CANNOT_APPLY_EXIT);
+    });
+  });
+
+  describe(COUNTRY_NAME_5, () => {
+    it(`should redirect to ${CANNOT_APPLY_EXIT} exit page`, () => {
+      cy.enterCountryAndAssertExitPageUrlBuyerCountry(COUNTRY_NAME_5, CANNOT_APPLY_EXIT);
+    });
+  });
+
+  describe(COUNTRY_NAME_6, () => {
+    it(`should redirect to ${CANNOT_APPLY_EXIT} exit page`, () => {
+      cy.enterCountryAndAssertExitPageUrlBuyerCountry(COUNTRY_NAME_6, CANNOT_APPLY_EXIT);
     });
   });
 });

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -9229,7 +9229,7 @@ var {
   CIS: {
     COUNTRY_RATINGS: { NOT_APPLICABLE },
     ESRA_CLASSIFICATION: { NONE },
-    SHORT_TERM_COVER: { UNLISTED, CILC },
+    SHORT_TERM_COVER: { UNLISTED, CILC, NO: NO2 },
   },
 } = EXTERNAL_API_DEFINITIONS;
 var hasNoSupport = ({ countryRating, esraClassification, shortTermCover }) => {
@@ -9245,6 +9245,9 @@ var hasNoSupport = ({ countryRating, esraClassification, shortTermCover }) => {
   if (shortTermCover === CILC && countryRatingIsNotApplicable && esraClassificationConditions) {
     return true;
   }
+  if (shortTermCover === NO2) {
+    return true;
+  }
   return false;
 };
 var has_no_support_default = hasNoSupport;
@@ -9253,7 +9256,7 @@ var has_no_support_default = hasNoSupport;
 var {
   CIS: {
     ESRA_CLASSIFICATION: { STANDARD: STANDARD2, HIGH: HIGH2, VERY_HIGH: VERY_HIGH2, NONE: NONE2 },
-    SHORT_TERM_COVER: { NO: NO2, ILC, CILC: CILC2 },
+    SHORT_TERM_COVER: { NO: NO3, ILC, CILC: CILC2 },
   },
 } = EXTERNAL_API_DEFINITIONS;
 var aAndBRatingConditions = ({ countryRating, esraClassification, shortTermCover }) => {
@@ -9267,11 +9270,8 @@ var aAndBRatingConditions = ({ countryRating, esraClassification, shortTermCover
     if (shortTermCover === CILC2) {
       return true;
     }
-    if (shortTermCover === NO2) {
-      return true;
-    }
   }
-  if (esraClassification === NONE2 && shortTermCover === NO2) {
+  if (esraClassification === NONE2 && shortTermCover === NO3) {
     return true;
   }
   return false;
@@ -9282,7 +9282,7 @@ var a_and_b_rating_conditions_default = aAndBRatingConditions;
 var {
   CIS: {
     ESRA_CLASSIFICATION: { STANDARD: STANDARD3, HIGH: HIGH3, VERY_HIGH: VERY_HIGH3, NONE: NONE3 },
-    SHORT_TERM_COVER: { YES: YES2, NO: NO3, ILC: ILC2, CILC: CILC3, REFER, UNLISTED: UNLISTED2 },
+    SHORT_TERM_COVER: { YES: YES2, NO: NO4, ILC: ILC2, CILC: CILC3, REFER, UNLISTED: UNLISTED2 },
   },
 } = EXTERNAL_API_DEFINITIONS;
 var cAndDRatingConditions = ({ countryRating, esraClassification, shortTermCover }) => {
@@ -9305,11 +9305,8 @@ var cAndDRatingConditions = ({ countryRating, esraClassification, shortTermCover
     if (shortTermCover === UNLISTED2) {
       return true;
     }
-    if (shortTermCover === NO3) {
-      return true;
-    }
   }
-  if (esraClassification === NONE3 && shortTermCover === NO3) {
+  if (esraClassification === NONE3 && shortTermCover === NO4) {
     return true;
   }
   return false;

--- a/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-online-support/a-and-b-rating-conditions/index-rating-a.test.ts
+++ b/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-online-support/a-and-b-rating-conditions/index-rating-a.test.ts
@@ -5,7 +5,7 @@ const {
   CIS: {
     COUNTRY_RATINGS,
     ESRA_CLASSIFICATION: { STANDARD, HIGH, VERY_HIGH },
-    SHORT_TERM_COVER: { NO, ILC, CILC },
+    SHORT_TERM_COVER: { ILC, CILC },
   },
 } = EXTERNAL_API_DEFINITIONS;
 
@@ -20,17 +20,14 @@ const params = {
   STANDARD: {
     [ILC]: createMockParams(STANDARD, ILC),
     [CILC]: createMockParams(STANDARD, CILC),
-    [NO]: createMockParams(STANDARD, NO),
   },
   HIGH: {
     [ILC]: createMockParams(HIGH, ILC),
     [CILC]: createMockParams(HIGH, CILC),
-    [NO]: createMockParams(HIGH, NO),
   },
   VERY_HIGH: {
     [ILC]: createMockParams(VERY_HIGH, ILC),
     [CILC]: createMockParams(VERY_HIGH, CILC),
-    [NO]: createMockParams(VERY_HIGH, NO),
   },
 };
 
@@ -45,14 +42,6 @@ describe('helpers/map-CIS-countries/map-CIS-country/no-online-support/a-and-b-ra
     });
 
     describe.each(params.STANDARD[CILC])(`when the short term cover is ${CILC}`, (countryObj) => {
-      it(`should return true for ${countryObj.countryRating}`, () => {
-        const result = aAndBRatingConditions(countryObj);
-
-        expect(result).toEqual(true);
-      });
-    });
-
-    describe.each(params.STANDARD[NO])(`when the short term cover is ${NO}`, (countryObj) => {
       it(`should return true for ${countryObj.countryRating}`, () => {
         const result = aAndBRatingConditions(countryObj);
 
@@ -77,14 +66,6 @@ describe('helpers/map-CIS-countries/map-CIS-country/no-online-support/a-and-b-ra
         expect(result).toEqual(true);
       });
     });
-
-    describe.each(params.HIGH[NO])(`when the short term cover is ${NO}`, (countryObj) => {
-      it(`should return true for ${countryObj.countryRating}`, () => {
-        const result = aAndBRatingConditions(countryObj);
-
-        expect(result).toEqual(true);
-      });
-    });
   });
 
   describe(`when the ESRA classification is ${VERY_HIGH}`, () => {
@@ -97,14 +78,6 @@ describe('helpers/map-CIS-countries/map-CIS-country/no-online-support/a-and-b-ra
     });
 
     describe.each(params.VERY_HIGH[CILC])(`when the short term cover is ${CILC}`, (countryObj) => {
-      it(`should return true for ${countryObj.countryRating}`, () => {
-        const result = aAndBRatingConditions(countryObj);
-
-        expect(result).toEqual(true);
-      });
-    });
-
-    describe.each(params.VERY_HIGH[NO])(`when the short term cover is ${NO}`, (countryObj) => {
       it(`should return true for ${countryObj.countryRating}`, () => {
         const result = aAndBRatingConditions(countryObj);
 

--- a/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-online-support/a-and-b-rating-conditions/index-rating-b.test.ts
+++ b/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-online-support/a-and-b-rating-conditions/index-rating-b.test.ts
@@ -5,7 +5,7 @@ const {
   CIS: {
     COUNTRY_RATINGS,
     ESRA_CLASSIFICATION: { STANDARD, HIGH, VERY_HIGH },
-    SHORT_TERM_COVER: { NO, ILC, CILC },
+    SHORT_TERM_COVER: { ILC, CILC },
   },
 } = EXTERNAL_API_DEFINITIONS;
 
@@ -20,17 +20,14 @@ const params = {
   STANDARD: {
     [ILC]: createMockParams(STANDARD, ILC),
     [CILC]: createMockParams(STANDARD, CILC),
-    [NO]: createMockParams(STANDARD, NO),
   },
   HIGH: {
     [ILC]: createMockParams(HIGH, ILC),
     [CILC]: createMockParams(HIGH, CILC),
-    [NO]: createMockParams(HIGH, NO),
   },
   VERY_HIGH: {
     [ILC]: createMockParams(VERY_HIGH, ILC),
     [CILC]: createMockParams(VERY_HIGH, CILC),
-    [NO]: createMockParams(VERY_HIGH, NO),
   },
 };
 
@@ -45,14 +42,6 @@ describe('helpers/map-CIS-countries/map-CIS-country/no-online-support/a-and-b-ra
     });
 
     describe.each(params.STANDARD[CILC])(`when the short term cover is ${CILC}`, (countryObj) => {
-      it(`should return true for ${countryObj.countryRating}`, () => {
-        const result = aAndBRatingConditions(countryObj);
-
-        expect(result).toEqual(true);
-      });
-    });
-
-    describe.each(params.STANDARD[NO])(`when the short term cover is ${NO}`, (countryObj) => {
       it(`should return true for ${countryObj.countryRating}`, () => {
         const result = aAndBRatingConditions(countryObj);
 
@@ -77,14 +66,6 @@ describe('helpers/map-CIS-countries/map-CIS-country/no-online-support/a-and-b-ra
         expect(result).toEqual(true);
       });
     });
-
-    describe.each(params.HIGH[NO])(`when the short term cover is ${NO}`, (countryObj) => {
-      it(`should return true for ${countryObj.countryRating}`, () => {
-        const result = aAndBRatingConditions(countryObj);
-
-        expect(result).toEqual(true);
-      });
-    });
   });
 
   describe(`when the ESRA classification is ${VERY_HIGH}`, () => {
@@ -97,14 +78,6 @@ describe('helpers/map-CIS-countries/map-CIS-country/no-online-support/a-and-b-ra
     });
 
     describe.each(params.VERY_HIGH[CILC])(`when the short term cover is ${CILC}`, (countryObj) => {
-      it(`should return true for ${countryObj.countryRating}`, () => {
-        const result = aAndBRatingConditions(countryObj);
-
-        expect(result).toEqual(true);
-      });
-    });
-
-    describe.each(params.VERY_HIGH[NO])(`when the short term cover is ${NO}`, (countryObj) => {
       it(`should return true for ${countryObj.countryRating}`, () => {
         const result = aAndBRatingConditions(countryObj);
 

--- a/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-online-support/a-and-b-rating-conditions/index.ts
+++ b/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-online-support/a-and-b-rating-conditions/index.ts
@@ -31,10 +31,6 @@ const aAndBRatingConditions = ({ countryRating, esraClassification, shortTermCov
     if (shortTermCover === CILC) {
       return true;
     }
-
-    if (shortTermCover === NO) {
-      return true;
-    }
   }
 
   if (esraClassification === NONE && shortTermCover === NO) {

--- a/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-online-support/c-and-d-rating-conditions/index-rating-c.test.ts
+++ b/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-online-support/c-and-d-rating-conditions/index-rating-c.test.ts
@@ -5,7 +5,7 @@ const {
   CIS: {
     COUNTRY_RATINGS,
     ESRA_CLASSIFICATION: { STANDARD, HIGH, VERY_HIGH },
-    SHORT_TERM_COVER: { YES, NO, ILC, CILC, REFER, UNLISTED },
+    SHORT_TERM_COVER: { YES, ILC, CILC, REFER, UNLISTED },
   },
 } = EXTERNAL_API_DEFINITIONS;
 
@@ -23,7 +23,6 @@ const params = {
     [CILC]: createMockParams(STANDARD, CILC),
     [REFER]: createMockParams(STANDARD, REFER),
     [UNLISTED]: createMockParams(STANDARD, UNLISTED),
-    [NO]: createMockParams(STANDARD, NO),
   },
   HIGH: {
     [YES]: createMockParams(HIGH, YES),
@@ -31,7 +30,6 @@ const params = {
     [CILC]: createMockParams(HIGH, CILC),
     [REFER]: createMockParams(HIGH, REFER),
     [UNLISTED]: createMockParams(HIGH, UNLISTED),
-    [NO]: createMockParams(HIGH, NO),
   },
   VERY_HIGH: {
     [YES]: createMockParams(VERY_HIGH, YES),
@@ -39,7 +37,6 @@ const params = {
     [CILC]: createMockParams(VERY_HIGH, CILC),
     [REFER]: createMockParams(VERY_HIGH, REFER),
     [UNLISTED]: createMockParams(VERY_HIGH, UNLISTED),
-    [NO]: createMockParams(VERY_HIGH, NO),
   },
 };
 
@@ -78,14 +75,6 @@ describe('helpers/map-CIS-countries/map-CIS-country/no-online-support/c-and-d-ra
     });
 
     describe.each(params.STANDARD[UNLISTED])(`when the short term cover is ${UNLISTED}`, (countryObj) => {
-      it(`should return true for ${countryObj.countryRating}`, () => {
-        const result = cAndDRatingConditions(countryObj);
-
-        expect(result).toEqual(true);
-      });
-    });
-
-    describe.each(params.STANDARD[NO])(`when the short term cover is ${NO}`, (countryObj) => {
       it(`should return true for ${countryObj.countryRating}`, () => {
         const result = cAndDRatingConditions(countryObj);
 
@@ -134,14 +123,6 @@ describe('helpers/map-CIS-countries/map-CIS-country/no-online-support/c-and-d-ra
         expect(result).toEqual(true);
       });
     });
-
-    describe.each(params.HIGH[NO])(`when the short term cover is ${NO}`, (countryObj) => {
-      it(`should return true for ${countryObj.countryRating}`, () => {
-        const result = cAndDRatingConditions(countryObj);
-
-        expect(result).toEqual(true);
-      });
-    });
   });
 
   describe(`when the ESRA classification is ${VERY_HIGH}`, () => {
@@ -178,14 +159,6 @@ describe('helpers/map-CIS-countries/map-CIS-country/no-online-support/c-and-d-ra
     });
 
     describe.each(params.VERY_HIGH[UNLISTED])(`when the short term cover is ${UNLISTED}`, (countryObj) => {
-      it(`should return true for ${countryObj.countryRating}`, () => {
-        const result = cAndDRatingConditions(countryObj);
-
-        expect(result).toEqual(true);
-      });
-    });
-
-    describe.each(params.VERY_HIGH[NO])(`when the short term cover is ${NO}`, (countryObj) => {
       it(`should return true for ${countryObj.countryRating}`, () => {
         const result = cAndDRatingConditions(countryObj);
 

--- a/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-online-support/c-and-d-rating-conditions/index-rating-d.test.ts
+++ b/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-online-support/c-and-d-rating-conditions/index-rating-d.test.ts
@@ -5,7 +5,7 @@ const {
   CIS: {
     COUNTRY_RATINGS,
     ESRA_CLASSIFICATION: { STANDARD, HIGH, VERY_HIGH },
-    SHORT_TERM_COVER: { YES, NO, ILC, CILC, REFER, UNLISTED },
+    SHORT_TERM_COVER: { YES, ILC, CILC, REFER, UNLISTED },
   },
 } = EXTERNAL_API_DEFINITIONS;
 
@@ -23,7 +23,6 @@ const params = {
     [CILC]: createMockParams(STANDARD, CILC),
     [REFER]: createMockParams(STANDARD, REFER),
     [UNLISTED]: createMockParams(STANDARD, UNLISTED),
-    [NO]: createMockParams(STANDARD, NO),
   },
   HIGH: {
     [YES]: createMockParams(HIGH, YES),
@@ -31,7 +30,6 @@ const params = {
     [CILC]: createMockParams(HIGH, CILC),
     [REFER]: createMockParams(HIGH, REFER),
     [UNLISTED]: createMockParams(HIGH, UNLISTED),
-    [NO]: createMockParams(HIGH, NO),
   },
   VERY_HIGH: {
     [YES]: createMockParams(VERY_HIGH, YES),
@@ -39,7 +37,6 @@ const params = {
     [CILC]: createMockParams(VERY_HIGH, CILC),
     [REFER]: createMockParams(VERY_HIGH, REFER),
     [UNLISTED]: createMockParams(VERY_HIGH, UNLISTED),
-    [NO]: createMockParams(VERY_HIGH, NO),
   },
 };
 
@@ -78,14 +75,6 @@ describe('helpers/map-CIS-countries/map-CIS-country/no-online-support/c-and-d-ra
     });
 
     describe.each(params.STANDARD[UNLISTED])(`when the short term cover is ${UNLISTED}`, (countryObj) => {
-      it(`should return true for ${countryObj.countryRating}`, () => {
-        const result = cAndDRatingConditions(countryObj);
-
-        expect(result).toEqual(true);
-      });
-    });
-
-    describe.each(params.STANDARD[NO])(`when the short term cover is ${NO}`, (countryObj) => {
       it(`should return true for ${countryObj.countryRating}`, () => {
         const result = cAndDRatingConditions(countryObj);
 
@@ -134,14 +123,6 @@ describe('helpers/map-CIS-countries/map-CIS-country/no-online-support/c-and-d-ra
         expect(result).toEqual(true);
       });
     });
-
-    describe.each(params.HIGH[NO])(`when the short term cover is ${NO}`, (countryObj) => {
-      it(`should return true for ${countryObj.countryRating}`, () => {
-        const result = cAndDRatingConditions(countryObj);
-
-        expect(result).toEqual(true);
-      });
-    });
   });
 
   describe(`when the ESRA classification is ${VERY_HIGH}`, () => {
@@ -178,14 +159,6 @@ describe('helpers/map-CIS-countries/map-CIS-country/no-online-support/c-and-d-ra
     });
 
     describe.each(params.VERY_HIGH[UNLISTED])(`when the short term cover is ${UNLISTED}`, (countryObj) => {
-      it(`should return true for ${countryObj.countryRating}`, () => {
-        const result = cAndDRatingConditions(countryObj);
-
-        expect(result).toEqual(true);
-      });
-    });
-
-    describe.each(params.VERY_HIGH[NO])(`when the short term cover is ${NO}`, (countryObj) => {
       it(`should return true for ${countryObj.countryRating}`, () => {
         const result = cAndDRatingConditions(countryObj);
 

--- a/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-online-support/c-and-d-rating-conditions/index.ts
+++ b/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-online-support/c-and-d-rating-conditions/index.ts
@@ -43,10 +43,6 @@ const cAndDRatingConditions = ({ countryRating, esraClassification, shortTermCov
     if (shortTermCover === UNLISTED) {
       return true;
     }
-
-    if (shortTermCover === NO) {
-      return true;
-    }
   }
 
   if (esraClassification === NONE && shortTermCover === NO) {

--- a/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-support/index.test.ts
+++ b/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-support/index.test.ts
@@ -5,7 +5,7 @@ const {
   CIS: {
     COUNTRY_RATINGS,
     ESRA_CLASSIFICATION: { VERY_HIGH, HIGH, STANDARD, NONE },
-    SHORT_TERM_COVER: { UNLISTED, CILC },
+    SHORT_TERM_COVER: { UNLISTED, CILC, NO },
   },
 } = EXTERNAL_API_DEFINITIONS;
 
@@ -111,6 +111,20 @@ describe('helpers/map-CIS-countries/map-CIS-country/has-no-support', () => {
           expect(result).toEqual(expectation);
         });
       });
+    });
+  });
+
+  describe(`when a country does not meet any other conditions and has shortTermCover as ${NO}`, () => {
+    it('should return true', () => {
+      const mockCountry = {
+        countryRating: COUNTRY_RATINGS.NOT_APPLICABLE,
+        esraClassification: NONE,
+        shortTermCover: NO,
+      };
+
+      const result = hasNoSupport(mockCountry);
+
+      expect(result).toEqual(true);
     });
   });
 });

--- a/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-support/index.ts
+++ b/src/api/helpers/map-CIS-countries/map-CIS-country/has-no-support/index.ts
@@ -8,7 +8,7 @@ const {
   CIS: {
     COUNTRY_RATINGS: { NOT_APPLICABLE },
     ESRA_CLASSIFICATION: { NONE },
-    SHORT_TERM_COVER: { UNLISTED, CILC },
+    SHORT_TERM_COVER: { UNLISTED, CILC, NO },
   },
 } = EXTERNAL_API_DEFINITIONS;
 
@@ -34,6 +34,10 @@ const hasNoSupport = ({ countryRating, esraClassification, shortTermCover }: NoI
   const esraClassificationConditions = esraClassificationIsStandardHighOrVeryHigh(esraClassification) || esraClassificationIsNone;
 
   if (shortTermCover === CILC && countryRatingIsNotApplicable && esraClassificationConditions) {
+    return true;
+  }
+
+  if (shortTermCover === NO) {
     return true;
   }
 

--- a/src/ui/server/controllers/quote/buyer-country/index.ts
+++ b/src/ui/server/controllers/quote/buyer-country/index.ts
@@ -122,8 +122,8 @@ export const post = async (req: Request, res: Response) => {
     }
 
     /**
-     * If a country cannot get a quote online,
-     * redirect to a specific exit page.
+     * If a country can get a quote online,
+     * redirect to the next part of the flow.
      */
     if (country.canGetAQuoteOnline) {
       console.info('Country support - %s - can get a quote online', country.name);


### PR DESCRIPTION
## Introduction :pencil2:
- QA identified some business logic that conflicts with GOV guidelines.
- This PR changes the country risk logic to adhere to the guidelines.

## Resolution :heavy_check_mark:
- Tweak E2E test coverage, add additional coverage for countries that are not supported (online or offline).
- Update the `hasNoOnlineSupport` risk logic so that:
  - If a country has an A or B rating and a `shortTermCover` flag of "no", a `true` flag is returned.
  - If a country has an C or D rating and a `shortTermCover` flag of "no", a `true` flag is returned.
- Update the `hasNoSupport` risk logic so that:
  - If no existing conditions are met and the country has a `shortTermCover` flag of "no", a `true` flag is returned.

## Miscellaneous :heavy_plus_sign:
- Fix a documentation typo.
