### PR TITLE
chore(EMS-4217): dependabot - remove typescript version limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,8 +41,6 @@ updates:
         versions: [">=5.0.0"]
       - dependency-name: "prettier"
         versions: [">=3.0.0"]
-      - dependency-name: "typescript"
-        versions: [">5.8.0"]
     groups:
       npm-packages:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,18 @@ updates:
         patterns:
           - '*'
 
+  # UI package-*.json files
+  - package-ecosystem: 'npm'
+    directory: '/src/ui'
+    schedule:
+      interval: 'monthly'
+      time: '03:00'
+    labels:
+      - 'chore'
+    allow:
+      - dependency-name: "typescript"
+        versions: ["<=5.4.5"]
+
   # `UI and API` Dockerfile
   - package-ecosystem: 'docker'
     directories:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,18 +46,6 @@ updates:
         patterns:
           - '*'
 
-  # UI package-*.json files
-  - package-ecosystem: 'npm'
-    directory: '/src/ui'
-    schedule:
-      interval: 'monthly'
-      time: '03:00'
-    labels:
-      - 'chore'
-    allow:
-      - dependency-name: "typescript"
-        versions: ["<=5.4.5"]
-
   # `UI and API` Dockerfile
   - package-ecosystem: 'docker'
     directories:


### PR DESCRIPTION
## Introduction :pencil2:
This PR limits dependabot only updating typescript up to 5.4.5 in the UI directory (but allows newer versions in other directories)

## Resolution :heavy_check_mark:
* added an allow section in dependabot to limit version of typescript in ui
