### PR TITLE
fix(EMS-4137-4138): declarations - modern slavery - content, validation errors

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -558,16 +558,16 @@ export const ERROR_MESSAGES = {
         },
         CONDITIONAL_REASONS: {
           [FIELD_IDS.INSURANCE.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASONS.CANNOT_ADHERE_TO_ALL_REQUIREMENTS]: {
-            IS_EMPTY: 'Enter full details of why you cannot confirm',
-            ABOVE_MAXIMUM: `The  explanation of why you cannot confirm cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
+            IS_EMPTY: 'Enter full details of why you cannot adhere',
+            ABOVE_MAXIMUM: `The  explanation of why you cannot adhere cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
           },
           [FIELD_IDS.INSURANCE.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASONS.OFFENSES_OR_INVESTIGATIONS]: {
-            IS_EMPTY: 'Enter full details of why you cannot confirm',
-            ABOVE_MAXIMUM: `The  explanation of why you cannot confirm cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
+            IS_EMPTY: 'Enter full details of why you cannot adhere',
+            ABOVE_MAXIMUM: `The  explanation of why you cannot adhere cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
           },
           [FIELD_IDS.INSURANCE.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASONS.AWARE_OF_EXISTING_SLAVERY]: {
-            IS_EMPTY: 'Enter full details of why you cannot confirm',
-            ABOVE_MAXIMUM: `The  explanation of why you cannot confirm cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
+            IS_EMPTY: 'Enter full details of why you cannot adhere',
+            ABOVE_MAXIMUM: `The  explanation of why you cannot adhere cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
           },
         },
       },

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/validation/modern-slavery-validation-has-no-offenses-or-investigations.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/validation/modern-slavery-validation-has-no-offenses-or-investigations.spec.js
@@ -11,7 +11,7 @@ const {
 
 const {
   MODERN_SLAVERY: {
-    HAS_NO_OFFENSES_OR_INVESTIGATIONS,
+    HAS_NO_OFFENSES_OR_INVESTIGATIONS: FIELD_ID,
     CONDITIONAL_REASONS: { OFFENSES_OR_INVESTIGATIONS },
   },
 } = DECLARATIONS_FIELD_IDS;
@@ -22,12 +22,11 @@ const MAXIMUM = MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASO
 
 const reasonOverMaximum = 'a'.repeat(MAXIMUM + 1);
 
-const fieldId = HAS_NO_OFFENSES_OR_INVESTIGATIONS;
 const conditionalFieldId = OFFENSES_OR_INVESTIGATIONS;
 
 const baseUrl = Cypress.config('baseUrl');
 
-context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId}`, () => {
+context(`Insurance - Declarations - Modern slavery page - validation - ${FIELD_ID}`, () => {
   let referenceNumber;
   let url;
 
@@ -52,7 +51,7 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
     cy.deleteApplication(referenceNumber);
   });
 
-  describe(`when ${fieldId} is 'no', but ${conditionalFieldId} is not provided`, () => {
+  describe(`when ${FIELD_ID} is 'no', but ${conditionalFieldId} is not provided`, () => {
     it(`should render a ${conditionalFieldId} validation error`, () => {
       cy.navigateToUrl(url);
 
@@ -69,7 +68,7 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
     });
   });
 
-  describe(`when ${fieldId} is 'no', but ${conditionalFieldId} is over ${MAXIMUM} characters`, () => {
+  describe(`when ${FIELD_ID} is 'no', but ${conditionalFieldId} is over ${MAXIMUM} characters`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
 
@@ -85,8 +84,8 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
     it(`should render a ${conditionalFieldId} validation error`, () => {
       cy.assertFieldErrors({
         field: autoCompleteField(conditionalFieldId),
-        errorIndex: 1,
-        errorSummaryLength: 3,
+        errorIndex: 0,
+        errorSummaryLength: 1,
         errorMessage: ERROR_STRINGS.CONDITIONAL_REASONS[conditionalFieldId].ABOVE_MAXIMUM,
       });
     });
@@ -98,6 +97,34 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
       });
 
       cy.assertNoRadioOptionIsChecked();
+    });
+  });
+
+  describe(`when ${FIELD_ID} is 'yes' and no other required radio fields are provided`, () => {
+    it('should retain the submitted radio value', () => {
+      cy.navigateToUrl(url);
+
+      cy.completeAndSubmitModernSlaveryForm({
+        willAdhereToAllRequirements: null,
+        hasNoOffensesOrInvestigations: true,
+        isNotAwareOfExistingSlavery: null,
+      });
+
+      cy.assertYesRadioOptionIsChecked(1);
+    });
+  });
+
+  describe(`when ${FIELD_ID} is 'no', and no other required radio fields are provided`, () => {
+    it('should retain the submitted radio value', () => {
+      cy.navigateToUrl(url);
+
+      cy.completeAndSubmitModernSlaveryForm({
+        willAdhereToAllRequirements: null,
+        hasNoOffensesOrInvestigations: false,
+        isNotAwareOfExistingSlavery: null,
+      });
+
+      cy.assertNoRadioOptionIsChecked(1);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/validation/modern-slavery-validation-is-not-aware-of-existing-slavery.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/validation/modern-slavery-validation-is-not-aware-of-existing-slavery.spec.js
@@ -11,7 +11,7 @@ const {
 
 const {
   MODERN_SLAVERY: {
-    IS_NOT_AWARE_OF_EXISTING_SLAVERY,
+    IS_NOT_AWARE_OF_EXISTING_SLAVERY: FIELD_ID,
     CONDITIONAL_REASONS: { AWARE_OF_EXISTING_SLAVERY },
   },
 } = DECLARATIONS_FIELD_IDS;
@@ -22,12 +22,11 @@ const MAXIMUM = MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASO
 
 const reasonOverMaximum = 'a'.repeat(MAXIMUM + 1);
 
-const fieldId = IS_NOT_AWARE_OF_EXISTING_SLAVERY;
 const conditionalFieldId = AWARE_OF_EXISTING_SLAVERY;
 
 const baseUrl = Cypress.config('baseUrl');
 
-context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId}`, () => {
+context(`Insurance - Declarations - Modern slavery page - validation - ${FIELD_ID}`, () => {
   let referenceNumber;
   let url;
 
@@ -52,7 +51,7 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
     cy.deleteApplication(referenceNumber);
   });
 
-  describe(`when ${fieldId} is 'no', but ${conditionalFieldId} is not provided`, () => {
+  describe(`when ${FIELD_ID} is 'no', but ${conditionalFieldId} is not provided`, () => {
     it(`should render a ${conditionalFieldId} validation error`, () => {
       cy.navigateToUrl(url);
 
@@ -69,7 +68,7 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
     });
   });
 
-  describe(`when ${fieldId} is 'no', but ${conditionalFieldId} is over ${MAXIMUM} characters`, () => {
+  describe(`when ${FIELD_ID} is 'no', but ${conditionalFieldId} is over ${MAXIMUM} characters`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
 
@@ -87,19 +86,47 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
     it(`should render a ${conditionalFieldId} validation error`, () => {
       cy.assertFieldErrors({
         field: autoCompleteField(conditionalFieldId),
-        errorIndex: 2,
-        errorSummaryLength: 3,
+        errorIndex: 0,
+        errorSummaryLength: 1,
         errorMessage: ERROR_STRINGS.CONDITIONAL_REASONS[conditionalFieldId].ABOVE_MAXIMUM,
       });
     });
 
     it('should retain the submitted values', () => {
+      cy.assertNoRadioOptionIsChecked();
+
       cy.checkTextareaValue({
         fieldId: conditionalFieldId,
         expectedValue: reasonOverMaximum,
       });
+    });
+  });
 
-      cy.assertNoRadioOptionIsChecked();
+  describe(`when ${FIELD_ID} is 'yes' and no other required radio fields are provided`, () => {
+    it('should retain the submitted radio value', () => {
+      cy.navigateToUrl(url);
+
+      cy.completeAndSubmitModernSlaveryForm({
+        willAdhereToAllRequirements: null,
+        hasNoOffensesOrInvestigations: null,
+        isNotAwareOfExistingSlavery: true,
+      });
+
+      cy.assertYesRadioOptionIsChecked(2);
+    });
+  });
+
+  describe(`when ${FIELD_ID} is 'no' and no other required radio fields are provided`, () => {
+    it('should retain the submitted radio value', () => {
+      cy.navigateToUrl(url);
+
+      cy.completeAndSubmitModernSlaveryForm({
+        willAdhereToAllRequirements: null,
+        hasNoOffensesOrInvestigations: null,
+        isNotAwareOfExistingSlavery: false,
+      });
+
+      cy.assertNoRadioOptionIsChecked(2);
     });
   });
 });

--- a/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/validation/modern-slavery-validation-will-adhere-to-all-requirements.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/declarations/modern-slavery/validation/modern-slavery-validation-will-adhere-to-all-requirements.spec.js
@@ -11,7 +11,7 @@ const {
 
 const {
   MODERN_SLAVERY: {
-    WILL_ADHERE_TO_ALL_REQUIREMENTS,
+    WILL_ADHERE_TO_ALL_REQUIREMENTS: FIELD_ID,
     CONDITIONAL_REASONS: { CANNOT_ADHERE_TO_ALL_REQUIREMENTS },
   },
 } = DECLARATIONS_FIELD_IDS;
@@ -22,12 +22,11 @@ const MAXIMUM = MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASO
 
 const reasonOverMaximum = 'a'.repeat(MAXIMUM + 1);
 
-const fieldId = WILL_ADHERE_TO_ALL_REQUIREMENTS;
 const conditionalFieldId = CANNOT_ADHERE_TO_ALL_REQUIREMENTS;
 
 const baseUrl = Cypress.config('baseUrl');
 
-context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId}`, () => {
+context(`Insurance - Declarations - Modern slavery page - validation - ${FIELD_ID}`, () => {
   let referenceNumber;
   let url;
 
@@ -52,7 +51,7 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
     cy.deleteApplication(referenceNumber);
   });
 
-  describe(`when ${fieldId} is 'no', but ${conditionalFieldId} is not provided`, () => {
+  describe(`when ${FIELD_ID} is 'no', but ${conditionalFieldId} is not provided`, () => {
     it(`should render a ${conditionalFieldId} validation error`, () => {
       cy.navigateToUrl(url);
 
@@ -60,22 +59,16 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
         willAdhereToAllRequirements: false,
       });
 
-      cy.completeAndSubmitModernSlaveryFormConditionalFields({
-        cannotAdhereToAllRequirements: null,
-        awareOfExistingSlavery: null,
-        offensesOrInvestigations: null,
-      });
-
       cy.assertFieldErrors({
         field: autoCompleteField(conditionalFieldId),
         errorIndex: 0,
-        errorSummaryLength: 3,
+        errorSummaryLength: 1,
         errorMessage: ERROR_STRINGS.CONDITIONAL_REASONS[conditionalFieldId].IS_EMPTY,
       });
     });
   });
 
-  describe(`when ${fieldId} is 'no', but ${conditionalFieldId} is over ${MAXIMUM} characters`, () => {
+  describe(`when ${FIELD_ID} is 'no', but ${conditionalFieldId} is over ${MAXIMUM} characters`, () => {
     beforeEach(() => {
       cy.navigateToUrl(url);
 
@@ -94,18 +87,46 @@ context(`Insurance - Declarations - Modern slavery page - validation - ${fieldId
       cy.assertFieldErrors({
         field: autoCompleteField(conditionalFieldId),
         errorIndex: 0,
-        errorSummaryLength: 3,
+        errorSummaryLength: 1,
         errorMessage: ERROR_STRINGS.CONDITIONAL_REASONS[conditionalFieldId].ABOVE_MAXIMUM,
       });
     });
 
     it('should retain the submitted values', () => {
+      cy.assertNoRadioOptionIsChecked();
+
       cy.checkTextareaValue({
         fieldId: conditionalFieldId,
         expectedValue: reasonOverMaximum,
       });
+    });
+  });
 
