### PR TITLE
chore(github-hooks): only run commit hooks on staged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "spellcheck": "cspell lint --gitignore --no-must-find-files --quiet --unique --no-progress --show-suggestions --color '**/*'",
     "type-check:all": "cd src/ui && tsc --noEmit --pretty && cd ../api && tsc --noEmit --pretty && cd ../../e2e-tests && tsc --noEmit --pretty",
     "update:all": "npm update --save && cd src/ui && npm update --save && cd ../api && npm update --save && cd ../../generate-exip-pricing-grid && npm update --save",
-    "validate:md": "npx markdownlint-cli --config .markdownlint.json '**/*.md'",
+    "validate:md": "npx markdownlint-cli --config .markdownlint.json \"**/*.md\"",
     "validate:yml": "npx yaml-lint **/*.yml --ignore=**/node_modules"
   },
   "lint-staged": {
@@ -36,10 +36,10 @@
     ],
     "**/*.md": [
       "prettier --write",
-      "npm run validate:md"
+      "npx markdownlint-cli --config .markdownlint.json"
     ],
     "**/*.yml": [
-      "npm run validate:yml"
+      "npx yaml-lint --ignore=**/node_modules"
     ],
     "**/*": [
       "cspell lint --gitignore --no-must-find-files --unique --no-progress --show-suggestions --color"


### PR DESCRIPTION
# Introduction :pencil2:

`.md` and `.yml` validation was running in commit hooks even if no such files were staged.

## Resolution :heavy_check_mark:

- Update `package.json`.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```
</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
