### PR TITLE
fix(EMS-4130): broker zero addresses url, minor tech improvements

### DIFF
--- a/e2e-tests/constants/routes/insurance/policy/broker.js
+++ b/e2e-tests/constants/routes/insurance/policy/broker.js
@@ -4,7 +4,7 @@ const ROOT = `${POLICY_ROOT}/broker`;
 const BROKER_DETAILS_ROOT = `${POLICY_ROOT}/broker-details`;
 const BROKER_ADDRESSES_ROOT = `${POLICY_ROOT}/broker-addresses`;
 const BROKER_CONFIRM_ADDRESS_ROOT = `${POLICY_ROOT}/broker-confirm-address`;
-const BROKER_ZERO_ADDRESSES_ROOT = `${BROKER_DETAILS_ROOT}/broker-zero-addresses`;
+const BROKER_ZERO_ADDRESSES_ROOT = `${POLICY_ROOT}/broker-zero-addresses`;
 const BROKER_MANUAL_ADDRESS_ROOT = `${POLICY_ROOT}/broker-manual-address`;
 
 const BROKER_ROUTES = {

--- a/e2e-tests/insurance/cypress/e2e/journeys/all-sections.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/all-sections.spec.js
@@ -169,7 +169,7 @@ context('Insurance - All sections - new application', () => {
       cy.checkText(insurance.allSectionsPage.submissionDeadlineHeading(), CONTENT_STRINGS.DEADLINE_TO_SUBMIT);
     });
 
-    it('should render correct submission deadline', () => {
+    it('should render the correct submission deadline', () => {
       insurance.allSectionsPage.submissionDeadline().should('exist');
 
       const now = new Date();

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-business-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-business-fully-populated.spec.js
@@ -26,7 +26,7 @@ context('Insurance - submit an application - Multiple policy - fully populated b
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-business-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-business-fully-populated.spec.js
@@ -26,7 +26,7 @@ context('Insurance - submit an application - Multiple policy - fully populated b
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-alternative-turnover-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-alternative-turnover-currency.spec.js
@@ -26,7 +26,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-alternative-turnover-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-alternative-turnover-currency.spec.js
@@ -26,7 +26,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-address-and-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-address-and-broker.spec.js
@@ -27,7 +27,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-address-and-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-address-and-broker.spec.js
@@ -27,7 +27,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-address.spec.js
@@ -26,7 +26,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-address.spec.js
@@ -26,7 +26,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name-address-and-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name-address-and-broker.spec.js
@@ -28,7 +28,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name-address-and-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name-address-and-broker.spec.js
@@ -28,7 +28,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name-and-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name-and-address.spec.js
@@ -27,7 +27,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name-and-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name-and-address.spec.js
@@ -27,7 +27,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name-and-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name-and-broker.spec.js
@@ -27,7 +27,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name-and-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name-and-broker.spec.js
@@ -27,7 +27,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name.spec.js
@@ -26,7 +26,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/business-conditions/submit-an-application-multiple-policy-type-with-different-trading-name.spec.js
@@ -26,7 +26,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-buyer-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-buyer-fully-populated.spec.js
@@ -30,7 +30,7 @@ context('Insurance - submit an application - Multiple policy type, fully populat
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-buyer-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-buyer-fully-populated.spec.js
@@ -30,7 +30,7 @@ context('Insurance - submit an application - Multiple policy type, fully populat
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-buyer-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-buyer-minimal.spec.js
@@ -30,7 +30,7 @@ context('Insurance - submit an application - multiple policy type, minimal buyer
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-buyer-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-buyer-minimal.spec.js
@@ -30,7 +30,7 @@ context('Insurance - submit an application - multiple policy type, minimal buyer
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-buyer-no-financial-accounts.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-buyer-no-financial-accounts.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type, fully populat
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-buyer-no-financial-accounts.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-buyer-no-financial-accounts.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type, fully populat
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-connection-and-traded-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-connection-and-traded-with-buyer.spec.js
@@ -26,7 +26,7 @@ context('Insurance - submit an application - Multiple policy type, exporter has 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-connection-and-traded-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-connection-and-traded-with-buyer.spec.js
@@ -26,7 +26,7 @@ context('Insurance - submit an application - Multiple policy type, exporter has 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-connection-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-connection-with-buyer.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type, exporter has 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-connection-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/submit-an-application-multiple-policy-type-connection-with-buyer.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type, exporter has 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-failed-to-pay-on-time.spec.js
@@ -26,7 +26,7 @@ context('Insurance - submit an application - Multiple policy type, exporter has 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-failed-to-pay-on-time.spec.js
@@ -26,7 +26,7 @@ context('Insurance - submit an application - Multiple policy type, exporter has 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-not-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-not-failed-to-pay-on-time.spec.js
@@ -26,7 +26,7 @@ context('Insurance - submit an application - Multiple policy type, exporter has 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-not-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-not-failed-to-pay-on-time.spec.js
@@ -26,7 +26,7 @@ context('Insurance - submit an application - Multiple policy type, exporter has 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-alternative-currency.spec.js
@@ -29,7 +29,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-alternative-currency.spec.js
@@ -29,7 +29,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-failed-to-pay-on-time.spec.js
@@ -26,7 +26,7 @@ context('Insurance - submit an application - Multiple policy type, exporter has 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-failed-to-pay-on-time.spec.js
@@ -26,7 +26,7 @@ context('Insurance - submit an application - Multiple policy type, exporter has 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-not-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-not-failed-to-pay-on-time.spec.js
@@ -26,7 +26,7 @@ context('Insurance - submit an application - Multiple policy type, exporter has 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-not-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-not-failed-to-pay-on-time.spec.js
@@ -26,7 +26,7 @@ context('Insurance - submit an application - Multiple policy type, exporter has 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/declarations-conditions/submit-an-application-multiple-policy-type-has-not-traded-with-buyer-and-no-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/declarations-conditions/submit-an-application-multiple-policy-type-has-not-traded-with-buyer-and-no-code-of-conduct.spec.js
@@ -30,7 +30,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/declarations-conditions/submit-an-application-multiple-policy-type-has-not-traded-with-buyer-and-no-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/declarations-conditions/submit-an-application-multiple-policy-type-has-not-traded-with-buyer-and-no-code-of-conduct.spec.js
@@ -30,7 +30,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/declarations-conditions/submit-an-application-multiple-policy-type-without-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/declarations-conditions/submit-an-application-multiple-policy-type-without-code-of-conduct.spec.js
@@ -25,7 +25,7 @@ context('Insurance - submit an application - Multiple policy type, without `have
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/declarations-conditions/submit-an-application-multiple-policy-type-without-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/declarations-conditions/submit-an-application-multiple-policy-type-without-code-of-conduct.spec.js
@@ -25,7 +25,7 @@ context('Insurance - submit an application - Multiple policy type, without `have
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/declarations-conditions/submit-an-application-multiple-policy-type-without-exporting-with-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/declarations-conditions/submit-an-application-multiple-policy-type-without-exporting-with-code-of-conduct.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type, without `expo
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/declarations-conditions/submit-an-application-multiple-policy-type-without-exporting-with-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/declarations-conditions/submit-an-application-multiple-policy-type-without-exporting-with-code-of-conduct.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type, without `expo
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover-and-using-an-agent-no-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover-and-using-an-agent-no-charges.spec.js
@@ -27,7 +27,7 @@ context('Insurance - submit an application - Multiple policy type, attempted pri
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover-and-using-an-agent-no-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover-and-using-an-agent-no-charges.spec.js
@@ -27,7 +27,7 @@ context('Insurance - submit an application - Multiple policy type, attempted pri
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-fixed-sum.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-fixed-sum.spec.js
@@ -30,7 +30,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-fixed-sum.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-fixed-sum.spec.js
@@ -30,7 +30,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-percentage.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-percentage.spec.js
@@ -30,7 +30,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-percentage.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-percentage.spec.js
@@ -30,7 +30,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover.spec.js
@@ -25,7 +25,7 @@ context('Insurance - submit an application - Multiple policy type, attempted pri
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-attempted-private-market-cover.spec.js
@@ -25,7 +25,7 @@ context('Insurance - submit an application - Multiple policy type, attempted pri
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-contract-awarded-other-method.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-contract-awarded-other-method.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type, contract awar
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-contract-awarded-other-method.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-contract-awarded-other-method.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type, contract awar
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-export-contract-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-export-contract-fully-populated.spec.js
@@ -30,7 +30,7 @@ context('Insurance - submit an application - Multiple policy type, fully populat
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-export-contract-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-export-contract-fully-populated.spec.js
@@ -30,7 +30,7 @@ context('Insurance - submit an application - Multiple policy type, fully populat
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-export-contract-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-export-contract-minimal.spec.js
@@ -27,7 +27,7 @@ context('Insurance - submit an application - Multiple policy type, minimal expor
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-export-contract-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-export-contract-minimal.spec.js
@@ -27,7 +27,7 @@ context('Insurance - submit an application - Multiple policy type, minimal expor
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-alternative-currency.spec.js
@@ -27,7 +27,7 @@ context('Insurance - submit an application - Multiple policy type, using an agen
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-alternative-currency.spec.js
@@ -27,7 +27,7 @@ context('Insurance - submit an application - Multiple policy type, using an agen
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-no-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-no-charges.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type, using an agen
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-no-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-no-charges.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type, using an agen
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-percentage-method.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-percentage-method.spec.js
@@ -26,7 +26,7 @@ context('Insurance - submit an application - Multiple policy type, using an agen
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-percentage-method.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/export-contract-conditions/submit-an-application-multiple-policy-type-using-an-agent-percentage-method.spec.js
@@ -26,7 +26,7 @@ context('Insurance - submit an application - Multiple policy type, using an agen
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-alternative-currency.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type - alternative 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-alternative-currency.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type - alternative 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-broker-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-broker-based-in-uk.spec.js
@@ -27,7 +27,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-broker-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-broker-based-in-uk.spec.js
@@ -27,7 +27,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-broker-not-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-broker-not-based-in-uk.spec.js
@@ -27,7 +27,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-broker-not-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-broker-not-based-in-uk.spec.js
@@ -27,7 +27,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-different-name-on-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-different-name-on-policy.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type, with a differ
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-different-name-on-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-different-name-on-policy.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type, with a differ
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-loss-payee-international.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-loss-payee-international.spec.js
@@ -25,7 +25,7 @@ context('Insurance - submit an application - Multiple policy type, Loss payee - 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-loss-payee-international.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-loss-payee-international.spec.js
@@ -25,7 +25,7 @@ context('Insurance - submit an application - Multiple policy type, Loss payee - 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-loss-payee-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-loss-payee-uk.spec.js
@@ -25,7 +25,7 @@ context('Insurance - submit an application - Single policy type, Loss payee - Fi
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-loss-payee-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-loss-payee-uk.spec.js
@@ -25,7 +25,7 @@ context('Insurance - submit an application - Single policy type, Loss payee - Fi
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-maximum-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-maximum-cover.spec.js
@@ -26,7 +26,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-maximum-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-maximum-cover.spec.js
@@ -26,7 +26,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-other-company-involved.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-other-company-involved.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type - other compan
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-other-company-involved.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-other-company-involved.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type - other compan
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-policy-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-policy-fully-populated.spec.js
@@ -31,7 +31,7 @@ context('Insurance - submit an application - Multiple policy type - fully popula
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-policy-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-policy-fully-populated.spec.js
@@ -31,7 +31,7 @@ context('Insurance - submit an application - Multiple policy type - fully popula
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-pre-credit-period.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type - need a pre-c
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-pre-credit-period.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type - need a pre-c
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-total-contract-value-over-threshold.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-total-contract-value-over-threshold.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type - total contra
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-total-contract-value-over-threshold.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-total-contract-value-over-threshold.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Multiple policy type - total contra
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-with-broker-based-in-uk-building-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-with-broker-based-in-uk-building-name.spec.js
@@ -29,7 +29,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-with-broker-based-in-uk-building-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-with-broker-based-in-uk-building-name.spec.js
@@ -29,7 +29,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-with-broker-based-in-uk-building-number.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-with-broker-based-in-uk-building-number.spec.js
@@ -29,7 +29,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-with-broker-based-in-uk-building-number.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/policy-conditions/submit-an-application-multiple-policy-type-with-broker-based-in-uk-building-number.spec.js
@@ -29,7 +29,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-fully-populated.spec.js
@@ -52,7 +52,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-fully-populated.spec.js
@@ -52,7 +52,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-minimal.spec.js
@@ -25,7 +25,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/multiple-policy-type/submit-an-application-multiple-policy-type-minimal.spec.js
@@ -25,7 +25,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-business-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-business-fully-populated.spec.js
@@ -23,7 +23,7 @@ context('Insurance - submit an application - Single policy - fully populated bus
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-business-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-business-fully-populated.spec.js
@@ -23,7 +23,7 @@ context('Insurance - submit an application - Single policy - fully populated bus
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-alternative-turnover-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-alternative-turnover-currency.spec.js
@@ -21,7 +21,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-alternative-turnover-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-alternative-turnover-currency.spec.js
@@ -21,7 +21,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-address-and-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-address-and-broker.spec.js
@@ -24,7 +24,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-address-and-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-address-and-broker.spec.js
@@ -24,7 +24,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-address.spec.js
@@ -21,7 +21,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-address.spec.js
@@ -21,7 +21,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name-address-and-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name-address-and-broker.spec.js
@@ -25,7 +25,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name-address-and-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name-address-and-broker.spec.js
@@ -25,7 +25,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name-and-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name-and-address.spec.js
@@ -24,7 +24,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name-and-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name-and-address.spec.js
@@ -24,7 +24,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name-and-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name-and-broker.spec.js
@@ -24,7 +24,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name-and-broker.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name-and-broker.spec.js
@@ -24,7 +24,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name.spec.js
@@ -21,7 +21,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/business-conditions/submit-an-application-single-policy-type-with-different-trading-name.spec.js
@@ -21,7 +21,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-buyer-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-buyer-fully-populated.spec.js
@@ -27,7 +27,7 @@ context('Insurance - submit an application - Single policy type, fully populated
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-buyer-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-buyer-fully-populated.spec.js
@@ -27,7 +27,7 @@ context('Insurance - submit an application - Single policy type, fully populated
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-buyer-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-buyer-minimal.spec.js
@@ -27,7 +27,7 @@ context('Insurance - submit an application - Single policy type, minimal buyer',
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-buyer-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-buyer-minimal.spec.js
@@ -27,7 +27,7 @@ context('Insurance - submit an application - Single policy type, minimal buyer',
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-buyer-no-financial-accounts.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-buyer-no-financial-accounts.spec.js
@@ -21,7 +21,7 @@ context('Insurance - submit an application - Single policy type, fully populated
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-buyer-no-financial-accounts.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-buyer-no-financial-accounts.spec.js
@@ -21,7 +21,7 @@ context('Insurance - submit an application - Single policy type, fully populated
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-connection-and-traded-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-connection-and-traded-with-buyer.spec.js
@@ -23,7 +23,7 @@ context('Insurance - submit an application - Single policy type, exporter has co
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-connection-and-traded-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-connection-and-traded-with-buyer.spec.js
@@ -23,7 +23,7 @@ context('Insurance - submit an application - Single policy type, exporter has co
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-connection-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-connection-with-buyer.spec.js
@@ -21,7 +21,7 @@ context('Insurance - submit an application - Single policy type, exporter has co
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-connection-with-buyer.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/submit-an-application-single-policy-type-connection-with-buyer.spec.js
@@ -21,7 +21,7 @@ context('Insurance - submit an application - Single policy type, exporter has co
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-failed-to-pay-on-time.spec.js
@@ -23,7 +23,7 @@ context('Insurance - submit an application - Single policy type, exporter has tr
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-failed-to-pay-on-time.spec.js
@@ -23,7 +23,7 @@ context('Insurance - submit an application - Single policy type, exporter has tr
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-not-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-not-failed-to-pay-on-time.spec.js
@@ -23,7 +23,7 @@ context('Insurance - submit an application - Single policy type, exporter has tr
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-not-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/no-outstanding-payments-not-failed-to-pay-on-time.spec.js
@@ -23,7 +23,7 @@ context('Insurance - submit an application - Single policy type, exporter has tr
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-alternative-currency.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Single policy type, exporter has tr
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-alternative-currency.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Single policy type, exporter has tr
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-failed-to-pay-on-time.spec.js
@@ -23,7 +23,7 @@ context('Insurance - submit an application - Single policy type, exporter has tr
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-failed-to-pay-on-time.spec.js
@@ -23,7 +23,7 @@ context('Insurance - submit an application - Single policy type, exporter has tr
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-not-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-not-failed-to-pay-on-time.spec.js
@@ -23,7 +23,7 @@ context('Insurance - submit an application - Single policy type, exporter has tr
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-not-failed-to-pay-on-time.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/buyer-conditions/traded-with-buyer/outstanding-payments-not-failed-to-pay-on-time.spec.js
@@ -23,7 +23,7 @@ context('Insurance - submit an application - Single policy type, exporter has tr
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/declarations-conditions/submit-an-application-single-policy-type-has-not-traded-with-buyer-and-no-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/declarations-conditions/submit-an-application-single-policy-type-has-not-traded-with-buyer-and-no-code-of-conduct.spec.js
@@ -27,7 +27,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/declarations-conditions/submit-an-application-single-policy-type-has-not-traded-with-buyer-and-no-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/declarations-conditions/submit-an-application-single-policy-type-has-not-traded-with-buyer-and-no-code-of-conduct.spec.js
@@ -27,7 +27,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/declarations-conditions/submit-an-application-single-policy-type-without-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/declarations-conditions/submit-an-application-single-policy-type-without-code-of-conduct.spec.js
@@ -19,7 +19,7 @@ context('Insurance - submit an application - Single policy type, without `have c
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/declarations-conditions/submit-an-application-single-policy-type-without-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/declarations-conditions/submit-an-application-single-policy-type-without-code-of-conduct.spec.js
@@ -19,7 +19,7 @@ context('Insurance - submit an application - Single policy type, without `have c
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/declarations-conditions/submit-an-application-single-policy-type-without-exporting-with-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/declarations-conditions/submit-an-application-single-policy-type-without-exporting-with-code-of-conduct.spec.js
@@ -19,7 +19,7 @@ context('Insurance - submit an application - Single policy type, without `export
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/declarations-conditions/submit-an-application-single-policy-type-without-exporting-with-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/declarations-conditions/submit-an-application-single-policy-type-without-exporting-with-code-of-conduct.spec.js
@@ -19,7 +19,7 @@ context('Insurance - submit an application - Single policy type, without `export
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover-and-using-an-agent-no-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover-and-using-an-agent-no-charges.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Single policy type, attempted priva
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover-and-using-an-agent-no-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover-and-using-an-agent-no-charges.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Single policy type, attempted priva
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-fixed-sum.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-fixed-sum.spec.js
@@ -25,7 +25,7 @@ context('Insurance - submit an application - Single policy type, attempted priva
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-fixed-sum.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-fixed-sum.spec.js
@@ -25,7 +25,7 @@ context('Insurance - submit an application - Single policy type, attempted priva
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-percentage.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-percentage.spec.js
@@ -25,7 +25,7 @@ context('Insurance - submit an application - Single policy type, attempted priva
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-percentage.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover-and-using-an-agent-with-charges-percentage.spec.js
@@ -25,7 +25,7 @@ context('Insurance - submit an application - Single policy type, attempted priva
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover.spec.js
@@ -22,7 +22,7 @@ context('Insurance - submit an application - Single policy type, attempted priva
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-attempted-private-market-cover.spec.js
@@ -22,7 +22,7 @@ context('Insurance - submit an application - Single policy type, attempted priva
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-contract-awarded-other-method.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-contract-awarded-other-method.spec.js
@@ -19,7 +19,7 @@ context('Insurance - submit an application - Single policy type, contract awarde
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-contract-awarded-other-method.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-contract-awarded-other-method.spec.js
@@ -19,7 +19,7 @@ context('Insurance - submit an application - Single policy type, contract awarde
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-export-contract-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-export-contract-fully-populated.spec.js
@@ -27,7 +27,7 @@ context('Insurance - submit an application - Single policy type, fully populated
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-export-contract-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-export-contract-fully-populated.spec.js
@@ -27,7 +27,7 @@ context('Insurance - submit an application - Single policy type, fully populated
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-export-contract-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-export-contract-minimal.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Single policy type, minimal export 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-export-contract-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-export-contract-minimal.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Single policy type, minimal export 
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-alternative-currency.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Single policy type, using an agent,
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-alternative-currency.spec.js
@@ -24,7 +24,7 @@ context('Insurance - submit an application - Single policy type, using an agent,
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-no-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-no-charges.spec.js
@@ -21,7 +21,7 @@ context('Insurance - submit an application - Single policy type, using an agent,
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-no-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-no-charges.spec.js
@@ -21,7 +21,7 @@ context('Insurance - submit an application - Single policy type, using an agent,
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-percentage-method.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-percentage-method.spec.js
@@ -23,7 +23,7 @@ context('Insurance - submit an application - Single policy type, using an agent,
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-percentage-method.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/export-contract-conditions/submit-an-application-single-policy-type-using-an-agent-percentage-method.spec.js
@@ -23,7 +23,7 @@ context('Insurance - submit an application - Single policy type, using an agent,
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-alternative-currency.spec.js
@@ -21,7 +21,7 @@ context('Insurance - submit an application - Single policy type - Alternative cu
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-alternative-currency.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-alternative-currency.spec.js
@@ -21,7 +21,7 @@ context('Insurance - submit an application - Single policy type - Alternative cu
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-broker-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-broker-based-in-uk.spec.js
@@ -24,7 +24,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-broker-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-broker-based-in-uk.spec.js
@@ -24,7 +24,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-broker-not-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-broker-not-based-in-uk.spec.js
@@ -24,7 +24,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-broker-not-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-broker-not-based-in-uk.spec.js
@@ -24,7 +24,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-different-name-on-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-different-name-on-policy.spec.js
@@ -19,7 +19,7 @@ context('Insurance - submit an application - Single policy type, with a differen
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-different-name-on-policy.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-different-name-on-policy.spec.js
@@ -19,7 +19,7 @@ context('Insurance - submit an application - Single policy type, with a differen
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-loss-payee-international.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-loss-payee-international.spec.js
@@ -22,7 +22,7 @@ context('Insurance - submit an application - Single policy type, Loss payee - Fi
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-loss-payee-international.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-loss-payee-international.spec.js
@@ -22,7 +22,7 @@ context('Insurance - submit an application - Single policy type, Loss payee - Fi
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-loss-payee-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-loss-payee-uk.spec.js
@@ -22,7 +22,7 @@ context('Insurance - submit an application - Single policy type, Loss payee - Fi
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-loss-payee-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-loss-payee-uk.spec.js
@@ -22,7 +22,7 @@ context('Insurance - submit an application - Single policy type, Loss payee - Fi
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-maximum-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-maximum-cover.spec.js
@@ -23,7 +23,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-maximum-cover.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-maximum-cover.spec.js
@@ -23,7 +23,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-other-company-involved.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-other-company-involved.spec.js
@@ -19,7 +19,7 @@ context('Insurance - submit an application - Single policy type, other company i
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-other-company-involved.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-other-company-involved.spec.js
@@ -19,7 +19,7 @@ context('Insurance - submit an application - Single policy type, other company i
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-policy-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-policy-fully-populated.spec.js
@@ -28,7 +28,7 @@ context('Insurance - submit an application - Single policy type - fully populate
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-policy-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-policy-fully-populated.spec.js
@@ -28,7 +28,7 @@ context('Insurance - submit an application - Single policy type - fully populate
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-pre-credit-period.spec.js
@@ -19,7 +19,7 @@ context('Insurance - submit an application - Single policy type, need a pre-cred
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-pre-credit-period.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-pre-credit-period.spec.js
@@ -19,7 +19,7 @@ context('Insurance - submit an application - Single policy type, need a pre-cred
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-total-contract-value-over-threshold.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-total-contract-value-over-threshold.spec.js
@@ -19,7 +19,7 @@ context('Insurance - submit an application - Single policy type - total contract
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render a `submitted` state in the dashboard', () => {
+  it('should render the application in a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-total-contract-value-over-threshold.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-total-contract-value-over-threshold.spec.js
@@ -19,7 +19,7 @@ context('Insurance - submit an application - Single policy type - total contract
     cy.assertApplicationSubmittedUrl(referenceNumber);
   });
 
-  it('should render in a `submitted` state in the dashboard', () => {
+  it('should render a `submitted` state in the dashboard', () => {
     cy.assertDashboardApplicationSubmitted(referenceNumber);
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-with-broker-based-in-uk-building-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-with-broker-based-in-uk-building-name.spec.js
@@ -28,7 +28,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-with-broker-based-in-uk-building-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-with-broker-based-in-uk-building-name.spec.js
@@ -28,7 +28,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-with-broker-based-in-uk-building-number.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-with-broker-based-in-uk-building-number.spec.js
@@ -28,7 +28,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-with-broker-based-in-uk-building-number.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/policy-conditions/submit-an-application-single-policy-type-with-broker-based-in-uk-building-number.spec.js
@@ -28,7 +28,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-fully-populated.spec.js
@@ -49,7 +49,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-fully-populated.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-fully-populated.spec.js
@@ -49,7 +49,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-minimal.spec.js
@@ -21,7 +21,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render in a `submitted` state in the dashboard', () => {
+    it('should render a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-minimal.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/application-submission/single-policy-type/submit-an-application-single-policy-type-minimal.spec.js
@@ -21,7 +21,7 @@ context(
       cy.assertApplicationSubmittedUrl(referenceNumber);
     });
 
-    it('should render a `submitted` state in the dashboard', () => {
+    it('should render the application in a `submitted` state in the dashboard', () => {
       cy.assertDashboardApplicationSubmitted(referenceNumber);
     });
   },

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/anti-bribery/code-of-conduct/anti-bribery-code-of-conduct.spec.js
@@ -90,7 +90,7 @@ context(
         codeOfConductPage.revealText().should('not.be.visible');
       });
 
-      it('should display conditional `we will email you` hint when selecting the "yes" radio', () => {
+      it('should render conditional `we will email you` hint when selecting the "yes" radio', () => {
         cy.clickYesRadioInput();
 
         codeOfConductPage.revealText().should('be.visible');

--- a/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-search/companies-house-search.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/eligibility/companies-house/companies-house-search/companies-house-search.spec.js
@@ -76,7 +76,7 @@ context('Insurance - Eligibility - Companies house search page - I want to check
         cy.navigateToUrl(url);
       });
 
-      it('should display the `is empty` error', () => {
+      it('should render the `is empty` error', () => {
         cy.submitAndAssertFieldErrors({
           field,
           value: companyNumber,
@@ -92,7 +92,7 @@ context('Insurance - Eligibility - Companies house search page - I want to check
         companyNumber = COMPANIES_HOUSE_NUMBER_EMPTY;
       });
 
-      it('should display the `is empty` error', () => {
+      it('should render the `is empty` error', () => {
         cy.submitAndAssertFieldErrors({
           field,
           value: companyNumber,
@@ -108,7 +108,7 @@ context('Insurance - Eligibility - Companies house search page - I want to check
         companyNumber = COMPANIES_HOUSE_NUMBER_TOO_SHORT;
       });
 
-      it('should display the `incorrect format` error', () => {
+      it('should render the `incorrect format` error', () => {
         cy.submitAndAssertFieldErrors({
           field,
           value: companyNumber,
@@ -126,7 +126,7 @@ context('Insurance - Eligibility - Companies house search page - I want to check
         cy.interceptCompaniesHousePost({ companyNumber });
       });
 
-      it('should display the `incorrect format` error', () => {
+      it('should render the `incorrect format` error', () => {
         cy.submitAndAssertFieldErrors({
           field,
           value: companyNumber,
@@ -144,7 +144,7 @@ context('Insurance - Eligibility - Companies house search page - I want to check
         cy.interceptCompaniesHousePost({ companyNumber });
       });
 
-      it('should display the `not found` error', () => {
+      it('should render the `not found` error', () => {
         cy.submitAndAssertFieldErrors({
           field,
           value: companyNumber,

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/validation/about-goods-or-services-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/about-goods-or-services/validation/about-goods-or-services-validation.spec.js
@@ -85,7 +85,7 @@ context('Insurance - Export contract - About goods or services page - form valid
     });
   });
 
-  it(`should display validation errors if ${DESCRIPTION} is over ${MAXIMUM} characters`, () => {
+  it(`should render validation errors if ${DESCRIPTION} is over ${MAXIMUM} characters`, () => {
     cy.navigateToUrl(url);
 
     cy.submitAndAssertFieldErrors({

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent-charges/agent-charges.spec.js
@@ -90,7 +90,7 @@ context(
           fieldSelector(PERCENTAGE_CHARGE).input().should('not.be.visible');
         });
 
-        it(`should display conditional "${PERCENTAGE_CHARGE}" field when selecting the ${PERCENTAGE} radio`, () => {
+        it(`should render conditional "${PERCENTAGE_CHARGE}" field when selecting the ${PERCENTAGE} radio`, () => {
           agentChargesPage[METHOD][PERCENTAGE].label().click();
 
           const fieldId = PERCENTAGE_CHARGE;
@@ -163,7 +163,7 @@ context(
             cy.assertAgentChargesFieldValues({ percentageMethod: true });
           });
 
-          it(`should display conditional "${PERCENTAGE_CHARGE}" field`, () => {
+          it(`should render conditional "${PERCENTAGE_CHARGE}" field`, () => {
             fieldSelector(PERCENTAGE_CHARGE).input().should('be.visible');
           });
         });

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent/agent.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/agent/agent.spec.js
@@ -96,7 +96,7 @@ context(
       });
 
       describe('when submitting an empty form', () => {
-        it(`should display validation errors if ${FIELD_ID} radio is not selected`, () => {
+        it(`should render validation errors if ${FIELD_ID} radio is not selected`, () => {
           const radioField = {
             ...fieldSelector(FIELD_ID),
             input: noRadioInput,

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/declined-by-private-market/declined-by-private-market.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/declined-by-private-market/declined-by-private-market.spec.js
@@ -93,7 +93,7 @@ context(
         cy.navigateToUrl(url);
       });
 
-      it(`should display validation errors if ${FIELD_ID} is left empty`, () => {
+      it(`should render validation errors if ${FIELD_ID} is left empty`, () => {
         cy.submitAndAssertFieldErrors({
           field: textareaField,
           expectedErrorMessage: ERRORS[FIELD_ID].IS_EMPTY,
@@ -101,7 +101,7 @@ context(
       });
 
       describe(`when ${FIELD_ID} is over ${MAXIMUM_CHARACTERS.DECLINED_BY_PRIVATE_MARKET_DESCRIPTION} characters`, () => {
-        it('should display validation errors and retain the submitted value', () => {
+        it('should render validation errors and retain the submitted value', () => {
           const submittedValue = 'a'.repeat(MAXIMUM_CHARACTERS.DECLINED_BY_PRIVATE_MARKET_DESCRIPTION + 1);
 
           cy.submitAndAssertFieldErrors({

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-much-the-agent-is-charging/validation/how-much-the-agent-is-charging-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-much-the-agent-is-charging/validation/how-much-the-agent-is-charging-validation.spec.js
@@ -51,11 +51,11 @@ context('Insurance - Export contract - How much the agent is charging page - for
     cy.deleteApplication(referenceNumber);
   });
 
-  it(`should display validation errors when ${FIELD_ID} is left empty`, () => {
+  it(`should render validation errors when ${FIELD_ID} is left empty`, () => {
     cy.submitAndAssertFieldErrors({ ...assertions, expectedErrorMessage: ERROR_MESSAGES_OBJECT.IS_EMPTY });
   });
 
-  it(`should display validation errors when ${FIELD_ID} has special characters`, () => {
+  it(`should render validation errors when ${FIELD_ID} has special characters`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: '10!',
@@ -63,7 +63,7 @@ context('Insurance - Export contract - How much the agent is charging page - for
     });
   });
 
-  it(`should display validation errors when ${FIELD_ID} has letters`, () => {
+  it(`should render validation errors when ${FIELD_ID} has letters`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: 'one',
@@ -71,7 +71,7 @@ context('Insurance - Export contract - How much the agent is charging page - for
     });
   });
 
-  it(`should display validation errors when ${FIELD_ID} is below ${MINIMUM_CHARACTERS.ONE}`, () => {
+  it(`should render validation errors when ${FIELD_ID} is below ${MINIMUM_CHARACTERS.ONE}`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: String(MINIMUM_CHARACTERS.ONE - 1),

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-was-the-contract-awarded/how-was-the-contract-awarded-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-was-the-contract-awarded/how-was-the-contract-awarded-validation.spec.js
@@ -56,7 +56,7 @@ context('Insurance - Export contract - How was the contract awarded page - form 
       cy.navigateToUrl(url);
     });
 
-    it('should display validation error', () => {
+    it('should render validation error', () => {
       const expectedErrorMessage = ERROR_MESSAGES_OBJECT[AWARD_METHOD].IS_EMPTY;
 
       const radioField = {

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-was-the-contract-awarded/how-was-the-contract-awarded.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-was-the-contract-awarded/how-was-the-contract-awarded.spec.js
@@ -107,7 +107,7 @@ context(
         fieldSelector(OTHER_AWARD_METHOD).input().should('not.be.visible');
       });
 
-      it(`should display conditional "${OTHER_AWARD_METHOD}" section when selecting the "${OTHER.VALUE}" radio`, () => {
+      it(`should render conditional "${OTHER_AWARD_METHOD}" section when selecting the "${OTHER.VALUE}" radio`, () => {
         radios(AWARD_METHOD_OPTIONS.OTHER.ID).option.label().click();
 
         fieldSelector(OTHER_AWARD_METHOD).input().should('be.visible');

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/how-will-you-get-paid.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/how-will-you-get-paid/how-will-you-get-paid.spec.js
@@ -95,7 +95,7 @@ context(
         cy.navigateToUrl(url);
       });
 
-      it(`should display validation errors if ${FIELD_ID} is left empty`, () => {
+      it(`should render validation errors if ${FIELD_ID} is left empty`, () => {
         cy.submitAndAssertFieldErrors({
           field,
           expectedErrorsCount,
@@ -104,7 +104,7 @@ context(
       });
 
       describe(`when ${FIELD_ID} is over ${MAXIMUM_CHARACTERS.PAYMENT_TERMS_DESCRIPTION} characters`, () => {
-        it('should display validation errors and retain the submitted value', () => {
+        it('should render validation errors and retain the submitted value', () => {
           const submittedValue = 'a'.repeat(MAXIMUM_CHARACTERS.PAYMENT_TERMS_DESCRIPTION + 1);
 
           cy.submitAndAssertFieldErrors({

--- a/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/private-market.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/export-contract/private-market/private-market.spec.js
@@ -110,7 +110,7 @@ context(
       });
 
       describe('when submitting an empty form', () => {
-        it(`should display validation errors if ${FIELD_ID} radio is not selected`, () => {
+        it(`should render validation errors if ${FIELD_ID} radio is not selected`, () => {
           const radioField = {
             ...fieldSelector(FIELD_ID),
             input: noRadioInput,

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker/broker-page.spec.js
@@ -156,7 +156,7 @@ context(
       });
 
       describe('when submitting an empty form', () => {
-        it(`should display validation errors if ${FIELD_ID} radio is not selected`, () => {
+        it(`should render validation errors if ${FIELD_ID} radio is not selected`, () => {
           cy.navigateToUrl(url);
 
           const { numberOfExpectedErrors, errorIndex } = ERROR_ASSERTIONS;

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/different-name-on-policy/different-name-on-policy-page.spec.js
@@ -72,7 +72,7 @@ context(
         cy.checkText(fieldSelector(POLICY_CONTACT_DETAIL).hint(), CONTENT_STRINGS.HINT);
       });
 
-      it(`should display ${FIRST_NAME} field and be prepopulated`, () => {
+      it(`should render ${FIRST_NAME} field and be prepopulated`, () => {
         const fieldId = FIRST_NAME;
         const field = fieldSelector(fieldId);
 
@@ -81,7 +81,7 @@ context(
         cy.checkText(field.label(), ACCOUNT_FIELDS[fieldId].LABEL);
       });
 
-      it(`should display ${LAST_NAME} field and be prepopulated`, () => {
+      it(`should render ${LAST_NAME} field and be prepopulated`, () => {
         const fieldId = LAST_NAME;
         const field = fieldSelector(fieldId);
 
@@ -90,7 +90,7 @@ context(
         cy.checkText(field.label(), ACCOUNT_FIELDS[fieldId].LABEL);
       });
 
-      it(`should display ${EMAIL} field and be prepopulated`, () => {
+      it(`should render ${EMAIL} field and be prepopulated`, () => {
         const fieldId = EMAIL;
         const field = fieldSelector(fieldId);
 
@@ -99,7 +99,7 @@ context(
         cy.checkText(field.label(), ACCOUNT_FIELDS[fieldId].LABEL);
       });
 
-      it(`should display ${POSITION} field and should not be prepopulated`, () => {
+      it(`should render ${POSITION} field and should not be prepopulated`, () => {
         const fieldId = POSITION;
         const field = fieldSelector(fieldId);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/validation/loss-payee-details-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee-details/validation/loss-payee-details-validation.spec.js
@@ -67,7 +67,7 @@ context('Insurance - Policy - Loss Payee Details - Validation', () => {
     const FIELD_ID = LOCATION;
     const ERROR = ERRORS[FIELD_ID];
 
-    it('should display validation error when radio is not selected', () => {
+    it('should render a validation error when radio is not selected', () => {
       const radioField = {
         ...fieldSelector(FIELD_ID),
         input: fieldSelector(`${LOCATION}-${IS_LOCATED_IN_UK}`).input,

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee/loss-payee.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/loss-payee/loss-payee.spec.js
@@ -107,7 +107,7 @@ context(
       });
 
       describe('when submitting an empty form', () => {
-        it(`should display validation errors if ${FIELD_ID} radio is not selected`, () => {
+        it(`should render validation errors if ${FIELD_ID} radio is not selected`, () => {
           const radioField = {
             ...fieldSelector(FIELD_ID),
             input: noRadioInput,

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/name-on-policy-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/name-on-policy-page.spec.js
@@ -81,7 +81,7 @@ context(
         field(POSITION).input().should('not.be.visible');
       });
 
-      it(`should display conditional "${POSITION}" section when selecting the "yes" radio`, () => {
+      it(`should render conditional "${POSITION}" section when selecting the "yes" radio`, () => {
         field(SAME_NAME).label().click();
 
         field(POSITION).input().should('be.visible');

--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/name-on-policy/validation/name-on-policy-validation.spec.js
@@ -56,7 +56,7 @@ context('Insurance - Policy - Name on policy - Validation', () => {
       cy.navigateToUrl(url);
     });
 
-    it('should display validation error', () => {
+    it('should render validation error', () => {
       const expectedErrorsCount = 1;
       const expectedErrorMessage = NAME_ON_POLICY_ERRORS[NAME].IS_EMPTY;
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/alternative-trading-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/alternative-trading-address/alternative-trading-address.spec.js
@@ -93,7 +93,7 @@ context(
         cy.checkText(html(COMPANY_ADDRESS), addressText);
       });
 
-      it(`should display ${FULL_ADDRESS} textarea`, () => {
+      it(`should render ${FULL_ADDRESS} textarea`, () => {
         const fieldStrings = FIELD_STRINGS[fieldId];
 
         cy.assertTextareaRendering({
@@ -109,14 +109,14 @@ context(
         cy.navigateToUrl(alternativeAddressUrl);
       });
 
-      it(`should display validation errors if ${FULL_ADDRESS} is left empty`, () => {
+      it(`should render validation errors if ${FULL_ADDRESS} is left empty`, () => {
         cy.submitAndAssertFieldErrors({
           field: textareaField,
           expectedErrorMessage: ERRORS[FULL_ADDRESS].IS_EMPTY,
         });
       });
 
-      it(`should display validation errors if ${FULL_ADDRESS} is over ${MAXIMUM_CHARACTERS.FULL_ADDRESS} characters`, () => {
+      it(`should render validation errors if ${FULL_ADDRESS} is over ${MAXIMUM_CHARACTERS.FULL_ADDRESS} characters`, () => {
         cy.submitAndAssertFieldErrors({
           field: textareaField,
           value: 'a'.repeat(MAXIMUM_CHARACTERS.FULL_ADDRESS + 1),

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-page.spec.js
@@ -93,7 +93,7 @@ context(
         });
       });
 
-      it('should display the trading name radios', () => {
+      it('should render the trading name radios', () => {
         cy.checkText(companyDetails[HAS_DIFFERENT_TRADING_NAME].label(), CONTENT_STRINGS.HAS_DIFFERENT_TRADING_NAME);
 
         cy.checkRadioInputYesAriaLabel(CONTENT_STRINGS.HAS_DIFFERENT_TRADING_NAME);
@@ -105,7 +105,7 @@ context(
         field(DIFFERENT_TRADING_NAME).input().should('not.be.visible');
       });
 
-      it(`should display conditional ${DIFFERENT_TRADING_NAME} input when selecting the trading name "yes" radio`, () => {
+      it(`should render conditional ${DIFFERENT_TRADING_NAME} input when selecting the trading name "yes" radio`, () => {
         cy.clickYesRadioInput();
 
         field(DIFFERENT_TRADING_NAME).input().should('be.visible');
@@ -114,7 +114,7 @@ context(
         cy.checkText(field(DIFFERENT_TRADING_NAME).hint(), CONTENT_STRINGS.DIFFERENT_TRADING_NAME_HINT);
       });
 
-      it('should display the trading address radios', () => {
+      it('should render the trading address radios', () => {
         cy.checkText(companyDetails[HAS_DIFFERENT_TRADING_ADDRESS].label(), CONTENT_STRINGS.HAS_DIFFERENT_TRADING_ADDRESS);
 
         cy.checkAriaLabel(yesRadioInput().eq(1), `${CONTENT_STRINGS.HAS_DIFFERENT_TRADING_ADDRESS} Yes`);
@@ -122,14 +122,14 @@ context(
         cy.checkAriaLabel(noRadioInput().eq(1), `${CONTENT_STRINGS.HAS_DIFFERENT_TRADING_ADDRESS} No`);
       });
 
-      it('should display the company website text input', () => {
+      it('should render the company website text input', () => {
         cy.checkText(field(WEBSITE).label(), CONTENT_STRINGS.WEBSITE);
 
         field(WEBSITE).input().should('exist');
         cy.checkAriaLabel(field(WEBSITE).input(), CONTENT_STRINGS.WEBSITE);
       });
 
-      it('should display the phone number text input', () => {
+      it('should render the phone number text input', () => {
         cy.checkText(field(PHONE_NUMBER).label(), CONTENT_STRINGS.PHONE_NUMBER);
 
         cy.checkText(field(PHONE_NUMBER).hint(), CONTENT_STRINGS.PHONE_NUMBER_HINT);

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-submit.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/company-details-submit.spec.js
@@ -58,7 +58,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
   });
 
   describe('all page errors', () => {
-    it('should display the validation error for trading name in radio error summary', () => {
+    it('should render the validation error for trading name in radio error summary', () => {
       const field = companyDetails[HAS_DIFFERENT_TRADING_NAME];
 
       const radioField = {
@@ -73,7 +73,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
     });
 
-    it('should display the validation error for trading address in radio error summary', () => {
+    it('should render the validation error for trading address in radio error summary', () => {
       const field = companyDetails[HAS_DIFFERENT_TRADING_ADDRESS];
 
       const radioField = {
@@ -89,7 +89,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
     });
 
-    it('should display the validation error for company website in company website section', () => {
+    it('should render the validation error for company website in company website section', () => {
       cy.submitAndAssertFieldErrors({
         field: fieldSelector(WEBSITE),
         value: WEBSITE_EXAMPLES.INVALID,
@@ -99,7 +99,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
     });
 
-    it('should display the validation error for phone number in phone number section', () => {
+    it('should render the validation error for phone number in phone number section', () => {
       cy.submitAndAssertFieldErrors({
         field: fieldSelector(PHONE_NUMBER),
         value: INVALID_PHONE_NUMBER,

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-company-website-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-company-website-validation.spec.js
@@ -52,7 +52,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
         cy.completeCompanyDetailsForm({});
       });
 
-      it('should display validation errors', () => {
+      it('should render validation errors', () => {
         cy.submitAndAssertFieldErrors({
           field,
           value: WEBSITE_EXAMPLES.INVALID,
@@ -68,7 +68,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
         cy.completeCompanyDetailsForm({});
       });
 
-      it('should display validation errors', () => {
+      it('should render validation errors', () => {
         cy.submitAndAssertFieldErrors({
           field,
           value: WEBSITE_EXAMPLES.ABOVE_MAX_LENGTH,

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-different-trading-name-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-different-trading-name-validation.spec.js
@@ -44,7 +44,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     cy.deleteApplication(referenceNumber);
   });
 
-  it(`should display validation errors if ${FIELD_ID} is left empty`, () => {
+  it(`should render validation errors if ${FIELD_ID} is left empty`, () => {
     cy.submitAndAssertFieldErrors({
       field: fieldSelector(FIELD_ID),
       expectedErrorMessage: COMPANY_DETAILS_ERRORS[FIELD_ID].IS_EMPTY,
@@ -52,7 +52,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
   });
 
   describe(`when ${FIELD_ID} is over ${MAXIMUM_CHARACTERS.COMPANY_DIFFERENT_TRADING_NAME} characters`, () => {
-    it('should display validation errors and retain the submitted value', () => {
+    it('should render validation errors and retain the submitted value', () => {
       const submittedValue = 'a'.repeat(MAXIMUM_CHARACTERS.COMPANY_DIFFERENT_TRADING_NAME + 1);
 
       cy.submitAndAssertFieldErrors({

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-invalid-phone-number-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-invalid-phone-number-validation.spec.js
@@ -64,7 +64,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
         completeAllFields();
       });
 
-      it('should display validation errors', () => {
+      it('should render validation errors', () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: INVALID_PHONE_NUMBERS.LANDLINE.LONG,
@@ -79,7 +79,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
         completeAllFields();
       });
 
-      it('should display validation errors', () => {
+      it('should render validation errors', () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: INVALID_PHONE_NUMBERS.INTERNATIONAL,
@@ -94,7 +94,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
         completeAllFields();
       });
 
-      it('should display validation errors', () => {
+      it('should render validation errors', () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: INVALID_PHONE_NUMBERS.INTERNATIONAL_PLUS,
@@ -109,7 +109,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
         completeAllFields();
       });
 
-      it('should display validation errors', () => {
+      it('should render validation errors', () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: INVALID_PHONE_NUMBERS.MOBILE.LONG,
@@ -124,7 +124,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
         completeAllFields();
       });
 
-      it('should display validation errors', () => {
+      it('should render validation errors', () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: INVALID_PHONE_NUMBERS.LANDLINE.SHORT,
@@ -139,7 +139,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
         completeAllFields();
       });
 
-      it('should display validation errors', () => {
+      it('should render validation errors', () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: INVALID_PHONE_NUMBERS.LANDLINE.SPECIAL_CHAR,
@@ -154,7 +154,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
         completeAllFields();
       });
 
-      it('should display validation errors', () => {
+      it('should render validation errors', () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: INVALID_PHONE_NUMBERS.LANDLINE.LETTER,
@@ -169,7 +169,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
         completeAllFields();
       });
 
-      it('should display validation errors', () => {
+      it('should render validation errors', () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: INVALID_PHONE_NUMBERS.MOBILE.SPECIAL_CHAR,
@@ -184,7 +184,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
         completeAllFields();
       });
 
-      it('should display validation errors', () => {
+      it('should render validation errors', () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: INVALID_PHONE_NUMBERS.TOO_SHORT,
@@ -192,14 +192,14 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
       });
     });
 
-    describe('should display validation errors for a number above the maximum allowed characters', () => {
+    describe('should render validation errors for a number above the maximum allowed characters', () => {
       beforeEach(() => {
         cy.navigateToUrl(url);
 
         completeAllFields();
       });
 
-      it('should display validation errors', () => {
+      it('should render validation errors', () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: INVALID_PHONE_NUMBERS.ABOVE_MAX_CHARS,

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-address-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-address-validation.spec.js
@@ -44,7 +44,7 @@ describe("Insurance - Your business - Company details page - As an Exporter I wa
     cy.deleteApplication(referenceNumber);
   });
 
-  it(`should display validation errors if ${HAS_DIFFERENT_TRADING_ADDRESS} is left empty`, () => {
+  it(`should render validation errors if ${HAS_DIFFERENT_TRADING_ADDRESS} is left empty`, () => {
     const field = companyDetails[HAS_DIFFERENT_TRADING_ADDRESS];
 
     const radioField = {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-name-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/company-details/validation/company-details-trading-name-validation.spec.js
@@ -44,7 +44,7 @@ describe("Insurance - Your business - Company details page- As an Exporter I wan
     cy.deleteApplication(referenceNumber);
   });
 
-  it('should display validation errors if trading name question is not answered', () => {
+  it('should render validation errors if trading name question is not answered', () => {
     const field = companyDetails[HAS_DIFFERENT_TRADING_NAME];
 
     const radioField = {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/nature-of-business-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/nature-of-business-page.spec.js
@@ -67,7 +67,7 @@ context(
         cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
       });
 
-      it(`should display ${GOODS_OR_SERVICES} label, input and hint`, () => {
+      it(`should render ${GOODS_OR_SERVICES} label, input and hint`, () => {
         const fieldId = GOODS_OR_SERVICES;
         const field = fieldSelector(fieldId);
 
@@ -77,7 +77,7 @@ context(
         field.hint().contains(FIELDS.NATURE_OF_YOUR_BUSINESS[fieldId].HINT);
       });
 
-      it(`should display ${YEARS_EXPORTING} label, input and hint`, () => {
+      it(`should render ${YEARS_EXPORTING} label, input and hint`, () => {
         const fieldId = YEARS_EXPORTING;
         const field = fieldSelector(fieldId);
 
@@ -88,7 +88,7 @@ context(
         cy.assertSuffix({ fieldId, value: FIELDS.NATURE_OF_YOUR_BUSINESS[fieldId].SUFFIX });
       });
 
-      it(`should display ${EMPLOYEES_UK} label and input`, () => {
+      it(`should render ${EMPLOYEES_UK} label and input`, () => {
         const fieldId = EMPLOYEES_UK;
         const field = fieldSelector(fieldId);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-employees-validation.spec.js
@@ -60,7 +60,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
     });
 
     describe(`when ${FIELD_ID} is left empty`, () => {
-      it(`should display validation errors for ${FIELD_ID}`, () => {
+      it(`should render validation errors for ${FIELD_ID}`, () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           expectedErrorMessage: NATURE_OF_BUSINESS_ERRORS[FIELD_ID].IS_EMPTY,
@@ -69,7 +69,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
     });
 
     describe(`when ${FIELD_ID} is a decimal place number`, () => {
-      it(`should display validation errors for ${FIELD_ID}`, () => {
+      it(`should render validation errors for ${FIELD_ID}`, () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: '5.5',
@@ -79,7 +79,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
     });
 
     describe(`when ${FIELD_ID} has special characters`, () => {
-      it(`should display validation errors for ${FIELD_ID}`, () => {
+      it(`should render validation errors for ${FIELD_ID}`, () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: '35!',
@@ -89,7 +89,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
     });
 
     describe(`when ${FIELD_ID} has letters`, () => {
-      it(`should display validation errors for ${FIELD_ID}`, () => {
+      it(`should render validation errors for ${FIELD_ID}`, () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: 'one',
@@ -99,7 +99,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
     });
 
     describe(`when ${FIELD_ID} is below 0`, () => {
-      it(`should display validation errors for ${FIELD_ID}`, () => {
+      it(`should render validation errors for ${FIELD_ID}`, () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: '-5',
@@ -109,7 +109,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
     });
 
     describe(`when ${FIELD_ID} is entered as 0`, () => {
-      it(`should display validation errors for ${FIELD_ID}`, () => {
+      it(`should render validation errors for ${FIELD_ID}`, () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: '0',

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-goods-or-services-validation.spec.js
@@ -53,7 +53,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
   });
 
   describe(`when ${FIELD_ID} is left empty`, () => {
-    it('should display validation errors', () => {
+    it('should render validation errors', () => {
       cy.submitAndAssertFieldErrors({
         ...assertions,
         expectedErrorMessage: NATURE_OF_BUSINESS_ERRORS[FIELD_ID].IS_EMPTY,
@@ -69,7 +69,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
   });
 
   describe(`when ${FIELD_ID} has over the maximum`, () => {
-    it('should display validation errors', () => {
+    it('should render validation errors', () => {
       cy.submitAndAssertFieldErrors({
         ...assertions,
         value: 'a'.repeat(MAXIMUM_CHARACTERS.BUSINESS.GOODS_OR_SERVICES_DESCRIPTION + 1),

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/nature-of-business/validation/nature-of-business-years-exporting-validation.spec.js
@@ -49,7 +49,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
         cy.navigateToUrl(url);
       });
 
-      it(`should display validation errors if ${FIELD_ID} is left empty`, () => {
+      it(`should render validation errors if ${FIELD_ID} is left empty`, () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           expectedErrorMessage: NATURE_OF_BUSINESS_ERRORS[FIELD_ID].IS_EMPTY,
@@ -69,7 +69,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
         cy.navigateToUrl(url);
       });
 
-      it(`should display validation errors for ${FIELD_ID}`, () => {
+      it(`should render validation errors for ${FIELD_ID}`, () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: '5.5',
@@ -83,7 +83,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
         cy.navigateToUrl(url);
       });
 
-      it(`should display validation errors for ${FIELD_ID}`, () => {
+      it(`should render validation errors for ${FIELD_ID}`, () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: '5!',
@@ -97,7 +97,7 @@ describe('Insurance - Your business - Nature of your business page - As an Expor
         cy.navigateToUrl(url);
       });
 
-      it(`should display validation errors for ${FIELD_ID}`, () => {
+      it(`should render validation errors for ${FIELD_ID}`, () => {
         cy.submitAndAssertFieldErrors({
           ...assertions,
           value: 'one',

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-financial-year-end.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-financial-year-end.spec.js
@@ -55,7 +55,7 @@ context(`Insurance - Your business - Turnover page - when ${fieldId} exists`, ()
     cy.deleteApplication(referenceNumber);
   });
 
-  it(`should display ${FINANCIAL_YEAR_END_DATE} section`, () => {
+  it(`should render ${FINANCIAL_YEAR_END_DATE} section`, () => {
     cy.checkText(field.label(), FIELDS.TURNOVER[fieldId].LABEL);
 
     cy.checkText(turnoverPage[fieldId](), expectedValue);

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/turnover-page.spec.js
@@ -74,7 +74,7 @@ context(
         cy.checkText(headingCaption(), CONTENT_STRINGS.HEADING_CAPTION);
       });
 
-      it(`should display ${FINANCIAL_YEAR_END_DATE} section`, () => {
+      it(`should render ${FINANCIAL_YEAR_END_DATE} section`, () => {
         const fieldId = FINANCIAL_YEAR_END_DATE;
         const field = fieldSelector(fieldId);
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-business/turnover/validation/turnover-estimated-annual-turnover-validation.spec.js
@@ -43,11 +43,11 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
     cy.deleteApplication(referenceNumber);
   });
 
-  it(`should display validation errors when ${FIELD_ID} is left empty`, () => {
+  it(`should render validation errors when ${FIELD_ID} is left empty`, () => {
     cy.submitAndAssertFieldErrors({ ...assertions, expectedErrorMessage: ERROR_MESSAGE.IS_EMPTY });
   });
 
-  it(`should display validation errors when ${FIELD_ID} is a decimal place number`, () => {
+  it(`should render validation errors when ${FIELD_ID} is a decimal place number`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: '5.5',
@@ -55,7 +55,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
     });
   });
 
-  it(`should display validation errors when ${FIELD_ID} has special characters`, () => {
+  it(`should render validation errors when ${FIELD_ID} has special characters`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: '50!',
@@ -63,7 +63,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
     });
   });
 
-  it(`should display validation errors when ${FIELD_ID} has letters`, () => {
+  it(`should render validation errors when ${FIELD_ID} has letters`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: 'one',
@@ -71,7 +71,7 @@ describe(`Insurance - Your business - Turnover page - form validation - ${FIELD_
     });
   });
 
-  it(`should display validation errors when ${FIELD_ID} is negative but has a decimal place`, () => {
+  it(`should render validation errors when ${FIELD_ID} is negative but has a decimal place`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: '-123.456',

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/buyer-financial-information/buyer-financial-information-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/buyer-financial-information/buyer-financial-information-page.spec.js
@@ -82,7 +82,7 @@ context(
         cy.checkRadioInputNoAriaLabel(CONTENT_STRINGS.PAGE_TITLE);
       });
 
-      it('should display summary text with collapsed conditional `details` content', () => {
+      it('should render summary text with collapsed conditional `details` content', () => {
         cy.checkText(buyerFinancialInformationPage.summary(), CONTENT_STRINGS.SUMMARY);
 
         buyerFinancialInformationPage.details().should('not.have.attr', 'open');

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-name.spec.js
@@ -48,7 +48,7 @@ context('Insurance - Your buyer - Company or organisation page - form validation
   });
 
   describe(`when ${FIELD_ID} is over ${MAXIMUM_CHARACTERS.BUYER.COMPANY_OR_ORGANISATION} characters`, () => {
-    it('should display validation errors and retain the submitted value', () => {
+    it('should render validation errors and retain the submitted value', () => {
       const submittedValue = 'a'.repeat(MAXIMUM_CHARACTERS.BUYER.COMPANY_OR_ORGANISATION + 1);
 
       cy.submitAndAssertFieldErrors({

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-website.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/company-or-organisation/validation/company-or-organisation-validation-website.spec.js
@@ -50,7 +50,7 @@ context('Insurance - Your buyer - Company or organisation page - form validation
     expectedErrorsCount: 3,
   };
 
-  it(`should display validation errors if when ${FIELD_ID} is the incorrect format`, () => {
+  it(`should render validation errors if when ${FIELD_ID} is the incorrect format`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: WEBSITE_EXAMPLES.INVALID,
@@ -58,7 +58,7 @@ context('Insurance - Your buyer - Company or organisation page - form validation
     });
   });
 
-  it(`should display validation errors when ${FIELD_ID} is above 191 characters`, () => {
+  it(`should render validation errors when ${FIELD_ID} is above 191 characters`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: WEBSITE_EXAMPLES.ABOVE_MAX_LENGTH,

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-with-the-buyer/validation/connection-with-the-buyer-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/connection-with-the-buyer/validation/connection-with-the-buyer-validation.spec.js
@@ -44,7 +44,7 @@ context('Insurance - Your buyer - Connection to the buyer page - form validation
   });
 
   describe(`when ${CONNECTION_WITH_BUYER} 'no' is selected`, () => {
-    it('should display validation errors', () => {
+    it('should render validation errors', () => {
       cy.navigateToUrl(url);
 
       const radioField = {

--- a/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/validation/credit-insurance-cover-validation.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/your-buyer/credit-insurance-cover/validation/credit-insurance-cover-validation.spec.js
@@ -46,7 +46,7 @@ context('Insurance - Your buyer - Credit insurance cover - form validation', () 
   describe(`when ${HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER} 'no' is selected`, () => {
     const FIELD_ID = HAS_PREVIOUS_CREDIT_INSURANCE_COVER_WITH_BUYER;
 
-    it('should display validation errors', () => {
+    it('should render validation errors', () => {
       cy.navigateToUrl(url);
 
       const radioField = {

--- a/e2e-tests/shared-test-assertions/currency-form-fields/prefix.js
+++ b/e2e-tests/shared-test-assertions/currency-form-fields/prefix.js
@@ -8,7 +8,7 @@ import { SYMBOLS, USD_CURRENCY_CODE, JPY_CURRENCY_CODE, EUR_CURRENCY_CODE } from
  */
 const prefixAssertions = ({ fieldId }) => {
   describe('when not selecting a currency', () => {
-    it(`should display ${SYMBOLS.GBP} as the prefix`, () => {
+    it(`should render ${SYMBOLS.GBP} as the prefix`, () => {
       cy.clickSubmitButton();
 
       cy.assertPrefix({ fieldId, value: SYMBOLS.GBP });
@@ -16,21 +16,21 @@ const prefixAssertions = ({ fieldId }) => {
   });
 
   describe(`when selecting ${USD_CURRENCY_CODE} as the currency code`, () => {
-    it(`should display ${SYMBOLS.USD} as the prefix`, () => {
+    it(`should render ${SYMBOLS.USD} as the prefix`, () => {
       cy.completeAndSubmitCurrencyForm({ isoCode: USD_CURRENCY_CODE });
       cy.assertPrefix({ fieldId, value: SYMBOLS.USD });
     });
   });
 
   describe(`when selecting ${JPY_CURRENCY_CODE} as the currency code`, () => {
-    it(`should display ${SYMBOLS.JPY} as the prefix`, () => {
+    it(`should render ${SYMBOLS.JPY} as the prefix`, () => {
       cy.completeAndSubmitCurrencyForm({ isoCode: JPY_CURRENCY_CODE });
       cy.assertPrefix({ fieldId, value: SYMBOLS.JPY });
     });
   });
 
   describe(`when selecting ${EUR_CURRENCY_CODE} as the currency code`, () => {
-    it(`should display ${SYMBOLS.EUR} as the prefix`, () => {
+    it(`should render ${SYMBOLS.EUR} as the prefix`, () => {
       cy.completeAndSubmitCurrencyForm({ isoCode: EUR_CURRENCY_CODE });
       cy.assertPrefix({ fieldId, value: SYMBOLS.EUR });
     });

--- a/e2e-tests/shared-test-assertions/percentage-field-validation/index.js
+++ b/e2e-tests/shared-test-assertions/percentage-field-validation/index.js
@@ -28,11 +28,11 @@ export const percentageFieldValidation = ({
     expectedErrorsCount: totalExpectedErrors,
   };
 
-  it(`should display validation errors when ${fieldId} percentage field is left empty`, () => {
+  it(`should render validation errors when ${fieldId} percentage field is left empty`, () => {
     cy.submitAndAssertFieldErrors({ ...assertions, expectedErrorMessage: errorMessages.IS_EMPTY });
   });
 
-  it(`should display validation errors when ${fieldId} percentage field is a decimal place number`, () => {
+  it(`should render validation errors when ${fieldId} percentage field is a decimal place number`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: '5.5',
@@ -40,7 +40,7 @@ export const percentageFieldValidation = ({
     });
   });
 
-  it(`should display validation errors when ${fieldId} percentage has a comma`, () => {
+  it(`should render validation errors when ${fieldId} percentage has a comma`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: '4,4',
@@ -48,7 +48,7 @@ export const percentageFieldValidation = ({
     });
   });
 
-  it(`should display validation errors when ${fieldId} percentage has special characters`, () => {
+  it(`should render validation errors when ${fieldId} percentage has special characters`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: '50!',
@@ -56,7 +56,7 @@ export const percentageFieldValidation = ({
     });
   });
 
-  it(`should display validation errors when ${fieldId} percentage has letters`, () => {
+  it(`should render validation errors when ${fieldId} percentage has letters`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: 'one',
@@ -64,7 +64,7 @@ export const percentageFieldValidation = ({
     });
   });
 
-  it(`should display validation errors when ${fieldId} percentage field is over 100`, () => {
+  it(`should render validation errors when ${fieldId} percentage field is over 100`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: '101',
@@ -72,7 +72,7 @@ export const percentageFieldValidation = ({
     });
   });
 
-  it(`should display validation errors when ${fieldId} percentage field is below ${minimum}`, () => {
+  it(`should render validation errors when ${fieldId} percentage field is below ${minimum}`, () => {
     cy.submitAndAssertFieldErrors({
       ...assertions,
       value: `${minimum - 1}`,

--- a/src/api/custom-resolvers/mutations/account-password-reset/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-password-reset/index.test.ts
@@ -66,7 +66,7 @@ describe('custom-resolvers/account-password-reset', () => {
     await authRetries.deleteAll(context);
   });
 
-  test('it should return success=true', () => {
+  it('should return success=true', () => {
     const expected = {
       success: true,
     };
@@ -74,20 +74,20 @@ describe('custom-resolvers/account-password-reset', () => {
     expect(result).toEqual(expected);
   });
 
-  test(`it should wipe the account's retry entires`, async () => {
+  it(`should wipe the account's retry entires`, async () => {
     // get the latest retries
     const retries = await authRetries.findAll(context);
 
     expect(retries.length).toEqual(0);
   });
 
-  test('it should add an authentication entry', async () => {
+  it('should add an authentication entry', async () => {
     const entries = await context.query.Authentication.findMany();
 
     expect(entries.length).toEqual(1);
   });
 
-  test("it should update the account's salt and hash", async () => {
+  it("should update the account's salt and hash", async () => {
     // get the latest account
     account = await accounts.get(context, account.id);
 
@@ -100,13 +100,13 @@ describe('custom-resolvers/account-password-reset', () => {
     expect(account.hash).not.toEqual(mockAccount.hash);
   });
 
-  test("it should nullify the account's password reset hash and expiry", async () => {
+  it("should nullify the account's password reset hash and expiry", async () => {
     expect(account.passwordResetHash).toEqual('');
     expect(account.passwordResetExpiry).toBeNull();
   });
 
   describe('when the account is blocked', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       await accountStatusHelper.update(context, account.status.id, { isBlocked: true });
 
       result = await accountPasswordReset({}, variables, context);
@@ -120,7 +120,7 @@ describe('custom-resolvers/account-password-reset', () => {
   });
 
   describe('when the account does not have a password reset expiry', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       (await context.query.Account.updateOne({
         where: { id: account.id },
         data: {
@@ -142,7 +142,7 @@ describe('custom-resolvers/account-password-reset', () => {
   });
 
   describe('when the account does not have a password reset hash', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       (await context.query.Account.updateOne({
         where: { id: account.id },
         data: {
@@ -173,7 +173,7 @@ describe('custom-resolvers/account-password-reset', () => {
       })) as Account;
     });
 
-    test('it should return success=false with expired=true', async () => {
+    it('should return success=false with expired=true', async () => {
       result = await accountPasswordReset({}, variables, context);
 
       const expected = {
@@ -186,7 +186,7 @@ describe('custom-resolvers/account-password-reset', () => {
   });
 
   describe('when the provided password matches the existing account password', () => {
-    test('it should return success=false and hasBeenUsedBefore=true', async () => {
+    it('should return success=false and hasBeenUsedBefore=true', async () => {
       // update the account to have default test password (MOCK_ACCOUNT_PASSWORD)
       await context.query.Account.updateOne({
         where: { id: account.id },
@@ -208,7 +208,7 @@ describe('custom-resolvers/account-password-reset', () => {
   });
 
   describe('when the provided password has been used before', () => {
-    test('it should return success=false and hasBeenUsedBefore=true', async () => {
+    it('should return success=false and hasBeenUsedBefore=true', async () => {
       // create an account
       account = await accounts.create({ context });
 
@@ -239,7 +239,7 @@ describe('custom-resolvers/account-password-reset', () => {
   });
 
   describe('when no account is found', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       // wipe accounts so an account will not be found.
       await accounts.deleteAll(context);
 

--- a/src/api/custom-resolvers/mutations/account-sign-in-new-code/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in-new-code/index.test.ts
@@ -48,13 +48,13 @@ describe('custom-resolvers/account-sign-in-new-code', () => {
   });
 
   describe('when the provided password is valid', () => {
-    test('it should generate an OTP and save to the account', () => {
+    it('should generate an OTP and save to the account', () => {
       expect(account.otpSalt).toEqual(mockOTP.salt);
       expect(account.otpHash).toEqual(mockOTP.hash);
       expect(new Date(account.otpExpiry)).toEqual(mockOTP.expiry);
     });
 
-    test('it should call sendEmail.accessCodeEmail', () => {
+    it('should call sendEmail.accessCodeEmail', () => {
       const { email } = account;
 
       const name = getFullNameString(account);
@@ -63,7 +63,7 @@ describe('custom-resolvers/account-sign-in-new-code', () => {
       expect(accessCodeEmailSpy).toHaveBeenCalledWith(email, name, mockOTP.securityCode);
     });
 
-    test('it should return the email response and accountId', () => {
+    it('should return the email response and accountId', () => {
       const expected = {
         ...mockSendEmailResponse,
         accountId: account.id,
@@ -74,7 +74,7 @@ describe('custom-resolvers/account-sign-in-new-code', () => {
   });
 
   describe('when no account is found', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       // wipe accounts so an account will not be found.
       await accounts.deleteAll(context);
 
@@ -91,7 +91,7 @@ describe('custom-resolvers/account-sign-in-new-code', () => {
       sendEmail.accessCodeEmail = mockSpyPromiseRejection;
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await accountSignInSendNewCode({}, variables, context);
       } catch (error) {

--- a/src/api/custom-resolvers/mutations/account-sign-in/account-sign-in-checks/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/account-sign-in-checks/index.test.ts
@@ -221,7 +221,7 @@ describe('custom-resolvers/account-sign-in/account-sign-in-checks', () => {
       sendEmail.accessCodeEmail = mockSpyPromiseRejection;
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await accountSignInChecks(context, account, mockUrlOrigin);
       } catch (error) {

--- a/src/api/custom-resolvers/mutations/account-sign-in/index.test.ts
+++ b/src/api/custom-resolvers/mutations/account-sign-in/index.test.ts
@@ -61,7 +61,7 @@ describe('custom-resolvers/account-sign-in', () => {
       result = await accountSignIn({}, variables, context);
     });
 
-    test('it should return the result of accountChecks', async () => {
+    it('should return the result of accountChecks', async () => {
       account = await accounts.get(context, account.id);
 
       const expected = await accountChecks(context, account, mockUrlOrigin);
@@ -69,7 +69,7 @@ describe('custom-resolvers/account-sign-in', () => {
       expect(result).toEqual(expected);
     });
 
-    test('it should NOT add an authentication retry entry', async () => {
+    it('should NOT add an authentication retry entry', async () => {
       const retries = await authRetries.findAll(context);
 
       expect(retries.length).toEqual(0);
@@ -93,7 +93,7 @@ describe('custom-resolvers/account-sign-in', () => {
       await accountStatusHelper.update(context, account.status.id, { isBlocked: true });
     });
 
-    test('it should return success=false, isBlocked=true and accountId', async () => {
+    it('should return success=false, isBlocked=true and accountId', async () => {
       result = await accountSignIn({}, variables, context);
 
       const expected = {
@@ -124,7 +124,7 @@ describe('custom-resolvers/account-sign-in', () => {
       variables[PASSWORD] = mockPassword;
     });
 
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       result = await accountSignIn({}, variables, context);
 
       const expected = { success: false };
@@ -132,7 +132,7 @@ describe('custom-resolvers/account-sign-in', () => {
       expect(result).toEqual(expected);
     });
 
-    test('it should add an authentication retry entry', async () => {
+    it('should add an authentication retry entry', async () => {
       // get the latest retries
       const retries = await authRetries.findAll(context);
 
@@ -163,7 +163,7 @@ describe('custom-resolvers/account-sign-in', () => {
         result = await accountSignIn({}, variables, context);
       });
 
-      test('it should return success=false, isBlocked=true and accountId', async () => {
+      it('should return success=false, isBlocked=true and accountId', async () => {
         const expected = {
           success: false,
           isBlocked: true,
@@ -173,7 +173,7 @@ describe('custom-resolvers/account-sign-in', () => {
         expect(result).toEqual(expected);
       });
 
-      test('it should mark the account as isBlocked=true', async () => {
+      it('should mark the account as isBlocked=true', async () => {
         // get the latest account
         account = await accounts.get(context, account.id);
 
@@ -183,7 +183,7 @@ describe('custom-resolvers/account-sign-in', () => {
   });
 
   describe('when no account is found', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       // wipe accounts so an account will not be found.
       await accounts.deleteAll(context);
 
@@ -200,7 +200,7 @@ describe('custom-resolvers/account-sign-in', () => {
       sendEmail.accessCodeEmail = mockSpyPromiseRejection;
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await accountSignIn({}, variables, context);
       } catch (error) {

--- a/src/api/custom-resolvers/mutations/add-and-get-OTP/index.test.ts
+++ b/src/api/custom-resolvers/mutations/add-and-get-OTP/index.test.ts
@@ -33,7 +33,7 @@ describe('custom-resolvers/add-and-get-OTP', () => {
     account = await accounts.get(context, account.id);
   });
 
-  test('it should generate an OTP and save to the account', () => {
+  it('should generate an OTP and save to the account', () => {
     expect(account.otpSalt).toEqual(mockOTP.salt);
     expect(account.otpHash).toEqual(mockOTP.hash);
     // @ts-ignore
@@ -58,7 +58,7 @@ describe('custom-resolvers/add-and-get-OTP', () => {
       };
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await addAndGetOTP({}, variables, context);
       } catch (error) {

--- a/src/api/custom-resolvers/mutations/create-an-abandoned-application/index.test.ts
+++ b/src/api/custom-resolvers/mutations/create-an-abandoned-application/index.test.ts
@@ -35,20 +35,20 @@ describe('custom-resolvers/create-an-abandoned-application', () => {
     variables.accountId = account.id;
   });
 
-  test('it should return success=true', async () => {
+  it('should return success=true', async () => {
     result = await createAnAbandonedApplication({}, variables, context);
 
     expect(result.success).toEqual(true);
   });
 
-  test(`it should return status as ${STATUS.ABANDONED}`, async () => {
+  it(`should return status as ${STATUS.ABANDONED}`, async () => {
     result = await createAnAbandonedApplication({}, variables, context);
 
     expect(result.status).toEqual(STATUS.ABANDONED);
   });
 
   describe('when there is no account for the provided accountId', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       variables.accountId = mockInvalidId;
 
       result = await createAnAbandonedApplication({}, variables, context);
@@ -58,7 +58,7 @@ describe('custom-resolvers/create-an-abandoned-application', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       await expect(createAnAbandonedApplication({}, variables, {})).rejects.toThrow('Creating an abandoned application');
     });
   });

--- a/src/api/custom-resolvers/mutations/create-an-account/index.test.ts
+++ b/src/api/custom-resolvers/mutations/create-an-account/index.test.ts
@@ -232,7 +232,7 @@ describe('custom-resolvers/create-an-account', () => {
         await accountStatus.update(context, status.id, statusUpdate);
       });
 
-      test('should throw an error', async () => {
+      it('should throw an error', async () => {
         try {
           await createAnAccount({}, variables, context);
         } catch (error) {
@@ -251,7 +251,7 @@ describe('custom-resolvers/create-an-account', () => {
         sendEmail.confirmEmailAddress = jest.fn(() => Promise.resolve(emailFailureResponse));
       });
 
-      test('should throw an error', async () => {
+      it('should throw an error', async () => {
         try {
           await createAnAccount({}, variables, context);
         } catch (error) {

--- a/src/api/custom-resolvers/mutations/create-an-application/index.test.ts
+++ b/src/api/custom-resolvers/mutations/create-an-application/index.test.ts
@@ -35,20 +35,20 @@ describe('custom-resolvers/create-an-application', () => {
     variables.accountId = account.id;
   });
 
-  test('it should return success=true', async () => {
+  it('should return success=true', async () => {
     result = await createAnApplication({}, variables, context);
 
     expect(result.success).toEqual(true);
   });
 
-  test(`it should return status as ${STATUS.IN_PROGRESS}`, async () => {
+  it(`should return status as ${STATUS.IN_PROGRESS}`, async () => {
     result = await createAnApplication({}, variables, context);
 
     expect(result.status).toEqual(STATUS.IN_PROGRESS);
   });
 
   describe('when there is no account for the provided accountId', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       variables.accountId = mockInvalidId;
 
       result = await createAnApplication({}, variables, context);
@@ -58,7 +58,7 @@ describe('custom-resolvers/create-an-application', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createAnApplication({}, variables, {});

--- a/src/api/custom-resolvers/mutations/create-feedback/index.test.ts
+++ b/src/api/custom-resolvers/mutations/create-feedback/index.test.ts
@@ -44,14 +44,14 @@ describe('custom-resolvers/create-feedback', () => {
       expect(success).toEqual(true);
     });
 
-    test('it should generate createdAt timestamp', () => {
+    it('should generate createdAt timestamp', () => {
       const feedbackCreatedAtTimestamp = format(new Date(feedbackResponse.createdAt), 'dd/mm/yyyy');
       const nowTimestamp = format(new Date(), 'dd/mm/yyyy');
 
       expect(feedbackCreatedAtTimestamp).toEqual(nowTimestamp);
     });
 
-    test('it should call sendEmail.insuranceFeedbackEmail', async () => {
+    it('should call sendEmail.insuranceFeedbackEmail', async () => {
       expect(sendInsuranceFeedbackEmailSpy).toHaveBeenCalledTimes(1);
     });
   });
@@ -66,7 +66,7 @@ describe('custom-resolvers/create-feedback', () => {
       feedbackResponse = (await createInsuranceFeedbackAndEmail({}, variables, context)) as Feedback;
     });
 
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       expect(feedbackResponse.success).toEqual(false);
     });
   });
@@ -79,7 +79,7 @@ describe('custom-resolvers/create-feedback', () => {
       sendEmail.insuranceFeedbackEmail = sendInsuranceFeedbackEmailSpy;
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         feedbackResponse = (await createInsuranceFeedbackAndEmail({}, variables, context)) as Feedback;
       } catch (error) {

--- a/src/api/custom-resolvers/mutations/create-many-applications/index.test.ts
+++ b/src/api/custom-resolvers/mutations/create-many-applications/index.test.ts
@@ -33,13 +33,13 @@ describe('custom-resolvers/create-many-applications', () => {
     await referenceNumber.deleteAll(context);
   });
 
-  test('it should return success=true', async () => {
+  it('should return success=true', async () => {
     result = await createManyApplications({}, variables, context);
 
     expect(result.success).toEqual(true);
   });
 
-  test(`it should return an array of applications`, async () => {
+  it(`should return an array of applications`, async () => {
     result = await createManyApplications({}, variables, context);
 
     const applications = await application.getAll(context);
@@ -64,7 +64,7 @@ describe('custom-resolvers/create-many-applications', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createManyApplications({}, variables, {});

--- a/src/api/custom-resolvers/mutations/delete-an-account/index.test.ts
+++ b/src/api/custom-resolvers/mutations/delete-an-account/index.test.ts
@@ -23,7 +23,7 @@ describe('custom-resolvers/delete-an-account', () => {
     account = await accounts.create({ context });
   });
 
-  test('it should return success=true', async () => {
+  it('should return success=true', async () => {
     result = await deleteAnAccount({}, variables, context);
 
     const expected = {
@@ -52,7 +52,7 @@ describe('custom-resolvers/delete-an-account', () => {
       expect(retries.length).toEqual(2);
     });
 
-    test('it should delete the retries', async () => {
+    it('should delete the retries', async () => {
       result = await deleteAnAccount({}, variables, context);
 
       retries = await authRetries.findAll(context);

--- a/src/api/custom-resolvers/mutations/delete-application-by-reference-number/index.test.ts
+++ b/src/api/custom-resolvers/mutations/delete-application-by-reference-number/index.test.ts
@@ -21,7 +21,7 @@ describe('custom-resolvers/delete-application-by-reference-number', () => {
     })) as Application;
   });
 
-  test('it should return success=true', async () => {
+  it('should return success=true', async () => {
     variables.referenceNumber = application.referenceNumber;
 
     result = await deleteApplicationByReferenceNumber({}, variables, context);

--- a/src/api/custom-resolvers/mutations/send-email-confirm-email-address/index.test.ts
+++ b/src/api/custom-resolvers/mutations/send-email-confirm-email-address/index.test.ts
@@ -36,7 +36,7 @@ describe('custom-resolvers/send-email-confirm-email-address', () => {
     sendEmail.confirmEmailAddress = sendConfirmEmailAddressEmailSpy;
   });
 
-  test('it should call sendEmail.confirmEmailAddress and return success=true', async () => {
+  it('should call sendEmail.confirmEmailAddress and return success=true', async () => {
     const result = await sendEmailConfirmEmailAddressMutation({}, variables, context);
 
     const { email, verificationHash } = account;
@@ -55,7 +55,7 @@ describe('custom-resolvers/send-email-confirm-email-address', () => {
   });
 
   describe('when sendEmailConfirmEmailAddress does not return success=true', () => {
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await sendEmailConfirmEmailAddressMutation({}, variables, context);
       } catch (error) {

--- a/src/api/custom-resolvers/mutations/send-email-insurance-feedback/index.test.ts
+++ b/src/api/custom-resolvers/mutations/send-email-insurance-feedback/index.test.ts
@@ -22,7 +22,7 @@ describe('custom-resolvers/send-email-insurance-feedback', () => {
     sendEmail.insuranceFeedbackEmail = sendInsuranceFeedbackEmailSpy;
   });
 
-  test('it should call sendEmail.insuranceFeedbackEmail and return success=true', async () => {
+  it('should call sendEmail.insuranceFeedbackEmail and return success=true', async () => {
     const result = await sendEmailInsuranceFeedback({}, variables);
 
     expect(sendInsuranceFeedbackEmailSpy).toHaveBeenCalledTimes(1);
@@ -41,7 +41,7 @@ describe('custom-resolvers/send-email-insurance-feedback', () => {
       sendEmail.insuranceFeedbackEmail = mockSpyPromiseRejection;
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await sendEmailInsuranceFeedback({}, variables);
       } catch (error) {

--- a/src/api/custom-resolvers/mutations/send-email-password-reset-link/index.test.ts
+++ b/src/api/custom-resolvers/mutations/send-email-password-reset-link/index.test.ts
@@ -92,7 +92,7 @@ describe('custom-resolvers/send-email-password-reset-link', () => {
     expect(expiryMinutes).toEqual(expectedMinutes);
   });
 
-  test('it should call sendEmail.passwordResetLink', () => {
+  it('should call sendEmail.passwordResetLink', () => {
     const { email, passwordResetHash } = account;
 
     const name = getFullNameString(account);
@@ -117,7 +117,7 @@ describe('custom-resolvers/send-email-password-reset-link', () => {
   });
 
   describe('when AuthenticationRetry table entry fails', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       // delete the account so the relationship creation will fail
       await context.query.Account.deleteOne({
         where: {
@@ -134,7 +134,7 @@ describe('custom-resolvers/send-email-password-reset-link', () => {
   });
 
   describe('when no account is found', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       // wipe accounts so an account will not be found.
       await accounts.deleteAll(context);
 
@@ -181,7 +181,7 @@ describe('custom-resolvers/send-email-password-reset-link', () => {
       sendEmail.passwordResetLink = mockSpyPromiseRejection;
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await sendEmailPasswordResetLink({}, variables, context);
       } catch (error) {

--- a/src/api/custom-resolvers/mutations/submit-application/index.test.ts
+++ b/src/api/custom-resolvers/mutations/submit-application/index.test.ts
@@ -105,7 +105,7 @@ describe('custom-resolvers/submit-application', () => {
       });
     });
 
-    test('it should call generate.XLSX', async () => {
+    it('should call generate.XLSX', async () => {
       expect(generateXLSXSpy).toHaveBeenCalledTimes(1);
 
       const expectedCountries = await getCountries(context);
@@ -113,7 +113,7 @@ describe('custom-resolvers/submit-application', () => {
       expect(generateXLSXSpy).toHaveBeenCalledWith(populatedApplication, expectedCountries);
     });
 
-    test('it should call applicationSubmittedEmails.send', async () => {
+    it('should call applicationSubmittedEmails.send', async () => {
       expect(applicationSubmittedEmailsSpy).toHaveBeenCalledTimes(1);
 
       expect(applicationSubmittedEmailsSpy).toHaveBeenCalledWith(populatedApplication, mockGenerateXLSXResponse);
@@ -195,7 +195,7 @@ describe('custom-resolvers/submit-application', () => {
   });
 
   describe('error handling', () => {
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       variables = {
         applicationId: 'invalidId',
       };

--- a/src/api/custom-resolvers/mutations/verify-account-email-address/index.test.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-email-address/index.test.ts
@@ -80,7 +80,7 @@ describe('custom-resolvers/verify-account-email-address', () => {
     account = await accounts.get(context, account.id);
   });
 
-  test('should return success=true with accountId and emailRecipient', () => {
+  it('should return success=true with accountId and emailRecipient', () => {
     const expected = {
       success: true,
       accountId: account.id,
@@ -90,26 +90,26 @@ describe('custom-resolvers/verify-account-email-address', () => {
     expect(result).toEqual(expected);
   });
 
-  test(`should update the account to be ${IS_VERIFIED}=true`, () => {
+  it(`should update the account to be ${IS_VERIFIED}=true`, () => {
     expect(account.status[IS_VERIFIED]).toEqual(true);
   });
 
-  test(`should remove ${VERIFICATION_HASH} from the account`, () => {
+  it(`should remove ${VERIFICATION_HASH} from the account`, () => {
     expect(account[VERIFICATION_HASH]).toEqual('');
   });
 
-  test(`should nullify ${VERIFICATION_EXPIRY} from the account`, () => {
+  it(`should nullify ${VERIFICATION_EXPIRY} from the account`, () => {
     expect(account[VERIFICATION_EXPIRY]).toBeNull();
   });
 
-  test('should remove all entries for the account in the AuthenticationRetry table', async () => {
+  it('should remove all entries for the account in the AuthenticationRetry table', async () => {
     const retries = await authRetries.findAll(context);
 
     expect(retries.length).toEqual(0);
   });
 
   describe(`when the ${VERIFICATION_EXPIRY} has expired`, () => {
-    test('it should return success=false and expired=true', async () => {
+    it('should return success=false and expired=true', async () => {
       const oneMinuteInThePast = DATE_ONE_MINUTE_IN_THE_PAST();
 
       const accountVerificationExpired = {
@@ -136,7 +136,7 @@ describe('custom-resolvers/verify-account-email-address', () => {
   });
 
   describe('when an account is already verified', () => {
-    test('it should return success=true', async () => {
+    it('should return success=true', async () => {
       account = await accounts.create({ context, data: mockAccountUpdate });
       await accountStatusHelper.update(context, account.status.id, { [IS_VERIFIED]: true });
       variables.token = account[VERIFICATION_HASH];
@@ -155,7 +155,7 @@ describe('custom-resolvers/verify-account-email-address', () => {
   });
 
   describe(`when no account is found from the provided ${ID}`, () => {
-    test('it should return success=false and invalid=true', async () => {
+    it('should return success=false and invalid=true', async () => {
       variables[ID] = 'invalid';
 
       result = await verifyAccountEmailAddress({}, variables, context);
@@ -167,7 +167,7 @@ describe('custom-resolvers/verify-account-email-address', () => {
   });
 
   describe(`when the verification hash does not match the received token`, () => {
-    test('it should return success=false and invalid=true', async () => {
+    it('should return success=false and invalid=true', async () => {
       variables.token = 'invalid';
       variables.accountId = account.id;
 
@@ -180,7 +180,7 @@ describe('custom-resolvers/verify-account-email-address', () => {
   });
 
   describe(`when the verification hash is valid but account id is invalid`, () => {
-    test('it should return success=false and invalid=true', async () => {
+    it('should return success=false and invalid=true', async () => {
       variables.token = account[VERIFICATION_HASH];
       variables.accountId = 'invalid';
 
@@ -193,7 +193,7 @@ describe('custom-resolvers/verify-account-email-address', () => {
   });
 
   describe(`when the verification hash is valid but account id is not provided`, () => {
-    test('it should return success=false and invalid=true', async () => {
+    it('should return success=false and invalid=true', async () => {
       variables.token = account[VERIFICATION_HASH];
       variables.accountId = null;
 
@@ -206,7 +206,7 @@ describe('custom-resolvers/verify-account-email-address', () => {
   });
 
   describe(`when the verification hash is not provided but account id is valid`, () => {
-    test('it should return success=false and invalid=true', async () => {
+    it('should return success=false and invalid=true', async () => {
       variables.token = null;
       variables.accountId = account.id;
 
@@ -219,7 +219,7 @@ describe('custom-resolvers/verify-account-email-address', () => {
   });
 
   describe('when no account is found', () => {
-    test('it should return success=false and invalid=true', async () => {
+    it('should return success=false and invalid=true', async () => {
       // ensure we have the valid token that was previously created
       variables.token = verificationHash;
 

--- a/src/api/custom-resolvers/mutations/verify-account-reactivation-token/index.test.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-reactivation-token/index.test.ts
@@ -88,7 +88,7 @@ describe('custom-resolvers/verify-account-reactivation-token', () => {
     account = await accounts.get(context, account.id);
   });
 
-  test('should return success=true', () => {
+  it('should return success=true', () => {
     const expected = {
       success: true,
     };
@@ -96,30 +96,30 @@ describe('custom-resolvers/verify-account-reactivation-token', () => {
     expect(result).toEqual(expected);
   });
 
-  test(`should update the account to be ${IS_BLOCKED}=false`, () => {
+  it(`should update the account to be ${IS_BLOCKED}=false`, () => {
     expect(account.status[IS_BLOCKED]).toEqual(false);
   });
 
-  test(`should update the account to be ${IS_VERIFIED}=true`, () => {
+  it(`should update the account to be ${IS_VERIFIED}=true`, () => {
     expect(account.status[IS_VERIFIED]).toEqual(true);
   });
 
-  test(`should remove ${REACTIVATION_HASH} from the account`, () => {
+  it(`should remove ${REACTIVATION_HASH} from the account`, () => {
     expect(account[REACTIVATION_HASH]).toEqual('');
   });
 
-  test(`should nullify ${REACTIVATION_EXPIRY} from the account`, () => {
+  it(`should nullify ${REACTIVATION_EXPIRY} from the account`, () => {
     expect(account[REACTIVATION_EXPIRY]).toBeNull();
   });
 
-  test('should remove all entries for the account in the AuthenticationRetry table', async () => {
+  it('should remove all entries for the account in the AuthenticationRetry table', async () => {
     const retries = await authRetries.findAll(context);
 
     expect(retries.length).toEqual(0);
   });
 
   describe(`when the ${REACTIVATION_EXPIRY} has expired`, () => {
-    test('it should return success=false and expired=true', async () => {
+    it('should return success=false and expired=true', async () => {
       const oneMinuteInThePast = DATE_ONE_MINUTE_IN_THE_PAST();
 
       const accountBlockedAndReactivationExpired = {
@@ -146,7 +146,7 @@ describe('custom-resolvers/verify-account-reactivation-token', () => {
   });
 
   describe(`when no account is found from the provided ${REACTIVATION_HASH}`, () => {
-    test('it should return success=false and invalid=true', async () => {
+    it('should return success=false and invalid=true', async () => {
       variables.token = 'invalid';
 
       result = await verifyAccountReactivationToken({}, variables, context);
@@ -158,7 +158,7 @@ describe('custom-resolvers/verify-account-reactivation-token', () => {
   });
 
   describe('when no account is found', () => {
-    test('it should return success=false and invalid=true', async () => {
+    it('should return success=false and invalid=true', async () => {
       // ensure we have the valid token that was previously created
       variables.token = reactivationHash;
 

--- a/src/api/custom-resolvers/mutations/verify-account-sign-in-code/index.test.ts
+++ b/src/api/custom-resolvers/mutations/verify-account-sign-in-code/index.test.ts
@@ -60,22 +60,22 @@ describe('custom-resolvers/verify-account-sign-in-code', () => {
     });
   });
 
-  test('it should return success=true', async () => {
+  it('should return success=true', async () => {
     expect(result.success).toEqual(true);
   });
 
-  test('it should return account details', async () => {
+  it('should return account details', async () => {
     expect(result.accountId).toEqual(account.id);
     expect(result.firstName).toEqual(account.firstName);
     expect(result.lastName).toEqual(account.lastName);
   });
 
-  test('it should return JWT', async () => {
+  it('should return JWT', async () => {
     expect(result.token).toEqual(mockJWT.token);
     expect(result.sessionIdentifier).toEqual(mockJWT.sessionIdentifier);
   });
 
-  test(`it should wipe the account's retry entires`, async () => {
+  it(`should wipe the account's retry entires`, async () => {
     const retries = await authRetries.findAll(context);
 
     expect(retries.length).toEqual(0);
@@ -147,7 +147,7 @@ describe('custom-resolvers/verify-account-sign-in-code', () => {
   });
 
   describe('when no account is found', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       // no need to delete here - account is (correctly) already deleted due to afterEach()
 
       result = await verifyAccountSignInCode({}, variables, context);
@@ -164,7 +164,7 @@ describe('custom-resolvers/verify-account-sign-in-code', () => {
     });
 
     const otp = generate.otp();
-    test('it should return success=false and expired=true', async () => {
+    it('should return success=false and expired=true', async () => {
       // add OTP to the account
       const { salt, hash } = otp;
 
@@ -208,7 +208,7 @@ describe('custom-resolvers/verify-account-sign-in-code', () => {
   });
 
   describe('when the account does not have OTP salt, hash or expiry', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       account = await accounts.create({ context });
 
       result = await verifyAccountSignInCode({}, variables, context);

--- a/src/api/custom-resolvers/queries/get-account-password-reset-token/index.test.ts
+++ b/src/api/custom-resolvers/queries/get-account-password-reset-token/index.test.ts
@@ -41,7 +41,7 @@ describe('custom-resolvers/get-account-password-reset-token', () => {
   });
 
   describe(`when the account does not have ${PASSWORD_RESET_HASH}`, () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       // update the account so it does not have a PASSWORD_RESET_HASH
       await context.query.Account.updateOne({
         where: { id: account.id },
@@ -59,7 +59,7 @@ describe('custom-resolvers/get-account-password-reset-token', () => {
   });
 
   describe('when no account is found', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       // wipe accounts so an account will not be found.
       await accounts.deleteAll(context);
 

--- a/src/api/custom-resolvers/queries/verify-account-password-reset-token/index.test.ts
+++ b/src/api/custom-resolvers/queries/verify-account-password-reset-token/index.test.ts
@@ -40,7 +40,7 @@ describe('custom-resolvers/verify-account-password-reset-token', () => {
   });
 
   describe(`when the account does not have ${PASSWORD_RESET_HASH}`, () => {
-    test('it should return success=false and invalid=true', async () => {
+    it('should return success=false and invalid=true', async () => {
       // update the account so it does not have a PASSWORD_RESET_HASH
       await context.query.Account.updateOne({
         where: { id: account.id },
@@ -61,7 +61,7 @@ describe('custom-resolvers/verify-account-password-reset-token', () => {
   });
 
   describe(`when the account's ${PASSWORD_RESET_EXPIRY} has expired`, () => {
-    test('it should return success=false and expired=true with account ID', async () => {
+    it('should return success=false and expired=true with account ID', async () => {
       const today = new Date();
 
       const previousTime = subMinutes(today, 6);
@@ -87,7 +87,7 @@ describe('custom-resolvers/verify-account-password-reset-token', () => {
   });
 
   describe(`when no account is found from the provided ${PASSWORD_RESET_HASH}`, () => {
-    test('it should return success=false and invalid=true', async () => {
+    it('should return success=false and invalid=true', async () => {
       // update the account so PASSWORD_RESET_HASH has a value
       await context.query.Account.updateOne({
         where: { id: account.id },
@@ -107,7 +107,7 @@ describe('custom-resolvers/verify-account-password-reset-token', () => {
   });
 
   describe('when no account is found', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       // wipe accounts so an account will not be found.
       await accounts.deleteAll(context);
 

--- a/src/api/emails/access-code-email/index.test.ts
+++ b/src/api/emails/access-code-email/index.test.ts
@@ -24,7 +24,7 @@ describe('emails/access-code-email', () => {
     notify.sendEmail = sendEmailSpy;
   });
 
-  test('it should call notify.sendEmail and return the response', async () => {
+  it('should call notify.sendEmail and return the response', async () => {
     const result = await accessCodeEmail(email, fullName, mockSecurityCode);
 
     expect(sendEmailSpy).toHaveBeenCalledTimes(1);
@@ -41,7 +41,7 @@ describe('emails/access-code-email', () => {
       notify.sendEmail = mockSpyPromiseRejection;
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await accessCodeEmail(email, fullName, mockSecurityCode);
       } catch (error) {

--- a/src/api/emails/application/index.test.ts
+++ b/src/api/emails/application/index.test.ts
@@ -43,7 +43,7 @@ describe('emails/application', () => {
       fileSystem.unlink = unlinkSpy;
     });
 
-    test('it should call notify.sendEmail and return the response', async () => {
+    it('should call notify.sendEmail and return the response', async () => {
       notify.sendEmail = sendEmailSpy;
 
       const result = await application.submittedEmail(variables);
@@ -61,7 +61,7 @@ describe('emails/application', () => {
         notify.sendEmail = mockSpyPromiseRejection;
       });
 
-      test('should throw an error', async () => {
+      it('should throw an error', async () => {
         try {
           await application.submittedEmail(variables);
         } catch (error) {
@@ -86,7 +86,7 @@ describe('emails/application', () => {
       fileSystem.unlink = unlinkSpy;
     });
 
-    test('it should call notify.sendEmail and return the response', async () => {
+    it('should call notify.sendEmail and return the response', async () => {
       notify.sendEmail = sendEmailSpy;
 
       const result = await application.underwritingTeam(variables, mockFilePath, templateId);
@@ -109,7 +109,7 @@ describe('emails/application', () => {
         notify.sendEmail = mockSpyPromiseRejection;
       });
 
-      test('should throw an error', async () => {
+      it('should throw an error', async () => {
         try {
           await application.underwritingTeam(variables, mockFilePath, templateId);
         } catch (error) {

--- a/src/api/emails/call-notify/index.test.ts
+++ b/src/api/emails/call-notify/index.test.ts
@@ -15,7 +15,7 @@ describe('emails/call-notify', () => {
     notify.sendEmail = sendEmailSpy;
   });
 
-  test('it should call notify.sendEmail and return the response', async () => {
+  it('should call notify.sendEmail and return the response', async () => {
     const templateId = 'mockTemplateId';
     const mockVariables = { test: true };
 

--- a/src/api/emails/confirm-email-address/index.test.ts
+++ b/src/api/emails/confirm-email-address/index.test.ts
@@ -23,7 +23,7 @@ describe('emails/confirm-email-address', () => {
     notify.sendEmail = sendEmailSpy;
   });
 
-  test('it should call notify.sendEmail and return the response', async () => {
+  it('should call notify.sendEmail and return the response', async () => {
     const result = await confirmEmailAddress(email, mockUrlOrigin, fullName, verificationHash, id);
 
     expect(sendEmailSpy).toHaveBeenCalledTimes(1);
@@ -40,7 +40,7 @@ describe('emails/confirm-email-address', () => {
       notify.sendEmail = mockSpyPromiseRejection;
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await confirmEmailAddress(email, mockUrlOrigin, fullName, verificationHash, id);
       } catch (error) {

--- a/src/api/emails/documents/index.test.ts
+++ b/src/api/emails/documents/index.test.ts
@@ -29,7 +29,7 @@ describe('emails/documents', () => {
     jest.clearAllMocks();
   });
 
-  test('it should call notify.sendEmail and return the response', async () => {
+  it('should call notify.sendEmail and return the response', async () => {
     notify.sendEmail = sendEmailSpy;
 
     const result = await documentsEmail(variables, templateId);
@@ -47,7 +47,7 @@ describe('emails/documents', () => {
       notify.sendEmail = mockSpyPromiseRejection;
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await documentsEmail(variables, templateId);
       } catch (error) {

--- a/src/api/emails/insurance-feedback-email/index.test.ts
+++ b/src/api/emails/insurance-feedback-email/index.test.ts
@@ -20,7 +20,7 @@ describe('emails/insurance-feedback-email', () => {
     jest.clearAllMocks();
   });
 
-  test('it should call notify.sendEmail and return the response with all variables provided', async () => {
+  it('should call notify.sendEmail and return the response with all variables provided', async () => {
     notify.sendEmail = sendEmailSpy;
 
     const emailVariables = {
@@ -45,7 +45,7 @@ describe('emails/insurance-feedback-email', () => {
     expect(result).toEqual(expected);
   });
 
-  test('it should call notify.sendEmail and return the response with no satisfaction provided', async () => {
+  it('should call notify.sendEmail and return the response with no satisfaction provided', async () => {
     notify.sendEmail = sendEmailSpy;
 
     const { satisfaction, ...mockInsuranceFeedbackNoSatisfaction } = mockInsuranceFeedback;
@@ -76,7 +76,7 @@ describe('emails/insurance-feedback-email', () => {
       notify.sendEmail = mockSpyPromiseRejection;
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await insuranceFeedbackEmail(mockInsuranceFeedback);
       } catch (error) {

--- a/src/api/emails/password-reset-link/index.test.ts
+++ b/src/api/emails/password-reset-link/index.test.ts
@@ -25,7 +25,7 @@ describe('emails/password-reset-link', () => {
     notify.sendEmail = sendEmailSpy;
   });
 
-  test('it should call notify.sendEmail and return the response', async () => {
+  it('should call notify.sendEmail and return the response', async () => {
     notify.sendEmail = sendEmailSpy;
 
     const result = await passwordResetLink(mockUrlOrigin, email, fullName, mockPasswordResetHash);
@@ -43,7 +43,7 @@ describe('emails/password-reset-link', () => {
       notify.sendEmail = mockSpyPromiseRejection;
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await passwordResetLink(mockUrlOrigin, email, fullName, mockPasswordResetHash);
       } catch (error) {

--- a/src/api/emails/reactivate-account-link/index.test.ts
+++ b/src/api/emails/reactivate-account-link/index.test.ts
@@ -25,7 +25,7 @@ describe('emails/reactivate-account-link', () => {
     notify.sendEmail = sendEmailSpy;
   });
 
-  test('it should call notify.sendEmail and return the response', async () => {
+  it('should call notify.sendEmail and return the response', async () => {
     notify.sendEmail = sendEmailSpy;
 
     const result = await reactivateAccountLink(mockUrlOrigin, email, fullName, mockReactivationHash);
@@ -43,7 +43,7 @@ describe('emails/reactivate-account-link', () => {
       notify.sendEmail = mockSpyPromiseRejection;
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await reactivateAccountLink(mockUrlOrigin, email, fullName, mockReactivationHash);
       } catch (error) {

--- a/src/api/emails/send-application-submitted-emails/index.test.ts
+++ b/src/api/emails/send-application-submitted-emails/index.test.ts
@@ -79,14 +79,14 @@ describe('emails/send-email-application-submitted', () => {
     });
 
     describe('when application owner and policy contact emails are the same', () => {
-      test('it should call sendEmail.application.applicationSubmittedEmail once', async () => {
+      it('should call sendEmail.application.applicationSubmittedEmail once', async () => {
         await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
 
         expect(applicationSubmittedEmailSpy).toHaveBeenCalledTimes(1);
         expect(applicationSubmittedEmailSpy).toHaveBeenCalledWith(expectedSendOwnerEmailVars);
       });
 
-      test('it should call sendEmail.application.applicationSubmittedEmail with the correct template ID', async () => {
+      it('should call sendEmail.application.applicationSubmittedEmail with the correct template ID', async () => {
         await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
 
         expect(underwritingTeamEmailSpy).toHaveBeenCalledTimes(1);
@@ -96,7 +96,7 @@ describe('emails/send-email-application-submitted', () => {
         expect(underwritingTeamEmailSpy).toHaveBeenCalledWith(expectedSendOwnerEmailVars, mockXlsxPath, templateId);
       });
 
-      test('it should call sendEmail.documentsEmail with the correct template ID', async () => {
+      it('should call sendEmail.documentsEmail with the correct template ID', async () => {
         await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
 
         expect(documentsEmailSpy).toHaveBeenCalledTimes(1);
@@ -112,7 +112,7 @@ describe('emails/send-email-application-submitted', () => {
         application.policyContact.isSameAsOwner = false;
       });
 
-      test('it should call sendEmail.application.submittedEmail twice', async () => {
+      it('should call sendEmail.application.submittedEmail twice', async () => {
         expectedContactSendEmailVars.emailAddress = application.policyContact.email;
 
         await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
@@ -122,7 +122,7 @@ describe('emails/send-email-application-submitted', () => {
         expect(applicationSubmittedEmailSpy).toHaveBeenCalledWith(expectedContactSendEmailVars);
       });
 
-      test('it should call sendEmail.application.submittedEmail with the correct template ID', async () => {
+      it('should call sendEmail.application.submittedEmail with the correct template ID', async () => {
         await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
 
         expect(underwritingTeamEmailSpy).toHaveBeenCalledTimes(1);
@@ -132,7 +132,7 @@ describe('emails/send-email-application-submitted', () => {
         expect(underwritingTeamEmailSpy).toHaveBeenCalledWith(expectedSendOwnerEmailVars, mockXlsxPath, templateId);
       });
 
-      test('it should call sendEmail.documentsEmail with the correct template ID twice', async () => {
+      it('should call sendEmail.documentsEmail with the correct template ID twice', async () => {
         expectedContactSendEmailVars.emailAddress = application.policyContact.email;
 
         await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
@@ -159,7 +159,7 @@ describe('emails/send-email-application-submitted', () => {
         };
       });
 
-      test('it should call sendEmail.documentsEmail with the correct template ID', async () => {
+      it('should call sendEmail.documentsEmail with the correct template ID', async () => {
         await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
 
         expect(documentsEmailSpy).toHaveBeenCalledTimes(1);
@@ -183,7 +183,7 @@ describe('emails/send-email-application-submitted', () => {
         };
       });
 
-      test('it should NOT call sendEmail.documentsEmail', async () => {
+      it('should NOT call sendEmail.documentsEmail', async () => {
         await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
 
         expect(documentsEmailSpy).toHaveBeenCalledTimes(0);
@@ -203,7 +203,7 @@ describe('emails/send-email-application-submitted', () => {
         };
       });
 
-      test('it should NOT call sendEmail.documentsEmail', async () => {
+      it('should NOT call sendEmail.documentsEmail', async () => {
         await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
 
         expect(documentsEmailSpy).toHaveBeenCalledTimes(1);
@@ -234,7 +234,7 @@ describe('emails/send-email-application-submitted', () => {
         );
       });
 
-      test('should throw an error', async () => {
+      it('should throw an error', async () => {
         try {
           await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
         } catch (error) {
@@ -255,7 +255,7 @@ describe('emails/send-email-application-submitted', () => {
         );
       });
 
-      test('should throw an error', async () => {
+      it('should throw an error', async () => {
         try {
           await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
         } catch (error) {
@@ -276,7 +276,7 @@ describe('emails/send-email-application-submitted', () => {
         );
       });
 
-      test('should throw an error', async () => {
+      it('should throw an error', async () => {
         try {
           await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
         } catch (error) {
@@ -292,7 +292,7 @@ describe('emails/send-email-application-submitted', () => {
         sendEmail.application.submittedEmail = mockSpyPromiseRejection;
       });
 
-      test('should throw an error', async () => {
+      it('should throw an error', async () => {
         try {
           await sendApplicationSubmittedEmails.send(application, mockXlsxPath);
         } catch (error) {

--- a/src/api/emails/submission-deadline/index.test.ts
+++ b/src/api/emails/submission-deadline/index.test.ts
@@ -22,7 +22,7 @@ describe('emails/submission-deadline', () => {
     notify.sendEmail = sendEmailSpy;
   });
 
-  test('it should call notify.sendEmail and return the response', async () => {
+  it('should call notify.sendEmail and return the response', async () => {
     const result = await submissionDeadlineEmail(variables.email, variables);
 
     expect(sendEmailSpy).toHaveBeenCalledTimes(1);
@@ -39,7 +39,7 @@ describe('emails/submission-deadline', () => {
       notify.sendEmail = mockSpyPromiseRejection;
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       await expect(submissionDeadlineEmail(variables.email, variables)).rejects.toThrow(`Sending submission deadline email for ${variables.referenceNumber}`);
     });
   });

--- a/src/api/helpers/block-account/index.test.ts
+++ b/src/api/helpers/block-account/index.test.ts
@@ -23,18 +23,18 @@ describe('helpers/block-account', () => {
     result = await blockAccount(context, account.status.id);
   });
 
-  test('it should update an account to be blocked', async () => {
+  it('should update an account to be blocked', async () => {
     account = await accounts.get(context, account.id);
 
     expect(account.status.isBlocked).toEqual(true);
   });
 
-  test('it should return true', async () => {
+  it('should return true', async () => {
     expect(result).toEqual(true);
   });
 
   describe('when an account is NOT updated - invalid ID', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await blockAccount(context, mockInvalidId);
       } catch (error) {
@@ -47,7 +47,7 @@ describe('helpers/block-account', () => {
   });
 
   describe('when an account is NOT updated - account not found', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       await accounts.deleteAll(context);
 
       try {

--- a/src/api/helpers/create-a-broker/index.test.ts
+++ b/src/api/helpers/create-a-broker/index.test.ts
@@ -14,7 +14,7 @@ describe('helpers/create-a-broker', () => {
     application = (await applications.create({ context })) as Application;
   });
 
-  test('it should return a broker', async () => {
+  it('should return a broker', async () => {
     const result = await createABroker(context, application.id);
 
     expect(result.id).toBeDefined();
@@ -33,13 +33,13 @@ describe('helpers/create-a-broker', () => {
   });
 
   describe('when an invalid application ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       await expect(createABroker(context, mockInvalidId)).rejects.toThrow('Creating a broker');
     });
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       await expect(createABroker({}, application.id)).rejects.toThrow('Creating a broker');
     });
   });

--- a/src/api/helpers/create-a-business/index.test.ts
+++ b/src/api/helpers/create-a-business/index.test.ts
@@ -21,7 +21,7 @@ describe('helpers/create-a-business', () => {
     application = (await applications.create({ context })) as Application;
   });
 
-  test('it should return a business with an application relationship', async () => {
+  it('should return a business with an application relationship', async () => {
     const result = await createABusiness(context, application.id);
 
     expect(typeof result.id).toEqual('string');
@@ -40,7 +40,7 @@ describe('helpers/create-a-business', () => {
   });
 
   describe('when an invalid application ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createABusiness(context, mockInvalidId);
       } catch (error) {
@@ -50,7 +50,7 @@ describe('helpers/create-a-business', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createABusiness({}, application.id);

--- a/src/api/helpers/create-a-buyer-contact/index.test.ts
+++ b/src/api/helpers/create-a-buyer-contact/index.test.ts
@@ -26,7 +26,7 @@ describe('helpers/create-a-buyer-contact', () => {
     buyer = (await buyerHelpers.create(context)) as ApplicationBuyer;
   });
 
-  test('it should return a buyer contact with respective IDs', async () => {
+  it('should return a buyer contact with respective IDs', async () => {
     const result = await createABuyerContact(context, buyer.id, applicationId);
 
     expect(result).toBeDefined();
@@ -34,7 +34,7 @@ describe('helpers/create-a-buyer-contact', () => {
     expect(result.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty buyerContact fields', async () => {
+  it('should return empty buyerContact fields', async () => {
     const result = await createABuyerContact(context, buyer.id, applicationId);
 
     expect(result.contactFirstName).toEqual('');
@@ -45,7 +45,7 @@ describe('helpers/create-a-buyer-contact', () => {
   });
 
   describe('when an invalid buyer ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createABuyerContact(context, mockInvalidId, applicationId);
       } catch (error) {
@@ -55,7 +55,7 @@ describe('helpers/create-a-buyer-contact', () => {
   });
 
   describe('when an invalid application ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createABuyerContact(context, buyer.id, mockInvalidId);
       } catch (error) {
@@ -65,7 +65,7 @@ describe('helpers/create-a-buyer-contact', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createABuyerContact({}, buyer.id, applicationId);

--- a/src/api/helpers/create-a-buyer-relationship/index.test.ts
+++ b/src/api/helpers/create-a-buyer-relationship/index.test.ts
@@ -26,7 +26,7 @@ describe('helpers/create-a-buyer-relationship', () => {
     buyer = (await buyerHelpers.create(context)) as ApplicationBuyer;
   });
 
-  test('it should return a buyer relationship with respective IDs', async () => {
+  it('should return a buyer relationship with respective IDs', async () => {
     const result = await createABuyerRelationship(context, buyer.id, applicationId);
 
     expect(result).toBeDefined();
@@ -34,7 +34,7 @@ describe('helpers/create-a-buyer-relationship', () => {
     expect(result.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty buyerRelationship fields', async () => {
+  it('should return empty buyerRelationship fields', async () => {
     const result = await createABuyerRelationship(context, buyer.id, applicationId);
 
     expect(result.exporterIsConnectedWithBuyer).toBeNull();
@@ -45,7 +45,7 @@ describe('helpers/create-a-buyer-relationship', () => {
   });
 
   describe('when an invalid buyer ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createABuyerRelationship(context, mockInvalidId, applicationId);
       } catch (error) {
@@ -55,7 +55,7 @@ describe('helpers/create-a-buyer-relationship', () => {
   });
 
   describe('when an invalid application ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createABuyerRelationship(context, buyer.id, mockInvalidId);
       } catch (error) {
@@ -65,7 +65,7 @@ describe('helpers/create-a-buyer-relationship', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createABuyerRelationship({}, buyer.id, applicationId);

--- a/src/api/helpers/create-a-buyer-trading-history/index.test.ts
+++ b/src/api/helpers/create-a-buyer-trading-history/index.test.ts
@@ -27,7 +27,7 @@ describe('helpers/create-a-buyer-trading-history', () => {
     buyer = (await buyerHelpers.create(context)) as ApplicationBuyer;
   });
 
-  test('it should return a buyer trading history with respective IDs', async () => {
+  it('should return a buyer trading history with respective IDs', async () => {
     const result = await createABuyerTradingHistory(context, buyer.id, applicationId);
 
     expect(result).toBeDefined();
@@ -35,7 +35,7 @@ describe('helpers/create-a-buyer-trading-history', () => {
     expect(result.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty buyerTradingAddress fields with default currencyCode', async () => {
+  it('should return empty buyerTradingAddress fields with default currencyCode', async () => {
     const result = await createABuyerTradingHistory(context, buyer.id, applicationId);
 
     expect(result.exporterHasTradedWithBuyer).toBeNull();
@@ -45,7 +45,7 @@ describe('helpers/create-a-buyer-trading-history', () => {
   });
 
   describe('when an invalid buyer ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createABuyerTradingHistory(context, mockInvalidId, applicationId);
       } catch (error) {
@@ -55,7 +55,7 @@ describe('helpers/create-a-buyer-trading-history', () => {
   });
 
   describe('when an invalid application ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createABuyerTradingHistory(context, buyer.id, mockInvalidId);
       } catch (error) {
@@ -65,7 +65,7 @@ describe('helpers/create-a-buyer-trading-history', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createABuyerTradingHistory({}, buyer.id, applicationId);

--- a/src/api/helpers/create-a-buyer/index.test.ts
+++ b/src/api/helpers/create-a-buyer/index.test.ts
@@ -22,7 +22,7 @@ describe('helpers/create-a-buyer', () => {
     country = await getCountryByField(context, 'isoCode', countryIsoCode);
   });
 
-  test('it should return a buyer', async () => {
+  it('should return a buyer', async () => {
     const result = await createABuyer(context, country.id);
 
     expect(result).toBeDefined();
@@ -30,7 +30,7 @@ describe('helpers/create-a-buyer', () => {
     expect(result.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty buyer fields', async () => {
+  it('should return empty buyer fields', async () => {
     const result = await createABuyer(context, country.id);
 
     expect(result.address).toEqual('');
@@ -41,7 +41,7 @@ describe('helpers/create-a-buyer', () => {
   });
 
   describe('when an invalid country ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createABuyer(context, mockInvalidId);
       } catch (error) {
@@ -51,7 +51,7 @@ describe('helpers/create-a-buyer', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createABuyer({}, country.id);

--- a/src/api/helpers/create-a-company-address/index.test.ts
+++ b/src/api/helpers/create-a-company-address/index.test.ts
@@ -22,7 +22,7 @@ describe('helpers/create-a-company-address', () => {
     company = (await companyHelpers.createCompany(context)) as object;
   });
 
-  test('it should return a company address with ID', async () => {
+  it('should return a company address with ID', async () => {
     const result = await createACompanyAddress(context, mockAddress, company.id);
 
     expect(typeof result.id).toEqual('string');
@@ -39,7 +39,7 @@ describe('helpers/create-a-company-address', () => {
   });
 
   describe('when an invalid company ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createACompanyAddress(context, mockAddress, mockInvalidId);
       } catch (error) {
@@ -49,7 +49,7 @@ describe('helpers/create-a-company-address', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createACompanyAddress({}, mockAddress, company.id);

--- a/src/api/helpers/create-a-company-different-trading-address/index.test.ts
+++ b/src/api/helpers/create-a-company-different-trading-address/index.test.ts
@@ -20,7 +20,7 @@ describe('helpers/create-a-company-different-trading-address', () => {
     company = (await companyHelpers.createCompany(context)) as object;
   });
 
-  test('it should return a company different trading address with ID', async () => {
+  it('should return a company different trading address with ID', async () => {
     const result = await createACompanyDifferentTradingAddress(context, company.id);
 
     expect(typeof result.id).toEqual('string');
@@ -28,7 +28,7 @@ describe('helpers/create-a-company-different-trading-address', () => {
   });
 
   describe('when an invalid company ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createACompanyDifferentTradingAddress(context, mockInvalidId);
       } catch (error) {
@@ -38,7 +38,7 @@ describe('helpers/create-a-company-different-trading-address', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createACompanyDifferentTradingAddress({}, company.id);

--- a/src/api/helpers/create-a-company/index.test.ts
+++ b/src/api/helpers/create-a-company/index.test.ts
@@ -20,7 +20,7 @@ describe('helpers/create-a-company', () => {
     application = (await applications.create({ context })) as Application;
   });
 
-  test('it should return a company with an application relationship, address, SIC code, different trading address relationships', async () => {
+  it('should return a company with an application relationship, address, SIC code, different trading address relationships', async () => {
     const result = await createACompany(context, application.id, mockCompany);
 
     expect(typeof result.id).toEqual('string');
@@ -43,7 +43,7 @@ describe('helpers/create-a-company', () => {
   });
 
   describe('when an invalid application ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createACompany(context, mockInvalidId, mockCompany);
       } catch (error) {
@@ -53,7 +53,7 @@ describe('helpers/create-a-company', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createACompany({}, application.id, mockCompany);

--- a/src/api/helpers/create-a-declaration-version/index.test.ts
+++ b/src/api/helpers/create-a-declaration-version/index.test.ts
@@ -25,7 +25,7 @@ describe('helpers/create-a-declaration-version', () => {
     declaration = (await declarations.create(context)) as ApplicationDeclaration;
   });
 
-  test('it should return a declaration version with ID', async () => {
+  it('should return a declaration version with ID', async () => {
     const result = await createADeclarationVersion(context, declaration.id);
 
     expect(result.id).toBeDefined();
@@ -33,13 +33,13 @@ describe('helpers/create-a-declaration-version', () => {
     expect(result.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return a declaration ID', async () => {
+  it('should return a declaration ID', async () => {
     const result = await createADeclarationVersion(context, declaration.id);
 
     expect(result.declarationId).toEqual(declaration.id);
   });
 
-  test('it should return declaration version fields with the latest versions', async () => {
+  it('should return declaration version fields with the latest versions', async () => {
     const result = await createADeclarationVersion(context, declaration.id);
 
     expect(result.agreeHowDataWillBeUsed).toEqual('');
@@ -51,7 +51,7 @@ describe('helpers/create-a-declaration-version', () => {
   });
 
   describe('when an invalid declaration ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createADeclarationVersion(context, invalidId);
       } catch (error) {

--- a/src/api/helpers/create-a-declaration/index.test.ts
+++ b/src/api/helpers/create-a-declaration/index.test.ts
@@ -21,7 +21,7 @@ describe('helpers/create-a-declaration', () => {
     application = (await applications.create({ context, data: {} })) as Application;
   });
 
-  test('it should return a declaration with ID', async () => {
+  it('should return a declaration with ID', async () => {
     const result = await createADeclaration(context, application.id);
 
     expect(result.id).toBeDefined();
@@ -30,13 +30,13 @@ describe('helpers/create-a-declaration', () => {
   });
 
   // declarationVersion
-  test('it should return an application ID', async () => {
+  it('should return an application ID', async () => {
     const result = await createADeclaration(context, application.id);
 
     expect(result.applicationId).toEqual(application.id);
   });
 
-  test('it should return empty declaration fields', async () => {
+  it('should return empty declaration fields', async () => {
     const result = await createADeclaration(context, application.id);
 
     expect(result.agreeHowDataWillBeUsed).toBeNull();
@@ -47,7 +47,7 @@ describe('helpers/create-a-declaration', () => {
     expect(result.willExportWithAntiBriberyCodeOfConduct).toBeNull();
   });
 
-  test('it should return declaration version fields via createADeclarationVersion helper', async () => {
+  it('should return declaration version fields via createADeclarationVersion helper', async () => {
     const result = await createADeclaration(context, application.id);
 
     const {
@@ -80,13 +80,13 @@ describe('helpers/create-a-declaration', () => {
   });
 
   describe('when an invalid application ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       await expect(createADeclaration(context, mockInvalidId)).rejects.toThrow('Creating an application declaration');
     });
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       await expect(createADeclaration({}, application.id)).rejects.toThrow('Creating an application declaration');
       try {
         await createADeclaration(context, mockInvalidId);

--- a/src/api/helpers/create-a-jointly-insured-party/index.test.ts
+++ b/src/api/helpers/create-a-jointly-insured-party/index.test.ts
@@ -25,7 +25,7 @@ describe('helpers/create-a-jointly-insured-party', () => {
     applicationPolicy = createdPolicy;
   });
 
-  test('it should return a jointlyInsuredParty with ID', async () => {
+  it('should return a jointlyInsuredParty with ID', async () => {
     const result = await createAJointlyInsuredParty(context, applicationPolicy.id);
 
     expect(result.id).toBeDefined();
@@ -33,7 +33,7 @@ describe('helpers/create-a-jointly-insured-party', () => {
     expect(result.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return a policy relationship and empty jointlyInsuredParty fields', async () => {
+  it('should return a policy relationship and empty jointlyInsuredParty fields', async () => {
     const result = await createAJointlyInsuredParty(context, applicationPolicy.id);
 
     expect(result.policyId).toEqual(applicationPolicy.id);
@@ -44,7 +44,7 @@ describe('helpers/create-a-jointly-insured-party', () => {
   });
 
   describe('when an invalid policy ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createAJointlyInsuredParty(context, mockInvalidId);
       } catch (error) {
@@ -54,7 +54,7 @@ describe('helpers/create-a-jointly-insured-party', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createAJointlyInsuredParty({}, applicationPolicy.id);

--- a/src/api/helpers/create-a-loss-payee-financial-international/index.test.ts
+++ b/src/api/helpers/create-a-loss-payee-financial-international/index.test.ts
@@ -23,7 +23,7 @@ describe('helpers/create-a-loss-payee-financial-international', () => {
     nominatedLossPayee = await createANominatedLossPayee(context, application.id);
   });
 
-  test('it should return a loss payee financial UK with ID', async () => {
+  it('should return a loss payee financial UK with ID', async () => {
     const lossPayeeFinancialInternational = await createALossPayeeFinancialInternational(context, nominatedLossPayee.id);
 
     expect(lossPayeeFinancialInternational.id).toBeDefined();
@@ -31,7 +31,7 @@ describe('helpers/create-a-loss-payee-financial-international', () => {
     expect(lossPayeeFinancialInternational.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return lossPayee ID and empty loss payee financial UK fields', async () => {
+  it('should return lossPayee ID and empty loss payee financial UK fields', async () => {
     const lossPayeeFinancialInternational = await createALossPayeeFinancialInternational(context, nominatedLossPayee.id);
 
     expect(lossPayeeFinancialInternational.lossPayeeId).toEqual(nominatedLossPayee.id);
@@ -40,7 +40,7 @@ describe('helpers/create-a-loss-payee-financial-international', () => {
     expect(lossPayeeFinancialInternational.bankAddress).toEqual('');
   });
 
-  test('it should create an empty loss payee financial international vector relationship', async () => {
+  it('should create an empty loss payee financial international vector relationship', async () => {
     // create the Loss payee financial international
     const created = await createALossPayeeFinancialInternational(context, nominatedLossPayee.id);
 
@@ -72,7 +72,7 @@ describe('helpers/create-a-loss-payee-financial-international', () => {
   });
 
   describe('when an invalid nominated loss payee ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createALossPayeeFinancialInternational(context, mockInvalidId);
       } catch (error) {
@@ -82,7 +82,7 @@ describe('helpers/create-a-loss-payee-financial-international', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createALossPayeeFinancialInternational({}, application.id);

--- a/src/api/helpers/create-a-loss-payee-financial-uk/index.test.ts
+++ b/src/api/helpers/create-a-loss-payee-financial-uk/index.test.ts
@@ -23,7 +23,7 @@ describe('helpers/create-a-loss-payee-financial-uk', () => {
     nominatedLossPayee = await createANominatedLossPayee(context, application.id);
   });
 
-  test('it should return a loss payee financial UK with ID', async () => {
+  it('should return a loss payee financial UK with ID', async () => {
     const lossPayeeFinancialUk = await createALossPayeeFinancialUk(context, nominatedLossPayee.id);
 
     expect(lossPayeeFinancialUk.id).toBeDefined();
@@ -31,7 +31,7 @@ describe('helpers/create-a-loss-payee-financial-uk', () => {
     expect(lossPayeeFinancialUk.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return lossPayee ID and empty loss payee financial UK fields', async () => {
+  it('should return lossPayee ID and empty loss payee financial UK fields', async () => {
     const lossPayeeFinancialUk = await createALossPayeeFinancialUk(context, nominatedLossPayee.id);
 
     expect(lossPayeeFinancialUk.lossPayeeId).toEqual(nominatedLossPayee.id);
@@ -40,7 +40,7 @@ describe('helpers/create-a-loss-payee-financial-uk', () => {
     expect(lossPayeeFinancialUk.bankAddress).toEqual('');
   });
 
-  test('it should create an empty loss payee financial UK vector relationship', async () => {
+  it('should create an empty loss payee financial UK vector relationship', async () => {
     // create the Loss payee financial uk
     const created = await createALossPayeeFinancialUk(context, nominatedLossPayee.id);
 
@@ -72,7 +72,7 @@ describe('helpers/create-a-loss-payee-financial-uk', () => {
   });
 
   describe('when an invalid nominated loss payee ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createALossPayeeFinancialUk(context, mockInvalidId);
       } catch (error) {
@@ -82,7 +82,7 @@ describe('helpers/create-a-loss-payee-financial-uk', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createALossPayeeFinancialUk({}, application.id);

--- a/src/api/helpers/create-a-nominated-loss-payee/index.test.ts
+++ b/src/api/helpers/create-a-nominated-loss-payee/index.test.ts
@@ -20,7 +20,7 @@ describe('helpers/create-a-nominated-loss-payee', () => {
     application = (await applications.create({ context })) as Application;
   });
 
-  test('it should return a nominated loss payee with ID', async () => {
+  it('should return a nominated loss payee with ID', async () => {
     const nominatedLossPayee = await createANominatedLossPayee(context, application.id);
 
     expect(nominatedLossPayee.id).toBeDefined();
@@ -28,7 +28,7 @@ describe('helpers/create-a-nominated-loss-payee', () => {
     expect(nominatedLossPayee.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return application ID and empty nominated loss payee fields', async () => {
+  it('should return application ID and empty nominated loss payee fields', async () => {
     const nominatedLossPayee = await createANominatedLossPayee(context, application.id);
 
     expect(nominatedLossPayee.applicationId).toEqual(application.id);
@@ -39,7 +39,7 @@ describe('helpers/create-a-nominated-loss-payee', () => {
   });
 
   describe('when an invalid application ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createANominatedLossPayee(context, mockInvalidId);
       } catch (error) {
@@ -49,7 +49,7 @@ describe('helpers/create-a-nominated-loss-payee', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createANominatedLossPayee({}, application.id);

--- a/src/api/helpers/create-a-policy-contact/index.test.ts
+++ b/src/api/helpers/create-a-policy-contact/index.test.ts
@@ -20,7 +20,7 @@ describe('helpers/create-a-policy-contact', () => {
     application = (await applications.create({ context })) as Application;
   });
 
-  test('it should return a policy contact with an application relationship', async () => {
+  it('should return a policy contact with an application relationship', async () => {
     const result = await createAPolicyContact(context, application.id);
 
     expect(typeof result.id).toEqual('string');
@@ -36,7 +36,7 @@ describe('helpers/create-a-policy-contact', () => {
   });
 
   describe('when an invalid application ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createAPolicyContact(context, mockInvalidId);
       } catch (error) {
@@ -46,7 +46,7 @@ describe('helpers/create-a-policy-contact', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createAPolicyContact({}, application.id);

--- a/src/api/helpers/create-a-policy/index.test.ts
+++ b/src/api/helpers/create-a-policy/index.test.ts
@@ -21,7 +21,7 @@ describe('helpers/create-a-policy', () => {
     application = (await applications.create({ context })) as Application;
   });
 
-  test('it should return a policy with ID and jointlyInsuredParty relationship', async () => {
+  it('should return a policy with ID and jointlyInsuredParty relationship', async () => {
     const result = await createAPolicy(context, application.id);
 
     expect(result.id).toBeDefined();
@@ -29,7 +29,7 @@ describe('helpers/create-a-policy', () => {
     expect(result.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty policy fields, default needPreCreditPeriodCover', async () => {
+  it('should return empty policy fields, default needPreCreditPeriodCover', async () => {
     const result = await createAPolicy(context, application.id);
 
     expect(result.applicationId).toEqual(application.id);
@@ -45,7 +45,7 @@ describe('helpers/create-a-policy', () => {
     expect(result.maximumBuyerWillOwe).toBeNull();
   });
 
-  test('it should return empty jointlyInsuredParty fields', async () => {
+  it('should return empty jointlyInsuredParty fields', async () => {
     const { jointlyInsuredParty } = await createAPolicy(context, application.id);
 
     expect(jointlyInsuredParty.requested).toBeNull();
@@ -55,7 +55,7 @@ describe('helpers/create-a-policy', () => {
   });
 
   describe('when an invalid application ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createAPolicy(context, mockInvalidId);
       } catch (error) {
@@ -65,7 +65,7 @@ describe('helpers/create-a-policy', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createAPolicy({}, application.id);

--- a/src/api/helpers/create-a-populated-buyer/index.test.ts
+++ b/src/api/helpers/create-a-populated-buyer/index.test.ts
@@ -27,7 +27,7 @@ describe('helpers/create-a-populated-buyer', () => {
     country = await getCountryByField(context, 'isoCode', countryIsoCode);
   });
 
-  test('it should return a buyer and buyer trading history with respective IDs', async () => {
+  it('should return a buyer and buyer trading history with respective IDs', async () => {
     const result = await createAPopulatedBuyer(context, country.id, application.id);
 
     const { buyerTradingHistory } = result;
@@ -40,7 +40,7 @@ describe('helpers/create-a-populated-buyer', () => {
     expect(buyerTradingHistory.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty buyer fields', async () => {
+  it('should return empty buyer fields', async () => {
     const result = await createAPopulatedBuyer(context, country.id, application.id);
 
     expect(result.address).toEqual('');
@@ -51,7 +51,7 @@ describe('helpers/create-a-populated-buyer', () => {
     expect(result.website).toEqual('');
   });
 
-  test('it should return empty buyerTradingAddress fields with default currencyCode', async () => {
+  it('should return empty buyerTradingAddress fields with default currencyCode', async () => {
     const { buyerTradingHistory } = await createAPopulatedBuyer(context, country.id, application.id);
 
     expect(buyerTradingHistory.currencyCode).toEqual(GBP);
@@ -59,7 +59,7 @@ describe('helpers/create-a-populated-buyer', () => {
     expect(buyerTradingHistory.failedPayments).toBeNull();
   });
 
-  test('it should return empty buyer relationship fields', async () => {
+  it('should return empty buyer relationship fields', async () => {
     const { relationship } = await createAPopulatedBuyer(context, country.id, application.id);
 
     expect(relationship.exporterIsConnectedWithBuyer).toBeNull();
@@ -69,7 +69,7 @@ describe('helpers/create-a-populated-buyer', () => {
     expect(relationship.previousCreditInsuranceWithBuyerDescription).toEqual('');
   });
 
-  test('it should return empty buyerContact fields', async () => {
+  it('should return empty buyerContact fields', async () => {
     const { buyerContact } = await createAPopulatedBuyer(context, country.id, application.id);
 
     expect(buyerContact.contactFirstName).toEqual('');
@@ -80,7 +80,7 @@ describe('helpers/create-a-populated-buyer', () => {
   });
 
   describe('when an invalid country ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createAPopulatedBuyer(context, mockInvalidId, application.id);
       } catch (error) {
@@ -90,7 +90,7 @@ describe('helpers/create-a-populated-buyer', () => {
   });
 
   describe('when an invalid application ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createAPopulatedBuyer(context, country.id, mockInvalidId);
       } catch (error) {
@@ -100,7 +100,7 @@ describe('helpers/create-a-populated-buyer', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createAPopulatedBuyer({}, country.id, application.id);

--- a/src/api/helpers/create-a-private-market/index.test.ts
+++ b/src/api/helpers/create-a-private-market/index.test.ts
@@ -26,7 +26,7 @@ describe('helpers/create-a-private-market', () => {
     applicationExportContract = createdExportContract;
   });
 
-  test('it should return a privateMarket with ID', async () => {
+  it('should return a privateMarket with ID', async () => {
     const result = await createAPrivateMarket(context, applicationExportContract.id);
 
     expect(result.id).toBeDefined();
@@ -34,7 +34,7 @@ describe('helpers/create-a-private-market', () => {
     expect(result.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty privateMarket fields and default finalDestinationKnown', async () => {
+  it('should return empty privateMarket fields and default finalDestinationKnown', async () => {
     const result = await createAPrivateMarket(context, applicationExportContract.id);
 
     expect(result.attempted).toBeNull();
@@ -42,7 +42,7 @@ describe('helpers/create-a-private-market', () => {
   });
 
   describe('when an invalid exportContract ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createAPrivateMarket(context, mockInvalidId);
       } catch (error) {
@@ -52,7 +52,7 @@ describe('helpers/create-a-private-market', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createAPrivateMarket({}, applicationExportContract.id);

--- a/src/api/helpers/create-a-reference-number/index.test.ts
+++ b/src/api/helpers/create-a-reference-number/index.test.ts
@@ -20,7 +20,7 @@ describe('helpers/create-a-reference-number', () => {
     application = (await applications.create({ context })) as Application;
   });
 
-  test('it should return a reference number and with a respective ID', async () => {
+  it('should return a reference number and with a respective ID', async () => {
     const result = await createAReferenceNumber(context, application.id);
 
     expect(typeof result).toEqual('number');
@@ -28,7 +28,7 @@ describe('helpers/create-a-reference-number', () => {
   });
 
   describe('when an invalid application ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createAReferenceNumber(context, mockInvalidId);
       } catch (error) {
@@ -38,7 +38,7 @@ describe('helpers/create-a-reference-number', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createAReferenceNumber({}, application.id);

--- a/src/api/helpers/create-a-section-review/index.test.ts
+++ b/src/api/helpers/create-a-section-review/index.test.ts
@@ -23,7 +23,7 @@ describe('helpers/create-a-section-review', () => {
     sectionReview = { eligibility: true };
   });
 
-  test('it should return a sectionReview with ID', async () => {
+  it('should return a sectionReview with ID', async () => {
     const result = await createASectionReview(context, application.id, sectionReview);
 
     expect(result.id).toBeDefined();
@@ -31,7 +31,7 @@ describe('helpers/create-a-section-review', () => {
     expect(result.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty sectionReview fields apart from eligibility', async () => {
+  it('should return empty sectionReview fields apart from eligibility', async () => {
     const result = await createASectionReview(context, application.id, sectionReview);
 
     expect(result.applicationId).toEqual(application.id);
@@ -42,7 +42,7 @@ describe('helpers/create-a-section-review', () => {
   });
 
   describe('when an invalid sectionReview is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createASectionReview(context, application.id, {} as SectionReview);
       } catch (error) {
@@ -52,7 +52,7 @@ describe('helpers/create-a-section-review', () => {
   });
 
   describe('when an invalid application ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createASectionReview(context, mockInvalidId, {} as SectionReview);
       } catch (error) {

--- a/src/api/helpers/create-an-application/create-application-relationships/index.test.ts
+++ b/src/api/helpers/create-an-application/create-application-relationships/index.test.ts
@@ -30,7 +30,7 @@ describe('helpers/create-an-application/create-application-relationships', () =>
     });
   });
 
-  test('it should return relationship IDs and a reference number', () => {
+  it('should return relationship IDs and a reference number', () => {
     expect(typeof result.brokerId).toEqual('string');
     expect(typeof result.businessId).toEqual('string');
     expect(typeof result.buyerId).toEqual('string');
@@ -46,7 +46,7 @@ describe('helpers/create-an-application/create-application-relationships', () =>
   });
 
   describe('when a buyer country is not found', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         result = await applicationRelationships.create({
@@ -72,7 +72,7 @@ describe('helpers/create-an-application/create-application-relationships', () =>
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         result = await applicationRelationships.create({

--- a/src/api/helpers/create-an-application/create-initial-application/index.test.ts
+++ b/src/api/helpers/create-an-application/create-initial-application/index.test.ts
@@ -31,7 +31,7 @@ describe('helpers/create-an-application/create-initial-application', () => {
     result = await initialApplication.create({ context, accountId });
   });
 
-  test('it should return with some empty data/ relationships', () => {
+  it('should return with some empty data/ relationships', () => {
     expect(result.business).toBeUndefined();
     expect(result.broker).toBeUndefined();
     expect(result.buyer).toBeUndefined();
@@ -47,28 +47,28 @@ describe('helpers/create-an-application/create-initial-application', () => {
     expect(result.sectionReview).toBeUndefined();
   });
 
-  test('it should have a default submissionType', () => {
+  it('should have a default submissionType', () => {
     expect(result.submissionType).toEqual(SUBMISSION_TYPE.MIA);
   });
 
-  test('it should have a default previousStatus', () => {
+  it('should have a default previousStatus', () => {
     expect(result.previousStatus).toEqual('');
   });
 
-  test('it should have a default dealType', () => {
+  it('should have a default dealType', () => {
     expect(result.dealType).toEqual(DEAL_TYPE);
   });
 
-  test('it should have a default submissionCount', () => {
+  it('should have a default submissionCount', () => {
     expect(result.submissionCount).toEqual(SUBMISSION_COUNT_DEFAULT);
   });
 
-  test('it should have a default submissionType', () => {
+  it('should have a default submissionType', () => {
     expect(result.submissionType).toEqual(SUBMISSION_TYPE.MIA);
   });
 
   describe('when a status is provided', () => {
-    test('it should return an application with the provided status', async () => {
+    it('should return an application with the provided status', async () => {
       const { status } = await initialApplication.create({ context, accountId, status: ABANDONED });
 
       expect(status).toEqual(ABANDONED);
@@ -76,7 +76,7 @@ describe('helpers/create-an-application/create-initial-application', () => {
   });
 
   describe('when a status is NOT provided', () => {
-    test(`it should return an application with a ${IN_PROGRESS} status`, async () => {
+    it(`should return an application with a ${IN_PROGRESS} status`, async () => {
       const { status } = await initialApplication.create({ context, accountId });
 
       expect(status).toEqual(IN_PROGRESS);
@@ -86,7 +86,7 @@ describe('helpers/create-an-application/create-initial-application', () => {
   describe('timestamp fields', () => {
     const now = new Date();
 
-    test('it should have a submission deadline date', () => {
+    it('should have a submission deadline date', () => {
       const submissionDeadlineDay = new Date(result.submissionDeadline).getDate();
       const submissionDeadlineMonth = new Date(result.submissionDeadline).getMonth();
       const submissionDeadlineYear = new Date(result.submissionDeadline).getFullYear();
@@ -98,7 +98,7 @@ describe('helpers/create-an-application/create-initial-application', () => {
       expect(submissionDeadlineYear).toEqual(new Date(expectedDate).getFullYear());
     });
 
-    test('it should have a createdAt date', () => {
+    it('should have a createdAt date', () => {
       const createdAtDay = new Date(result.createdAt).getDate();
       const createdAtMonth = new Date(result.createdAt).getMonth();
       const createdAtYear = new Date(result.createdAt).getFullYear();
@@ -108,7 +108,7 @@ describe('helpers/create-an-application/create-initial-application', () => {
       expect(createdAtYear).toEqual(new Date().getFullYear());
     });
 
-    test('it should have updatedAt date', () => {
+    it('should have updatedAt date', () => {
       const updatedAtDay = new Date(result.updatedAt).getDate();
       const updatedAtMonth = new Date(result.updatedAt).getMonth();
       const updatedAtYear = new Date(result.updatedAt).getFullYear();
@@ -119,14 +119,14 @@ describe('helpers/create-an-application/create-initial-application', () => {
     });
   });
 
-  test('it should have a default latest version number', () => {
+  it('should have a default latest version number', () => {
     const expected = LATEST_VERSION_NUMBER;
 
     expect(result.version).toEqual(expected);
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       await expect(initialApplication.create({ context: {}, accountId })).rejects.toThrow(
         `Creating initial application (createInitialApplication helper) for user ${account.id}`,
       );

--- a/src/api/helpers/create-an-application/index.api-error.test.ts
+++ b/src/api/helpers/create-an-application/index.api-error.test.ts
@@ -108,7 +108,7 @@ describe('helpers/create-an-application - error handling', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createAnApplicationHelper({}, variables, {});

--- a/src/api/helpers/create-an-application/index.test.ts
+++ b/src/api/helpers/create-an-application/index.test.ts
@@ -142,7 +142,7 @@ describe('helpers/create-an-application', () => {
     });
   });
 
-  test('it should return the result of applicationColumns.update', async () => {
+  it('should return the result of applicationColumns.update', async () => {
     const result = await createAnApplicationHelper(variables, context);
 
     const createdApplication = await applications.get({ context, applicationId: result.id });
@@ -151,7 +151,7 @@ describe('helpers/create-an-application', () => {
   });
 
   describe('when there is no account for the provided accountId', () => {
-    test('it should return null', async () => {
+    it('should return null', async () => {
       variables.accountId = mockInvalidId;
 
       const result = await createAnApplicationHelper(variables, context);

--- a/src/api/helpers/create-an-application/update-application-columns/index.test.ts
+++ b/src/api/helpers/create-an-application/update-application-columns/index.test.ts
@@ -47,7 +47,7 @@ describe('helpers/create-an-application/update-application-columns', () => {
     });
   });
 
-  test('it should return an application', () => {
+  it('should return an application', () => {
     expect(result.buyerId).toEqual(createdRelationships.buyerId);
     expect(result.companyId).toEqual(createdRelationships.companyId);
     expect(result.declarationId).toEqual(createdRelationships.declarationId);
@@ -59,7 +59,7 @@ describe('helpers/create-an-application/update-application-columns', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await applicationColumns.update({

--- a/src/api/helpers/create-an-eligibility/index.test.ts
+++ b/src/api/helpers/create-an-eligibility/index.test.ts
@@ -34,7 +34,7 @@ describe('helpers/create-an-eligibility', () => {
     totalContractValue = await totalContractValueTestHelper.create(context);
   });
 
-  test('it should return a eligibility with ID', async () => {
+  it('should return a eligibility with ID', async () => {
     const result = await creatAnEligibility(context, country.id, application.id, coverPeriod.id, totalContractValue.id);
 
     expect(result.id).toBeDefined();
@@ -42,7 +42,7 @@ describe('helpers/create-an-eligibility', () => {
     expect(result.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty eligibility fields', async () => {
+  it('should return empty eligibility fields', async () => {
     const result = await creatAnEligibility(context, country.id, application.id, coverPeriod.id, totalContractValue.id);
 
     expect(result.applicationId).toEqual(application.id);
@@ -58,7 +58,7 @@ describe('helpers/create-an-eligibility', () => {
   });
 
   describe('when an invalid country ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await creatAnEligibility(context, mockInvalidId, application.id, coverPeriod.id, totalContractValue.id);
       } catch (error) {
@@ -68,7 +68,7 @@ describe('helpers/create-an-eligibility', () => {
   });
 
   describe('when an invalid application ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await creatAnEligibility(context, country.id, mockInvalidId, coverPeriod.id, totalContractValue.id);
       } catch (error) {
@@ -78,7 +78,7 @@ describe('helpers/create-an-eligibility', () => {
   });
 
   describe('when an invalid coverPeriod ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await creatAnEligibility(context, country.id, application.id, mockInvalidId, totalContractValue.id);
       } catch (error) {
@@ -88,7 +88,7 @@ describe('helpers/create-an-eligibility', () => {
   });
 
   describe('when an invalid totalContractValue ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await creatAnEligibility(context, country.id, application.id, coverPeriod.id, mockInvalidId);
       } catch (error) {
@@ -98,7 +98,7 @@ describe('helpers/create-an-eligibility', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await creatAnEligibility({}, country.id, application.id, coverPeriod.id, totalContractValue.id);

--- a/src/api/helpers/create-an-export-contract-agent-service-charge/index.test.ts
+++ b/src/api/helpers/create-an-export-contract-agent-service-charge/index.test.ts
@@ -26,7 +26,7 @@ describe('helpers/create-an-export-contract-agent-service-charge', () => {
     applicationExportContractAgentService = agentService;
   });
 
-  test('it should return an agentServiceCharge ID', async () => {
+  it('should return an agentServiceCharge ID', async () => {
     const agentServiceCharge = await createAnExportContractAgentServiceCharge(context, applicationExportContractAgentService.id);
 
     expect(agentServiceCharge.id).toBeDefined();
@@ -34,7 +34,7 @@ describe('helpers/create-an-export-contract-agent-service-charge', () => {
     expect(agentServiceCharge.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty agentServiceCharge fields with default currency code', async () => {
+  it('should return empty agentServiceCharge fields with default currency code', async () => {
     const agentServiceCharge = await createAnExportContractAgentServiceCharge(context, applicationExportContractAgentService.id);
 
     expect(agentServiceCharge.percentageCharge).toBeNull();
@@ -45,7 +45,7 @@ describe('helpers/create-an-export-contract-agent-service-charge', () => {
   });
 
   describe('when an invalid agentServiceId ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createAnExportContractAgentServiceCharge(context, mockInvalidId);
       } catch (error) {
@@ -55,7 +55,7 @@ describe('helpers/create-an-export-contract-agent-service-charge', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createAnExportContractAgentServiceCharge({}, mockInvalidId);

--- a/src/api/helpers/create-an-export-contract-agent-service/index.test.ts
+++ b/src/api/helpers/create-an-export-contract-agent-service/index.test.ts
@@ -25,7 +25,7 @@ describe('helpers/create-an-export-contract-agent-service', () => {
     applicationExportContractAgent = agent;
   });
 
-  test('it should return an agentService ID', async () => {
+  it('should return an agentService ID', async () => {
     const agentService = await createAnExportContractAgentService(context, applicationExportContractAgent.id);
 
     expect(agentService.id).toBeDefined();
@@ -33,7 +33,7 @@ describe('helpers/create-an-export-contract-agent-service', () => {
     expect(agentService.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty agentService fields', async () => {
+  it('should return empty agentService fields', async () => {
     const agentService = await createAnExportContractAgentService(context, applicationExportContractAgent.id);
 
     expect(agentService.agentIsCharging).toBeNull();
@@ -41,7 +41,7 @@ describe('helpers/create-an-export-contract-agent-service', () => {
   });
 
   describe('when an invalid agentId ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createAnExportContractAgentService(context, mockInvalidId);
       } catch (error) {
@@ -51,7 +51,7 @@ describe('helpers/create-an-export-contract-agent-service', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createAnExportContractAgentService({}, mockInvalidId);

--- a/src/api/helpers/create-an-export-contract-agent/index.test.ts
+++ b/src/api/helpers/create-an-export-contract-agent/index.test.ts
@@ -23,7 +23,7 @@ describe('helpers/create-an-export-contract-agent', () => {
     applicationExportContract = await createAnExportContract(context, application.id);
   });
 
-  test('it should return an agent ID', async () => {
+  it('should return an agent ID', async () => {
     const { agent } = await createAnExportContractAgent(context, applicationExportContract.id);
 
     expect(agent.id).toBeDefined();
@@ -31,7 +31,7 @@ describe('helpers/create-an-export-contract-agent', () => {
     expect(agent.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty agent fields', async () => {
+  it('should return empty agent fields', async () => {
     const { agent } = await createAnExportContractAgent(context, applicationExportContract.id);
 
     expect(agent.countryCode).toEqual('');
@@ -40,7 +40,7 @@ describe('helpers/create-an-export-contract-agent', () => {
     expect(agent.name).toEqual('');
   });
 
-  test('it should return an agentService ID', async () => {
+  it('should return an agentService ID', async () => {
     const { agentService } = await createAnExportContractAgent(context, applicationExportContract.id);
 
     expect(agentService.id).toBeDefined();
@@ -48,14 +48,14 @@ describe('helpers/create-an-export-contract-agent', () => {
     expect(agentService.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty agentService fields', async () => {
+  it('should return empty agentService fields', async () => {
     const { agentService } = await createAnExportContractAgent(context, applicationExportContract.id);
 
     expect(agentService.agentIsCharging).toBeNull();
     expect(agentService.serviceDescription).toEqual('');
   });
 
-  test('it should return an agentServiceCharge ID', async () => {
+  it('should return an agentServiceCharge ID', async () => {
     const { agentServiceCharge } = await createAnExportContractAgent(context, applicationExportContract.id);
 
     expect(agentServiceCharge.id).toBeDefined();
@@ -63,7 +63,7 @@ describe('helpers/create-an-export-contract-agent', () => {
     expect(agentServiceCharge.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty agentService fields', async () => {
+  it('should return empty agentService fields', async () => {
     const { agentServiceCharge } = await createAnExportContractAgent(context, applicationExportContract.id);
 
     expect(agentServiceCharge.percentageCharge).toBeNull();
@@ -73,7 +73,7 @@ describe('helpers/create-an-export-contract-agent', () => {
   });
 
   describe('when an invalid exportContract ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createAnExportContractAgent(context, mockInvalidId);
       } catch (error) {
@@ -83,7 +83,7 @@ describe('helpers/create-an-export-contract-agent', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createAnExportContractAgent({}, mockInvalidId);

--- a/src/api/helpers/create-an-export-contract/index.test.ts
+++ b/src/api/helpers/create-an-export-contract/index.test.ts
@@ -21,7 +21,7 @@ describe('helpers/create-an-export-contract', () => {
     application = (await applications.create({ context })) as Application;
   });
 
-  test('it should return an export contract with ID and privateMarket relationship', async () => {
+  it('should return an export contract with ID and privateMarket relationship', async () => {
     const result = await createAnExportContract(context, application.id);
 
     const { privateMarket } = result;
@@ -31,7 +31,7 @@ describe('helpers/create-an-export-contract', () => {
     expect(privateMarket.id.length).toBeGreaterThan(0);
   });
 
-  test('it should return empty exportContract fields, application relationship and default finalDestinationKnown', async () => {
+  it('should return empty exportContract fields, application relationship and default finalDestinationKnown', async () => {
     const result = await createAnExportContract(context, application.id);
 
     expect(result.applicationId).toEqual(application.id);
@@ -43,7 +43,7 @@ describe('helpers/create-an-export-contract', () => {
     expect(result.paymentTermsDescription).toEqual('');
   });
 
-  test('it should return empty privateMarket fields', async () => {
+  it('should return empty privateMarket fields', async () => {
     const { privateMarket } = await createAnExportContract(context, application.id);
 
     expect(privateMarket.attempted).toBeNull();
@@ -51,7 +51,7 @@ describe('helpers/create-an-export-contract', () => {
   });
 
   describe('when an invalid policy ID is passed', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await createAnExportContract(context, mockInvalidId);
       } catch (error) {
@@ -61,7 +61,7 @@ describe('helpers/create-an-export-contract', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createAnExportContract({}, application.id);

--- a/src/api/helpers/create-authentication-entry/index.test.ts
+++ b/src/api/helpers/create-authentication-entry/index.test.ts
@@ -15,7 +15,7 @@ describe('helpers/create-authentication-entry', () => {
     account = await accounts.create({ context });
   });
 
-  test('it should create a new entry and return the entry with a timestamp', async () => {
+  it('should create a new entry and return the entry with a timestamp', async () => {
     const authEntry = {
       account: {
         connect: {

--- a/src/api/helpers/create-company-sic-codes/index.test.ts
+++ b/src/api/helpers/create-company-sic-codes/index.test.ts
@@ -64,7 +64,7 @@ describe('helpers/create-company-sic-codes', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createCompanySicCodes({}, mockInvalidId, mockSicCodes, mocIndustrySectorNames);

--- a/src/api/helpers/create-many-applications-and-reference-numbers/index.test.ts
+++ b/src/api/helpers/create-many-applications-and-reference-numbers/index.test.ts
@@ -34,7 +34,7 @@ describe('helpers/create-many-applications-and-reference-numbers', () => {
   });
 
   describe('when creation is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         // pass empty context object to force an error
         await createManyApplications({}, []);

--- a/src/api/helpers/delete-authentication-retries/index.test.ts
+++ b/src/api/helpers/delete-authentication-retries/index.test.ts
@@ -35,7 +35,7 @@ describe('helpers/delete-authentication-retries', () => {
     });
   });
 
-  test(`it should wipe the account's retry entires`, async () => {
+  it(`should wipe the account's retry entires`, async () => {
     // check initial retries count
     let retries = await authRetries.findAll(context);
 

--- a/src/api/helpers/generate-otp-and-update-account/index.test.ts
+++ b/src/api/helpers/generate-otp-and-update-account/index.test.ts
@@ -30,17 +30,17 @@ describe('helpers/generate-otp-and-update-account', () => {
     account = await accounts.get(context, account.id);
   });
 
-  test('it should generate an OTP and save to the account', async () => {
+  it('should generate an OTP and save to the account', async () => {
     expect(account.otpSalt).toEqual(mockOTP.salt);
     expect(account.otpHash).toEqual(mockOTP.hash);
     expect(new Date(account.otpExpiry)).toEqual(mockOTP.expiry);
   });
 
-  test("it should update the account's isInactive flag to be false", async () => {
+  it("should update the account's isInactive flag to be false", async () => {
     expect(account.status.isInactive).toEqual(false);
   });
 
-  test('it should return the success response and securityCode', async () => {
+  it('should return the success response and securityCode', async () => {
     const expected = {
       success: true,
       securityCode: mockOTP.securityCode,
@@ -58,7 +58,7 @@ describe('helpers/generate-otp-and-update-account', () => {
       };
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await generateOTPAndUpdateAccount(context, account.id);
       } catch (error) {

--- a/src/api/helpers/get-application-submitted-email-template-ids/index.test.ts
+++ b/src/api/helpers/get-application-submitted-email-template-ids/index.test.ts
@@ -12,7 +12,7 @@ const {
 describe('helpers/get-application-submitted-email-template-ids', () => {
   let application: Application;
 
-  test('it should return an object with the correct template IDs', async () => {
+  it('should return an object with the correct template IDs', async () => {
     application = mockApplication;
 
     const result = getApplicationSubmittedEmailTemplateIds(application);
@@ -43,7 +43,7 @@ describe('helpers/get-application-submitted-email-template-ids', () => {
       };
     });
 
-    test('it should return an object with the correct template IDs', async () => {
+    it('should return an object with the correct template IDs', async () => {
       const result = getApplicationSubmittedEmailTemplateIds(application);
 
       const expected = {
@@ -74,7 +74,7 @@ describe('helpers/get-application-submitted-email-template-ids', () => {
       };
     });
 
-    test('it should return an object with only a template ID for underwritingTeam', async () => {
+    it('should return an object with only a template ID for underwritingTeam', async () => {
       const result = getApplicationSubmittedEmailTemplateIds(application);
 
       const expected = {
@@ -104,7 +104,7 @@ describe('helpers/get-application-submitted-email-template-ids', () => {
       };
     });
 
-    test('it should return an object with the correct, empty template IDs', async () => {
+    it('should return an object with the correct, empty template IDs', async () => {
       const result = getApplicationSubmittedEmailTemplateIds(application);
 
       const expected = {

--- a/src/api/helpers/send-email-application-submission-deadline/index.test.ts
+++ b/src/api/helpers/send-email-application-submission-deadline/index.test.ts
@@ -49,7 +49,7 @@ describe('helpers/send-email-application-submission-deadline', () => {
   });
 
   describe(`when an account has an submissionDeadline ${REMINDER_DAYS} days in the future`, () => {
-    test('it should call sendEmail.submissionDeadlineEmail and return success=true', async () => {
+    it('should call sendEmail.submissionDeadlineEmail and return success=true', async () => {
       const result = await applicationSubmissionDeadlineEmail(context);
 
       expect(sendEmailSpy).toHaveBeenCalledTimes(1);
@@ -64,7 +64,7 @@ describe('helpers/send-email-application-submission-deadline', () => {
   });
 
   describe(`when an account has an submissionDeadline ${REMINDER_DAYS} days in the future but sendEmail.submissionDeadlineEmail returns an array of length 0`, () => {
-    test('it should call sendEmail.submissionDeadlineEmail and return success=false when sendEmail.submissionDeadlineEmail returns an array of 0 length', async () => {
+    it('should call sendEmail.submissionDeadlineEmail and return success=false when sendEmail.submissionDeadlineEmail returns an array of 0 length', async () => {
       applicationSubmissionDeadineEmail.send = jest.fn(() => Promise.resolve([]));
 
       const result = await applicationSubmissionDeadlineEmail(context);
@@ -78,7 +78,7 @@ describe('helpers/send-email-application-submission-deadline', () => {
   });
 
   describe(`when no accounts have a submissionDeadline ${REMINDER_DAYS} days in the future`, () => {
-    test('it should NOT call sendEmail.submissionDeadlineEmail and return success=true', async () => {
+    it('should NOT call sendEmail.submissionDeadlineEmail and return success=true', async () => {
       await applications.update({ context, applicationId: application.id, data: { submissionDeadline: DATE_24_HOURS_FROM_NOW() } });
 
       const result = await applicationSubmissionDeadlineEmail(context);
@@ -95,7 +95,7 @@ describe('helpers/send-email-application-submission-deadline', () => {
 
   describe('error handling', () => {
     describe('when an error occurs whilst getting and sending email for expiring applications', () => {
-      test('should throw an error', async () => {
+      it('should throw an error', async () => {
         jest.resetAllMocks();
         await expect(applicationSubmissionDeadlineEmail()).rejects.toThrow(
           'Sending application submission deadline email (emailApplicationSubmissionDeadlineEmail helper)',

--- a/src/api/helpers/send-email-application-submission-deadline/send-email/index.test.ts
+++ b/src/api/helpers/send-email-application-submission-deadline/send-email/index.test.ts
@@ -40,7 +40,7 @@ describe('helpers/send-email-application-submission-deadline/send-email', () => 
   });
 
   describe('when an account has an submissionDeadline 2 days in the future', () => {
-    test('it should call sendEmail.submissionDeadlineEmail', async () => {
+    it('should call sendEmail.submissionDeadlineEmail', async () => {
       await applicationSubmissionDeadineEmail.send([application]);
 
       const variables = mapApplicationSubmissionDeadlineVariables(application);
@@ -49,7 +49,7 @@ describe('helpers/send-email-application-submission-deadline/send-email', () => 
       expect(sendEmailSubmissionDeadlineSpy).toHaveBeenCalledWith(variables.email, variables);
     });
 
-    test('it should return an array of length 1', async () => {
+    it('should return an array of length 1', async () => {
       const result = await applicationSubmissionDeadineEmail.send([application]);
 
       expect(result.length).toEqual(1);
@@ -62,7 +62,7 @@ describe('helpers/send-email-application-submission-deadline/send-email', () => 
         sendEmail.submissionDeadlineEmail = jest.fn(() => Promise.reject(mockSpyPromiseRejection));
       });
 
-      test('should throw an error', async () => {
+      it('should throw an error', async () => {
         await expect(applicationSubmissionDeadineEmail.send([application])).rejects.toThrow('Sending application submission deadline email (send helper)');
       });
     });

--- a/src/api/helpers/send-email-confirm-email-address/index.test.ts
+++ b/src/api/helpers/send-email-confirm-email-address/index.test.ts
@@ -34,7 +34,7 @@ describe('helpers/send-email-confirm-email-address', () => {
   });
 
   describe('when verificationHash and verificationExpiry do not exist', () => {
-    test('it should call sendEmail.confirmEmailAddress and return success=true', async () => {
+    it('should call sendEmail.confirmEmailAddress and return success=true', async () => {
       const result = await confirmEmailAddressEmail.send(context, mockUrlOrigin, account.id);
 
       const { email, verificationHash } = account;
@@ -54,7 +54,7 @@ describe('helpers/send-email-confirm-email-address', () => {
   });
 
   describe('when verificationHash exists and verificationExpiry has elapsed', () => {
-    test("it should call sendEmail.confirmEmailAddress and return success=true but should NOT use the stored account's verificationHash", async () => {
+    it("should call sendEmail.confirmEmailAddress and return success=true but should NOT use the stored account's verificationHash", async () => {
       await accounts.update(context, account.id, { verificationExpiry: DATE_24_HOURS_IN_THE_PAST(), verificationHash: 'mock-hash' });
 
       const updatedAccount = await accounts.get(context, account.id);
@@ -79,7 +79,7 @@ describe('helpers/send-email-confirm-email-address', () => {
   });
 
   describe('when verificationHash exists and verificationExpiry has not elapsed', () => {
-    test('it should call sendEmail.confirmEmailAddress and return success=true', async () => {
+    it('should call sendEmail.confirmEmailAddress and return success=true', async () => {
       await accounts.update(context, account.id, { verificationExpiry: DATE_24_HOURS_FROM_NOW(), verificationHash: 'mock-hash' });
 
       const updatedAccount = await accounts.get(context, account.id);
@@ -103,7 +103,7 @@ describe('helpers/send-email-confirm-email-address', () => {
   });
 
   describe('when no account is found', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       await accounts.deleteAll(context);
 
       const result = await confirmEmailAddressEmail.send(context, mockUrlOrigin, account.id);
@@ -119,7 +119,7 @@ describe('helpers/send-email-confirm-email-address', () => {
       sendEmail.confirmEmailAddress = jest.fn(() => Promise.reject(mockSpyPromiseRejection));
     });
 
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       await expect(confirmEmailAddressEmail.send(context, mockUrlOrigin, account.id)).rejects.toThrow(
         'Sending email verification (sendEmailConfirmEmailAddress helper)',
       );

--- a/src/api/helpers/send-email-reactivate-account-link/index.test.ts
+++ b/src/api/helpers/send-email-reactivate-account-link/index.test.ts
@@ -85,7 +85,7 @@ describe('helpers/send-email-reactivate-account-link', () => {
     expect(expiryDay).toEqual(tomorrowDay);
   });
 
-  test('it should call sendEmail.reactivateAccountLink', () => {
+  it('should call sendEmail.reactivateAccountLink', () => {
     const { email, reactivationHash } = account;
 
     const name = getFullNameString(account);
@@ -95,7 +95,7 @@ describe('helpers/send-email-reactivate-account-link', () => {
   });
 
   describe('when no account is found', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       // wipe accounts so an account will not be found.
       await accounts.deleteAll(context);
 
@@ -108,7 +108,7 @@ describe('helpers/send-email-reactivate-account-link', () => {
   });
 
   describe('error handling', () => {
-    test('should throw an error', async () => {
+    it('should throw an error', async () => {
       await expect(sendEmailReactivateAccountLinkHelper.send()).rejects.toThrow(
         'Checking account and sending reactivate account email/link (sendEmailReactivateAccountLink helper)',
       );

--- a/src/api/helpers/update-applications-data/index.test.ts
+++ b/src/api/helpers/update-applications-data/index.test.ts
@@ -50,7 +50,7 @@ describe('helpers/update-applications-data', () => {
   });
 
   describe('when update is not successful', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await updateApplicationsData({}, []);
       } catch (error) {

--- a/src/api/integrations/APIM/index.test.ts
+++ b/src/api/integrations/APIM/index.test.ts
@@ -14,7 +14,7 @@ const url = `${APIM_MDM_URL}${APIM_MDM.MARKETS}`;
 
 describe('integrations/APIM', () => {
   describe('when a 200 status and data is returned', () => {
-    test('it should return success=true and data', async () => {
+    it('should return success=true and data', async () => {
       const mock = new MockAdapter(axios);
 
       const mockResponseData = mockCisCountries;
@@ -33,7 +33,7 @@ describe('integrations/APIM', () => {
   });
 
   describe('when no data is returned', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       const mock = new MockAdapter(axios);
 
       mock.onGet(url).reply(200);
@@ -49,7 +49,7 @@ describe('integrations/APIM', () => {
   });
 
   describe('when a 200 status is not returned', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       const mock = new MockAdapter(axios);
 
       mock.onGet(url).reply(500);

--- a/src/api/integrations/companies-house/index.test.ts
+++ b/src/api/integrations/companies-house/index.test.ts
@@ -9,7 +9,7 @@ const { company_number: companyNumber } = mockCompaniesHouseAPIResponse;
 
 describe('integrations/companies-house', () => {
   describe('when a 200 status and data is returned', () => {
-    test('it should return success=true and data', async () => {
+    it('should return success=true and data', async () => {
       const mock = new MockAdapter(axios);
 
       const mockResponse = mockCompaniesHouseAPIResponse;
@@ -28,7 +28,7 @@ describe('integrations/companies-house', () => {
   });
 
   describe('when no data is returned', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       const mock = new MockAdapter(axios);
 
       mock.onGet(`${companiesHouseURL}/company/${companyNumber}`).reply(200);
@@ -44,7 +44,7 @@ describe('integrations/companies-house', () => {
   });
 
   describe('when a 404 status is returned', () => {
-    test('it should return success=false and notFound=true', async () => {
+    it('should return success=false and notFound=true', async () => {
       const mock = new MockAdapter(axios);
 
       mock.onGet(`${companiesHouseURL}/company/${companyNumber}`).reply(404);
@@ -61,7 +61,7 @@ describe('integrations/companies-house', () => {
   });
 
   describe('when a 200 status is not returned', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       const mock = new MockAdapter(axios);
 
       mock.onGet(`${companiesHouseURL}/company/${companyNumber}`).reply(500);

--- a/src/api/integrations/industry-sector/index.test.ts
+++ b/src/api/integrations/industry-sector/index.test.ts
@@ -12,7 +12,7 @@ const { APIM_MDM } = EXTERNAL_API_ENDPOINTS;
 
 describe('integrations/industry-sector', () => {
   describe('when a 200 status and data is returned', () => {
-    test('it should return success=true and data', async () => {
+    it('should return success=true and data', async () => {
       const mock = new MockAdapter(axios);
 
       const mockResponseData = mockIndustrySectors;
@@ -31,7 +31,7 @@ describe('integrations/industry-sector', () => {
   });
 
   describe('when no data is returned', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       const mock = new MockAdapter(axios);
 
       mock.onGet(`${APIM_MDM_URL}${APIM_MDM.INDUSTRY_SECTORS}`).reply(200);
@@ -47,7 +47,7 @@ describe('integrations/industry-sector', () => {
   });
 
   describe('when a 200 status is not returned', () => {
-    test('it should return success=false and apiError=true', async () => {
+    it('should return success=false and apiError=true', async () => {
       const mock = new MockAdapter(axios);
 
       mock.onGet(`${APIM_MDM_URL}${APIM_MDM.INDUSTRY_SECTORS}`).reply(500);

--- a/src/api/integrations/notify/index.test.ts
+++ b/src/api/integrations/notify/index.test.ts
@@ -18,7 +18,7 @@ describe('integrations/notify', () => {
       });
     });
 
-    test('it should return success=true and emailRecipient', async () => {
+    it('should return success=true and emailRecipient', async () => {
       const result = await notify.sendEmail(mockTemplateId, mockSendToEmailAddress, mockVariables);
 
       const expected = {
@@ -38,7 +38,7 @@ describe('integrations/notify', () => {
       });
     });
 
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       try {
         await notify.sendEmail(mockTemplateId, mockSendToEmailAddress, mockVariables);
       } catch (error) {

--- a/src/api/integrations/ordnance-survey/index.test.ts
+++ b/src/api/integrations/ordnance-survey/index.test.ts
@@ -12,7 +12,7 @@ describe('integrations/ordnance-survey', () => {
   const url = `${ORDNANCE_SURVEY_API_URL}${ORDNANCE_SURVEY_QUERY_URL}${postcode}&key=${ORDNANCE_SURVEY_API_KEY}`;
 
   describe('when a successful request is made', () => {
-    test('it should return success=true and data', async () => {
+    it('should return success=true and data', async () => {
       const mock = new MockAdapter(axios);
 
       const mockResponse = mockOrdnanceSurveyResponse;
@@ -31,7 +31,7 @@ describe('integrations/ordnance-survey', () => {
   });
 
   describe('when no data is returned', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       const mock = new MockAdapter(axios);
 
       mock.onGet(url).reply(200);
@@ -47,7 +47,7 @@ describe('integrations/ordnance-survey', () => {
   });
 
   describe('when response.data.results does not exist', () => {
-    test('it should return success=false', async () => {
+    it('should return success=false', async () => {
       const mock = new MockAdapter(axios);
 
       mock.onGet(url).reply(200, {});
@@ -63,7 +63,7 @@ describe('integrations/ordnance-survey', () => {
   });
 
   describe('when a 200 status is not returned', () => {
-    test('it should throw an error', async () => {
+    it('should throw an error', async () => {
       const mock = new MockAdapter(axios);
 
       mock.onGet(url).reply(500);

--- a/src/api/keystone-application-timestamp-updates.test.ts
+++ b/src/api/keystone-application-timestamp-updates.test.ts
@@ -126,7 +126,7 @@ describe('Keystone - Application timestamp updates', () => {
   };
 
   describe('Business', () => {
-    test('it should call updateApplication.timestamp', async () => {
+    it('should call updateApplication.timestamp', async () => {
       await context.query.Business.updateOne({
         where: { id: application.businessId },
         data: {},
@@ -138,7 +138,7 @@ describe('Keystone - Application timestamp updates', () => {
   });
 
   describe('Broker', () => {
-    test('it should call updateApplication.timestamp', async () => {
+    it('should call updateApplication.timestamp', async () => {
       await context.query.Broker.updateOne({
         where: { id: application.brokerId },
         data: {},
@@ -150,7 +150,7 @@ describe('Keystone - Application timestamp updates', () => {
   });
 
   describe('Buyer', () => {
-    test('it should call updateApplication.timestamp', async () => {
+    it('should call updateApplication.timestamp', async () => {
       await context.query.Buyer.updateOne({
         where: { id: application.buyerId },
         data: {},
@@ -162,7 +162,7 @@ describe('Keystone - Application timestamp updates', () => {
   });
 
   describe('BuyerTradingHistory', () => {
-    test('it should call updateApplication.timestamp', async () => {
+    it('should call updateApplication.timestamp', async () => {
       await context.query.BuyerTradingHistory.updateOne({
         where: { id: application.buyer.buyerTradingHistory.id },
         data: {},
@@ -174,7 +174,7 @@ describe('Keystone - Application timestamp updates', () => {
   });
 
   describe('Company', () => {
-    test('it should call updateApplication.timestamp', async () => {
+    it('should call updateApplication.timestamp', async () => {
       await context.query.Company.updateOne({
         where: { id: application.company.id },
         data: {},
@@ -186,7 +186,7 @@ describe('Keystone - Application timestamp updates', () => {
   });
 
   describe('Declaration', () => {
-    test('it should call updateApplication.timestamp', async () => {
+    it('should call updateApplication.timestamp', async () => {
       await context.query.Declaration.updateOne({
         where: { id: application.declaration.id },
         data: {},
@@ -198,7 +198,7 @@ describe('Keystone - Application timestamp updates', () => {
   });
 
   describe('ExportContract', () => {
-    test('it should call updateApplication.timestamp', async () => {
+    it('should call updateApplication.timestamp', async () => {
       await context.query.ExportContract.updateOne({
         where: { id: application.exportContract.id },
         data: {},
@@ -210,7 +210,7 @@ describe('Keystone - Application timestamp updates', () => {
   });
 
   describe('Policy', () => {
-    test('it should call updateApplication.timestamp', async () => {
+    it('should call updateApplication.timestamp', async () => {
       await context.query.Policy.updateOne({
         where: { id: application.policy.id },
         data: {},
@@ -222,7 +222,7 @@ describe('Keystone - Application timestamp updates', () => {
   });
 
   describe('SectionReview', () => {
-    test('it should call updateApplication.timestamp', async () => {
+    it('should call updateApplication.timestamp', async () => {
       await context.query.SectionReview.updateOne({
         where: { id: application.sectionReview.id },
         data: {},

--- a/src/ui/server/api/keystone/APIM/index.ts
+++ b/src/ui/server/api/keystone/APIM/index.ts
@@ -9,7 +9,7 @@ const APIM = {
       const response = (await apollo('GET', getApimCisCountries, {})) as ApolloResponse;
 
       if (response.errors) {
-        console.error('GraphQL network error querying APIM - CIS countries API %o', response.errors);
+        console.error('GraphQL error querying APIM - CIS countries API %o', response.errors);
       }
 
       if (response?.networkError?.result?.errors) {
@@ -34,7 +34,7 @@ const APIM = {
       const response = (await apollo('GET', getApimCurrencies, {})) as ApolloResponse;
 
       if (response.errors) {
-        console.error('GraphQL network error querying APIM - currencies API %o', response.errors);
+        console.error('GraphQL error querying APIM - currencies API %o', response.errors);
       }
 
       if (response?.networkError?.result?.errors) {

--- a/src/ui/server/api/keystone/get-companies-house-information/index.ts
+++ b/src/ui/server/api/keystone/get-companies-house-information/index.ts
@@ -11,7 +11,7 @@ const getCompaniesHouseInformation = async (companiesHouseNumber: string) => {
     const response = (await apollo('GET', getCompaniesHouseInformationQuery, queryParams)) as ApolloResponse;
 
     if (response.errors) {
-      console.error('GraphQL network error querying companies house information %o', response.errors);
+      console.error('GraphQL error querying companies house information %o', response.errors);
     }
 
     if (response.apiError) {

--- a/src/ui/server/api/keystone/get-ordnance-survey-addresses/index.ts
+++ b/src/ui/server/api/keystone/get-ordnance-survey-addresses/index.ts
@@ -20,7 +20,7 @@ const getOrdnanceSurveyAddresses = async (postcode: string, houseNameOrNumber: s
     const response = (await apollo('GET', ordnanceSurveyAddressesQuery, queryParams)) as ApolloResponse;
 
     if (response.errors) {
-      console.error('GraphQL network error querying Ordnance Survey addresses %o', response.errors);
+      console.error('GraphQL error querying Ordnance Survey addresses %o', response.errors);
     }
 
     if (response.apiError) {

--- a/src/ui/server/constants/routes/insurance/policy/broker.ts
+++ b/src/ui/server/constants/routes/insurance/policy/broker.ts
@@ -4,7 +4,7 @@ const ROOT = `${POLICY_ROOT}/broker`;
 const BROKER_DETAILS_ROOT = `${POLICY_ROOT}/broker-details`;
 const BROKER_ADDRESSES_ROOT = `${POLICY_ROOT}/broker-addresses`;
 const BROKER_CONFIRM_ADDRESS_ROOT = `${POLICY_ROOT}/broker-confirm-address`;
-const BROKER_ZERO_ADDRESSES_ROOT = `${BROKER_DETAILS_ROOT}/broker-zero-addresses`;
+const BROKER_ZERO_ADDRESSES_ROOT = `${POLICY_ROOT}/broker-zero-addresses`;
 const BROKER_MANUAL_ADDRESS_ROOT = `${POLICY_ROOT}/broker-manual-address`;
 
 const BROKER_ROUTES = {

--- a/src/ui/server/controllers/insurance/business/alternative-trading-address/validation/rules/alternative-trading-address.ts
+++ b/src/ui/server/controllers/insurance/business/alternative-trading-address/validation/rules/alternative-trading-address.ts
@@ -15,6 +15,6 @@ const {
  * @param {Object} errors: Other validation errors for the same form
  * @returns {ValidationErrors} fullAddressValidation
  */
-const alternativeTradingAddress = (responseBody: RequestBody, errors: object) => fullAddressValidation(responseBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
+const alternativeTradingAddress = (formBody: RequestBody, errors: object) => fullAddressValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
 
 export default alternativeTradingAddress;

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/index.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/index.ts
@@ -5,7 +5,7 @@ import combineValidationRules from '../../../../../../helpers/combine-validation
 /**
  * validates company details page response
  * throws validation errors if any fields are not completed or incorrectly completed
- * @param {RequestBody} formBody: containing an object with the company details response body
+ * @param {RequestBody} formBody: Form body
  * @returns {Object} Errors or empty object
  */
 const validation = (formBody: RequestBody): ValidationErrors => combineValidationRules(validationRules, formBody) as ValidationErrors;

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-address.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-address.ts
@@ -16,10 +16,10 @@ const {
 /**
  * validate the "tradingAddress" in "company details" request body
  * throws validation errors if there is no tradingAddress property
- * @param {RequestBody} formBody: containing an object with the company details response
+ * @param {RequestBody} formBody: Form body
  * @param {Object} errors: Other validation errors for the same form
  * @returns {ValidationErrors} fullAddressValidation
  */
-const tradingAddress = (responseBody: RequestBody, errors: object) => fullAddressValidation(responseBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
+const tradingAddress = (formBody: RequestBody, errors: object) => fullAddressValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
 
 export default tradingAddress;

--- a/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-name.ts
+++ b/src/ui/server/controllers/insurance/business/company-details/validation/company-details/rules/trading-name.ts
@@ -14,7 +14,7 @@ const ERROR_MESSAGE = EXPORTER_BUSINESS[FIELD_ID];
 /**
  * validates tradingName in company details response body
  * throws validation errors if there is no tradingName property
- * @param {RequestBody} formBody: containing an object with the company details response
+ * @param {RequestBody} formBody: Form body
  * @param {Object} errors: Other validation errors for the same form
  * @returns {Object} Errors or empty object
  */

--- a/src/ui/server/controllers/insurance/policy/broker-details/validation/rules/name/index.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-details/validation/rules/name/index.ts
@@ -18,7 +18,7 @@ const {
  * @param {Object} errors: Other validation errors for the same form
  * @returns {ValidationErrors} providedAndMaxLength
  */
-const brokerName = (responseBody: RequestBody, errors: object) =>
-  providedAndMaxLength(responseBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MAXIMUM_CHARACTERS.BROKER_NAME);
+const brokerName = (formBody: RequestBody, errors: object) =>
+  providedAndMaxLength(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MAXIMUM_CHARACTERS.BROKER_NAME);
 
 export default brokerName;

--- a/src/ui/server/controllers/insurance/policy/broker-manual-address/validation/rules/full-address/index.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-manual-address/validation/rules/full-address/index.ts
@@ -17,6 +17,6 @@ const {
  * @param {Object} errors: Other validation errors for the same form
  * @returns {ValidationErrors} fullAddressValidation
  */
-const fullBrokerAddress = (responseBody: RequestBody, errors: object) => fullAddressValidation(responseBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
+const fullBrokerAddress = (formBody: RequestBody, errors: object) => fullAddressValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
 
 export default fullBrokerAddress;

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-name/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-name/index.ts
@@ -16,10 +16,10 @@ const MAXIMUM = MAXIMUM_CHARACTERS.REQUESTED_JOINTLY_INSURED_PARTY.COMPANY_NAME;
 
 /**
  * validate the "company name" in other company details response body
- * @param {RequestBody} formBody: containing an object with the company details response
+ * @param {RequestBody} formBody: Form body
  * @param {Object} errors: Other validation errors for the same form
  * @returns {Object} Errors or empty object
  */
-const companyName = (responseBody: RequestBody, errors: object) => providedAndMaxLength(responseBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MAXIMUM);
+const companyName = (formBody: RequestBody, errors: object) => providedAndMaxLength(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors, MAXIMUM);
 
 export default companyName;

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-number/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/company-number/index.ts
@@ -19,7 +19,7 @@ const MAXIMUM = MAXIMUM_CHARACTERS.REQUESTED_JOINTLY_INSURED_PARTY.COMPANY_NUMBE
 
 /**
  * validate the "company number" in other company details response body
- * @param {RequestBody} formBody: containing an object with the company details response
+ * @param {RequestBody} formBody: Form body
  * @param {Object} errors: Other validation errors for the same form
  * @returns {Object} Errors or empty object
  */

--- a/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/country-code/index.ts
+++ b/src/ui/server/controllers/insurance/policy/other-company-details/validation/rules/country-code/index.ts
@@ -15,7 +15,7 @@ const {
 
 /**
  * validate the "country" in other company details response body
- * @param {RequestBody} formBody: containing an object with the company details response
+ * @param {RequestBody} formBody: Form body
  * @param {Object} errors: Other validation errors for the same form
  * @returns {ValidationErrors}
  */

--- a/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/validation/rules/address.ts
+++ b/src/ui/server/controllers/insurance/your-buyer/company-or-organisation/validation/rules/address.ts
@@ -25,6 +25,6 @@ const {
  * @param {Object} errors: Other validation errors for the same form
  * @returns {ValidationErrors} fullAddressValidation
  */
-const addressRules = (responseBody: RequestBody, errors: object) => fullAddressValidation(responseBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
+const addressRules = (formBody: RequestBody, errors: object) => fullAddressValidation(formBody, FIELD_ID, ERROR_MESSAGES_OBJECT, errors);
 
 export default addressRules;

--- a/src/ui/server/helpers/combine-validation-rules/index.ts
+++ b/src/ui/server/helpers/combine-validation-rules/index.ts
@@ -5,7 +5,7 @@ import { ValidationErrors } from '../../../types';
  * combineValidationRules
  * combine multiple validation rule results into a single object
  * throws validation errors if any fields are not completed or incorrectly completed
- * @param {RequestBody} formBody: containing an object with the company details response body
+ * @param {RequestBody} formBody: Form body
  * @returns {Object} Errors or empty object
  */
 /* eslint-disable no-unused-vars, prettier/prettier */

--- a/src/ui/server/helpers/required-fields/business/index.ts
+++ b/src/ui/server/helpers/required-fields/business/index.ts
@@ -12,7 +12,7 @@ const { FINANCIAL_YEAR_END_DATE, TURNOVER_CURRENCY_CODE, ...TURNOVER_FIELDS } = 
  * getYourCompanyTasks
  * Get your company tasks depending on the hasDifferentTradingName field
  * @param {Boolean} hasDifferentTradingName "has different trading name" flag
- * @returns {Array} Array of tasks
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 export const getYourCompanyTasks = (hasDifferentTradingName?: boolean): Array<string> => {
   if (hasDifferentTradingName) {

--- a/src/ui/server/helpers/required-fields/check-your-answers/index.ts
+++ b/src/ui/server/helpers/required-fields/check-your-answers/index.ts
@@ -14,7 +14,7 @@ const {
 /**
  * Required fields for the insurance - check your answers section
  * @param {ApplicationFlat} application
- * @param {Array<string>} Required field IDs
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 const requiredFields = (application: ApplicationFlat): Array<string> => [
   ...requiredBusinessFields(),

--- a/src/ui/server/helpers/required-fields/declarations/index.ts
+++ b/src/ui/server/helpers/required-fields/declarations/index.ts
@@ -9,7 +9,7 @@ const { AGREE_CONFIDENTIALITY, AGREE_ANTI_BRIBERY, HAS_ANTI_BRIBERY_CODE_OF_COND
  * getAntiBriberyCodeOfConductTasks
  * Get anti-bribery code of conduct tasks depending on if "has anti-bribery code of conduct" answer
  * @param {String} Application "Has anti-bribery code of conduct" flag
- * @returns {Array} Anti-bribery code of conduct tasks
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 export const getAntiBriberyCodeOfConductTasks = (hasAntiBriberyCodeOfConduct?: boolean | null): Array<string> => {
   // has not been answered yet.

--- a/src/ui/server/helpers/required-fields/eligibility/index.ts
+++ b/src/ui/server/helpers/required-fields/eligibility/index.ts
@@ -34,7 +34,7 @@ export const IRRELEVANT_FIELD_IDS = [
 
 /**
  * Required fields for the insurance - eligibility section
- * @returns {Array} Required field IDs
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 const requiredFields = (): Array<string> => {
   const fieldIds = Object.values(FIELD_IDS);

--- a/src/ui/server/helpers/required-fields/export-contract/index.ts
+++ b/src/ui/server/helpers/required-fields/export-contract/index.ts
@@ -19,7 +19,7 @@ const {
 /**
  * getAboutGoodsOrServicesTasks
  * @param {Boolean} finalDestinationKnown: "Final destination known"
- * @returns {Array} Array of tasks
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 export const getAboutGoodsOrServicesTasks = (finalDestinationKnown?: boolean) => {
   if (finalDestinationKnown) {
@@ -43,7 +43,7 @@ interface RequiredFields {
  * privateCoverTasks
  * @param {Boolean} totalContractValueOverThreshold: If total contract value in eligibility should be over threshold.
  * @param {Boolean} attemptedPrivateMarketCover: "Attempted cover via the private market" flag
- * @returns {Array} Array of tasks
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 export const privateCoverTasks = ({ totalContractValueOverThreshold, attemptedPrivateMarketCover }: RequiredFields): Array<string> => {
   if (totalContractValueOverThreshold) {
@@ -61,7 +61,7 @@ export const privateCoverTasks = ({ totalContractValueOverThreshold, attemptedPr
  * agentServiceChargeTasks
  * @param {Boolean} agentIsCharging: "Is the agent charging for their support in the export contract?" flag
  * @param {Boolean} agentChargeMethod: Agent charge method
- * @returns {Array} Array of tasks
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 export const agentServiceChargeTasks = ({ agentIsCharging, agentChargeMethod }: RequiredFields): Array<string> => {
   if (agentIsCharging) {
@@ -86,7 +86,7 @@ export const agentServiceChargeTasks = ({ agentIsCharging, agentChargeMethod }: 
  * @param {Boolean} isUsingAgent: "Is using an agent to help win the export contract" flag
  * @param {Boolean} agentIsCharging: "Is the agent charging for their support in the export contract?" flag
  * @param {Boolean} agentChargeMethod: Agent charge method
- * @returns {Array} Array of tasks
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 export const agentTasks = ({ isUsingAgent, agentIsCharging, agentChargeMethod }: RequiredFields): Array<string> => {
   if (isUsingAgent) {
@@ -108,7 +108,7 @@ export const agentTasks = ({ isUsingAgent, agentIsCharging, agentChargeMethod }:
 /**
  * awardMethodTasks
  * @param {String} awardMethodId: Export contract award method ID
- * @returns {Array} Array of tasks
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 export const awardMethodTasks = (awardMethodId?: string): Array<string> => {
   if (awardMethodId === EXPORT_CONTRACT_AWARD_METHOD.OTHER.DB_ID) {

--- a/src/ui/server/helpers/required-fields/index.ts
+++ b/src/ui/server/helpers/required-fields/index.ts
@@ -11,7 +11,7 @@ const {
 /**
  * Required fields for an application
  * @param {ApplicationFlat} application
- * @returns {Array} Required field IDs
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 const requiredFields = (application: ApplicationFlat) => [
   ...requiredPrepareApplicationFields(application),

--- a/src/ui/server/helpers/required-fields/policy/index.ts
+++ b/src/ui/server/helpers/required-fields/policy/index.ts
@@ -59,7 +59,7 @@ export const getContractPolicyTasks = (policyType?: string): object => {
  * getJointlyInsuredPartyTasks
  * Get "Jointly insured party" tasks depending on the jointlyInsuredParty field.
  * @param {Boolean} jointlyInsuredParty: "Jointly insured party" flag
- * @returns {Array} Array of tasks
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 export const getJointlyInsuredPartyTasks = (jointlyInsuredParty?: boolean) => {
   if (jointlyInsuredParty) {
@@ -74,7 +74,7 @@ export const getJointlyInsuredPartyTasks = (jointlyInsuredParty?: boolean) => {
  * Get "Broker" tasks depending on the isUsingBroker field
  * @param {Boolean} isUsingBroker: "Is using broker" flag
  * @param {Boolean} brokerIsBasedInUk: "Broker is based in the UK" flag
- * @returns {Array} Array of tasks
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 export const getBrokerTasks = (isUsingBroker?: boolean, brokerIsBasedInUk?: boolean) => {
   let tasks: Array<string> = [];
@@ -98,7 +98,7 @@ export const getBrokerTasks = (isUsingBroker?: boolean, brokerIsBasedInUk?: bool
  * @param {Boolean} isAppointingLossPayee: "Is using loss payee" flag
  * @param {Boolean} lossPayeeIsLocatedInUk: "Loss payee is located in the UK" flag
  * @param {Boolean} lossPayeeIsLocatedInternationally: "Loss payee is located internationally" flag
- * @returns {Array} Array of tasks
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 export const lossPayeeTasks = (isAppointingLossPayee?: boolean, lossPayeeIsLocatedInUk?: boolean, lossPayeeIsLocatedInternationally?: boolean) => {
   if (isAppointingLossPayee) {

--- a/src/ui/server/helpers/required-fields/prepare-application/index.ts
+++ b/src/ui/server/helpers/required-fields/prepare-application/index.ts
@@ -30,7 +30,7 @@ const {
 /**
  * Required fields for the insurance - check your answers section
  * @param {ApplicationFlat} application
- * @returns {Array<string>} Required field IDs
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 const requiredFields = (application: ApplicationFlat): Array<string> => [
   ...requiredEligibilityFields(),

--- a/src/ui/server/helpers/required-fields/section-review/index.ts
+++ b/src/ui/server/helpers/required-fields/section-review/index.ts
@@ -5,7 +5,7 @@ const { ELIGIBILITY, EXPORTER_BUSINESS, BUYER, POLICY, EXPORT_CONTRACT } = FIELD
 /**
  * requiredFields
  * Required fields for the insurance - check your answers section.
- * @returns {Array<string>} Required field IDs
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 const requiredFields = () => [ELIGIBILITY, EXPORTER_BUSINESS, BUYER, POLICY, EXPORT_CONTRACT];
 

--- a/src/ui/server/helpers/required-fields/your-buyer/index.ts
+++ b/src/ui/server/helpers/required-fields/your-buyer/index.ts
@@ -21,7 +21,7 @@ const {
  * then returns CONNECTION_WITH_BUYER_DESCRIPTION, CONNECTION_WITH_BUYER, TRADED_WITH_BUYER (yes no radios and description field)
  * else returns CONNECTION_WITH_BUYER, TRADED_WITH_BUYER (yes no radios)
  * @param {Boolean} connectionWithBuyer
- * @returns {Array<String>} Array of fieldIds
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 export const workingWithBuyerTasks = ({ connectionWithBuyer }: { connectionWithBuyer?: boolean }): Array<string> => {
   if (connectionWithBuyer) {
@@ -41,7 +41,7 @@ export const workingWithBuyerTasks = ({ connectionWithBuyer }: { connectionWithB
  * if none are true, then returns an empty array as page will not be rendered
  * @param {Boolean} tradedWithBuyer
  * @param {Boolean} outstandingPayments
- * @returns {Array<String>} fieldIds
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 export const tradingHistoryTasks = ({ tradedWithBuyer, outstandingPayments }: { tradedWithBuyer?: boolean; outstandingPayments?: boolean }): Array<string> => {
   if (tradedWithBuyer) {
@@ -65,7 +65,7 @@ export const tradingHistoryTasks = ({ tradedWithBuyer, outstandingPayments }: { 
  * if none are true, then returns an empty array
  * @param {Boolean} totalContractValueOverThreshold
  * @param {Boolean} hasPreviousCreditInsuranceWithBuyer
- * @returns {Array<String>} fieldIds
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 export const creditInsuranceCoverTasks = ({
   totalContractValueOverThreshold,
@@ -93,7 +93,7 @@ export const creditInsuranceCoverTasks = ({
  * @param {Boolean} outstandingPayments
  * @param {Boolean} hasPreviousCreditInsuranceWithBuyer
  * @param {Boolean} totalContractValueOverThreshold
- * @returns {Array} Required field IDs
+ * @returns {Array<string>} Array of tasks/field IDs
  */
 const requiredFields = ({
   connectionWithBuyer,

--- a/src/ui/server/shared-validation/phone-number/index.test.ts
+++ b/src/ui/server/shared-validation/phone-number/index.test.ts
@@ -10,49 +10,49 @@ describe('shared-validation/phone-number', () => {
   const errorMessage = 'incorrect format';
 
   describe('with errors', () => {
-    it(`should display error when phone number is ${INVALID_PHONE_NUMBERS.EMERGENCY_NUMBER}`, () => {
+    it(`should render error when phone number is ${INVALID_PHONE_NUMBERS.EMERGENCY_NUMBER}`, () => {
       const result = validatePhoneNumber(INVALID_PHONE_NUMBERS.EMERGENCY_NUMBER, fieldId, errorMessage, errors);
       const expected = generateValidationErrors(fieldId, errorMessage);
 
       expect(result).toEqual(expected);
     });
 
-    it('should display error when landline number is too long', () => {
+    it('should render error when landline number is too long', () => {
       const result = validatePhoneNumber(INVALID_PHONE_NUMBERS.LANDLINE_LONG, fieldId, errorMessage, errors);
       const expected = generateValidationErrors(fieldId, errorMessage);
 
       expect(result).toEqual(expected);
     });
 
-    it('should display error when landline number is too short', () => {
+    it('should render error when landline number is too short', () => {
       const result = validatePhoneNumber(INVALID_PHONE_NUMBERS.LANDLINE_SHORT, fieldId, errorMessage, errors);
       const expected = generateValidationErrors(fieldId, errorMessage);
 
       expect(result).toEqual(expected);
     });
 
-    it('should display error when mobile number is too long', () => {
+    it('should render error when mobile number is too long', () => {
       const result = validatePhoneNumber(INVALID_PHONE_NUMBERS.MOBILE_LONG, fieldId, errorMessage, errors);
       const expected = generateValidationErrors(fieldId, errorMessage);
 
       expect(result).toEqual(expected);
     });
 
-    it('should display error when number has letters in it', () => {
+    it('should render error when number has letters in it', () => {
       const result = validatePhoneNumber(INVALID_PHONE_NUMBERS.LANDLINE_LETTER, fieldId, errorMessage, errors);
       const expected = generateValidationErrors(fieldId, errorMessage);
 
       expect(result).toEqual(expected);
     });
 
-    it('should display error when number has special characters in it', () => {
+    it('should render error when number has special characters in it', () => {
       const result = validatePhoneNumber(INVALID_PHONE_NUMBERS.LANDLINE_SPECIAL_CHAR, fieldId, errorMessage, errors);
       const expected = generateValidationErrors(fieldId, errorMessage);
 
       expect(result).toEqual(expected);
     });
 
-    it('should display error entering international number', () => {
+    it('should render error entering international number', () => {
       let result = validatePhoneNumber(INVALID_PHONE_NUMBERS.INTERNATIONAL, fieldId, errorMessage, errors);
       let expected = generateValidationErrors(fieldId, errorMessage);
 
@@ -69,28 +69,28 @@ describe('shared-validation/phone-number', () => {
       expect(result).toEqual(expected);
     });
 
-    it('should display error entering just 2 digits', () => {
+    it('should render error entering just 2 digits', () => {
       const result = validatePhoneNumber(INVALID_PHONE_NUMBERS.TOO_SHORT, fieldId, errorMessage, errors);
       const expected = generateValidationErrors(fieldId, errorMessage);
 
       expect(result).toEqual(expected);
     });
 
-    it('should display error entering just 2 digits with a special character', () => {
+    it('should render error entering just 2 digits with a special character', () => {
       const result = validatePhoneNumber(INVALID_PHONE_NUMBERS.TOO_SHORT_SPECIAL_CHAR, fieldId, errorMessage, errors);
       const expected = generateValidationErrors(fieldId, errorMessage);
 
       expect(result).toEqual(expected);
     });
 
-    it('should display error entering mobile number with a special character', () => {
+    it('should render error entering mobile number with a special character', () => {
       const result = validatePhoneNumber(INVALID_PHONE_NUMBERS.MOBILE_SPECIAL_CHAR, fieldId, errorMessage, errors);
       const expected = generateValidationErrors(fieldId, errorMessage);
 
       expect(result).toEqual(expected);
     });
 
-    it('should display error entering mobile number which is above 191 characters', () => {
+    it('should render error entering mobile number which is above 191 characters', () => {
       const result = validatePhoneNumber(INVALID_PHONE_NUMBERS.ABOVE_MAX_CHARS, fieldId, errorMessage, errors);
       const expected = generateValidationErrors(fieldId, errorMessage);
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issues where the UI's "Broker - zero addresses" URL was incorrect.

Also introduces some technical alignments regarding tests and documentation.

## Resolution :heavy_check_mark:
- EMS-4130: Update `BROKER_ZERO_ADDRESSES_ROOT` constant.
- EMS-4131: Replace instances of e.g `test('it should ...` with `it('should ...`
- Update some UI GQL call error handlings that incorrectly had "network error" in some console errors.
- Update some UI validation functions to use `formBody` param, instead of `responseBody`.
- Simplify some UI validation functions documentation.

## Miscellaneous :heavy_plus_sign:
- Fix some typos.
- Replace instances of "should display" with "should render".
- Minor task function documentation improvements.