-      cy.assertNoRadioOptionIsChecked();
+  describe(`when ${FIELD_ID} is 'yes' and no other required radio fields are provided`, () => {
+    it('should retain the submitted radio value', () => {
+      cy.navigateToUrl(url);
+
+      cy.completeAndSubmitModernSlaveryForm({
+        willAdhereToAllRequirements: true,
+        hasNoOffensesOrInvestigations: null,
+        isNotAwareOfExistingSlavery: null,
+      });
+
+      cy.assertYesRadioOptionIsChecked(0);
+    });
+  });
+
+  describe(`when ${FIELD_ID} is 'no' and no other required radio fields are provided`, () => {
+    it('should retain the submitted radio value', () => {
+      cy.navigateToUrl(url);
+
+      cy.completeAndSubmitModernSlaveryForm({
+        willAdhereToAllRequirements: false,
+        hasNoOffensesOrInvestigations: null,
+        isNotAwareOfExistingSlavery: null,
+      });
+
+      cy.assertNoRadioOptionIsChecked(0);
     });
   });
 });

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -562,16 +562,16 @@ export const ERROR_MESSAGES = {
         },
         CONDITIONAL_REASONS: {
           [FIELD_IDS.INSURANCE.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASONS.CANNOT_ADHERE_TO_ALL_REQUIREMENTS]: {
-            IS_EMPTY: 'Enter full details of why you cannot confirm',
-            ABOVE_MAXIMUM: `The  explanation of why you cannot confirm cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
+            IS_EMPTY: 'Enter full details of why you cannot adhere',
+            ABOVE_MAXIMUM: `The  explanation of why you cannot adhere cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
           },
           [FIELD_IDS.INSURANCE.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASONS.OFFENSES_OR_INVESTIGATIONS]: {
-            IS_EMPTY: 'Enter full details of why you cannot confirm',
-            ABOVE_MAXIMUM: `The  explanation of why you cannot confirm cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
+            IS_EMPTY: 'Enter full details of why you cannot adhere',
+            ABOVE_MAXIMUM: `The  explanation of why you cannot adhere cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
           },
           [FIELD_IDS.INSURANCE.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASONS.AWARE_OF_EXISTING_SLAVERY]: {
-            IS_EMPTY: 'Enter full details of why you cannot confirm',
-            ABOVE_MAXIMUM: `The  explanation of why you cannot confirm cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
+            IS_EMPTY: 'Enter full details of why you cannot adhere',
+            ABOVE_MAXIMUM: `The  explanation of why you cannot adhere cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
           },
         },
       },

