### PR TITLE
fix(EMS-4138): declarations - modern slavery - error messages

### DIFF
--- a/e2e-tests/content-strings/error-messages.js
+++ b/e2e-tests/content-strings/error-messages.js
@@ -562,12 +562,12 @@ export const ERROR_MESSAGES = {
             ABOVE_MAXIMUM: `The  explanation of why you cannot adhere cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
           },
           [FIELD_IDS.INSURANCE.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASONS.OFFENSES_OR_INVESTIGATIONS]: {
-            IS_EMPTY: 'Enter full details of why you cannot adhere',
-            ABOVE_MAXIMUM: `The  explanation of why you cannot adhere cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
+            IS_EMPTY: 'Enter full details of why you cannot confirm',
+            ABOVE_MAXIMUM: `The  explanation of why you cannot confirm cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
           },
           [FIELD_IDS.INSURANCE.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASONS.AWARE_OF_EXISTING_SLAVERY]: {
-            IS_EMPTY: 'Enter full details of why you cannot adhere',
-            ABOVE_MAXIMUM: `The  explanation of why you cannot adhere cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
+            IS_EMPTY: 'Enter full details of why you cannot confirm',
+            ABOVE_MAXIMUM: `The  explanation of why you cannot confirm cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
           },
         },
       },

--- a/src/ui/server/content-strings/error-messages.ts
+++ b/src/ui/server/content-strings/error-messages.ts
@@ -566,12 +566,12 @@ export const ERROR_MESSAGES = {
             ABOVE_MAXIMUM: `The  explanation of why you cannot adhere cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
           },
           [FIELD_IDS.INSURANCE.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASONS.OFFENSES_OR_INVESTIGATIONS]: {
-            IS_EMPTY: 'Enter full details of why you cannot adhere',
-            ABOVE_MAXIMUM: `The  explanation of why you cannot adhere cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
+            IS_EMPTY: 'Enter full details of why you cannot confirm',
+            ABOVE_MAXIMUM: `The  explanation of why you cannot confirm cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
           },
           [FIELD_IDS.INSURANCE.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASONS.AWARE_OF_EXISTING_SLAVERY]: {
-            IS_EMPTY: 'Enter full details of why you cannot adhere',
-            ABOVE_MAXIMUM: `The  explanation of why you cannot adhere cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
+            IS_EMPTY: 'Enter full details of why you cannot confirm',
+            ABOVE_MAXIMUM: `The  explanation of why you cannot confirm cannot be more than ${MAXIMUM_CHARACTERS.DECLARATIONS.MODERN_SLAVERY.CONDITIONAL_REASON} characters`,
           },
         },
       },


### PR DESCRIPTION
## Introduction :pencil2:
- 2x error messages for "Declarations - modern slavery" have some incorrect copy.

## Resolution :heavy_check_mark:
- Update error messages content strings.
