### PR TITLE
chore(EMS-4217): dependabot - limit typescript to 5.4 only in ui directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,8 +41,10 @@ updates:
         versions: [">=5.0.0"]
       - dependency-name: "prettier"
         versions: [">=3.0.0"]
+    allow:
       - dependency-name: "typescript"
-        versions: [">5.8.0"]
+        versions: ["<=5.4.5"]
+        directory: "/src/ui"
     groups:
       npm-packages:
         patterns:


### PR DESCRIPTION
## Introduction :pencil2:
This PR limits dependabot only updating typescript up to 5.4.5 in the UI directory (but allows newer versions in other directories)

## Resolution :heavy_check_mark:
* added an allow section in dependabot to limit version of typescript in ui
