### PR TITLE
chore(EMS-4217): dependabot - limit typescript to below 5.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,8 @@ updates:
         versions: [">=5.0.0"]
       - dependency-name: "prettier"
         versions: [">=3.0.0"]
+      - dependency-name: "typescript"
+        versions: [">5.8.0"]
     groups:
       npm-packages:
         patterns:


### PR DESCRIPTION
## Introduction :pencil2:
Typescript 5.8 is a breaking change causing ui not to compile.  This PR limits the version to below 5.8 for dependabot updates

## Resolution :heavy_check_mark:
* Added dependabot condition for typescript

