### PR TITLE
fix(EMS-4209): fixed incorrect policy check-your-answers page status

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/another-company/change-your-answers-change-another-company-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/another-company/change-your-answers-change-another-company-no-to-yes.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -74,6 +74,10 @@ context(
         cy.completeAndSubmitOtherCompanyDetailsForm({});
 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId: FIELD_ID });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it(`should render new answers and change links for ${FIELD_ID} and all other company details fields`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/another-company/change-your-answers-change-another-company-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/another-company/change-your-answers-change-another-company-yes-to-no.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -72,6 +72,10 @@ context(
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId: FIELD_ID });
       });
 
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
+      });
+
       it(`should render new answers and change links for ${FIELD_ID} and all other company details fields`, () => {
         checkSummaryList.REQUESTED_JOINTLY_INSURED_PARTY[FIELD_ID]({ requested: false });
         checkSummaryList.REQUESTED_JOINTLY_INSURED_PARTY[COMPANY_NAME]({ shouldRender: false });
@@ -86,6 +90,10 @@ context(
           summaryList.field(FIELD_ID).changeLink().click();
 
           cy.completeAndSubmitAnotherCompanyForm({ otherCompanyInvolved: true });
+        });
+
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
         });
 
         describe(`when going back to ${OTHER_COMPANY_DETAILS}`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/another-company/change-your-answers-change-another-company-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/another-company/change-your-answers-change-another-company-yes-to-no.spec.js
@@ -92,10 +92,6 @@ context(
           cy.completeAndSubmitAnotherCompanyForm({ otherCompanyInvolved: true });
         });
 
