### PR TITLE
fix(EMS-4205): enter your brokers address button label

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-manual-address/broker-manual-address-page.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-manual-address/broker-manual-address-page.spec.js
@@ -1,6 +1,6 @@
 import { headingCaption } from '../../../../../../pages/shared';
 import { brokerManualAddressPage } from '../../../../../../pages/insurance/policy';
-import { PAGES } from '../../../../../../content-strings';
+import { BUTTONS, PAGES } from '../../../../../../content-strings';
 import { INSURANCE_ROUTES } from '../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../constants/field-ids/insurance/policy';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../content-strings/fields/insurance/policy';
@@ -61,6 +61,7 @@ context(
         pageTitle: CONTENT_STRINGS.PAGE_TITLE,
         currentHref: `${ROOT}/${referenceNumber}${BROKER_MANUAL_ADDRESS_ROOT}`,
         backLink: `${ROOT}/${referenceNumber}${BROKER_DETAILS_ROOT}`,
+        submitButtonCopy: BUTTONS.USE_THIS_ADDRESS,
       });
     });
 

--- a/src/ui/server/controllers/insurance/policy/broker-manual-address/index.test.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-manual-address/index.test.ts
@@ -1,5 +1,5 @@
 import { pageVariables, FIELD_ID, PAGE_CONTENT_STRINGS, TEMPLATE, get, post } from '.';
-import { PAGES } from '../../../../content-strings';
+import { BUTTONS, PAGES } from '../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance/policy';
 import { TEMPLATES } from '../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
@@ -84,6 +84,7 @@ describe('controllers/insurance/policy/broker-manual-address', () => {
         ...pageVariables(referenceNumber),
         userName: getUserNameFromSession(req.session.user),
         application: mockApplication,
+        SUBMIT_BUTTON_COPY: BUTTONS.USE_THIS_ADDRESS,
       });
     });
   });
@@ -113,6 +114,7 @@ describe('controllers/insurance/policy/broker-manual-address', () => {
           userName: getUserNameFromSession(req.session.user),
           submittedValues: payload,
           validationErrors,
+          SUBMIT_BUTTON_COPY: BUTTONS.USE_THIS_ADDRESS,
         });
       });
     });

--- a/src/ui/server/controllers/insurance/policy/broker-manual-address/index.ts
+++ b/src/ui/server/controllers/insurance/policy/broker-manual-address/index.ts
@@ -1,4 +1,4 @@
-import { PAGES } from '../../../../content-strings';
+import { BUTTONS, PAGES } from '../../../../content-strings';
 import { POLICY_FIELDS as FIELDS } from '../../../../content-strings/fields/insurance/policy';
 import { TEMPLATES } from '../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../constants/routes/insurance';
@@ -63,6 +63,7 @@ export const get = (req: Request, res: ResponseInsurance) => {
       ...pageVariables(application.referenceNumber),
       userName: getUserNameFromSession(req.session.user),
       application,
+      SUBMIT_BUTTON_COPY: BUTTONS.USE_THIS_ADDRESS,
     });
   } catch (error) {
     console.error('Error getting broker manual address %o', error);
@@ -99,6 +100,7 @@ export const post = async (req: Request, res: ResponseInsurance) => {
       userName: getUserNameFromSession(req.session.user),
       submittedValues: sanitisedData,
       validationErrors,
+      SUBMIT_BUTTON_COPY: BUTTONS.USE_THIS_ADDRESS,
     });
   }
 

--- a/src/ui/templates/insurance/policy/broker-manual-address.njk
+++ b/src/ui/templates/insurance/policy/broker-manual-address.njk
@@ -75,6 +75,7 @@
 
     {{ formButtons.render({
       contentStrings: CONTENT_STRINGS.BUTTONS,
+      submitText: SUBMIT_BUTTON_COPY,
       saveAndBackUrl: SAVE_AND_BACK_URL
     }) }}
 


### PR DESCRIPTION
## Introduction :pencil2:
In the "Enter manual broker address" page, the primary button requires the label to be `Use this address` instead of `Continue`.

## Resolution :heavy_check_mark:
* Added `SUBMIT_BUTTON_COPY` variable to view-controller.

## Miscellaneous :heavy_plus_sign:
* Updated unit and E2E tests.
