### PR TITLE
fix(EMS-4206): fix certain postcode searches going to problem with service page

### DIFF
--- a/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-zero-addresses/broker-zero-addresses-ordnance-survey-invalid-postcode.spec.js
+++ b/e2e-tests/insurance/cypress/e2e/journeys/policy/broker-zero-addresses/broker-zero-addresses-ordnance-survey-invalid-postcode.spec.js
@@ -6,7 +6,7 @@ const CONTENT_STRINGS = PAGES.INSURANCE.POLICY.BROKER_ZERO_ADDRESSES;
 
 const {
   ROOT,
-  POLICY: { BROKER_ZERO_ADDRESSES_ROOT },
+  POLICY: { BROKER_ZERO_ADDRESSES_ROOT, BROKER_DETAILS_ROOT },
 } = INSURANCE_ROUTES;
 
 const { outro } = brokerZeroAddressesPage;
@@ -16,6 +16,7 @@ const baseUrl = Cypress.config('baseUrl');
 context('Insurance - Policy - Broker - zero addresses page when searching for a postcode ordnance survey determines to be invalid', () => {
   let referenceNumber;
   let url;
+  let brokerDetailsUrl;
 
   const buildingNumberOrName = '8';
   const postcode = 'A9A 9AA';
@@ -33,6 +34,7 @@ context('Insurance - Policy - Broker - zero addresses page when searching for a 
         postcode,
       });
 
+      brokerDetailsUrl = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_DETAILS_ROOT}`;
       url = `${baseUrl}${ROOT}/${referenceNumber}${BROKER_ZERO_ADDRESSES_ROOT}`;
     });
   });
@@ -45,12 +47,99 @@ context('Insurance - Policy - Broker - zero addresses page when searching for a 
     cy.deleteApplication(referenceNumber);
   });
 
-  it(`should redirect to ${BROKER_ZERO_ADDRESSES_ROOT} and display the correct text`, () => {
-    cy.assertUrl(url);
+  describe('A9A 9AA', () => {
+    it(`should redirect to ${BROKER_ZERO_ADDRESSES_ROOT} and display the correct text`, () => {
+      cy.assertUrl(url);
 
-    cy.checkText(outro.couldNotFind(), CONTENT_STRINGS.OUTRO.COULD_NOT_FIND);
-    cy.checkText(outro.postcode(), postcode);
-    cy.checkText(outro.and(), CONTENT_STRINGS.OUTRO.AND);
-    cy.checkText(outro.buildingNumberOrName(), `${buildingNumberOrName}.`);
+      cy.checkText(outro.couldNotFind(), CONTENT_STRINGS.OUTRO.COULD_NOT_FIND);
+      cy.checkText(outro.postcode(), postcode);
+      cy.checkText(outro.and(), CONTENT_STRINGS.OUTRO.AND);
+      cy.checkText(outro.buildingNumberOrName(), `${buildingNumberOrName}.`);
+    });
+  });
+
+  describe('AA9A 9AA', () => {
+    const invalidPostcode = 'AA9A 9AA';
+
+    beforeEach(() => {
+      cy.navigateToUrl(brokerDetailsUrl);
+      cy.completeAndSubmitBrokerDetailsForm({ isBasedInUk: true, postcode: invalidPostcode, buildingNumberOrName });
+    });
+    it(`should redirect to ${BROKER_ZERO_ADDRESSES_ROOT} and display the correct text`, () => {
+      cy.assertUrl(url);
+
+      cy.checkText(outro.couldNotFind(), CONTENT_STRINGS.OUTRO.COULD_NOT_FIND);
+      cy.checkText(outro.postcode(), invalidPostcode);
+      cy.checkText(outro.and(), CONTENT_STRINGS.OUTRO.AND);
+      cy.checkText(outro.buildingNumberOrName(), `${buildingNumberOrName}.`);
+    });
+  });
+
+  describe('A9 9AA', () => {
+    const invalidPostcode = 'A9 9AA';
+
+    beforeEach(() => {
+      cy.navigateToUrl(brokerDetailsUrl);
+      cy.completeAndSubmitBrokerDetailsForm({ isBasedInUk: true, postcode: invalidPostcode, buildingNumberOrName });
+    });
+    it(`should redirect to ${BROKER_ZERO_ADDRESSES_ROOT} and display the correct text`, () => {
+      cy.assertUrl(url);
+
+      cy.checkText(outro.couldNotFind(), CONTENT_STRINGS.OUTRO.COULD_NOT_FIND);
+      cy.checkText(outro.postcode(), invalidPostcode);
+      cy.checkText(outro.and(), CONTENT_STRINGS.OUTRO.AND);
+      cy.checkText(outro.buildingNumberOrName(), `${buildingNumberOrName}.`);
+    });
+  });
+
+  describe('A99 9AA', () => {
+    const invalidPostcode = 'A99 9AA';
+
+    beforeEach(() => {
+      cy.navigateToUrl(brokerDetailsUrl);
+      cy.completeAndSubmitBrokerDetailsForm({ isBasedInUk: true, postcode: invalidPostcode, buildingNumberOrName });
+    });
+    it(`should redirect to ${BROKER_ZERO_ADDRESSES_ROOT} and display the correct text`, () => {
+      cy.assertUrl(url);
+
+      cy.checkText(outro.couldNotFind(), CONTENT_STRINGS.OUTRO.COULD_NOT_FIND);
+      cy.checkText(outro.postcode(), invalidPostcode);
+      cy.checkText(outro.and(), CONTENT_STRINGS.OUTRO.AND);
+      cy.checkText(outro.buildingNumberOrName(), `${buildingNumberOrName}.`);
+    });
+  });
+
+  describe('AA9 9AA', () => {
+    const invalidPostcode = 'AA9 9AA';
+
+    beforeEach(() => {
+      cy.navigateToUrl(brokerDetailsUrl);
+      cy.completeAndSubmitBrokerDetailsForm({ isBasedInUk: true, postcode: invalidPostcode, buildingNumberOrName });
+    });
+    it(`should redirect to ${BROKER_ZERO_ADDRESSES_ROOT} and display the correct text`, () => {
+      cy.assertUrl(url);
+
+      cy.checkText(outro.couldNotFind(), CONTENT_STRINGS.OUTRO.COULD_NOT_FIND);
+      cy.checkText(outro.postcode(), invalidPostcode);
+      cy.checkText(outro.and(), CONTENT_STRINGS.OUTRO.AND);
+      cy.checkText(outro.buildingNumberOrName(), `${buildingNumberOrName}.`);
+    });
+  });
+
+  describe('EC2M 4PL', () => {
+    const invalidPostcode = 'EC2M 4PL';
+
+    beforeEach(() => {
+      cy.navigateToUrl(brokerDetailsUrl);
+      cy.completeAndSubmitBrokerDetailsForm({ isBasedInUk: true, postcode: invalidPostcode, buildingNumberOrName });
+    });
+    it(`should redirect to ${BROKER_ZERO_ADDRESSES_ROOT} and display the correct text`, () => {
+      cy.assertUrl(url);
+
+      cy.checkText(outro.couldNotFind(), CONTENT_STRINGS.OUTRO.COULD_NOT_FIND);
+      cy.checkText(outro.postcode(), invalidPostcode);
+      cy.checkText(outro.and(), CONTENT_STRINGS.OUTRO.AND);
+      cy.checkText(outro.buildingNumberOrName(), `${buildingNumberOrName}.`);
+    });
   });
 });

--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -10283,7 +10283,8 @@ var getOrdnanceSurveyAddresses = async (root, variables) => {
       };
     }
     const response = await ordnance_survey_default.get(postcode);
-    if (!response.success && response.status === 400) {
+    const acceptableStatuses = [200, 400];
+    if (!response.success && acceptableStatuses.includes(response.status)) {
       return {
         success: false,
         noAddressesFound: true,
@@ -10292,6 +10293,7 @@ var getOrdnanceSurveyAddresses = async (root, variables) => {
     if (!response.success || !response.data) {
       return {
         success: false,
+        apiError: true,
       };
     }
     const uppercaseHouseNameOrNumber = houseNameOrNumber.toUpperCase();

--- a/src/api/custom-resolvers/queries/get-ordnance-survey-addresses/index.test.ts
+++ b/src/api/custom-resolvers/queries/get-ordnance-survey-addresses/index.test.ts
@@ -20,16 +20,16 @@ describe('getOrdnanceSurveyAddresses', () => {
       ordnanceSurvey.get = jest.fn(() => Promise.resolve({ success: false }));
     });
 
-    it('should return an object containing success=false', async () => {
+    it('should return an object containing success=false and apiError=true', async () => {
       const response = await getOrdnanceSurveyAddress({}, { postcode, houseNameOrNumber });
 
-      const expected = { success: false };
+      const expected = { success: false, apiError: true };
 
       expect(response).toEqual(expected);
     });
   });
 
-  describe('when ordnance survey API returns an empty data object', () => {
+  describe('when ordnance survey API returns an empty data object and apiError=true', () => {
     beforeEach(() => {
       ordnanceSurvey.get = jest.fn(() => Promise.resolve({ success: true, data: undefined, status: 200 }));
     });
@@ -37,7 +37,7 @@ describe('getOrdnanceSurveyAddresses', () => {
     it('should return an object containing success=false', async () => {
       const response = await getOrdnanceSurveyAddress({}, { postcode, houseNameOrNumber });
 
-      const expected = { success: false };
+      const expected = { success: false, apiError: true };
 
       expect(response).toEqual(expected);
     });
@@ -46,6 +46,20 @@ describe('getOrdnanceSurveyAddresses', () => {
   describe('when ordnance survey API returns a 400 status code', () => {
     beforeEach(() => {
       ordnanceSurvey.get = jest.fn(() => Promise.resolve({ success: false, status: 400 }));
+    });
+
+    it('should return an object containing success=false and noAddressesFound=true', async () => {
+      const response = await getOrdnanceSurveyAddress({}, { postcode, houseNameOrNumber });
+
+      const expected = { success: false, noAddressesFound: true };
+
+      expect(response).toEqual(expected);
+    });
+  });
+
+  describe('when ordnance survey API returns a 200 status code, success=false and no data object', () => {
+    beforeEach(() => {
+      ordnanceSurvey.get = jest.fn(() => Promise.resolve({ success: false, status: 200 }));
     });
 
     it('should return an object containing success=false and noAddressesFound=true', async () => {

--- a/src/api/custom-resolvers/queries/get-ordnance-survey-addresses/index.ts
+++ b/src/api/custom-resolvers/queries/get-ordnance-survey-addresses/index.ts
@@ -36,11 +36,15 @@ const getOrdnanceSurveyAddresses = async (root: any, variables: OrdnanceSurveyVa
 
     const response = await ordnanceSurvey.get(postcode);
 
+    const acceptableStatuses = [200, 400];
+
     /**
-     * if received status is 400
-     * then return noAddressesFound flag
+     * if received status is 200 or 400
+     * and success is false
+     * then no address has been found for provided postcode
+     * return noAddressesFound = true and success = false
      */
-    if (!response.success && response.status === 400) {
+    if (!response.success && acceptableStatuses.includes(response.status)) {
       return {
         success: false,
         noAddressesFound: true,
@@ -49,11 +53,12 @@ const getOrdnanceSurveyAddresses = async (root: any, variables: OrdnanceSurveyVa
 
     /**
      * If there is no success response, or no data,
-     * return success=false
+     * return success=false and apiError=true
      */
     if (!response.success || !response.data) {
       return {
         success: false,
+        apiError: true,
       };
     }
 

--- a/src/api/integrations/ordnance-survey/index.ts
+++ b/src/api/integrations/ordnance-survey/index.ts
@@ -16,6 +16,12 @@ const { ORDNANCE_SURVEY_API_KEY, ORDNANCE_SURVEY_API_URL } = process.env;
 const ordnanceSurvey = {
   get: async (postcode: string): Promise<OrdnanceSurveyAPIResponse> => {
     try {
+      /**
+       * 400 is on list of accepted status due to OS validation
+       * OS has very thorough validation for postcodes
+       * if a postcode fails their validation, it returns 400
+       * so 400 is handled as an accepted status
+       */
       const acceptableStatuses = [200, 400, 404];
 
       const response = await axios({


### PR DESCRIPTION
## Introduction :pencil2:
Certain postcodes were still redirecting to problem with service due to ordnance survey 

## Resolution :heavy_check_mark:
* Added check if response is 200 or 400 and no success, then to return noAddressesFound flag
* Added apiError return if no response data or success
* Added more e2e tests
* Added documentation