-        it('renders a `completed` status tag', () => {
-          cy.checkTaskStatusCompleted(status);
-        });
-
         describe(`when going back to ${OTHER_COMPANY_DETAILS}`, () => {
           it('should have empty field values', () => {
             cy.assertEmptyOtherCompanyDetailsFieldValues();

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-address-based-in-uk-to-not-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-address-based-in-uk-to-not-based-in-uk.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -72,6 +72,10 @@ context(
         cy.completeAndSubmitBrokerManualAddressForm({});
 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId: NAME });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it(`should render the new ${FULL_ADDRESS} answer and related fields`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-address-not-based-in-uk-to-based-in-uk-multiple-addresses-available.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-address-not-based-in-uk-to-based-in-uk-multiple-addresses-available.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { EXPECTED_UNDERGROUND_STATION_SINGLE_LINE_STRING, ADDRESS_LOOKUP_INPUT_EXAMPLES, ORDNANCE_SURVEY_EXAMPLES } from '../../../../../../../../constants';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
@@ -87,6 +87,10 @@ context(
         cy.completeAndSubmitBrokerAddressesForm({ optionValue });
 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it(`should render the new ${SELECT_THE_ADDRESS} answer and related fields`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-address-not-based-in-uk-to-based-in-uk-multiple-addresses-enter-address-manually.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-address-not-based-in-uk-to-based-in-uk-multiple-addresses-enter-address-manually.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { ADDRESS_LOOKUP_INPUT_EXAMPLES } from '../../../../../../../../constants';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
@@ -88,6 +88,10 @@ context(
         cy.completeAndSubmitBrokerManualAddressForm({});
 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it(`should render the new ${SELECT_THE_ADDRESS} answer and related fields`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-address-not-based-in-uk-to-based-in-uk-single-address-available.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-address-not-based-in-uk-to-based-in-uk-single-address-available.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -78,6 +78,10 @@ context(
         cy.clickSubmitButton();
 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it(`should render the new ${SELECT_THE_ADDRESS} answer and related fields`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-address-not-based-in-uk-to-based-in-uk-single-address-enter-address-manually.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-address-not-based-in-uk-to-based-in-uk-single-address-enter-address-manually.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -84,6 +84,10 @@ context(
         cy.completeAndSubmitBrokerManualAddressForm({});
 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it(`should render the new ${SELECT_THE_ADDRESS} answer and related fields`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-based-in-uk-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-based-in-uk-yes-to-no.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -62,6 +62,10 @@ context(
 
       it(`should redirect to ${TYPE_OF_POLICY}`, () => {
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId: NAME });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it('should render new broker details summary list rows', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-based-in-uk-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-based-in-uk-yes-to-no.spec.js
@@ -65,6 +65,8 @@ context(
       });
 
       it('renders a `completed` status tag', () => {
+        cy.navigateToUrl(checkYourAnswersUrl);
+
         cy.checkTaskStatusCompleted(status);
       });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-manual-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-manual-address.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -61,6 +61,10 @@ context('Insurance - Change your answers - Policy - Broker manual address - As a
       cy.completeAndSubmitBrokerManualAddressForm({ fullAddress: newAnswer });
 
       cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY });
+    });
+
+    it('renders a `completed` status tag', () => {
+      cy.checkTaskStatusCompleted(status);
     });
 
     it(`should render the new ${FULL_ADDRESS} answer and related fields`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-using-a-broker-no-to-yes-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-using-a-broker-no-to-yes-based-in-uk.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -71,6 +71,10 @@ context(
         cy.clickSubmitButton();
 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId: FIELD_ID });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it(`should render new ${FIELD_ID} answer and broker details fields`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-using-a-broker-no-to-yes-not-based-in-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-using-a-broker-no-to-yes-not-based-in-uk.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -71,6 +71,10 @@ context(
         cy.completeAndSubmitBrokerManualAddressForm({});
 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId: FIELD_ID });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it(`should render new ${FIELD_ID} answer and broker details fields`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-using-a-broker-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-field-using-a-broker-yes-to-no.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { FIELD_VALUES } from '../../../../../../../../constants';
@@ -68,6 +68,10 @@ context(
         cy.completeAndSubmitBrokerForm({ usingBroker: false });
 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId: FIELD_ID });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it(`should render new ${FIELD_ID} answer and change link, with no other broker details fields`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-fields-name-and-email.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/broker/change-your-answers-fields-name-and-email.spec.js
@@ -1,4 +1,4 @@
-import { field, summaryList } from '../../../../../../../../pages/shared';
+import { field, summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 
@@ -73,6 +73,10 @@ context('Insurance - Change your answers - Policy - Broker - As an exporter, I w
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
       });
 
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
+      });
+
       it('should render the new answer', () => {
         cy.assertSummaryListRowValue(summaryList, fieldId, newAnswer);
       });
@@ -109,6 +113,10 @@ context('Insurance - Change your answers - Policy - Broker - As an exporter, I w
 
       it(`should redirect to ${TYPE_OF_POLICY}`, () => {
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it('should render the new answer', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-international-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-international-name.spec.js
@@ -1,4 +1,4 @@
-import { field, summaryList } from '../../../../../../../../pages/shared';
+import { field, summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import application from '../../../../../../../../fixtures/application';
@@ -81,6 +81,10 @@ context(
         cy.completeAndSubmitLossPayeeFinancialDetailsInternationalForm({});
 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it('should render the new answer', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-uk-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-details-uk-name.spec.js
@@ -1,4 +1,4 @@
-import { field, summaryList } from '../../../../../../../../pages/shared';
+import { field, summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import application from '../../../../../../../../fixtures/application';
@@ -81,6 +81,10 @@ context(
         cy.completeAndSubmitLossPayeeFinancialDetailsUkForm({});
 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it('should render the new answer', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-international-to-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-international-to-uk.spec.js
@@ -1,4 +1,4 @@
-import { field, summaryList } from '../../../../../../../../pages/shared';
+import { field, summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -84,6 +84,10 @@ context(
         cy.completeAndSubmitLossPayeeFinancialDetailsUkForm({});
 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId: NAME });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it('should render new answers and change links for UK financial details, no International financial details', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-international.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-international.spec.js
@@ -1,4 +1,4 @@
-import { field, summaryList } from '../../../../../../../../pages/shared';
+import { field, summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../../content-strings/fields/insurance/policy';
@@ -84,6 +84,10 @@ context(
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
         });
 
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
+        });
+
         it('should render the new answer', () => {
           cy.assertSummaryListRowValue(summaryList, fieldId, newAnswer);
         });
@@ -120,6 +124,10 @@ context(
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
         });
 
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
+        });
+
         it('should render the new answer', () => {
           cy.assertSummaryListRowValue(summaryList, fieldId, newAnswer);
         });
@@ -154,6 +162,10 @@ context(
 
         it(`should redirect to ${TYPE_OF_POLICY}`, () => {
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+        });
+
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
         });
 
         it('should render the new answer', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-uk-to-international.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-uk-to-international.spec.js
@@ -1,4 +1,4 @@
-import { field, summaryList } from '../../../../../../../../pages/shared';
+import { field, summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -84,6 +84,10 @@ context(
         cy.completeAndSubmitLossPayeeFinancialDetailsInternationalForm({});
 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId: NAME });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it('should render new answers and change links for International financial details, no UK financial details', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-uk.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-financial-details-uk.spec.js
@@ -1,4 +1,4 @@
-import { field, summaryList } from '../../../../../../../../pages/shared';
+import { field, summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY_FIELDS as FIELDS } from '../../../../../../../../content-strings/fields/insurance/policy';
@@ -85,6 +85,10 @@ context(
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
         });
 
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
+        });
+
         it('should render the new answer', () => {
           const expectedAnswer = formatSortCode(newAnswer);
 
@@ -123,6 +127,10 @@ context(
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
         });
 
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
+        });
+
         it('should render the new answer', () => {
           cy.assertSummaryListRowValue(summaryList, fieldId, newAnswer);
         });
@@ -157,6 +165,10 @@ context(
 
         it(`should redirect to ${TYPE_OF_POLICY}`, () => {
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+        });
+
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
         });
 
         it('should render the new answer', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-no-to-yes.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-no-to-yes.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
@@ -71,6 +71,10 @@ context('Insurance - Change your answers - Policy - Loss payee - No to yes - As 
           lossPayeeFinancialUkUrl,
           referenceNumber,
         });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it(`should render new answers and change links for ${FIELD_ID} and all loss payee details fields`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-yes-to-no.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { FIELD_VALUES } from '../../../../../../../../constants';
@@ -64,6 +64,10 @@ context('Insurance - Change your answers - Policy - Loss payee - Yes to no - As 
         cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId: FIELD_ID });
       });
 
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
+      });
+
       it(`should render new ${FIELD_ID} answer and change link, with no other loss payee details fields`, () => {
         cy.assertSummaryListRowValue(summaryList, FIELD_ID, FIELD_VALUES.NO);
 
@@ -84,6 +88,10 @@ context('Insurance - Change your answers - Policy - Loss payee - Yes to no - As 
         });
 
         describe(`when going back to ${LOSS_PAYEE_DETAILS_ROOT} and ${LOSS_PAYEE_FINANCIAL_DETAILS_UK_ROOT}`, () => {
+          it('renders a `completed` status tag', () => {
+            cy.checkTaskStatusCompleted(status);
+          });
+
           it('should have empty field values', () => {
             cy.assertEmptyLossPayeeDetailsFieldValues();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-yes-to-no.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/loss-payee/change-your-answers-change-loss-payee-yes-to-no.spec.js
@@ -88,10 +88,6 @@ context('Insurance - Change your answers - Policy - Loss payee - Yes to no - As 
         });
 
         describe(`when going back to ${LOSS_PAYEE_DETAILS_ROOT} and ${LOSS_PAYEE_FINANCIAL_DETAILS_UK_ROOT}`, () => {
-          it('renders a `completed` status tag', () => {
-            cy.checkTaskStatusCompleted(status);
-          });
-
           it('should have empty field values', () => {
             cy.assertEmptyLossPayeeDetailsFieldValues();
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/multiple-policy/change-your-answers-policy-multiple-policy-type.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/multiple-policy/change-your-answers-policy-multiple-policy-type.spec.js
@@ -1,6 +1,6 @@
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
-import { field, summaryList } from '../../../../../../../../pages/shared';
+import { field, summaryList, status } from '../../../../../../../../pages/shared';
 import { multipleContractPolicyExportValuePage } from '../../../../../../../../pages/insurance/policy';
 import formatCurrency from '../../../../../../../../helpers/format-currency';
 import application from '../../../../../../../../fixtures/application';
@@ -104,6 +104,10 @@ context('Insurance - Change your answers - Policy - Multiple contract policy - S
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
         });
 
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
+        });
+
         it('should render the new answer', () => {
           fieldVariables.newValue = formatDate(createTimestampFromNumbers(newAnswer.day, newAnswer.month, newAnswer.year));
           cy.checkChangeAnswerRendered({ fieldVariables });
@@ -140,6 +144,10 @@ context('Insurance - Change your answers - Policy - Multiple contract policy - S
 
         it(`should redirect to ${TYPE_OF_POLICY}`, () => {
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+        });
+
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
         });
 
         it('should render the new answer', () => {
@@ -180,6 +188,10 @@ context('Insurance - Change your answers - Policy - Multiple contract policy - S
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
         });
 
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
+        });
+
         it('should render the new answer', () => {
           fieldVariables.newValue = formatCurrency(fieldVariables.newValueInput);
           cy.checkChangeAnswerRendered({ fieldVariables });
@@ -216,6 +228,10 @@ context('Insurance - Change your answers - Policy - Multiple contract policy - S
 
         it(`should redirect to ${TYPE_OF_POLICY}`, () => {
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+        });
+
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
         });
 
         it('should render the new answer', () => {
@@ -257,6 +273,10 @@ context('Insurance - Change your answers - Policy - Multiple contract policy - S
 
         it(`should redirect to ${TYPE_OF_POLICY}`, () => {
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+        });
+
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
         });
 
         it('should render the new answer', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/multiple-policy/change-your-answers-policy-type-change-multiple-to-single-policy-type-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/multiple-policy/change-your-answers-policy-type-change-multiple-to-single-policy-type-summary-list.spec.js
@@ -92,15 +92,15 @@ context('Insurance - Change your answers - Policy - Change multiple to single po
 
         cy.assertUrl(expectedUrl);
       });
-
-      it('renders a `completed` status tag', () => {
-        cy.checkTaskStatusCompleted(status);
-      });
     });
 
     describe('should render new answers and change links for new single policy fields', () => {
       beforeEach(() => {
         cy.navigateToUrl(checkYourAnswersUrl);
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it(POLICY_TYPE, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/multiple-policy/change-your-answers-policy-type-change-multiple-to-single-policy-type-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/multiple-policy/change-your-answers-policy-type-change-multiple-to-single-policy-type-summary-list.spec.js
@@ -1,7 +1,7 @@
 import { FIELD_VALUES } from '../../../../../../../../constants';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { typeOfPolicyPage } from '../../../../../../../../pages/insurance/policy';
 import { createTimestampFromNumbers, formatDate } from '../../../../../../../../helpers/date';
 import formatCurrency from '../../../../../../../../helpers/format-currency';
@@ -91,6 +91,10 @@ context('Insurance - Change your answers - Policy - Change multiple to single po
         const expectedUrl = `${checkYourAnswersUrl}#heading`;
 
         cy.assertUrl(expectedUrl);
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
     });
 

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-different-name-fields.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-different-name-fields.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 
@@ -79,6 +79,10 @@ context(
           });
         });
 
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
+        });
+
         it('should render the new answers when completing the different name on policy form', () => {
           cy.assertSummaryListRowValue(summaryList, fieldId, newPosition);
         });
@@ -110,6 +114,10 @@ context(
             email: newEmail,
             position: false,
           });
+        });
+
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
         });
 
         it('should render the new answers when completing the different name on policy form', () => {
@@ -146,6 +154,10 @@ context(
             email: false,
             position: false,
           });
+        });
+
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
         });
 
         it('should render the new answers when completing the different name on policy form', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-different-name-to-same-name-then-back-to-different-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-different-name-to-same-name-then-back-to-different-name.spec.js
@@ -1,6 +1,6 @@
 import { POLICY as FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
-import { summaryList, status } from '../../../../../../../../pages/shared';
+import { summaryList } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -80,10 +80,6 @@ context(
         summaryList.field(NAME).changeLink().click();
 
         cy.completeAndSubmitNameOnPolicyForm({ sameName: false });
-      });
-
-      it('renders a `completed` status tag', () => {
-        cy.checkTaskStatusCompleted(status);
       });
 
       it('should NOT have fields populated on different name on policy page', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-different-name-to-same-name-then-back-to-different-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-different-name-to-same-name-then-back-to-different-name.spec.js
@@ -1,6 +1,6 @@
 import { POLICY as FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -80,6 +80,10 @@ context(
         summaryList.field(NAME).changeLink().click();
 
         cy.completeAndSubmitNameOnPolicyForm({ sameName: false });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it('should NOT have fields populated on different name on policy page', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-different-name-to-same-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-different-name-to-same-name.spec.js
@@ -1,6 +1,6 @@
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import application from '../../../../../../../../fixtures/application';
 import account from '../../../../../../../../fixtures/account';
 
@@ -81,6 +81,10 @@ context('Insurance - Change your answers - Policy - Change from different name t
       summaryList.field(fieldId).changeLink().click();
 
       cy.completeAndSubmitNameOnPolicyForm({});
+    });
+
+    it('renders a `completed` status tag', () => {
+      cy.checkTaskStatusCompleted(status);
     });
 
     it(`should redirect to ${TYPE_OF_POLICY} and display new answers`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-same-name-position.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-same-name-position.spec.js
@@ -1,4 +1,4 @@
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 
@@ -70,6 +70,10 @@ context(
           email: false,
           position: newAnswer,
         });
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it('should render the new answers when completing the different name on policy form', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-same-name-to-different-name.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/name-on-policy/change-your-answers-same-name-to-different-name.spec.js
@@ -1,6 +1,6 @@
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
-import { summaryList } from '../../../../../../../../pages/shared';
+import { summaryList, status } from '../../../../../../../../pages/shared';
 import application from '../../../../../../../../fixtures/application';
 
 const {
@@ -93,6 +93,10 @@ context('Insurance - Change your answers - Policy - Change from same name to dif
     describe('should render new answers and change links for different name on policy', () => {
       beforeEach(() => {
         cy.navigateToUrl(url);
+      });
+
+      it('renders a `completed` status tag', () => {
+        cy.checkTaskStatusCompleted(status);
       });
 
       it(NAME, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/other-company-details/change-your-answers-change-other-company-details.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/change-your-answers/other-company-details/change-your-answers-change-other-company-details.spec.js
@@ -1,4 +1,4 @@
-import { autoCompleteField, field, summaryList } from '../../../../../../../../pages/shared';
+import { autoCompleteField, field, summaryList, status } from '../../../../../../../../pages/shared';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import application from '../../../../../../../../fixtures/application';
@@ -82,6 +82,10 @@ context(
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
         });
 
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
+        });
+
         it('should render the new answer', () => {
           cy.assertSummaryListRowValue(summaryList, fieldId, newValueInput);
         });
@@ -116,6 +120,10 @@ context(
           cy.changeAnswerField({ newValueInput }, field(fieldId).input());
 
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+        });
+
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
         });
 
         it('should render the new answer', () => {
@@ -153,6 +161,10 @@ context(
           cy.clickSubmitButton();
 
           cy.assertChangeAnswersPageUrl({ referenceNumber, route: TYPE_OF_POLICY, fieldId });
+        });
+
+        it('renders a `completed` status tag', () => {
+          cy.checkTaskStatusCompleted(status);
         });
 
         it('should render the new answer', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-broker-based-in-uk-summary-list-manual-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-broker-based-in-uk-summary-list-manual-address.spec.js
@@ -1,6 +1,7 @@
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+import { status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -48,6 +49,10 @@ context('Insurance - Check your answers - Policy - Multiple contract policy - Br
 
   after(() => {
     cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders a `completed` status tag', () => {
+    cy.checkTaskStatusCompleted(status);
   });
 
   it('should render generic policy summary list rows', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-broker-based-in-uk-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-broker-based-in-uk-summary-list.spec.js
@@ -1,6 +1,7 @@
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+import { status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -43,6 +44,10 @@ context('Insurance - Check your answers - Policy - Multiple contract policy - Br
 
   after(() => {
     cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders a `completed` status tag', () => {
+    cy.checkTaskStatusCompleted(status);
   });
 
   it('should render generic policy summary list rows', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-broker-not-based-in-uk-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-broker-not-based-in-uk-summary-list.spec.js
@@ -1,6 +1,7 @@
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+import { status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -44,6 +45,10 @@ context('Insurance - Check your answers - Policy - Multiple contract policy - Br
 
   after(() => {
     cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders a `completed` status tag', () => {
+    cy.checkTaskStatusCompleted(status);
   });
 
   it(`should render a ${USING_BROKER} summary list row`, () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-different-name-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-different-name-summary-list.spec.js
@@ -1,6 +1,7 @@
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+import { status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -44,6 +45,10 @@ context('Insurance - Check your answers - Policy - Multiple contract policy - Di
 
   after(() => {
     cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders a `completed` status tag', () => {
+    cy.checkTaskStatusCompleted(status);
   });
 
   it('should render generic policy summary list rows', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-other-company-no-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-other-company-no-summary-list.spec.js
@@ -1,6 +1,7 @@
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+import { status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -41,6 +42,10 @@ context('Insurance - Check your answers - Policy - Multiple contract policy - Ot
 
   after(() => {
     cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders a `completed` status tag', () => {
+    cy.checkTaskStatusCompleted(status);
   });
 
   it('should render generic policy summary list rows', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-other-company-yes-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-other-company-yes-summary-list.spec.js
@@ -1,6 +1,7 @@
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+import { status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -41,6 +42,10 @@ context('Insurance - Check your answers - Policy - Multiple contract policy - Ot
 
   after(() => {
     cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders a `completed` status tag', () => {
+    cy.checkTaskStatusCompleted(status);
   });
 
   it('should render generic policy summary list rows', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-same-name-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/multiple-policy/check-your-answers-policy-multiple-same-name-summary-list.spec.js
@@ -2,6 +2,7 @@ import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insur
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+import { status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -48,6 +49,10 @@ context('Insurance - Check your answers - Policy - Multiple contract policy - Sa
 
   after(() => {
     cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders a `completed` status tag', () => {
+    cy.checkTaskStatusCompleted(status);
   });
 
   it('should render generic policy summary list rows', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-broker-based-in-uk-summary-list-manual-address.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-broker-based-in-uk-summary-list-manual-address.spec.js
@@ -1,6 +1,7 @@
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+import { status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -48,6 +49,10 @@ context('Insurance - Check your answers - Policy - Single contract policy - Brok
 
   after(() => {
     cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders a `completed` status tag', () => {
+    cy.checkTaskStatusCompleted(status);
   });
 
   it('should render generic policy summary list rows', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-broker-based-in-uk-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-broker-based-in-uk-summary-list.spec.js
@@ -1,6 +1,7 @@
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+import { status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -43,6 +44,10 @@ context('Insurance - Check your answers - Policy - Single contract policy - Brok
 
   after(() => {
     cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders a `completed` status tag', () => {
+    cy.checkTaskStatusCompleted(status);
   });
 
   it('should render generic policy summary list rows', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-broker-not-based-in-uk-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-broker-not-based-in-uk-summary-list.spec.js
@@ -1,6 +1,7 @@
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+import { status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -43,6 +44,10 @@ context('Insurance - Check your answers - Policy - Single contract policy - Brok
 
   after(() => {
     cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders a `completed` status tag', () => {
+    cy.checkTaskStatusCompleted(status);
   });
 
   it('should render generic policy summary list rows', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-different-name-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-different-name-summary-list.spec.js
@@ -2,6 +2,7 @@ import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insur
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+import { status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -49,6 +50,10 @@ context('Insurance - Check your answers - Policy - Single contract policy - Diff
 
   after(() => {
     cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders a `completed` status tag', () => {
+    cy.checkTaskStatusCompleted(status);
   });
 
   it('should render generic policy summary list rows', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-other-company-no-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-other-company-no-summary-list.spec.js
@@ -1,6 +1,7 @@
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+import { status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -41,6 +42,10 @@ context('Insurance - Check your answers - Policy - Single contract policy - Othe
 
   after(() => {
     cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders a `completed` status tag', () => {
+    cy.checkTaskStatusCompleted(status);
   });
 
   it('should render generic policy summary list rows', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-other-company-yes-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-other-company-yes-summary-list.spec.js
@@ -1,6 +1,7 @@
 import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insurance';
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+import { status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -41,6 +42,10 @@ context('Insurance - Check your answers - Policy - Single contract policy - Othe
 
   after(() => {
     cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders a `completed` status tag', () => {
+    cy.checkTaskStatusCompleted(status);
   });
 
   it('should render generic policy summary list rows', () => {

--- a/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-same-name-summary-list.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/check-your-answers/policy/summary-list/single-policy/check-your-answers-policy-single-same-name-summary-list.spec.js
@@ -2,6 +2,7 @@ import { INSURANCE_ROUTES } from '../../../../../../../../constants/routes/insur
 import { POLICY as POLICY_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance/policy';
 import { INSURANCE_FIELD_IDS } from '../../../../../../../../constants/field-ids/insurance';
 import checkSummaryList from '../../../../../../../../commands/insurance/check-policy-summary-list';
+import { status } from '../../../../../../../../pages/shared';
 
 const {
   ROOT: INSURANCE_ROOT,
@@ -48,6 +49,10 @@ context('Insurance - Check your answers - Policy - Single contract policy - Same
 
   after(() => {
     cy.deleteApplication(referenceNumber);
+  });
+
+  it('renders a `completed` status tag', () => {
+    cy.checkTaskStatusCompleted(status);
   });
 
   it('should render generic policy summary list rows', () => {

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -10179,7 +10179,7 @@ var ordnanceSurvey = {
           return acceptableStatuses.includes(status);
         },
       });
-      if (!response?.data?.results || !acceptableStatuses.includes(response.status)) {
+      if (!response.data?.results || !acceptableStatuses.includes(response.status)) {
         return {
           success: false,
           status: response.status,

--- a/src/ui/server/controllers/insurance/check-your-answers/policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/policy/index.test.ts
@@ -110,12 +110,13 @@ describe('controllers/insurance/check-your-answers/policy', () => {
       });
 
       const { policyType } = policy;
-      const { isUsingBroker, isBasedInUk } = mockBroker;
+      const { isUsingBroker, isBasedInUk, fullAddress } = mockBroker;
 
       const fields = requiredFields({
         policyType,
         isUsingBroker,
         brokerIsBasedInUk: isBasedInUk,
+        brokerFullAddress: fullAddress,
       });
 
       const status = sectionStatus(fields, mockApplication);

--- a/src/ui/server/controllers/insurance/check-your-answers/policy/index.test.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/policy/index.test.ts
@@ -110,11 +110,12 @@ describe('controllers/insurance/check-your-answers/policy', () => {
       });
 
       const { policyType } = policy;
-      const { isUsingBroker } = mockBroker;
+      const { isUsingBroker, isBasedInUk } = mockBroker;
 
       const fields = requiredFields({
         policyType,
         isUsingBroker,
+        brokerIsBasedInUk: isBasedInUk,
       });
 
       const status = sectionStatus(fields, mockApplication);

--- a/src/ui/server/controllers/insurance/check-your-answers/policy/index.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/policy/index.ts
@@ -57,7 +57,7 @@ export const get = async (req: Request, res: ResponseInsurance) => {
     const { referenceNumber, policy, exportContract, policyContact, broker, nominatedLossPayee } = application;
 
     const { policyType } = policy;
-    const { isUsingBroker } = broker;
+    const { isUsingBroker, isBasedInUk } = broker;
 
     const { allCurrencies, countries } = await api.keystone.getCountriesAndCurrencies();
 
@@ -83,7 +83,7 @@ export const get = async (req: Request, res: ResponseInsurance) => {
       checkAndChange,
     });
 
-    const fields = requiredFields({ policyType, isUsingBroker });
+    const fields = requiredFields({ policyType, isUsingBroker, brokerIsBasedInUk: isBasedInUk });
 
     const status = sectionStatus(fields, application);
 

--- a/src/ui/server/controllers/insurance/check-your-answers/policy/index.ts
+++ b/src/ui/server/controllers/insurance/check-your-answers/policy/index.ts
@@ -57,7 +57,7 @@ export const get = async (req: Request, res: ResponseInsurance) => {
     const { referenceNumber, policy, exportContract, policyContact, broker, nominatedLossPayee } = application;
 
     const { policyType } = policy;
-    const { isUsingBroker, isBasedInUk } = broker;
+    const { isUsingBroker, isBasedInUk, fullAddress } = broker;
 
     const { allCurrencies, countries } = await api.keystone.getCountriesAndCurrencies();
 
@@ -83,7 +83,7 @@ export const get = async (req: Request, res: ResponseInsurance) => {
       checkAndChange,
     });
 
-    const fields = requiredFields({ policyType, isUsingBroker, brokerIsBasedInUk: isBasedInUk });
+    const fields = requiredFields({ policyType, isUsingBroker, brokerIsBasedInUk: isBasedInUk, brokerFullAddress: fullAddress });
 
     const status = sectionStatus(fields, application);
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where the incorrect status was displayed on the check your answers policy page of in progress instead of completed

## Resolution :heavy_check_mark:
* Passed missing isBasedInUk flag to requiredFields function
* Updated tests
* Updated e2e test to check status

## Miscellaneous :heavy_plus_sign:
* Updated policy check-your-answers tests to check for status