--- a/src/ui/templates/partials/insurance/declarations/modern-slavery/has-no-offenses-or-investigations.njk
+++ b/src/ui/templates/partials/insurance/declarations/modern-slavery/has-no-offenses-or-investigations.njk
@@ -6,16 +6,15 @@
 
 {% set fieldId = FIELDS.HAS_NO_OFFENSES_OR_INVESTIGATIONS.ID %}
 
-{#
-  When a submitted answer that is not saved in the database has a value of value,
-  to ensure that the "no" radio is checked,
-  we need to manually set the submittedAnswer after the application field.
-  Otherwise, if we do the following:
-  submittedValues[fieldId] or application.declaration.modernSlavery[fieldId]
-  It will always go to the application field, because the first value is false.
-#}
-{% set submittedAnswer = application.declaration.modernSlavery[fieldId] or submittedValues[fieldId] %}
+{% set submittedAnswer = submittedValues[fieldId] or application.declaration.modernSlavery[fieldId] %}
 
+{#
+  When a submitted answer has a boolean value of false,
+  to ensure that the "no" radio is checked,
+  we need to manually set the submittedAnswer to the false boolean.
+  Otherwise, nunjucks will not have a submittedAnswer variable of false
+  and submittedAnswer would be empty.
+#}
 {% if submittedValues[fieldId] === false %}
   {% set submittedAnswer = submittedValues[fieldId] %}
 {% endif %}

--- a/src/ui/templates/partials/insurance/declarations/modern-slavery/has-no-offenses-or-investigations.njk
+++ b/src/ui/templates/partials/insurance/declarations/modern-slavery/has-no-offenses-or-investigations.njk
@@ -14,7 +14,7 @@
   submittedValues[fieldId] or application.declaration.modernSlavery[fieldId]
   It will always go to the application field, because the first value is false.
 #}
-{% set submittedAnswer = application.declaration.modernSlavery[fieldId] %}
+{% set submittedAnswer = application.declaration.modernSlavery[fieldId] or submittedValues[fieldId] %}
 
 {% if submittedValues[fieldId] === false %}
   {% set submittedAnswer = submittedValues[fieldId] %}

--- a/src/ui/templates/partials/insurance/declarations/modern-slavery/is-not-aware-of-existing-slavery.njk
+++ b/src/ui/templates/partials/insurance/declarations/modern-slavery/is-not-aware-of-existing-slavery.njk
@@ -7,12 +7,11 @@
 {% set fieldId = FIELDS.IS_NOT_AWARE_OF_EXISTING_SLAVERY.ID %}
 
 {#
-  When a submitted answer that is not saved in the database has a value of value,
+  When a submitted answer has a boolean value of false,
   to ensure that the "no" radio is checked,
-  we need to manually set the submittedAnswer after the application field.
-  Otherwise, if we do the following:
-  submittedValues[fieldId] or application.declaration.modernSlavery[fieldId]
-  It will always go to the application field, because the first value is false.
+  we need to manually set the submittedAnswer to the false boolean.
+  Otherwise, nunjucks will not have a submittedAnswer variable of false
+  and submittedAnswer would be empty.
 #}
 {% set submittedAnswer = application.declaration.modernSlavery[fieldId] or submittedValues[fieldId] %}
 

--- a/src/ui/templates/partials/insurance/declarations/modern-slavery/is-not-aware-of-existing-slavery.njk
+++ b/src/ui/templates/partials/insurance/declarations/modern-slavery/is-not-aware-of-existing-slavery.njk
@@ -13,7 +13,7 @@
   Otherwise, nunjucks will not have a submittedAnswer variable of false
   and submittedAnswer would be empty.
 #}
-{% set submittedAnswer = application.declaration.modernSlavery[fieldId] or submittedValues[fieldId] %}
+{% set submittedAnswer = submittedValues[fieldId] or application.declaration.modernSlavery[fieldId] %}
 
 {% if submittedValues[fieldId] === false %}
   {% set submittedAnswer = submittedValues[fieldId] %}

--- a/src/ui/templates/partials/insurance/declarations/modern-slavery/is-not-aware-of-existing-slavery.njk
+++ b/src/ui/templates/partials/insurance/declarations/modern-slavery/is-not-aware-of-existing-slavery.njk
@@ -14,7 +14,7 @@
   submittedValues[fieldId] or application.declaration.modernSlavery[fieldId]
   It will always go to the application field, because the first value is false.
 #}
-{% set submittedAnswer = application.declaration.modernSlavery[fieldId] %}
+{% set submittedAnswer = application.declaration.modernSlavery[fieldId] or submittedValues[fieldId] %}
 
 {% if submittedValues[fieldId] === false %}
   {% set submittedAnswer = submittedValues[fieldId] %}

--- a/src/ui/templates/partials/insurance/declarations/modern-slavery/will-adhere-to-all-requirements.njk
+++ b/src/ui/templates/partials/insurance/declarations/modern-slavery/will-adhere-to-all-requirements.njk
@@ -6,15 +6,12 @@
 
 {% set fieldId = FIELDS.WILL_ADHERE_TO_ALL_REQUIREMENTS.ID %}
 
-{#  TODO: documentation - first line at least, does not make sense. #}
-
 {#
-  When a submitted answer that is not saved in the database has a value of value,
+  When a submitted answer has a boolean value of false,
   to ensure that the "no" radio is checked,
-  we need to manually set the submittedAnswer after the application field.
-  Otherwise, if we do the following:
-  submittedValues[fieldId] or application.declaration.modernSlavery[fieldId]
-  It will always go to the application field, because the first value is false.
+  we need to manually set the submittedAnswer to the false boolean.
+  Otherwise, nunjucks will not have a submittedAnswer variable of false
+  and submittedAnswer would be empty.
 #}
 {% set submittedAnswer = application.declaration.modernSlavery[fieldId] or submittedValues[fieldId] %}
 

--- a/src/ui/templates/partials/insurance/declarations/modern-slavery/will-adhere-to-all-requirements.njk
+++ b/src/ui/templates/partials/insurance/declarations/modern-slavery/will-adhere-to-all-requirements.njk
@@ -6,6 +6,8 @@
 
 {% set fieldId = FIELDS.WILL_ADHERE_TO_ALL_REQUIREMENTS.ID %}
 
+{#  TODO: documentation - first line at least, does not make sense. #}
+
 {#
   When a submitted answer that is not saved in the database has a value of value,
   to ensure that the "no" radio is checked,
@@ -14,7 +16,7 @@
   submittedValues[fieldId] or application.declaration.modernSlavery[fieldId]
   It will always go to the application field, because the first value is false.
 #}
-{% set submittedAnswer = application.declaration.modernSlavery[fieldId] %}
+{% set submittedAnswer = application.declaration.modernSlavery[fieldId] or submittedValues[fieldId] %}
 
 {% if submittedValues[fieldId] === false %}
   {% set submittedAnswer = submittedValues[fieldId] %}

--- a/src/ui/templates/partials/insurance/declarations/modern-slavery/will-adhere-to-all-requirements.njk
+++ b/src/ui/templates/partials/insurance/declarations/modern-slavery/will-adhere-to-all-requirements.njk
@@ -13,7 +13,7 @@
   Otherwise, nunjucks will not have a submittedAnswer variable of false
   and submittedAnswer would be empty.
 #}
-{% set submittedAnswer = application.declaration.modernSlavery[fieldId] or submittedValues[fieldId] %}
+{% set submittedAnswer = submittedValues[fieldId] or application.declaration.modernSlavery[fieldId] %}
 
 {% if submittedValues[fieldId] === false %}
   {% set submittedAnswer = submittedValues[fieldId] %}


### PR DESCRIPTION
## Introduction :pencil2:
- Modern slavery validation errors content was not up to date.
- If any one of the Modern slavery radios is valid and the form is submitted, the radio selection would not be retained.

## Resolution :heavy_check_mark:
- Update error messages content strings.
- Add E2E test coverage for each Modern slavery radio being valid, with no other radios being valid.
- Update nunjucks partials.

## Miscellaneous :heavy_plus_sign:
- Use a `FIELD_ID` const instead of `fieldId` in the relevant updated E2E tests.
- Minor documentation improvement in nunjucks partials.
