### PR TITLE
fix(EMS-4204): fix incorrect file format sent to mdm for submission email

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -1730,10 +1730,10 @@ var application = {
       const emailAddress = String(process.env.UNDERWRITING_TEAM_EMAIL);
       const file = await file_system_default.readFile(filePath);
       if (file) {
-        const fileBuffer = Buffer.from(file);
+        const bufferedHexString = file.toString('hex');
         const variablesWithFileBuffer = {
           ...variables,
-          file: fileBuffer,
+          file: bufferedHexString,
         };
         const response = await APIM_default.sendEmail(templateId, emailAddress, variablesWithFileBuffer);
         await file_system_default.unlink(filePath);

--- a/src/api/emails/application/index.test.ts
+++ b/src/api/emails/application/index.test.ts
@@ -96,9 +96,11 @@ describe('emails/application', () => {
 
       const emailAddress = process.env.UNDERWRITING_TEAM_EMAIL;
 
+      const bufferedHexString = mockFileSystemResponse.toString('hex');
+
       const expectedVariables = {
         ...variables,
-        file: Buffer.from(mockFileSystemResponse),
+        file: bufferedHexString,
       };
 
       expect(sendEmailSpy).toHaveBeenCalledWith(templateId, emailAddress, expectedVariables);

--- a/src/api/emails/application/index.ts
+++ b/src/api/emails/application/index.ts
@@ -49,11 +49,11 @@ const application = {
       const file = await fileSystem.readFile(filePath);
 
       if (file) {
-        const fileBuffer = Buffer.from(file);
+        const bufferedHexString = file.toString('hex');
 
         const variablesWithFileBuffer = {
           ...variables,
-          file: fileBuffer,
+          file: bufferedHexString,
         };
 
         const response = await APIM.sendEmail(templateId, emailAddress, variablesWithFileBuffer);


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where MDM was returning incorrect file type error from notify on application submission

## Resolution :heavy_check_mark:
* set file to hex string before sending to MDM
* Updated test
