### PR TITLE
fix(EMS-4216): remove buildingNameOrNumber from xlsx generation

### DIFF
--- a/src/api/.keystone/config.js
+++ b/src/api/.keystone/config.js
@@ -8146,12 +8146,8 @@ var map_jointly_insured_party_default = mapJointlyInsuredParty;
 
 // generate-xlsx/map-application-to-XLSX/map-policy/map-broker/map-broker-address/based-in-the-uk/index.ts
 var mapBrokerAddressBasedInTheUk = (broker) => {
-  const { buildingNumberOrName, addressLine1, addressLine2, town, county, postcode } = broker;
+  const { addressLine1, addressLine2, town, county, postcode } = broker;
   let addressString = '';
-  if (buildingNumberOrName) {
-    addressString += `${buildingNumberOrName}
-`;
-  }
   if (addressLine1) {
     addressString += `${addressLine1}
 `;

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-policy/map-broker/map-broker-address/based-in-the-uk/index.test.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-policy/map-broker/map-broker-address/based-in-the-uk/index.test.ts
@@ -9,7 +9,7 @@ const {
 
 const { broker } = mockApplication;
 
-const { buildingNumberOrName, addressLine1, addressLine2, town, county, postcode } = broker;
+const { addressLine1, addressLine2, town, county, postcode } = broker;
 
 describe('api/generate-xlsx/map-application-to-xlsx/map-policy/map-broker/map-broker-address/based-in-the-uk', () => {
   describe(`when a broker only has ${BUILDING_NUMBER_OR_NAME}, ${ADDRESS_LINE_1} and ${POSTCODE} generic fields`, () => {
@@ -23,7 +23,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-policy/map-broker/map-br
 
       const result = mapBrokerAddressBasedInTheUk(mockBroker);
 
-      const expected = `${buildingNumberOrName}\n${addressLine1}\n${postcode}`;
+      const expected = `${addressLine1}\n${postcode}`;
 
       expect(result).toEqual(expected);
     });
@@ -39,7 +39,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-policy/map-broker/map-br
 
       const result = mapBrokerAddressBasedInTheUk(mockBroker);
 
-      const expected = `${buildingNumberOrName}\n${addressLine1}\n${addressLine2}\n${postcode}`;
+      const expected = `${addressLine1}\n${addressLine2}\n${postcode}`;
 
       expect(result).toEqual(expected);
     });
@@ -55,7 +55,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-policy/map-broker/map-br
 
       const result = mapBrokerAddressBasedInTheUk(mockBroker);
 
-      const expected = `${buildingNumberOrName}\n${addressLine1}\n${town}\n${postcode}`;
+      const expected = `${addressLine1}\n${town}\n${postcode}`;
 
       expect(result).toEqual(expected);
     });
@@ -71,7 +71,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-policy/map-broker/map-br
 
       const result = mapBrokerAddressBasedInTheUk(mockBroker);
 
-      const expected = `${buildingNumberOrName}\n${addressLine1}\n${county}\n${postcode}`;
+      const expected = `${addressLine1}\n${county}\n${postcode}`;
 
       expect(result).toEqual(expected);
     });
@@ -81,7 +81,7 @@ describe('api/generate-xlsx/map-application-to-xlsx/map-policy/map-broker/map-br
     it('should return a single string with all fields', () => {
       const result = mapBrokerAddressBasedInTheUk(broker);
 
-      const expected = `${buildingNumberOrName}\n${addressLine1}\n${addressLine2}\n${town}\n${county}\n${postcode}`;
+      const expected = `${addressLine1}\n${addressLine2}\n${town}\n${county}\n${postcode}`;
 
       expect(result).toEqual(expected);
     });

--- a/src/api/generate-xlsx/map-application-to-XLSX/map-policy/map-broker/map-broker-address/based-in-the-uk/index.ts
+++ b/src/api/generate-xlsx/map-application-to-XLSX/map-policy/map-broker/map-broker-address/based-in-the-uk/index.ts
@@ -9,13 +9,9 @@ import { ApplicationBroker } from '../../../../../../types';
  * @returns {String} Broker UK address string
  */
 const mapBrokerAddressBasedInTheUk = (broker: ApplicationBroker) => {
-  const { buildingNumberOrName, addressLine1, addressLine2, town, county, postcode } = broker;
+  const { addressLine1, addressLine2, town, county, postcode } = broker;
 
   let addressString = '';
-
-  if (buildingNumberOrName) {
-    addressString += `${buildingNumberOrName}\n`;
-  }
 
   if (addressLine1) {
     addressString += `${addressLine1}\n`;


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where the user entered building name or number was visible on the generated xlsx spreadsheet as shown below, where the first 1 is not required

![image](https://github.com/user-attachments/assets/539fe20e-0f45-48d3-b861-b19a387c539f)


## Resolution :heavy_check_mark:
* Remove buildingNumberOrName from generated xlsx
* update tests
